### PR TITLE
fix: Delete key during active command & Enter adds bogus MeasureArea vertex

### DIFF
--- a/packages/cad-simple-viewer/src/command/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApMeasureAreaCmd.ts
@@ -252,6 +252,9 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
               AcApI18n.t('jig.measureArea.nextPoint')
             )
             prompt.useBasePoint = true
+            // Allow the user to press Enter (without typing coordinates) to
+            // finish picking vertices and close the area polygon.
+            prompt.allowNone = true
 
             const onMove = (cursor: AcGePoint3dLike) => {
               if (points.length < 2) return

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -146,7 +146,8 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
         onCancel: this.onCancel,
         onCommit: this.onCommit,
         onChange: this.onChange,
-        autoFocus: this.isDynamicInputEnabled()
+        autoFocus: this.isDynamicInputEnabled(),
+        allowNone: options.allowNone
       })
     }
 

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBoxes.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBoxes.ts
@@ -50,6 +50,13 @@ export interface AcEdFloatingInputBoxesOptions<T> {
    * Default: true
    */
   autoFocus?: boolean
+
+  /**
+   * When true, pressing Enter without having manually typed coordinates
+   * cancels the prompt (equivalent to Escape) instead of committing the
+   * current dynamic-preview value.  Mirrors AutoCAD's AllowNone behaviour.
+   */
+  allowNone?: boolean
 }
 
 /**
@@ -90,6 +97,7 @@ export class AcEdFloatingInputBoxes<T> {
   private onChange?: AcEdFloatingInputChangeCallback<T>
   private onCancel?: AcEdFloatingInputCancelCallback
   private validateFn: AcEdFloatingInputValidationCallback<T>
+  private allowNone: boolean
 
   /**
    * Constructs one instance of this class
@@ -117,6 +125,7 @@ export class AcEdFloatingInputBoxes<T> {
     this.onCommit = options.onCommit
     this.onChange = options.onChange
     this.onCancel = options.onCancel
+    this.allowNone = options.allowNone ?? false
 
     // Focus/select after mount
     if (options.autoFocus !== false) {
@@ -200,12 +209,19 @@ export class AcEdFloatingInputBoxes<T> {
     }
 
     if (e.key === 'Enter') {
-      const state = this.validate()
-      if (state.isValid && state.value != null) {
-        this.onCommit?.(state.value)
-        currentInput.markValid()
+      // When allowNone is set and the user has not manually typed coordinates,
+      // treat Enter as a cancel (finish the prompt without adding a point) so
+      // that commands like MeasureArea can use Enter-to-finish naturally.
+      if (this.allowNone && !this.userTyped) {
+        this.onCancel?.()
       } else {
-        currentInput.markInvalid()
+        const state = this.validate()
+        if (state.isValid && state.value != null) {
+          this.onCommit?.(state.value)
+          currentInput.markValid()
+        } else {
+          currentInput.markInvalid()
+        }
       }
       e.preventDefault()
       e.stopPropagation()

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputTypes.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputTypes.ts
@@ -174,4 +174,11 @@ export interface AcEdFloatingInputOptions<T> {
    * Callback invoked on cancellation (Escape or hide()).
    */
   onCancel?: AcEdFloatingInputCancelCallback
