### PR TITLE
feat: add master layer visibility toggle and improve sysvar UX

### DIFF
--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -3,7 +3,11 @@ import {
   AcApOpenDatabaseOptions,
   AcEdOpenMode
 } from '@mlightcad/cad-simple-viewer'
-import { AcDbSysVarManager, log } from '@mlightcad/data-model'
+import {
+  AcDbSystemVariables,
+  AcDbSysVarManager,
+  log
+} from '@mlightcad/data-model'
 
 class CadViewerApp {
   private container: HTMLDivElement
@@ -133,7 +137,7 @@ class CadViewerApp {
       }
 
       const currentPickbox = AcDbSysVarManager.instance().getVar(
-        'pickbox',
+        AcDbSystemVariables.PICKBOX,
         AcApDocManager.instance.curDocument.database
       )
       const initialPickbox =
@@ -152,7 +156,9 @@ class CadViewerApp {
         return
       }
 
-      AcApDocManager.instance.sendStringToExecute(`pickbox\n${pickboxValue}`)
+      AcApDocManager.instance.sendStringToExecute(
+        `${AcDbSystemVariables.PICKBOX}\n${pickboxValue}`
+      )
       this.showMessage(`Pickbox set to: ${pickboxValue}`, 'success')
     })
 

--- a/packages/cad-simple-viewer/src/command/AcApSysVarCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApSysVarCmd.ts
@@ -20,9 +20,22 @@ export class AcApSysVarCmd extends AcEdCommand {
    * @param context - The application context containing the view
    */
   async execute(context: AcApContext) {
-    const prompt = new AcEdPromptStringOptions(AcApI18n.t('jig.sysvar.prompt'))
-    const value = await AcApDocManager.instance.editor.getString(prompt)
     const sysVarManager = AcDbSysVarManager.instance()
+    const currentValue = sysVarManager.getVar(
+      this.globalName,
+      context.doc.database
+    )
+    const basePrompt = AcApI18n.t('jig.sysvar.prompt').trim()
+    const match = basePrompt.match(/([：:])\s*$/)
+    // Preserve the existing trailing colon style (Chinese or ASCII) if present.
+    const colon = match?.[1] ?? ':'
+    const promptCore = match
+      ? basePrompt.slice(0, match.index).trimEnd()
+      : basePrompt
+    const suffix = currentValue == null ? '' : ` <${String(currentValue)}>`
+    const promptMessage = `${promptCore}${suffix}${colon}`
+    const prompt = new AcEdPromptStringOptions(promptMessage)
+    const value = await AcApDocManager.instance.editor.getString(prompt)
     const sysVar = sysVarManager.getDescriptor(this.globalName)
     if (sysVar) {
       sysVarManager.setVar(this.globalName, value, context.doc.database)

--- a/packages/cad-simple-viewer/src/i18n/en/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/command.ts
@@ -17,6 +17,10 @@ export default {
     circle: {
       description: 'Creates one circle by center and radius'
     },
+    colortheme: {
+      description:
+        'Controls the color theme of the user interface (dark or light)'
+    },
     csvg: {
       description: 'Converts current drawing to SVG'
     },

--- a/packages/cad-simple-viewer/src/i18n/zh/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/command.ts
@@ -15,6 +15,9 @@ export default {
     circle: {
       description: '使用圆心和半径创建圆'
     },
+    colortheme: {
+      description: '控制用户界面的颜色主题（深色或浅色）'
+    },
     csvg: {
       description: '转换当前图纸为SVG格式'
     },

--- a/packages/cad-viewer/src/component/palette/MlLayerList.vue
+++ b/packages/cad-viewer/src/component/palette/MlLayerList.vue
@@ -16,6 +16,16 @@
       :label="t('main.toolPalette.layerManager.layerList.on')"
       width="50"
     >
+      <template #header>
+        <div class="ml-layer-list-header-toggle">
+          <el-checkbox
+            :model-value="isAllOn"
+            :indeterminate="isSomeOn"
+            :aria-label="t('main.toolPalette.layerManager.layerList.on')"
+            @change="handleToggleAll"
+          />
+        </div>
+      </template>
       <template #default="scope">
         <div class="ml-layer-list-cell">
           <el-checkbox
@@ -56,7 +66,7 @@
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { AcCmColor } from '@mlightcad/data-model'
 import { ElMessage, ElTable } from 'element-plus'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { LayerInfo, useLayers } from '../../composable'
@@ -82,6 +92,35 @@ const props = defineProps<Props>()
  * This composable also updates automatically when CAD document changes.
  */
 const { layers } = useLayers(props.editor)
+
+/**
+ * ===== Master Layer Visibility Toggle =====
+ */
+const isAllOn = computed(() => {
+  if (!layers.length) return false
+  return layers.every(layer => layer.isOn)
+})
+
+const isSomeOn = computed(() => {
+  if (!layers.length) return false
+  const anyOn = layers.some(layer => layer.isOn)
+  return anyOn && !isAllOn.value
+})
+
+const setLayerVisibility = (row: LayerInfo, isOn: boolean) => {
+  row.isOn = isOn
+  const layer = props.editor.curDocument.database.tables.layerTable.getAt(
+    row.name
+  )
+  if (layer) layer.isOff = !isOn
+}
+
+const handleToggleAll = (isOn: boolean) => {
+  layers.forEach(row => {
+    if (row.isOn === isOn) return
+    setLayerVisibility(row, isOn)
+  })
+}
 
 /**
  * Triggered when a row in the layer list table is double-clicked.
@@ -113,10 +152,7 @@ const handleRowDbClick = (row: LayerInfo) => {
  * @param row - LayerInfo for the row being changed
  */
 const handleLayerVisibility = (row: LayerInfo) => {
-  const layer = props.editor.curDocument.database.tables.layerTable.getAt(
-    row.name
-  )
-  if (layer) layer.isOff = !row.isOn
+  setLayerVisibility(row, row.isOn)
 }
 
 /**
@@ -197,6 +233,13 @@ const handleColorDialogCancel = () => {
 
 /* Flex container for centered cell content */
 .ml-layer-list-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Center master toggle in header */
+.ml-layer-list-header-toggle {
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
**Summary**  
This PR enhances layer management with a master visibility toggle, improves sysvar prompting by showing the current value, adds a COLORTHEME command description to i18n, and updates the example to use system variable constants.

**Changes**

-   Add a header checkbox in MlLayerList to toggle all layers on/off, with indeterminate state handling and shared visibility helper.
-   Show the current sysvar value in the prompt (preserving localized colon style) and streamline sysvar updates.
-   Add colortheme command descriptions to EN/ZH i18n.
-   Update example usage to use AcDbSystemVariables.PICKBOX constant when reading/setting pickbox.