### PR TITLE
fix: fix viewport render and scale

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -7,7 +7,6 @@ import {
   acdbHostApplicationServices,
   AcDbProgressdEventArgs,
   AcDbSysVarManager,
-  AcGeBox2d,
   log
 } from '@mlightcad/data-model'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
@@ -959,14 +958,11 @@ export class AcApDocManager {
       const doc = this.context.doc
       this.events.documentActivated.dispatch({ doc })
       this.setActiveLayout()
-      const db = doc.database
 
-      // The extents of drawing database may be empty. Espically dxf files.
-      if (db.extents.isEmpty()) {
-        this.curView.zoomToFitDrawing()
-      } else {
-        this.curView.zoomTo(new AcGeBox2d(db.extmin, db.extmax))
-      }
+      // The initial zoom is handled after batchConvert completes, so the
+      // camera goes directly to the viewport area without a visible jump.
+      // For files without viewports, zoomToFitDrawing provides the fallback.
+      this.curView.zoomToFitDrawing()
     }
   }
 

--- a/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
@@ -1,3 +1,4 @@
+import { AcGeBox2d } from '@mlightcad/data-model'
 import {
   AcTrBaseView,
   AcTrRenderer,
@@ -114,6 +115,21 @@ export class AcTrLayoutView extends AcTrBaseView {
    */
   get internalCamera() {
     return this._camera.internalCamera
+  }
+
+  /**
+   * Paper-space bounding box enclosing all viewport borders in this layout.
+   * Returns undefined when the layout has no viewports.
+   */
+  get viewportsBoundingBox(): AcGeBox2d | undefined {
+    if (this._viewportViews.size === 0) return undefined
+    const box = new AcGeBox2d()
+    this._viewportViews.forEach(vp => {
+      const vpBox = vp.viewport.box
+      box.expandByPoint(vpBox.min)
+      box.expandByPoint(vpBox.max)
+    })
+    return box.isEmpty() ? undefined : box
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -442,7 +442,11 @@ export class AcTrView2d extends AcEdBaseView {
     const waiter = new AcEdConditionWaiter(
       () => this._numOfEntitiesToProcess <= 0,
       () => {
-        if (this._scene.box) {
+        const vpBox = this.activeLayoutView?.viewportsBoundingBox
+        if (vpBox) {
+          this.zoomTo(vpBox)
+          this._isDirty = true
+        } else if (this._scene.box) {
           const box = AcTrGeometryUtil.threeBox3dToGeBox2d(this._scene.box)
           this.zoomTo(box)
           this._isDirty = true
@@ -761,7 +765,7 @@ export class AcTrView2d extends AcEdBaseView {
       camera: this.internalCamera
     })
 
-    if (!this._isDirty) return
+    if (!this._isDirty || this._numOfEntitiesToProcess > 0) return
     this._layoutViewManager.render(this._scene)
     if (this.internalCamera) {
       this._css2dRenderer.render(this._scene.internalScene, this.internalCamera)
@@ -835,6 +839,20 @@ export class AcTrView2d extends AcEdBaseView {
           if (layout) {
             layout.isLoaded = true
           }
+
+          // Zoom to the viewport area, or fall back to the full scene
+          // extent for model-space layouts without viewports.
+          const layoutView = this._layoutViewManager.getAt(layoutBtrId)
+          const vpBox = layoutView?.viewportsBoundingBox
+          if (vpBox) {
+            this.zoomTo(vpBox)
+          } else if (this._scene.box) {
+            const sceneBox = AcTrGeometryUtil.threeBox3dToGeBox2d(
+              this._scene.box
+            )
+            this.zoomTo(sceneBox)
+          }
+          this._isDirty = true
         })
       }
     } catch (error) {
@@ -900,13 +918,36 @@ export class AcTrView2d extends AcEdBaseView {
       }
 
       // First, try to ignore viewport with number === 1
-      const filtered = viewports.filter(vp => vp.number !== 1)
+      let filtered = viewports.filter(vp => vp.number !== 1)
 
       // If nothing was filtered (i.e., no viewport with number === 1),
       // then ignore the first viewport in this layout
       // if (filtered.length === viewports.length && viewports.length > 0) {
       //   filtered = viewports.slice(1)
       // }
+
+      // Skip the full-paper viewport whose paper-space area dwarfs every other
+      // viewport. AutoCAD auto-creates this viewport (number 2) when a new
+      // layout is added. Its border is the "big square" visible in the viewer.
+      if (filtered.length > 1) {
+        let maxArea = 0
+        let maxIdx = 0
+        for (let i = 0; i < filtered.length; i++) {
+          const a = filtered[i].width * filtered[i].height
+          if (a > maxArea) {
+            maxArea = a
+            maxIdx = i
+          }
+        }
+        const rest = filtered.filter((_, i) => i !== maxIdx)
+        const secondLargest = rest.reduce(
+          (max, vp) => Math.max(max, vp.width * vp.height),
+          0
+        )
+        if (maxArea > secondLargest * 10) {
+          filtered = rest
+        }
+      }
 
       filtered.forEach(vp => {
         validViewportIds.add(vp.objectId)
@@ -915,6 +956,14 @@ export class AcTrView2d extends AcEdBaseView {
 
     for (let i = 0; i < entities.length; ++i) {
       const entity = entities[i]
+
+      // Skip drawing filtered-out viewport entities entirely so their
+      // borders don't appear in paper space or affect the bounding box.
+      if (entity instanceof AcDbViewport && !validViewportIds.has(entity.objectId)) {
+        this.decreaseNumOfEntitiesToProcess()
+        continue
+      }
+
       const threeEntity: AcTrEntity | null = this.drawEntity(entity, true)
       if (threeEntity) {
         threeEntity.objectId = entity.objectId
@@ -946,19 +995,14 @@ export class AcTrView2d extends AcEdBaseView {
         }
 
         if (entity instanceof AcDbViewport) {
-          // In paper space layouts, there is always a system-defined "default" viewport that exists as
-          // the bottom-most item. This viewport doesn't show any entities and is mainly for internal
-          // AutoCAD purposes. The viewport id number of this system-defined "default" viewport is 1.
-          if (validViewportIds.has(entity.objectId)) {
-            const layoutView = this._layoutViewManager.getAt(entity.ownerId)
-            if (layoutView) {
-              const viewportView = new AcTrViewportView(
-                layoutView,
-                entity.toGiViewport(),
-                this._renderer
-              )
-              layoutView.addViewport(viewportView)
-            }
+          const layoutView = this._layoutViewManager.getAt(entity.ownerId)
+          if (layoutView) {
+            const viewportView = new AcTrViewportView(
+              layoutView,
+              entity.toGiViewport(),
+              this._renderer
+            )
+            layoutView.addViewport(viewportView)
           }
         } else if (entity instanceof AcDbRasterImage) {
           const fileName = entity.imageFileName

--- a/packages/three-renderer/src/viewport/AcTrViewportView.ts
+++ b/packages/three-renderer/src/viewport/AcTrViewportView.ts
@@ -44,8 +44,6 @@ export class AcTrViewportView extends AcTrBaseView {
     super(renderer, viewportSize.width, viewportSize.height)
     this._parentView = parentView
     this._viewport = viewport.clone()
-    this._frustum *= viewport.height / parentView.height
-    this.zoomTo(this._viewport.viewBox)
     this.enabled = false
   }
 
@@ -60,7 +58,7 @@ export class AcTrViewportView extends AcTrBaseView {
    * Update camera of this viewport
    */
   update() {
-    this.zoomTo(this._viewport.viewBox)
+    this.zoomTo(this._viewport.viewBox, 1.0)
   }
 
   /**
@@ -73,24 +71,31 @@ export class AcTrViewportView extends AcTrBaseView {
       this._viewport
     )
     if (!viewportWindowBox.isEmpty()) {
-      // The origin of the cient window coordinate system is the left-top corner of the client window.
-      // The origin of the viewport coordinate system is the left-bottom corner of the viewport. So the
-      // value of 'cwcsViewportBox.min.y' need to be converted to the viewport coordinate system.
+      const vpW = viewportWindowBox.size.width
+      const vpH = viewportWindowBox.size.height
+
+      if (vpW !== this._width || vpH !== this._height) {
+        this._width = vpW
+        this._height = vpH
+        this._frustum = vpH / 2
+        this.zoomTo(this._viewport.viewBox, 1.0)
+      }
+
       const y =
         this._parentView.height -
         viewportWindowBox.min.y -
-        viewportWindowBox.size.height
+        vpH
       this._renderer.setViewport(
         viewportWindowBox.min.x,
         y,
-        viewportWindowBox.size.width,
-        viewportWindowBox.size.height
+        vpW,
+        vpH
       )
       this._renderer.internalRenderer.setScissor(
         viewportWindowBox.min.x,
         y,
-        viewportWindowBox.size.width,
-        viewportWindowBox.size.height
+        vpW,
+        vpH
       )
       this._renderer.internalRenderer.setScissorTest(true)
       this._renderer.render(scene, this._camera)


### PR DESCRIPTION
## Context https://github.com/mlightcad/cad-viewer/issues/96

## Changes made

Fixing viewport rendering and initial scale of it.

BEFORE:

<img width="3198" height="1274" alt="image" src="https://github.com/user-attachments/assets/e2fc668e-3760-40f5-ba29-f16380449e7e" />

BEFORE WITH ZOOM: 
<img width="3195" height="1334" alt="image" src="https://github.com/user-attachments/assets/84ac667b-c60c-45e3-a2c4-b7bc4ddb9ba7" />

AFTER (Without zoom):
<img width="3192" height="1260" alt="image" src="https://github.com/user-attachments/assets/4a86b29a-dd53-4991-812c-9c87e86f68b6" />


File used for testing: [INN_TOM_AEX_LOB_10000-ACO-SUB_R03.zip](https://github.com/user-attachments/files/25349004/INN_TOM_AEX_LOB_10000-ACO-SUB_R03.zip)

