### PR TITLE
feat: add withCursor method to AcEditor for temporary cursor management

### DIFF
--- a/packages/cad-simple-viewer/src/editor/input/AcEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEditor.ts
@@ -160,6 +160,41 @@ export class AcEditor {
   }
 
   /**
+   * Temporarily sets a new cursor for the duration of a function execution.
+   *
+   * This method saves the current cursor, sets the new cursor, executes the provided function,
+   * and then restores the original cursor regardless of whether the function succeeds or fails.
+   *
+   * @param cursorType - The cursor type to use temporarily
+   * @param action - The function to execute with the temporary cursor
+   * @returns The result of the executed function
+   *
+   * @example
+   * ```typescript
+   * // Temporarily set grab cursor for a pan operation
+   * await editor.withCursor(AcEdCorsorType.Grab, async () => {
+   *   // Perform pan operation
+   *   await this.performPan();
+   * });
+   * // Cursor is automatically restored to previous state
+   * ```
+   */
+  async withCursor<T>(cursorType: AcEdCorsorType, action: () => Promise<T> | T): Promise<T> {
+    const originalCursor = this._currentCursor
+    this.setCursor(cursorType)
+    
+    try {
+      return await Promise.resolve(action())
+    } finally {
+      if (originalCursor !== undefined) {
+        this.setCursor(originalCursor)
+      } else {
+        this.restoreCursor()
+      }
+    }
+  }
+
+  /**
    * Sets the cursor color for the crosshair cursor
    *
    * @param color - The color for the cursor


### PR DESCRIPTION
This PR adds a new withCursor method to the AcEditor class that allows for temporary cursor management. The method saves the current cursor, sets a new cursor, executes a provided function, and then restores the original cursor regardless of whether the function succeeds or fails.

Key features:
- Supports both synchronous and asynchronous functions
- Automatically restores cursor state even on errors
- Provides a clean API for temporary cursor changes
- Maintains compatibility with existing cursor management methods

This implementation enhances the cursor management capabilities of the CAD editor, making it easier to handle temporary cursor changes during operations like panning, selection, and other interactive tasks.