+
+  /**
+   * When true, pressing Enter without having manually typed coordinates
+   * cancels the prompt instead of committing the dynamic-preview value.
+   * Mirrors AutoCAD's `PromptPointOptions.AllowNone`.
+   */
+  allowNone?: boolean
 }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -1191,6 +1191,10 @@ export class AcEdInputManager {
       if (!keywordSession) {
         this._commandLine.setPrompt(commandLineMessage)
       }
+      const allowNone =
+        'allowNone' in options.promptOptions
+          ? (options.promptOptions as { allowNone: boolean }).allowNone
+          : false
       const floatingInput = new AcEdFloatingInput(this.view, {
         parent: this.view.canvas,
         inputCount: options.inputCount,
@@ -1200,6 +1204,7 @@ export class AcEdInputManager {
         basePoint,
         baseAngle: promptDefaults.baseAngle,
         allowPrompt: options.allowPrompt !== false,
+        allowNone,
         validate: validate,
         getDynamicValue: options.getDynamicValue,
         drawPreview: (pos: AcGePoint2dLike) => {

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -290,7 +290,13 @@ export class AcTrView2d extends AcEdBaseView {
 
         case 'Delete':
         case 'Backspace':
-          AcApDocManager.instance.sendStringToExecute('erase')
+          // Only dispatch erase when no command is currently active.
+          // Dispatching erase mid-command (e.g. while LINE awaits the next
+          // point) corrupts the active command's input pipeline because
+          // sendStringToExecute clears scripted inputs unconditionally.
+          if (!this.editor.isActive) {
+            AcApDocManager.instance.sendStringToExecute('erase')
+          }
           break
       }
     })


### PR DESCRIPTION
## Summary

Fixes two bugs reported in issues **#189** and **#195**, both in `packages/cad-simple-viewer`.

---

### Fix 1 — Delete key cannot remove a line immediately after drawing it ([#189])

**Root cause**
`AcTrView2d` listens for `Delete`/`Backspace` at the document level and unconditionally dispatches `sendStringToExecute('erase')`, even when another command (e.g. `LINE`) is still active and awaiting the next point. `sendStringToExecute` clears the active command's scripted-input queue and starts a parallel ERASE command. Because `LINE` writes entities to the database only *after* its state-machine loop finishes, the ERASE command operates on IDs that do not yet exist — so the deletion is silently lost. When `LINE` eventually completes its loop, the entity is written and then never cleaned up, making it look as if the Delete key only takes effect on the *next* command's completion.

**Fix**
Added a guard in `AcTrView2d.ts` so that `erase` is only dispatched when `editor.isActive` is `false` (no command is currently awaiting input). This is consistent with the existing `canHandleSelectionGesture()` check used a few lines above for mouse-box selection.

```diff
- case 'Delete':
- case 'Backspace':
-   AcApDocManager.instance.sendStringToExecute('erase')
-   break
+ case 'Delete':
+ case 'Backspace':
+   if (!this.editor.isActive) {
+     AcApDocManager.instance.sendStringToExecute('erase')
+   }
+   break
```

---

### Fix 2 — Pressing Enter in the polygon area measurement adds a bogus extra vertex ([#195])

**Root cause**
`AcApMeasureAreaCmd` collects polygon vertices in a loop via `await editor.getPoint(prompt)`. `getPoint` resolves with `AcEdPromptStatus.OK` whenever `AcEdFloatingInputBoxes.handleKeyDown` receives `Enter` — because the floating input boxes are continuously updated with the live cursor position by `updateDynamicPreview`. Pressing Enter therefore commits the cursor hover position as a new vertex before the loop can exit, adding one phantom point to every finished polygon.

`AcEdPromptPointOptions` already declared an `allowNone` flag (matching AutoCAD's `PromptPointOptions.AllowNone`) but it was never wired into the floating-input machinery (unlike `getEntity`, which already honours it).

**Fix**
Thread `allowNone` through the input stack:

- `AcEdFloatingInputTypes.ts` — added `allowNone?: boolean` to `AcEdFloatingInputOptions`.
- `AcEdFloatingInputBoxes.ts` — added `allowNone?: boolean` to `AcEdFloatingInputBoxesOptions`; when `allowNone` is `true` and `userTyped` is `false` (user has not manually typed coordinates — the boxes show only the cursor preview), `Enter` now calls `onCancel()` instead of `onCommit()`.
- `AcEdFloatingInput.ts` — passes `allowNone` through to `AcEdFloatingInputBoxes`.
- `AcEdInputManager.ts` — reads `allowNone` from `promptOptions` and passes it to the `AcEdFloatingInput` constructor.
- `AcApMeasureAreaCmd.ts` — sets `prompt.allowNone = true` on the next-point prompt so that pressing Enter without typing coordinates finishes the polygon cleanly.

---

## Scope

All changes are confined to `packages/cad-simple-viewer`. No public API surface is broken and no rendering or data-model packages are touched.

## Test plan

- [ ] **#189** — Run `LINE`, click to place two points (command still active), press `Delete` → nothing should happen. Press `Escape` to finish `LINE`. Select the drawn line. Press `Delete` → line is removed.
- [ ] **#195** — Run the polygon area measurement command. Click 4–5 points around a region. Press `Enter` (without typing anything) → measurement finishes; the reported polygon has exactly the picked vertices and no phantom trailing point. Verify that typing explicit coordinates into the input boxes and pressing `Enter` still commits the typed point normally.
- [ ] Build: `pnpm build` passes with no errors.
- [ ] Lint: `pnpm lint` passes with no new errors (pre-existing i18n warnings are unrelated).
- [ ] Tests: `pnpm test` — all suites pass.

[#189]: https://github.com/mlightcad/cad-viewer/issues/189
[#195]: https://github.com/mlightcad/cad-viewer/issues/195