### PR TITLE
feat: auto-switch cursor to crosshair during measurement commands

### DIFF
--- a/packages/cad-simple-viewer/src/command/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureAngleCmd.ts
@@ -258,88 +258,77 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
     const editor = context.view.editor
     const color = measurementColor(context.doc.database)
 
-    // Save current cursor/mode so we can restore after the command
+    // Save current mode so we can restore after the command
     const previousMode = context.view.mode
-    const previousCursor = editor.currentCursor
-
-    // Switch to crosshair for measurement interaction
     context.view.mode = AcEdViewMode.SELECTION
-    context.view.setCursor(AcEdCorsorType.Crosshair)
 
     try {
-      // Pick vertex
-      const vertexPrompt = new AcEdPromptPointOptions(
-        AcApI18n.t('jig.measureAngle.vertex')
-      )
-      const vertex = await editor.getPoint(vertexPrompt)
+      await editor.withCursor(AcEdCorsorType.Crosshair, async () => {
+        // Pick vertex
+        const vertexPrompt = new AcEdPromptPointOptions(
+          AcApI18n.t('jig.measureAngle.vertex')
+        )
+        const vertex = await editor.getPoint(vertexPrompt)
 
-      // Pick first arm endpoint (jig provides preview line from vertex)
-      const arm1Prompt = new AcEdPromptPointOptions(
-        AcApI18n.t('jig.measureAngle.arm1')
-      )
-      arm1Prompt.useBasePoint = true
-      arm1Prompt.jig = new AcApMeasureArm1Jig(context.view, vertex, color)
-      const arm1 = await editor.getPoint(arm1Prompt)
+        // Pick first arm endpoint (jig provides preview line from vertex)
+        const arm1Prompt = new AcEdPromptPointOptions(
+          AcApI18n.t('jig.measureAngle.arm1')
+        )
+        arm1Prompt.useBasePoint = true
+        arm1Prompt.jig = new AcApMeasureArm1Jig(context.view, vertex, color)
+        const arm1 = await editor.getPoint(arm1Prompt)
 
-      // Construction-phase canvas for the first arm dashed line
-      const armCanvas = makeOverlayCanvas(context.view.container)
-      drawArm1OnCanvas(armCanvas, context.view, vertex, arm1, color)
-
-      const redrawOnViewChange = () =>
+        // Construction-phase canvas for the first arm dashed line
+        const armCanvas = makeOverlayCanvas(context.view.container)
         drawArm1OnCanvas(armCanvas, context.view, vertex, arm1, color)
-      context.view.events.viewChanged.addEventListener(redrawOnViewChange)
 
-      // Pick second arm endpoint with live preview (jig provides line + angle badge)
-      const arm2Prompt = new AcEdPromptPointOptions(
-        AcApI18n.t('jig.measureAngle.arm2')
-      )
-      arm2Prompt.jig = new AcApMeasureAngleJig(
-        context.view,
-        vertex,
-        arm1,
-        armCanvas,
-        color
-      )
+        const redrawOnViewChange = () =>
+          drawArm1OnCanvas(armCanvas, context.view, vertex, arm1, color)
+        context.view.events.viewChanged.addEventListener(redrawOnViewChange)
 
-      let arm2: AcGePoint3dLike
-      try {
-        arm2 = await editor.getPoint(arm2Prompt)
-      } catch {
-        // User pressed ESC / cancelled — clean up construction-phase DOM
+        // Pick second arm endpoint with live preview (jig provides line + angle badge)
+        const arm2Prompt = new AcEdPromptPointOptions(
+          AcApI18n.t('jig.measureAngle.arm2')
+        )
+        arm2Prompt.jig = new AcApMeasureAngleJig(
+          context.view,
+          vertex,
+          arm1,
+          armCanvas,
+          color
+        )
+
+        let arm2: AcGePoint3dLike
+        try {
+          arm2 = await editor.getPoint(arm2Prompt)
+        } catch {
+          // User pressed ESC / cancelled — clean up construction-phase DOM
+          context.view.events.viewChanged.removeEventListener(
+            redrawOnViewChange
+          )
+          armCanvas.remove()
+          return
+        }
+
+        // Clean up construction-phase canvas
         context.view.events.viewChanged.removeEventListener(redrawOnViewChange)
         armCanvas.remove()
-        return
-      }
 
-      // Clean up construction-phase canvas
-      context.view.events.viewChanged.removeEventListener(redrawOnViewChange)
-      armCanvas.remove()
+        const degrees = calcAngleDeg(vertex, arm1, arm2)
 
-      const degrees = calcAngleDeg(vertex, arm1, arm2)
+        // Persistent CAD transient lines for both arms (zoom/pan aware)
+        const line1 = new AcDbLine(vertex, arm1)
+        line1.color = color
+        line1.lineWeight = AcGiLineWeight.LineWeight070
+        context.view.addTransientEntity(line1)
 
-      // Persistent CAD transient lines for both arms (zoom/pan aware)
-      const line1 = new AcDbLine(vertex, arm1)
-      line1.color = color
-      line1.lineWeight = AcGiLineWeight.LineWeight070
-      context.view.addTransientEntity(line1)
+        const line2 = new AcDbLine(vertex, arm2)
+        line2.color = color
+        line2.lineWeight = AcGiLineWeight.LineWeight070
+        context.view.addTransientEntity(line2)
 
-      const line2 = new AcDbLine(vertex, arm2)
-      line2.color = color
-      line2.lineWeight = AcGiLineWeight.LineWeight070
-      context.view.addTransientEntity(line2)
-
-      // Persistent arc canvas — redrawn on viewChanged, cleaned up by Clear
-      const persistCanvas = makeOverlayCanvas(context.view.container)
-      drawAngleArcOnCanvas(
-        persistCanvas,
-        context.view,
-        vertex,
-        arm1,
-        arm2,
-        color
-      )
-
-      const redrawPersist = () =>
+        // Persistent arc canvas — redrawn on viewChanged, cleaned up by Clear
+        const persistCanvas = makeOverlayCanvas(context.view.container)
         drawAngleArcOnCanvas(
           persistCanvas,
           context.view,
@@ -348,71 +337,78 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
           arm2,
           color
         )
-      context.view.events.viewChanged.addEventListener(redrawPersist)
 
-      // Persistent overlays via htmlTransientManager (auto-positioned by CSS2DRenderer)
-      const htManager = (context.view as AcTrView2d).htmlTransientManager
-      const id = `angle-${Date.now()}`
+        const redrawPersist = () =>
+          drawAngleArcOnCanvas(
+            persistCanvas,
+            context.view,
+            vertex,
+            arm1,
+            arm2,
+            color
+          )
+        context.view.events.viewChanged.addEventListener(redrawPersist)
 
-      htManager.add(`${id}-dotV`, makeDot(color), vertex, 'measurement')
-      htManager.add(`${id}-dot1`, makeDot(color), arm1, 'measurement')
-      htManager.add(`${id}-dot2`, makeDot(color), arm2, 'measurement')
+        // Persistent overlays via htmlTransientManager (auto-positioned by CSS2DRenderer)
+        const htManager = (context.view as AcTrView2d).htmlTransientManager
+        const id = `angle-${Date.now()}`
 
-      // Place badge along the angle bisector in world space
-      const dx1 = arm1.x - vertex.x
-      const dy1 = arm1.y - vertex.y
-      const dx2 = arm2.x - vertex.x
-      const dy2 = arm2.y - vertex.y
-      const wLen1 = Math.hypot(dx1, dy1)
-      const wLen2 = Math.hypot(dx2, dy2)
-      // Unit vectors along each arm
-      const u1x = wLen1 > 0 ? dx1 / wLen1 : 1
-      const u1y = wLen1 > 0 ? dy1 / wLen1 : 0
-      const u2x = wLen2 > 0 ? dx2 / wLen2 : 1
-      const u2y = wLen2 > 0 ? dy2 / wLen2 : 0
-      // Bisector direction (sum of unit vectors)
-      let bx = u1x + u2x
-      let by = u1y + u2y
-      const bLen = Math.hypot(bx, by)
-      if (bLen > 0) {
-        bx /= bLen
-        by /= bLen
-      } else {
-        // Arms are exactly opposite — use perpendicular
-        bx = -u1y
-        by = u1x
-      }
-      const badgeOffset = Math.max(
-        Math.min(wLen1, wLen2) * 0.4,
-        Math.max(wLen1, wLen2) * 0.15
-      )
-      const badgeWorld = {
-        x: vertex.x + bx * badgeOffset,
-        y: vertex.y + by * badgeOffset
-      }
-      htManager.add(
-        `${id}-badge`,
-        makeBadge(color, `${degrees.toFixed(2)}\u00B0`),
-        badgeWorld,
-        'measurement'
-      )
+        htManager.add(`${id}-dotV`, makeDot(color), vertex, 'measurement')
+        htManager.add(`${id}-dot1`, makeDot(color), arm1, 'measurement')
+        htManager.add(`${id}-dot2`, makeDot(color), arm2, 'measurement')
 
-      registerMeasurementCleanup(() => {
-        context.view.removeTransientEntity(line1.objectId)
-        context.view.removeTransientEntity(line2.objectId)
-        persistCanvas.remove()
-        context.view.events.viewChanged.removeEventListener(redrawPersist)
-        htManager.remove(`${id}-dotV`)
-        htManager.remove(`${id}-dot1`)
-        htManager.remove(`${id}-dot2`)
-        htManager.remove(`${id}-badge`)
+        // Place badge along the angle bisector in world space
+        const dx1 = arm1.x - vertex.x
+        const dy1 = arm1.y - vertex.y
+        const dx2 = arm2.x - vertex.x
+        const dy2 = arm2.y - vertex.y
+        const wLen1 = Math.hypot(dx1, dy1)
+        const wLen2 = Math.hypot(dx2, dy2)
+        // Unit vectors along each arm
+        const u1x = wLen1 > 0 ? dx1 / wLen1 : 1
+        const u1y = wLen1 > 0 ? dy1 / wLen1 : 0
+        const u2x = wLen2 > 0 ? dx2 / wLen2 : 1
+        const u2y = wLen2 > 0 ? dy2 / wLen2 : 0
+        // Bisector direction (sum of unit vectors)
+        let bx = u1x + u2x
+        let by = u1y + u2y
+        const bLen = Math.hypot(bx, by)
+        if (bLen > 0) {
+          bx /= bLen
+          by /= bLen
+        } else {
+          // Arms are exactly opposite — use perpendicular
+          bx = -u1y
+          by = u1x
+        }
+        const badgeOffset = Math.max(
+          Math.min(wLen1, wLen2) * 0.4,
+          Math.max(wLen1, wLen2) * 0.15
+        )
+        const badgeWorld = {
+          x: vertex.x + bx * badgeOffset,
+          y: vertex.y + by * badgeOffset
+        }
+        htManager.add(
+          `${id}-badge`,
+          makeBadge(color, `${degrees.toFixed(2)}\u00B0`),
+          badgeWorld,
+          'measurement'
+        )
+
+        registerMeasurementCleanup(() => {
+          context.view.removeTransientEntity(line1.objectId)
+          context.view.removeTransientEntity(line2.objectId)
+          persistCanvas.remove()
+          context.view.events.viewChanged.removeEventListener(redrawPersist)
+          htManager.remove(`${id}-dotV`)
+          htManager.remove(`${id}-dot1`)
+          htManager.remove(`${id}-dot2`)
+          htManager.remove(`${id}-badge`)
+        })
       })
     } finally {
-      // Restore previous cursor/mode
       context.view.mode = previousMode
-      if (previousCursor != null) {
-        context.view.setCursor(previousCursor)
-      }
     }
   }
 }

