### PR TITLE
feat: improve OSNAP marker visibility and fix solid line picking

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApSettingManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApSettingManager.ts
@@ -67,7 +67,9 @@ const DEFAULT_VALUES: AcApSettings = {
   osnapModes: acdbOsnapModesToMask([
     AcDbOsnapMode.EndPoint,
     AcDbOsnapMode.MidPoint,
-    AcDbOsnapMode.Center
+    AcDbOsnapMode.Center,
+    AcDbOsnapMode.Quadrant,
+    AcDbOsnapMode.Nearest
   ])
 }
 

--- a/packages/cad-simple-viewer/src/editor/input/marker/AcEdMarker.ts
+++ b/packages/cad-simple-viewer/src/editor/input/marker/AcEdMarker.ts
@@ -41,7 +41,7 @@ export class AcEdMarker {
    */
   constructor(
     type: AcEdMarkerType = 'rect',
-    size: number = 8,
+    size: number = 12,
     color: string = 'green',
     host: HTMLElement
   ) {
@@ -121,12 +121,12 @@ export class AcEdMarker {
     
       .ml-marker-circle {
         border-radius: 50%;
-        border: 1px solid currentColor;
+        border: 2px solid currentColor;
         background: transparent;
       }
     
       .ml-marker-rect {
-        border: 1px solid currentColor;
+        border: 2px solid currentColor;
         background: transparent;
       }
     
@@ -140,7 +140,7 @@ export class AcEdMarker {
       }
     
       .ml-marker-diamond {
-        border: 1px solid currentColor;
+        border: 2px solid currentColor;
         background: transparent;
         transform: translate(-50%, -50%) rotate(45deg);
       }
@@ -152,7 +152,7 @@ export class AcEdMarker {
         top: 50%;
         left: 50%;
         width: 100%;
-        height: 1px;
+        height: 2px;
         background: currentColor;
         transform-origin: center;
       }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -259,6 +259,8 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
         return 'circle'
       case AcDbOsnapMode.Quadrant:
         return 'diamond'
+      case AcDbOsnapMode.Nearest:
+        return 'x'
       default:
         return 'rect'
     }

--- a/packages/cad-viewer/src/component/statusBar/MlOsnapButton.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlOsnapButton.vue
@@ -53,10 +53,10 @@ const osnapModes = [
   { value: AcDbOsnapMode.Center, label: t('main.statusBar.osnap.center') },
   { value: AcDbOsnapMode.Node, label: t('main.statusBar.osnap.node') },
   { value: AcDbOsnapMode.Quadrant, label: t('main.statusBar.osnap.quadrant') },
-  { value: AcDbOsnapMode.Insertion, label: t('main.statusBar.osnap.insertion') }
+  { value: AcDbOsnapMode.Insertion, label: t('main.statusBar.osnap.insertion') },
+  { value: AcDbOsnapMode.Nearest, label: t('main.statusBar.osnap.nearest') }
   // { value: AcDbOsnapMode.Perpendicular, label: t('main.statusBar.osnap.perpendicular') },
   // { value: AcDbOsnapMode.Tangent, label: t('main.statusBar.osnap.tangent') },
-  // { value: AcDbOsnapMode.Nearest, label: t('main.statusBar.osnap.nearest') },
   // { value: AcDbOsnapMode.Centroid, label: t('main.statusBar.osnap.centroid') }
 ]
 

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -112,7 +112,8 @@ export default {
       center: 'Center',
       node: 'Node',
       quadrant: 'Quadrant',
-      insertion: 'Insertion'
+      insertion: 'Insertion',
+      nearest: 'Nearest'
     },
     pointStyle: {
       tooltip: 'Modify point style'

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -105,7 +105,8 @@ export default {
       center: '圆心',
       node: '节点',
       quadrant: '象限点',
-      insertion: '插入'
+      insertion: '插入',
+      nearest: '最近点'
     },
     pointStyle: {
       tooltip: '修改点样式'

--- a/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
@@ -471,6 +471,38 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     _raycastObject.material = this.material as LineMaterial
     _raycastObject.raycast(raycaster, _batchIntersects)
 
+    // LineSegments2.raycast() ignores raycaster.params.Line.threshold and
+    // only uses the pixel-based LineMaterial.linewidth for hit detection.
+    // When linewidth is small the pick area can be too narrow, so fall back
+    // to a bounding-box intersection check when the precise raycast misses.
+    if (_batchIntersects.length === 0) {
+      this.getBoundingBoxAt(geometryId, _box)
+      if (raycaster.ray.intersectBox(_box, _vector)) {
+        // Verify the intersection point is within the Line threshold
+        const threshold = raycaster.params.Line.threshold
+        _box.expandByScalar(threshold)
+        if (raycaster.ray.intersectBox(_box, _vector2)) {
+          const distance = raycaster.ray.origin.distanceTo(_vector2)
+          ;(
+            intersects as Array<
+              THREE.Intersection & { batchId?: number; objectId?: string }
+            >
+          ).push({
+            distance,
+            point: _vector2.clone(),
+            object: this,
+            face: null,
+            faceIndex: undefined,
+            uv: undefined,
+            batchId: geometryId,
+            objectId: geometryInfo.objectId
+          })
+        }
+      }
+      geometry.dispose()
+      return
+    }
+
     for (let i = 0, l = _batchIntersects.length; i < l; i++) {
       const intersect = _batchIntersects[i]
       ;(


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                                                      
  ## Summary      

  - **Larger snap markers**: size 8→12px, border 1→2px, x-marker stroke 1→2px — matches AutoCAD web viewer visibility                                                                                                                                                                                                                                  
  - **New default snap modes**: added Quadrant and Nearest to default OSNAP modes (previously only EndPoint, MidPoint, Center)
  - **Nearest mode UI**: added marker type mapping (x), dropdown entry, and i18n translations (EN/ZH)                                                                                                                                                                                                                                                  
  - **Fix solid line picking**: `LineSegments2.raycast()` ignores `raycaster.params.Line.threshold`, making fat lines with small `linewidth` (~0.025) nearly impossible to pick. Added bounding-box fallback in `AcTrBatchedLine2` following the existing `bboxIntersectionCheck` pattern.                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                       
  ## Files changed                                                                                                                                                                                                                                                                                                                                     
                  
  | File | Package | Change |                                                                                                                                                                                                                                                                                                                          
  |------|---------|--------|
  | `AcEdMarker.ts` | cad-simple-viewer | size 12px, border 2px |
  | `AcApSettingManager.ts` | cad-simple-viewer | +Quadrant, +Nearest defaults |                                                                                                                                                                                                                                                                       
  | `AcEdFloatingInput.ts` | cad-simple-viewer | Nearest → 'x' mapping |                                                                                                                                                                                                                                                                               
  | `MlOsnapButton.vue` | cad-viewer | Nearest in dropdown |                                                                                                                                                                                                                                                                                           
  | `en/main.ts` | cad-viewer | nearest translation |                                                                                                                                                                                                                                                                                                  
  | `zh/main.ts` | cad-viewer | nearest translation |                                                                                                                                                                                                                                                                                                  
  | `AcTrBatchedLine2.ts` | three-renderer | bbox fallback for fat lines |                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                       
  ## Next steps (planned PRs)                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                       
  We have a few follow-up improvements planned and would like your feedback:                                                                                                                                                                                                                                                                           
                  
  ### PR 2 — Auto-switch to SELECTION mode on measurement commands                                                                                                                                                                                                                                                                                     
  When the user is in PAN mode and starts a measurement command, `getPoint()` works but the cursor still shows a grab hand. AutoCAD auto-switches to crosshair mode. **Question:** should `getPoint()` in `AcEdInputManager` auto-switch to SELECTION mode (centralized), or should each command manage its own mode?
                                                                                                                                                                                                                                                                                                                                                       
  ### PR 3 — Unify arc snap with native OSNAP
  `AcApMeasureArcCmd` has a parallel snap system (`AcApArcSnapJig` + `makeSnapIndicator`) that uses `document.body` and doesn't use standard markers. With Nearest now enabled, native OSNAP already handles arc/circle snapping. Plan is to remove the parallel system and use `getPoint()` + `view.pick()`. We also found that circles don't show    
  snap points at all in the arc measurement tool (see `images-ex/measure/arc1-*.png`).                                                                                                                                                                                                                                                                 
  
  ### PR on realdwg-web — Expand `subGetOsnapPoints` for Polyline and Hatch                                                                                                                                                                                                                                                                            
  Snap markers still don't appear on polylines (except vertices) or hatches because `subGetOsnapPoints` is incomplete:
  - `AcDbPolyline`: only EndPoint                                                                                                                                                                                                                                                                                                                      
  - `AcDbHatch`: no override (no-op)
                                                                                                                                                                                                                                                                                                                                                       
  Plan: add MidPoint, Nearest, Center (arc segments) to `AcDbPolyline`/`AcDb2dPolyline`/`AcDb3dPolyline`, and add boundary-edge snapping to `AcDbHatch`. Also add `nearestPoint()`/`midPointOfSegment()` to `AcGePolyline2d` in geometry-engine.                                                                                                       
                                                                                                                                                                                                                                                                                                                                                       
  **Questions:**                                                                                                                                                                                                                                                                                                                               
  1. Is it ok to add `nearestPoint` / `midPointOfSegment` to `AcGePolyline2d`? Or prefer a different approach for segment-level geometry queries?
  2. Should `AcDbHatch.subGetOsnapPoints` snap to boundary edges only, or also to internal pattern geometry?                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                       
  ## Test plan                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                       
  - [ ] Open a DXF with mixed line types (dashed + solid/fat lines)                                                                                                                                                                                                                                                                                    
  - [ ] Verify snap markers appear on both dashed and solid lines
  - [ ] Verify Nearest (x) and Quadrant (diamond) markers appear                                                                                                                                                                                                                                                                                       
  - [ ] Verify marker size is visibly larger than before                                                                                                                                                                                                                                                                                               
  - [ ] Verify solid lines are pickable for measurement tools                                                                                                                                                                                                                                                                                          
  - [ ] Verify no performance regression on large files         