### PR TITLE
feat: add withMode method to AcEdBaseView

### DIFF
--- a/packages/cad-simple-viewer/src/command/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureAngleCmd.ts
@@ -258,12 +258,8 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
     const editor = context.view.editor
     const color = measurementColor(context.doc.database)
 
-    // Save current mode so we can restore after the command
-    const previousMode = context.view.mode
-    context.view.mode = AcEdViewMode.SELECTION
-
-    try {
-      await editor.withCursor(AcEdCorsorType.Crosshair, async () => {
+    await context.view.withMode(AcEdViewMode.SELECTION, () =>
+      editor.withCursor(AcEdCorsorType.Crosshair, async () => {
         // Pick vertex
         const vertexPrompt = new AcEdPromptPointOptions(
           AcApI18n.t('jig.measureAngle.vertex')
@@ -407,8 +403,6 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
           htManager.remove(`${id}-badge`)
         })
       })
-    } finally {
-      context.view.mode = previousMode
-    }
+    )
   }
 }

--- a/packages/cad-simple-viewer/src/command/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureArcCmd.ts
@@ -307,15 +307,11 @@ export class AcApMeasureArcCmd extends AcEdCommand {
     const editor = context.view.editor
     const color = measurementColor(context.doc.database)
 
-    // Save current mode so we can restore after the command
-    const previousMode = context.view.mode
-    context.view.mode = AcEdViewMode.SELECTION
-
     // Construction-phase canvas — removed before this method returns
     const arcCanvas = makeOverlayCanvas(context.view.container)
 
-    try {
-      await editor.withCursor(AcEdCorsorType.Crosshair, async () => {
+    await context.view.withMode(AcEdViewMode.SELECTION, () =>
+      editor.withCursor(AcEdCorsorType.Crosshair, async () => {
         // ── Phase 1: snap to circle/arc entity ──────────────────────────────────
         let snapGeom: CircleGeom | null = null
         let snappedStart: AcGePoint3dLike | null = null
@@ -441,8 +437,6 @@ export class AcApMeasureArcCmd extends AcEdCommand {
           htManager.remove(`${id}-badge`)
         })
       })
-    } finally {
-      context.view.mode = previousMode
-    }
+    )
   }
 }

--- a/packages/cad-simple-viewer/src/command/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureAreaCmd.ts
@@ -170,10 +170,6 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
     const editor = context.view.editor
     const color = measurementColor(context.doc.database)
 
-    // Save current mode so we can restore after the command
-    const previousMode = context.view.mode
-    context.view.mode = AcEdViewMode.SELECTION
-
     const points: AcGePoint3dLike[] = []
 
     // Construction-phase canvas overlay — removed before this method returns
@@ -182,8 +178,8 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
     // Live area badge shown while the jig is active — also removed before returning
     const liveBadge = makeLiveBadge(color)
 
-    try {
-      await editor.withCursor(AcEdCorsorType.Crosshair, async () => {
+    await context.view.withMode(AcEdViewMode.SELECTION, () =>
+      editor.withCursor(AcEdCorsorType.Crosshair, async () => {
         const drawPolygon = (cursor?: AcGePoint3dLike) => {
           const rect = context.view.canvas.getBoundingClientRect()
           const dpr = window.devicePixelRatio || 1
@@ -349,8 +345,6 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
           })
         })
       })
-    } finally {
-      context.view.mode = previousMode
-    }
+    )
   }
 }

--- a/packages/cad-simple-viewer/src/command/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureDistanceCmd.ts
@@ -100,12 +100,8 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
     const editor = context.view.editor
     const color = measurementColor(context.doc.database)
 
-    // Save current mode so we can restore after the command
-    const previousMode = context.view.mode
-    context.view.mode = AcEdViewMode.SELECTION
-
-    try {
-      await editor.withCursor(AcEdCorsorType.Crosshair, async () => {
+    await context.view.withMode(AcEdViewMode.SELECTION, () =>
+      editor.withCursor(AcEdCorsorType.Crosshair, async () => {
         const p1Prompt = new AcEdPromptPointOptions(
           AcApI18n.t('jig.measureDistance.firstPoint')
         )
@@ -147,8 +143,6 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
           htManager.remove(`${id}-badge`)
         })
       })
-    } finally {
-      context.view.mode = previousMode
-    }
+    )
   }
 }

--- a/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
@@ -587,6 +587,38 @@ export abstract class AcEdBaseView {
   abstract onUnhover(id: AcDbObjectId): void
 
   /**
+   * Temporarily switches the view mode, executes an action, then restores
+   * the previous mode — even if the action throws.
+   *
+   * This is the mode-level counterpart of {@link AcEditor.withCursor} and
+   * follows the same save → set → restore pattern.
+   *
+   * @param mode - The temporary view mode to apply
+   * @param action - The async (or sync) action to run under the temporary mode
+   * @returns The value returned by the action
+   *
+   * @example
+   * ```typescript
+   * await view.withMode(AcEdViewMode.SELECTION, async () => {
+   *   const pt = await view.editor.getPoint('Pick a point')
+   * })
+   * // view.mode is restored to whatever it was before
+   * ```
+   */
+  async withMode<T>(
+    mode: AcEdViewMode,
+    action: () => Promise<T> | T
+  ): Promise<T> {
+    const previousMode = this.mode
+    this.mode = mode
+    try {
+      return await Promise.resolve(action())
+    } finally {
+      this.mode = previousMode
+    }
+  }
+
+  /**
    * Set cursor type of this view
    * @param cursorType Input cursor type
    */


### PR DESCRIPTION
## Summary
- Add `withMode<T>(mode, action)` to `AcEdBaseView` — the mode-level
  counterpart of `AcEditor.withCursor`, following the same save → set → restore
  pattern
- Refactor all 4 measurement commands (`Distance`, `Angle`, `Area`, `Arc`) to
  compose `withMode` + `withCursor` instead of manual try/finally

## Motivation
Lee suggested this approach in PR #160: "you can add one similar method
'withMode' in view to save the old mode, set the new mode, and restore the old
mode."

## Test plan
- [ ] Run `pnpm build` — passes
- [ ] Run `pnpm lint` — 0 errors
- [ ] Open a DWG, switch to PAN mode, run each measurement command — mode
      should switch to SELECTION during the command and restore to PAN after