### PR TITLE
fix: add priority tiers to OSNAP mode selection

### DIFF
--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -270,28 +270,58 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   // OSNAP calculation
   // ---------------------------------------------------------------------------
 
+  /**
+   * Returns the priority tier for a given OSNAP mode.
+   * Lower number = higher priority. Matches AutoCAD behavior where
+   * Endpoint/Midpoint/Center take precedence over Nearest.
+   */
+  private osnapModePriority(mode: AcDbOsnapMode): number {
+    switch (mode) {
+      case AcDbOsnapMode.EndPoint:
+      case AcDbOsnapMode.MidPoint:
+      case AcDbOsnapMode.Center:
+        return 0
+      case AcDbOsnapMode.Quadrant:
+        return 1
+      case AcDbOsnapMode.Nearest:
+        return 2
+      default:
+        return 1
+    }
+  }
+
   private getOsnapPoint(point?: AcGePoint2dLike, hitRadius = 20) {
     const snapPoints = this.getOsnapPoints(point, hitRadius)
+    if (snapPoints.length === 0) return undefined
 
-    let minDist = Number.MAX_VALUE
-    let index = -1
+    const p1 = this.view.screenToWorld({ x: 0, y: 0 })
+    const p2 = this.view.screenToWorld({ x: hitRadius, y: 0 })
+    const threshold = p2.x - p1.x
+
+    // Group candidates by priority tier, picking the nearest within each tier.
+    // Higher-priority modes (Endpoint, Midpoint, Center) always win over
+    // lower-priority ones (Nearest), matching AutoCAD behavior.
+    let bestPriority = Number.MAX_VALUE
+    let bestDist = Number.MAX_VALUE
+    let bestIndex = -1
 
     for (let i = 0; i < snapPoints.length; i++) {
       const d = this.view.curPos.distanceTo(snapPoints[i])
-      if (d < minDist) {
-        minDist = d
-        index = i
+      if (d >= threshold) continue
+
+      const priority = this.osnapModePriority(snapPoints[i].type)
+
+      if (
+        priority < bestPriority ||
+        (priority === bestPriority && d < bestDist)
+      ) {
+        bestPriority = priority
+        bestDist = d
+        bestIndex = i
       }
     }
 
-    if (index !== -1) {
-      const p1 = this.view.screenToWorld({ x: 0, y: 0 })
-      const p2 = this.view.screenToWorld({ x: hitRadius, y: 0 })
-      if (minDist < p2.x - p1.x) {
-        return snapPoints[index]
-      }
-    }
-    return undefined
+    return bestIndex !== -1 ? snapPoints[bestIndex] : undefined
   }
 
   private getOsnapPoints(point?: AcGePoint2dLike, hitRadius = 20) {


### PR DESCRIPTION
## Summary
  - OSNAP snap selection now uses a priority tier system instead of pure nearest-distance
  - Tier 0 (highest): Endpoint, Midpoint, Center
  - Tier 1: Quadrant
  - Tier 2 (lowest): Nearest
  - Within the same tier, the closest candidate wins
  - Fixes Nearest ("×") overriding Midpoint ("△") and other higher-priority snaps

  ## Context
  PR #154 enabled Nearest mode by default. Since the snap selection algorithm picked
  whichever candidate was closest to the cursor, Nearest (which by definition always
  has a point close to the cursor) would consistently override Midpoint, Center, etc.
  This matches AutoCAD's documented OSNAP priority behavior.

  ## Test plan
  - [ ] Hover over entity midpoint with Nearest enabled → Midpoint marker (△) shows, not Nearest (×)
  - [ ] Hover over empty segment with no other snap → Nearest (×) shows correctly
  - [ ] Hover over circle center → Center marker (○) shows, not Nearest (×)
  - [ ] `pnpm lint && pnpm test` pass