### PR TITLE
fix: fix issue 73

### DIFF
--- a/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
@@ -456,7 +456,8 @@ export abstract class AcEdBaseView {
    */
   abstract pick(
     point?: AcGePoint2dLike,
-    hitRadius?: number
+    hitRadius?: number,
+    pickOneOnly?: boolean
   ): AcEdSpatialQueryResultItemEx[]
 
   /**
@@ -710,7 +711,7 @@ export abstract class AcEdBaseView {
     this.clearHoverTimer()
     this._hoverTimer = setTimeout(() => {
       this.hoverAt(x, y)
-    }, 50)
+    }, 500)
   }
 
   private startPauseTimer(id: AcDbObjectId) {

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -191,7 +191,11 @@ const features = useSettings()
  */
 const handleFileRead = async (fileName: string, fileContent: ArrayBuffer) => {
   const options: AcDbOpenDatabaseOptions = { minimumChunkSize: 1000 }
-  const success = await AcApDocManager.instance.openDocument(fileName, fileContent, options)
+  const success = await AcApDocManager.instance.openDocument(
+    fileName,
+    fileContent,
+    options
+  )
   if (!success) {
     throw new Error('Failed to open file')
   }
@@ -246,7 +250,11 @@ const openLocalFile = async (file: File) => {
 
     // Open the file using the document manager
     const options: AcDbOpenDatabaseOptions = { minimumChunkSize: 1000 }
-    const success = await AcApDocManager.instance.openDocument(file.name, fileContent, options)
+    const success = await AcApDocManager.instance.openDocument(
+      file.name,
+      fileContent,
+      options
+    )
     if (!success) {
       throw new Error('Failed to open local file')
     }

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -340,7 +340,10 @@ export class AcTrBatchedGroup extends THREE.Group {
 
   protected highlight(objectId: string, containerGroup: THREE.Group) {
     const entityInfo = this._entitiesMap.get(objectId)
-    if (entityInfo) {
+    // TODO:
+    // If there are more than 1000 batched object to highlight, just ignore it due to
+    // performance reason. We will fix it in the future.
+    if (entityInfo && entityInfo.length < 1000) {
       entityInfo.forEach(item => {
         const batchedObject = this.getObjectById(
           item.batchedObjectId


### PR DESCRIPTION
There are two issues which results in this issue.
- sub-entities in one insert entity may be distributed in multiple layers. So in this time, its bounding boxes are inserted into spatial index multiple times. It results in intersect checking occurs many time if there are are lots of layers in one drawing when mouse hovers on some entities. This is fixed in this commit.
- Method `highlight` isn't implemented with good performance when it is one insert entities with lot of subentities. It isn't fixed in this commit. I just check the count of subentities. If the number of entities is greater than 1000, just don't highlight it to avoid hanging.

```
protected highlight(objectId: string, containerGroup: THREE.Group)
```