### PR TITLE
fix: cursor not updating when switching from pan to selection mode

### DIFF
--- a/packages/cad-simple-viewer/src/editor/input/AcEdCursorManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdCursorManager.ts
@@ -86,6 +86,7 @@ export class AcEdCursorManager {
   constructor(view: AcEdBaseView) {
     this._view = view
     this._cursorMap = new Map()
+    this.setCursorColor(this._backgroundColor === 0 ? 'white' : 'black')
     AcDbSysVarManager.instance().events.sysVarChanged.addEventListener(args => {
       if (args.name === AcDbSystemVariables.PICKBOX.toLowerCase()) {
         let size = args.newVal as number


### PR DESCRIPTION
## Summary
  - The crosshair cursor SVG was never created during `AcEdCursorManager` initialization — the `_cursorMap`
  started empty
  - `setCursor(Crosshair)` silently failed because the map had no entry, leaving the previous CSS cursor
  (e.g. `grab`) in place
  - The cursor only started working after a background color switch because that was the first code path
  that called `setCursorColor()`, which populated the map
  - Fix: call `setCursorColor()` in the constructor to initialize the crosshair entry before any
  `setCursor()` call

  ## Test plan
  - [ ] Open a drawing
  - [ ] Click **Pan** (grab cursor appears)
  - [ ] Click **Select** → crosshair cursor should appear immediately
  - [ ] Repeat without ever switching the background color