--- a/packages/cad-simple-viewer/src/command/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureArcCmd.ts
@@ -280,146 +280,142 @@ export class AcApMeasureArcCmd extends AcEdCommand {
     const editor = context.view.editor
     const color = measurementColor(context.doc.database)
 
-    // Save current cursor/mode so we can restore after the command
+    // Save current mode so we can restore after the command
     const previousMode = context.view.mode
-    const previousCursor = editor.currentCursor
-
-    // Switch to crosshair for measurement interaction
     context.view.mode = AcEdViewMode.SELECTION
-    context.view.setCursor(AcEdCorsorType.Crosshair)
 
     // Construction-phase canvas — removed before this method returns
     const arcCanvas = makeOverlayCanvas(context.view.container)
 
     try {
-      // ── Phase 1: snap to circle/arc entity ──────────────────────────────────
-      let snapGeom: CircleGeom | null = null
-      let snappedStart: AcGePoint3dLike | null = null
+      await editor.withCursor(AcEdCorsorType.Crosshair, async () => {
+        // ── Phase 1: snap to circle/arc entity ──────────────────────────────────
+        let snapGeom: CircleGeom | null = null
+        let snappedStart: AcGePoint3dLike | null = null
 
-      const snapJig = new AcApArcSnapJig(context, color, (geom, snapped) => {
-        snapGeom = geom
-        snappedStart = snapped
-      })
+        const snapJig = new AcApArcSnapJig(context, color, (geom, snapped) => {
+          snapGeom = geom
+          snappedStart = snapped
+        })
 
-      const p1Prompt = new AcEdPromptPointOptions(
-        AcApI18n.t('jig.measureArc.startPoint')
-      )
-      p1Prompt.jig = snapJig
+        const p1Prompt = new AcEdPromptPointOptions(
+          AcApI18n.t('jig.measureArc.startPoint')
+        )
+        p1Prompt.jig = snapJig
 
-      try {
-        await editor.getPoint(p1Prompt)
-      } catch {
-        arcCanvas.remove()
-        return
-      }
+        try {
+          await editor.getPoint(p1Prompt)
+        } catch {
+          arcCanvas.remove()
+          return
+        }
 
-      if (!snapGeom || !snappedStart) {
-        arcCanvas.remove()
-        return
-      }
+        if (!snapGeom || !snappedStart) {
+          arcCanvas.remove()
+          return
+        }
 
-      const geom = snapGeom
-      const start = snappedStart
+        const geom = snapGeom
+        const start = snappedStart
 
-      // ── Phase 2: end point with live arc preview ─────────────────────────────
-      // dot1 and liveBadge are short-lived during construction
-      const dot1 = makeLiveDot(color)
-      const liveBadge = makeLiveBadge(color)
+        // ── Phase 2: end point with live arc preview ─────────────────────────────
+        // dot1 and liveBadge are short-lived during construction
+        const dot1 = makeLiveDot(color)
+        const liveBadge = makeLiveBadge(color)
 
-      const reposDot1 = () => {
-        const rect = context.view.canvas.getBoundingClientRect()
-        const sp = context.view.worldToScreen(start)
-        dot1.style.left = `${sp.x + rect.left}px`
-        dot1.style.top = `${sp.y + rect.top}px`
-      }
-      reposDot1()
-
-      const redrawPreview = () =>
-        drawArcOnCanvas(arcCanvas, context.view, geom, start, start, color)
-      const onViewChangedPreview = () => {
+        const reposDot1 = () => {
+          const rect = context.view.canvas.getBoundingClientRect()
+          const sp = context.view.worldToScreen(start)
+          dot1.style.left = `${sp.x + rect.left}px`
+          dot1.style.top = `${sp.y + rect.top}px`
+        }
         reposDot1()
-        redrawPreview()
-      }
-      context.view.events.viewChanged.addEventListener(onViewChangedPreview)
 
-      const onMove = (snapped: AcGePoint3dLike) => {
-        drawArcOnCanvas(arcCanvas, context.view, geom, start, snapped, color)
+        const redrawPreview = () =>
+          drawArcOnCanvas(arcCanvas, context.view, geom, start, start, color)
+        const onViewChangedPreview = () => {
+          reposDot1()
+          redrawPreview()
+        }
+        context.view.events.viewChanged.addEventListener(onViewChangedPreview)
 
-        const len = shortArcLength(start, snapped, geom)
-        liveBadge.textContent = `~ ${len.toFixed(4)} m`
-        liveBadge.style.display = ''
+        const onMove = (snapped: AcGePoint3dLike) => {
+          drawArcOnCanvas(arcCanvas, context.view, geom, start, snapped, color)
 
-        const mid = shortArcMid(start, snapped, geom)
-        const rect = context.view.canvas.getBoundingClientRect()
-        const sm = context.view.worldToScreen(mid)
-        liveBadge.style.left = `${sm.x + rect.left}px`
-        liveBadge.style.top = `${sm.y + rect.top}px`
+          const len = shortArcLength(start, snapped, geom)
+          liveBadge.textContent = `~ ${len.toFixed(4)} m`
+          liveBadge.style.display = ''
 
-        reposDot1()
-      }
+          const mid = shortArcMid(start, snapped, geom)
+          const rect = context.view.canvas.getBoundingClientRect()
+          const sm = context.view.worldToScreen(mid)
+          liveBadge.style.left = `${sm.x + rect.left}px`
+          liveBadge.style.top = `${sm.y + rect.top}px`
 
-      const p2Prompt = new AcEdPromptPointOptions(
-        AcApI18n.t('jig.measureArc.endPoint')
-      )
-      p2Prompt.jig = new AcApArcEndSnapJig(context, geom, color, onMove)
+          reposDot1()
+        }
 
-      let p2Raw: AcGePoint3dLike
-      try {
-        p2Raw = await editor.getPoint(p2Prompt)
-      } catch {
-        arcCanvas.remove()
-        dot1.remove()
+        const p2Prompt = new AcEdPromptPointOptions(
+          AcApI18n.t('jig.measureArc.endPoint')
+        )
+        p2Prompt.jig = new AcApArcEndSnapJig(context, geom, color, onMove)
+
+        let p2Raw: AcGePoint3dLike
+        try {
+          p2Raw = await editor.getPoint(p2Prompt)
+        } catch {
+          arcCanvas.remove()
+          dot1.remove()
+          liveBadge.remove()
+          context.view.events.viewChanged.removeEventListener(
+            onViewChangedPreview
+          )
+          return
+        }
+
+        // Clean up construction-phase elements
         liveBadge.remove()
+        dot1.remove()
         context.view.events.viewChanged.removeEventListener(
           onViewChangedPreview
         )
-        return
-      }
+        arcCanvas.remove()
 
-      // Clean up construction-phase elements
-      liveBadge.remove()
-      dot1.remove()
-      context.view.events.viewChanged.removeEventListener(onViewChangedPreview)
-      arcCanvas.remove()
+        const end = snapToCircle(p2Raw, geom)
+        const arcLen = shortArcLength(start, end, geom)
+        const mid = shortArcMid(start, end, geom)
 
-      const end = snapToCircle(p2Raw, geom)
-      const arcLen = shortArcLength(start, end, geom)
-      const mid = shortArcMid(start, end, geom)
-
-      // Persistent arc canvas — redrawn on viewChanged, cleaned up by Clear
-      const persistCanvas = makeOverlayCanvas(context.view.container)
-      drawArcOnCanvas(persistCanvas, context.view, geom, start, end, color)
-
-      const redrawPersist = () =>
+        // Persistent arc canvas — redrawn on viewChanged, cleaned up by Clear
+        const persistCanvas = makeOverlayCanvas(context.view.container)
         drawArcOnCanvas(persistCanvas, context.view, geom, start, end, color)
-      context.view.events.viewChanged.addEventListener(redrawPersist)
 
-      // Persistent badge + dots via htmlTransientManager
-      const htManager = (context.view as AcTrView2d).htmlTransientManager
-      const id = `arc-${Date.now()}`
+        const redrawPersist = () =>
+          drawArcOnCanvas(persistCanvas, context.view, geom, start, end, color)
+        context.view.events.viewChanged.addEventListener(redrawPersist)
 
-      htManager.add(`${id}-dot1`, makeDot(color), start, 'measurement')
-      htManager.add(`${id}-dot2`, makeDot(color), end, 'measurement')
-      htManager.add(
-        `${id}-badge`,
-        makeBadge(color, `~ ${arcLen.toFixed(4)} m`),
-        mid,
-        'measurement'
-      )
+        // Persistent badge + dots via htmlTransientManager
+        const htManager = (context.view as AcTrView2d).htmlTransientManager
+        const id = `arc-${Date.now()}`
 
-      registerMeasurementCleanup(() => {
-        persistCanvas.remove()
-        context.view.events.viewChanged.removeEventListener(redrawPersist)
-        htManager.remove(`${id}-dot1`)
-        htManager.remove(`${id}-dot2`)
-        htManager.remove(`${id}-badge`)
+        htManager.add(`${id}-dot1`, makeDot(color), start, 'measurement')
+        htManager.add(`${id}-dot2`, makeDot(color), end, 'measurement')
+        htManager.add(
+          `${id}-badge`,
+          makeBadge(color, `~ ${arcLen.toFixed(4)} m`),
+          mid,
+          'measurement'
+        )
+
+        registerMeasurementCleanup(() => {
+          persistCanvas.remove()
+          context.view.events.viewChanged.removeEventListener(redrawPersist)
+          htManager.remove(`${id}-dot1`)
+          htManager.remove(`${id}-dot2`)
+          htManager.remove(`${id}-badge`)
+        })
       })
     } finally {
-      // Restore previous cursor/mode
       context.view.mode = previousMode
-      if (previousCursor != null) {
-        context.view.setCursor(previousCursor)
-      }
     }
   }
 }

--- a/packages/cad-simple-viewer/src/command/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureAreaCmd.ts
@@ -170,13 +170,9 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
     const editor = context.view.editor
     const color = measurementColor(context.doc.database)
 
-    // Save current cursor/mode so we can restore after the command
+    // Save current mode so we can restore after the command
     const previousMode = context.view.mode
-    const previousCursor = editor.currentCursor
-
-    // Switch to crosshair for measurement interaction
     context.view.mode = AcEdViewMode.SELECTION
-    context.view.setCursor(AcEdCorsorType.Crosshair)
 
     const points: AcGePoint3dLike[] = []
 
@@ -187,176 +183,174 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
     const liveBadge = makeLiveBadge(color)
 
     try {
-      const drawPolygon = (cursor?: AcGePoint3dLike) => {
-        const rect = context.view.canvas.getBoundingClientRect()
-        const dpr = window.devicePixelRatio || 1
-        const w = Math.round(rect.width)
-        const h = Math.round(rect.height)
+      await editor.withCursor(AcEdCorsorType.Crosshair, async () => {
+        const drawPolygon = (cursor?: AcGePoint3dLike) => {
+          const rect = context.view.canvas.getBoundingClientRect()
+          const dpr = window.devicePixelRatio || 1
+          const w = Math.round(rect.width)
+          const h = Math.round(rect.height)
 
-        const origin = context.view.canvasToContainer({ x: 0, y: 0 })
-        fillCanvas.style.left = `${origin.x}px`
-        fillCanvas.style.top = `${origin.y}px`
-        fillCanvas.style.width = `${w}px`
-        fillCanvas.style.height = `${h}px`
+          const origin = context.view.canvasToContainer({ x: 0, y: 0 })
+          fillCanvas.style.left = `${origin.x}px`
+          fillCanvas.style.top = `${origin.y}px`
+          fillCanvas.style.width = `${w}px`
+          fillCanvas.style.height = `${h}px`
 
-        if (fillCanvas.width !== w * dpr || fillCanvas.height !== h * dpr) {
-          fillCanvas.width = w * dpr
-          fillCanvas.height = h * dpr
-        }
-
-        const ctx = fillCanvas.getContext('2d')
-        if (!ctx || points.length < 1) return
-
-        ctx.clearRect(0, 0, fillCanvas.width, fillCanvas.height)
-        ctx.save()
-        ctx.scale(dpr, dpr)
-
-        const confirmedSpts = points.map(p => context.view.worldToScreen(p))
-        const fillSpts = cursor
-          ? [...confirmedSpts, context.view.worldToScreen(cursor)]
-          : confirmedSpts
-
-        if (fillSpts.length >= 3) {
-          ctx.beginPath()
-          ctx.moveTo(fillSpts[0].x, fillSpts[0].y)
-          for (let i = 1; i < fillSpts.length; i++)
-            ctx.lineTo(fillSpts[i].x, fillSpts[i].y)
-          ctx.closePath()
-          ctx.fillStyle = colorToCssAlpha(color, 0.2)
-          ctx.fill()
-        }
-
-        if (confirmedSpts.length >= 2) {
-          ctx.beginPath()
-          ctx.moveTo(confirmedSpts[0].x, confirmedSpts[0].y)
-          for (let i = 1; i < confirmedSpts.length; i++)
-            ctx.lineTo(confirmedSpts[i].x, confirmedSpts[i].y)
-          ctx.strokeStyle = cssColor(color)
-          ctx.lineWidth = 2.5
-          ctx.setLineDash([8, 5])
-          ctx.stroke()
-          ctx.setLineDash([])
-        }
-
-        ctx.restore()
-      }
-
-      const redrawOnViewChange = () => drawPolygon()
-      context.view.events.viewChanged.addEventListener(redrawOnViewChange)
-
-      const p1 = await editor.getPoint(
-        new AcEdPromptPointOptions(AcApI18n.t('jig.measureArea.firstPoint'))
-      )
-      points.push(p1)
-      drawPolygon()
-
-      try {
-        while (points.length < 50) {
-          const prompt = new AcEdPromptPointOptions(
-            AcApI18n.t('jig.measureArea.nextPoint')
-          )
-          prompt.useBasePoint = true
-
-          const onMove = (cursor: AcGePoint3dLike) => {
-            if (points.length < 2) return
-            const tempPts = [...points, cursor]
-            const area = shoelaceArea(tempPts)
-            liveBadge.textContent = `~ ${area.toFixed(3)} m²`
-            liveBadge.style.display = ''
-            const mid = centroid(tempPts)
-            const rect = context.view.canvas.getBoundingClientRect()
-            const sc = context.view.worldToScreen(mid)
-            liveBadge.style.left = `${sc.x + rect.left}px`
-            liveBadge.style.top = `${sc.y + rect.top}px`
-            drawPolygon(cursor)
+          if (fillCanvas.width !== w * dpr || fillCanvas.height !== h * dpr) {
+            fillCanvas.width = w * dpr
+            fillCanvas.height = h * dpr
           }
 
-          prompt.jig = new AcApMeasureAreaJig(
-            context.view,
-            points[points.length - 1],
-            color,
-            onMove
-          )
+          const ctx = fillCanvas.getContext('2d')
+          if (!ctx || points.length < 1) return
 
-          const p = await editor.getPoint(prompt)
-          liveBadge.style.display = 'none'
+          ctx.clearRect(0, 0, fillCanvas.width, fillCanvas.height)
+          ctx.save()
+          ctx.scale(dpr, dpr)
 
-          if (points.length >= 3) {
-            const sp = context.view.worldToScreen(p)
-            const snap = (anchor: AcGePoint3dLike) => {
-              const sa = context.view.worldToScreen(anchor)
-              const dx = sp.x - sa.x
-              const dy = sp.y - sa.y
-              return dx * dx + dy * dy <= 14 * 14
+          const confirmedSpts = points.map(p => context.view.worldToScreen(p))
+          const fillSpts = cursor
+            ? [...confirmedSpts, context.view.worldToScreen(cursor)]
+            : confirmedSpts
+
+          if (fillSpts.length >= 3) {
+            ctx.beginPath()
+            ctx.moveTo(fillSpts[0].x, fillSpts[0].y)
+            for (let i = 1; i < fillSpts.length; i++)
+              ctx.lineTo(fillSpts[i].x, fillSpts[i].y)
+            ctx.closePath()
+            ctx.fillStyle = colorToCssAlpha(color, 0.2)
+            ctx.fill()
+          }
+
+          if (confirmedSpts.length >= 2) {
+            ctx.beginPath()
+            ctx.moveTo(confirmedSpts[0].x, confirmedSpts[0].y)
+            for (let i = 1; i < confirmedSpts.length; i++)
+              ctx.lineTo(confirmedSpts[i].x, confirmedSpts[i].y)
+            ctx.strokeStyle = cssColor(color)
+            ctx.lineWidth = 2.5
+            ctx.setLineDash([8, 5])
+            ctx.stroke()
+            ctx.setLineDash([])
+          }
+
+          ctx.restore()
+        }
+
+        const redrawOnViewChange = () => drawPolygon()
+        context.view.events.viewChanged.addEventListener(redrawOnViewChange)
+
+        const p1 = await editor.getPoint(
+          new AcEdPromptPointOptions(AcApI18n.t('jig.measureArea.firstPoint'))
+        )
+        points.push(p1)
+        drawPolygon()
+
+        try {
+          while (points.length < 50) {
+            const prompt = new AcEdPromptPointOptions(
+              AcApI18n.t('jig.measureArea.nextPoint')
+            )
+            prompt.useBasePoint = true
+
+            const onMove = (cursor: AcGePoint3dLike) => {
+              if (points.length < 2) return
+              const tempPts = [...points, cursor]
+              const area = shoelaceArea(tempPts)
+              liveBadge.textContent = `~ ${area.toFixed(3)} m²`
+              liveBadge.style.display = ''
+              const mid = centroid(tempPts)
+              const rect = context.view.canvas.getBoundingClientRect()
+              const sc = context.view.worldToScreen(mid)
+              liveBadge.style.left = `${sc.x + rect.left}px`
+              liveBadge.style.top = `${sc.y + rect.top}px`
+              drawPolygon(cursor)
             }
-            if (snap(points[0]) || snap(points[points.length - 1])) break
-          }
 
-          if (points.length >= 3) {
-            const last = points[points.length - 1]
-            let crosses = false
-            for (let i = 0; i < points.length - 2; i++) {
-              if (segmentsIntersect(last, p, points[i], points[i + 1])) {
-                crosses = true
-                break
+            prompt.jig = new AcApMeasureAreaJig(
+              context.view,
+              points[points.length - 1],
+              color,
+              onMove
+            )
+
+            const p = await editor.getPoint(prompt)
+            liveBadge.style.display = 'none'
+
+            if (points.length >= 3) {
+              const sp = context.view.worldToScreen(p)
+              const snap = (anchor: AcGePoint3dLike) => {
+                const sa = context.view.worldToScreen(anchor)
+                const dx = sp.x - sa.x
+                const dy = sp.y - sa.y
+                return dx * dx + dy * dy <= 14 * 14
               }
+              if (snap(points[0]) || snap(points[points.length - 1])) break
             }
-            if (crosses) break
+
+            if (points.length >= 3) {
+              const last = points[points.length - 1]
+              let crosses = false
+              for (let i = 0; i < points.length - 2; i++) {
+                if (segmentsIntersect(last, p, points[i], points[i + 1])) {
+                  crosses = true
+                  break
+                }
+              }
+              if (crosses) break
+            }
+
+            points.push(p)
+            drawPolygon()
           }
-
-          points.push(p)
-          drawPolygon()
+        } catch {
+          // user pressed Enter/ESC to finish
         }
-      } catch {
-        // user pressed Enter/ESC to finish
-      }
 
-      // Clean up construction-phase elements
-      liveBadge.remove()
-      context.view.events.viewChanged.removeEventListener(redrawOnViewChange)
-      fillCanvas.remove()
+        // Clean up construction-phase elements
+        liveBadge.remove()
+        context.view.events.viewChanged.removeEventListener(redrawOnViewChange)
+        fillCanvas.remove()
 
-      if (points.length < 3) return
+        if (points.length < 3) return
 
-      const area = shoelaceArea(points)
+        const area = shoelaceArea(points)
 
-      // Persistent fill canvas — redrawn on viewChanged, cleaned up by Clear
-      const persistCanvas = makeOverlayCanvas(context.view.container)
-      drawAreaOnCanvas(persistCanvas, context.view, points, color)
-
-      const redrawPersist = () =>
+        // Persistent fill canvas — redrawn on viewChanged, cleaned up by Clear
+        const persistCanvas = makeOverlayCanvas(context.view.container)
         drawAreaOnCanvas(persistCanvas, context.view, points, color)
-      context.view.events.viewChanged.addEventListener(redrawPersist)
 
-      // Persistent badge + dots via htmlTransientManager
-      const htManager = (context.view as AcTrView2d).htmlTransientManager
-      const id = `area-${Date.now()}`
-      const mid = centroid(points)
+        const redrawPersist = () =>
+          drawAreaOnCanvas(persistCanvas, context.view, points, color)
+        context.view.events.viewChanged.addEventListener(redrawPersist)
 
-      htManager.add(
-        `${id}-badge`,
-        makeBadge(color, `~ ${area.toFixed(3)} m²`),
-        mid,
-        'measurement'
-      )
-      points.forEach((p, i) => {
-        htManager.add(`${id}-dot${i}`, makeDot(color), p, 'measurement')
-      })
+        // Persistent badge + dots via htmlTransientManager
+        const htManager = (context.view as AcTrView2d).htmlTransientManager
+        const id = `area-${Date.now()}`
+        const mid = centroid(points)
 
-      registerMeasurementCleanup(() => {
-        persistCanvas.remove()
-        context.view.events.viewChanged.removeEventListener(redrawPersist)
-        htManager.remove(`${id}-badge`)
-        points.forEach((_, i) => {
-          htManager.remove(`${id}-dot${i}`)
+        htManager.add(
+          `${id}-badge`,
+          makeBadge(color, `~ ${area.toFixed(3)} m²`),
+          mid,
+          'measurement'
+        )
+        points.forEach((p, i) => {
+          htManager.add(`${id}-dot${i}`, makeDot(color), p, 'measurement')
+        })
+
+        registerMeasurementCleanup(() => {
+          persistCanvas.remove()
+          context.view.events.viewChanged.removeEventListener(redrawPersist)
+          htManager.remove(`${id}-badge`)
+          points.forEach((_, i) => {
+            htManager.remove(`${id}-dot${i}`)
+          })
         })
       })
     } finally {
-      // Restore previous cursor/mode
       context.view.mode = previousMode
-      if (previousCursor != null) {
-        context.view.setCursor(previousCursor)
-      }
     }
   }
 }

--- a/packages/cad-simple-viewer/src/command/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureDistanceCmd.ts
@@ -100,61 +100,55 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
     const editor = context.view.editor
     const color = measurementColor(context.doc.database)
 
-    // Save current cursor/mode so we can restore after the command
+    // Save current mode so we can restore after the command
     const previousMode = context.view.mode
-    const previousCursor = editor.currentCursor
-
-    // Switch to crosshair for measurement interaction
     context.view.mode = AcEdViewMode.SELECTION
-    context.view.setCursor(AcEdCorsorType.Crosshair)
 
     try {
-      const p1Prompt = new AcEdPromptPointOptions(
-        AcApI18n.t('jig.measureDistance.firstPoint')
-      )
-      const p1 = await editor.getPoint(p1Prompt)
+      await editor.withCursor(AcEdCorsorType.Crosshair, async () => {
+        const p1Prompt = new AcEdPromptPointOptions(
+          AcApI18n.t('jig.measureDistance.firstPoint')
+        )
+        const p1 = await editor.getPoint(p1Prompt)
 
-      const p2Prompt = new AcEdPromptPointOptions(
-        AcApI18n.t('jig.measureDistance.secondPoint')
-      )
-      p2Prompt.useBasePoint = true
-      p2Prompt.jig = new AcApMeasureDistanceJig(context.view, p1, color)
-      const p2 = await editor.getPoint(p2Prompt)
+        const p2Prompt = new AcEdPromptPointOptions(
+          AcApI18n.t('jig.measureDistance.secondPoint')
+        )
+        p2Prompt.useBasePoint = true
+        p2Prompt.jig = new AcApMeasureDistanceJig(context.view, p1, color)
+        const p2 = await editor.getPoint(p2Prompt)
 
-      const dist = calcDist(p1, p2)
+        const dist = calcDist(p1, p2)
 
-      // CAD transient line (zoom/pan aware, rendered by the engine)
-      const line = new AcDbLine(p1, p2)
-      line.color = color
-      line.lineWeight = AcGiLineWeight.LineWeight070
-      context.view.addTransientEntity(line)
+        // CAD transient line (zoom/pan aware, rendered by the engine)
+        const line = new AcDbLine(p1, p2)
+        line.color = color
+        line.lineWeight = AcGiLineWeight.LineWeight070
+        context.view.addTransientEntity(line)
 
-      // Persistent overlays via htmlTransientManager (auto-positioned by CSS2DRenderer)
-      const htManager = (context.view as AcTrView2d).htmlTransientManager
-      const id = `dist-${Date.now()}`
-      const mid = { x: (p1.x + p2.x) / 2, y: (p1.y + p2.y) / 2 }
+        // Persistent overlays via htmlTransientManager (auto-positioned by CSS2DRenderer)
+        const htManager = (context.view as AcTrView2d).htmlTransientManager
+        const id = `dist-${Date.now()}`
+        const mid = { x: (p1.x + p2.x) / 2, y: (p1.y + p2.y) / 2 }
 
-      htManager.add(`${id}-dot1`, makeDot(color), p1, 'measurement')
-      htManager.add(`${id}-dot2`, makeDot(color), p2, 'measurement')
-      htManager.add(
-        `${id}-badge`,
-        makeBadge(color, `~ ${dist.toFixed(3)} m`),
-        mid,
-        'measurement'
-      )
+        htManager.add(`${id}-dot1`, makeDot(color), p1, 'measurement')
+        htManager.add(`${id}-dot2`, makeDot(color), p2, 'measurement')
+        htManager.add(
+          `${id}-badge`,
+          makeBadge(color, `~ ${dist.toFixed(3)} m`),
+          mid,
+          'measurement'
+        )
 
-      registerMeasurementCleanup(() => {
-        context.view.removeTransientEntity(line.objectId)
-        htManager.remove(`${id}-dot1`)
-        htManager.remove(`${id}-dot2`)
-        htManager.remove(`${id}-badge`)
+        registerMeasurementCleanup(() => {
+          context.view.removeTransientEntity(line.objectId)
+          htManager.remove(`${id}-dot1`)
+          htManager.remove(`${id}-dot2`)
+          htManager.remove(`${id}-badge`)
+        })
       })
     } finally {
-      // Restore previous cursor/mode
       context.view.mode = previousMode
-      if (previousCursor != null) {
-        context.view.setCursor(previousCursor)
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
  - Measurement commands now save/restore cursor type and view mode, ensuring the crosshair is shown even when invoked from PAN mode
  - Replaces `AcApDocManager.instance.editor` with `context.view.editor` in all 4 measurement commands (addresses PR #134 review feedback for multi-document
  support)

  ## Files changed
  - `AcApMeasureDistanceCmd.ts`
  - `AcApMeasureAreaCmd.ts`
  - `AcApMeasureArcCmd.ts`
  - `AcApMeasureAngleCmd.ts`

  ## Test plan
  - [ ] Start in PAN mode → click any Measure command → cursor switches to crosshair
  - [ ] Complete/cancel measurement → cursor restores to grab hand (PAN mode)
  - [ ] Start in SELECTION mode → measure → cursor stays crosshair throughout
  - [ ] `pnpm lint && pnpm test` pass