### PR TITLE
feat: add configurable command aliases and improve LINE command flow

### DIFF
--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -9,6 +9,24 @@ import {
   log
 } from '@mlightcad/data-model'
 
+/**
+ * Demo-only command alias overrides used by the example app.
+ *
+ * Purpose:
+ * - Provide visible alias differences from built-in defaults so the alias
+ *   feature can be validated quickly in command line UI and execution flow.
+ *
+ * Behavior:
+ * - This object is passed to `AcApDocManager.createInstance({ commandAliases })`.
+ * - For commands listed here, these aliases replace the built-in defaults.
+ * - Commands not listed keep their built-in alias set.
+ */
+const EXAMPLE_COMMAND_ALIASES = {
+  LINE: ['LX'],
+  CIRCLE: ['CI'],
+  ZOOM: ['ZZ']
+}
+
 class CadViewerApp {
   private container: HTMLDivElement
   private fileInput: HTMLInputElement
@@ -70,6 +88,7 @@ class CadViewerApp {
           container: this.container,
           autoResize: true,
           baseUrl: 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/',
+          commandAliases: EXAMPLE_COMMAND_ALIASES,
           webworkerFileUrls: {
             mtextRender: './workers/mtext-renderer-worker.js',
             dxfParser: './workers/dxf-parser-worker.js',

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -49,6 +49,7 @@ import {
   AcApSysVarCmd,
   AcApZoomCmd,
   AcApZoomToBoxCmd,
+  AcEdCommand,
   AcEdCommandStack
 } from '../command'
 import { AcEdCalculateSizeCallback, AcEdOpenMode, eventBus } from '../editor'
@@ -62,6 +63,43 @@ import { AcApProgress } from './AcApProgress'
 import { AcApOpenDatabaseOptions } from './AcDbOpenDatabaseOptions'
 
 const DEFAULT_BASE_URL = 'https://mlightcad.gitlab.io/cad-data/'
+/**
+ * Built-in command alias table used when users do not provide explicit alias overrides.
+ *
+ * Rules:
+ * - Key is the command global name in uppercase.
+ * - Value is one or more aliases in uppercase.
+ * - This table is intentionally partial; commands not listed here simply have no default aliases.
+ *
+ * Notes:
+ * - Runtime lookup is case-insensitive because all aliases are normalized to uppercase.
+ * - User-provided aliases in `AcApDocManagerOptions.commandAliases` have higher priority
+ *   and will fully replace the defaults for the same command name.
+ */
+const DEFAULT_COMMAND_ALIASES: Record<string, string[]> = {
+  ARC: ['A'],
+  CIRCLE: ['C'],
+  ELLIPSE: ['EL'],
+  ERASE: ['E'],
+  DIMLINEAR: ['DLI'],
+  MEASUREDISTANCE: ['DI', 'DIST'],
+  MEASUREAREA: ['AA', 'AREA'],
+  MEASUREANGLE: ['ANG'],
+  HATCH: ['H'],
+  '-LAYER': ['LA'],
+  LINE: ['L'],
+  MTEXT: ['T'],
+  OPEN: ['OP'],
+  PAN: ['P'],
+  POLYGON: ['POL'],
+  PLINE: ['PL'],
+  RECTANGLE: ['REC'],
+  REGEN: ['RE'],
+  SELECT: ['SE'],
+  SPLINE: ['SPL'],
+  ZOOM: ['Z'],
+  ZOOMW: ['ZW']
+}
 
 /**
  * Event arguments for document-related events.
@@ -198,6 +236,22 @@ export interface AcApDocManagerOptions {
       continueOnError?: boolean
     }
   }
+
+  /**
+   * Optional command alias overrides.
+   *
+   * Key is command global name, value is one alias or alias list.
+   * If a command is not configured here, built-in default aliases are used.
+   *
+   * @example
+   * ```typescript
+   * commandAliases: {
+   *   LINE: ['L', 'LN'],
+   *   CIRCLE: 'CI'
+   * }
+   * ```
+   */
+  commandAliases?: Record<string, string | string[]>
 }
 
 /**
@@ -225,6 +279,17 @@ export class AcApDocManager {
   private _commandManager: AcEdCommandStack
   /** Plugin manager */
   private _pluginManager: AcApPluginManager
+  /**
+   * Alias overrides provided by caller options.
+   *
+   * Storage format:
+   * - Key: normalized command global name (uppercase)
+   * - Value: normalized alias list (uppercase, deduplicated)
+   *
+   * The map is prepared once during manager initialization and reused when
+   * registering built-in and system-variable commands.
+   */
+  private _commandAliasOverrides: Map<string, string[]>
   /** Singleton instance */
   private static _instance?: AcApDocManager
 
@@ -247,6 +312,9 @@ export class AcApDocManager {
    */
   private constructor(options: AcApDocManagerOptions = {}) {
     this._baseUrl = options.baseUrl ?? DEFAULT_BASE_URL
+    this._commandAliasOverrides = this.normalizeCommandAliasConfig(
+      options.commandAliases
+    )
     if (options.useMainThreadDraw) {
       AcTrMTextRenderer.getInstance().setRenderMode('main')
     } else {
@@ -696,210 +764,76 @@ export class AcApDocManager {
    */
   private registerCommands() {
     const register = this._commandManager
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'arc',
-      'arc',
-      new AcApArcCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'circle',
-      'circle',
-      new AcApCircleCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'cdxf',
-      'cdxf',
-      new AcApConvertToDxfCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'csvg',
-      'csvg',
-      new AcApConvertToSvgCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'ellipse',
-      'ellipse',
-      new AcApEllipseCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'erase',
-      'erase',
-      new AcApEraseCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'dimlinear',
-      'dimlinear',
-      new AcApDimLinearCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
+    /**
+     * Helper for registering one built-in system command with resolved aliases.
+     *
+     * Alias resolution order:
+     * 1. User override from `options.commandAliases`
+     * 2. Built-in defaults from `DEFAULT_COMMAND_ALIASES`
+     * 3. Empty list (no alias)
+     *
+     * @param cmdGlobalName - Global command name (language-neutral)
+     * @param cmdLocalName - Localized/display command name
+     * @param cmd - Command implementation instance
+     */
+    const addSystemCommand = (
+      cmdGlobalName: string,
+      cmdLocalName: string,
+      cmd: AcEdCommand
+    ) => {
+      const defaults =
+        DEFAULT_COMMAND_ALIASES[cmdGlobalName.toUpperCase()] ?? []
+      register.addCommand(
+        AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
+        cmdGlobalName,
+        cmdLocalName,
+        cmd,
+        this.resolveCommandAliases(cmdGlobalName, defaults)
+      )
+    }
+
+    addSystemCommand('arc', 'arc', new AcApArcCmd())
+    addSystemCommand('circle', 'circle', new AcApCircleCmd())
+    addSystemCommand('cdxf', 'cdxf', new AcApConvertToDxfCmd())
+    addSystemCommand('csvg', 'csvg', new AcApConvertToSvgCmd())
+    addSystemCommand('ellipse', 'ellipse', new AcApEllipseCmd())
+    addSystemCommand('erase', 'erase', new AcApEraseCmd())
+    addSystemCommand('dimlinear', 'dimlinear', new AcApDimLinearCmd())
+    addSystemCommand(
       'measuredistance',
       'measuredistance',
       new AcApMeasureDistanceCmd()
     )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'measurearea',
-      'measurearea',
-      new AcApMeasureAreaCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'measureangle',
-      'measureangle',
-      new AcApMeasureAngleCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'measurearc',
-      'measurearc',
-      new AcApMeasureArcCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
+    addSystemCommand('measurearea', 'measurearea', new AcApMeasureAreaCmd())
+    addSystemCommand('measureangle', 'measureangle', new AcApMeasureAngleCmd())
+    addSystemCommand('measurearc', 'measurearc', new AcApMeasureArcCmd())
+    addSystemCommand(
       'clearmeasurements',
       'clearmeasurements',
       new AcApClearMeasurementsCmd()
     )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'hatch',
-      'hatch',
-      new AcApHatchCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      '-layer',
-      '-layer',
-      new AcApLayerCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'line',
-      'line',
-      new AcApLineCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'mtext',
-      'mtext',
-      new AcApMTextCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'log',
-      'log',
-      new AcApLogCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'open',
-      'open',
-      new AcApOpenCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'pan',
-      'pan',
-      new AcApPanCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'polygon',
-      'polygon',
-      new AcApPolygonCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'pline',
-      'pline',
-      new AcApPolylineCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'qnew',
-      'qnew',
-      new AcApQNewCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'rectangle',
-      'rectangle',
-      new AcApRectCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'regen',
-      'regen',
-      new AcApRegenCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'revcircle',
-      'revcircle',
-      new AcApRevCircleCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'revcloud',
-      'revcloud',
-      new AcApRevCloudCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'revrect',
-      'revrect',
-      new AcApRevRectCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'revvis',
-      'revvis',
-      new AcApRevVisibilityCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'select',
-      'select',
-      new AcApSelectCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'sketch',
-      'sketch',
-      new AcApSketchCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'spline',
-      'spline',
-      new AcApSplineCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'switchbg',
-      'switchbg',
-      new AcApSwitchBgCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'zoom',
-      'zoom',
-      new AcApZoomCmd()
-    )
-    register.addCommand(
-      AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
-      'zoomw',
-      'zoomw',
-      new AcApZoomToBoxCmd()
-    )
+    addSystemCommand('hatch', 'hatch', new AcApHatchCmd())
+    addSystemCommand('-layer', '-layer', new AcApLayerCmd())
+    addSystemCommand('line', 'line', new AcApLineCmd())
+    addSystemCommand('mtext', 'mtext', new AcApMTextCmd())
+    addSystemCommand('log', 'log', new AcApLogCmd())
+    addSystemCommand('open', 'open', new AcApOpenCmd())
+    addSystemCommand('pan', 'pan', new AcApPanCmd())
+    addSystemCommand('polygon', 'polygon', new AcApPolygonCmd())
+    addSystemCommand('pline', 'pline', new AcApPolylineCmd())
+    addSystemCommand('qnew', 'qnew', new AcApQNewCmd())
+    addSystemCommand('rectangle', 'rectangle', new AcApRectCmd())
+    addSystemCommand('regen', 'regen', new AcApRegenCmd())
+    addSystemCommand('revcircle', 'revcircle', new AcApRevCircleCmd())
+    addSystemCommand('revcloud', 'revcloud', new AcApRevCloudCmd())
+    addSystemCommand('revrect', 'revrect', new AcApRevRectCmd())
+    addSystemCommand('revvis', 'revvis', new AcApRevVisibilityCmd())
+    addSystemCommand('select', 'select', new AcApSelectCmd())
+    addSystemCommand('sketch', 'sketch', new AcApSketchCmd())
+    addSystemCommand('spline', 'spline', new AcApSplineCmd())
+    addSystemCommand('switchbg', 'switchbg', new AcApSwitchBgCmd())
+    addSystemCommand('zoom', 'zoom', new AcApZoomCmd())
+    addSystemCommand('zoomw', 'zoomw', new AcApZoomToBoxCmd())
 
     // Register system variables as commands
     const sysVars = AcDbSysVarManager.instance().getAllDescriptors()
@@ -908,9 +842,86 @@ export class AcApDocManager {
         AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
         sysVar.name,
         sysVar.name,
-        new AcApSysVarCmd()
+        new AcApSysVarCmd(),
+        this.resolveCommandAliases(sysVar.name, [])
       )
     })
+  }
+
+  /**
+   * Normalizes external command alias configuration into an internal map.
+   *
+   * Normalization rules:
+   * - Command names and aliases are trimmed and converted to uppercase.
+   * - Empty command names are ignored.
+   * - Alias strings are deduplicated per command.
+   * - Alias values identical to the command name are ignored.
+   *
+   * This method does not validate cross-command conflicts; conflict checks are
+   * handled by `AcEdCommandStack.addCommand` during registration.
+   *
+   * @param config - Optional command alias configuration from user options
+   * @returns Normalized alias override map keyed by command global name
+   */
+  private normalizeCommandAliasConfig(
+    config?: AcApDocManagerOptions['commandAliases']
+  ) {
+    const map = new Map<string, string[]>()
+    if (!config) {
+      return map
+    }
+
+    Object.entries(config).forEach(([commandName, aliases]) => {
+      const normalizedCommandName = commandName.trim().toUpperCase()
+      if (!normalizedCommandName) {
+        return
+      }
+      const aliasList = Array.isArray(aliases) ? aliases : [aliases]
+      const normalizedAliases = new Set<string>()
+      aliasList.forEach(alias => {
+        const normalizedAlias = alias.trim().toUpperCase()
+        if (normalizedAlias && normalizedAlias !== normalizedCommandName) {
+          normalizedAliases.add(normalizedAlias)
+        }
+      })
+      map.set(normalizedCommandName, [...normalizedAliases])
+    })
+
+    return map
+  }
+
+  /**
+   * Resolves the final alias list for a command.
+   *
+   * Behavior:
+   * - If the user configured aliases for this command, return that list directly.
+   * - Otherwise, return normalized built-in defaults.
+   *
+   * All returned aliases are uppercase and deduplicated. Any alias equal to the
+   * command name itself is dropped to avoid redundant/ambiguous registration.
+   *
+   * @param commandName - Command global name
+   * @param defaultAliases - Built-in default aliases for this command
+   * @returns Final aliases used for command registration
+   */
+  private resolveCommandAliases(commandName: string, defaultAliases: string[]) {
+    const normalizedCommandName = commandName.trim().toUpperCase()
+    const configuredAliases = this._commandAliasOverrides.get(
+      normalizedCommandName
+    )
+
+    if (configuredAliases) {
+      return [...configuredAliases]
+    }
+
+    const normalizedDefaults = new Set<string>()
+    defaultAliases.forEach(alias => {
+      const normalizedAlias = alias.trim().toUpperCase()
+      if (normalizedAlias && normalizedAlias !== normalizedCommandName) {
+        normalizedDefaults.add(normalizedAlias)
+      }
+    })
+    return [...normalizedDefaults]
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/AGENTS.md
+++ b/packages/cad-simple-viewer/src/command/AGENTS.md
@@ -142,6 +142,45 @@ register.addCommand(
 )
 ```
 
+### Command Alias
+
+CAD Viewer supports AutoCAD-style command aliases. You can register aliases when adding a command:
+
+```typescript
+register.addCommand(
+  AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
+  'line',
+  'line',
+  new AcApLineCmd(),
+  ['L', 'LN'] // alias
+)
+```
+
+Alias behavior:
+
+1. Aliases are case-insensitive (internally normalized to uppercase).
+2. Alias must be unique in the same command group.
+3. Alias cannot conflict with existing global/local command names.
+4. Command lookup and prefix search both support alias matching.
+
+You can also configure aliases globally when creating `AcApDocManager`:
+
+```typescript
+AcApDocManager.createInstance({
+  commandAliases: {
+    LINE: ['L', 'LN'],
+    CIRCLE: 'C'
+  }
+})
+```
+
+Rules for `commandAliases`:
+
+1. Key is the command global name.
+2. Value is one alias or alias list.
+3. If a command is not configured, built-in default aliases are used.
+4. If configured, user aliases replace built-in defaults for that command.
+
 ## Step 6: Update the Command Index
 
 Add the command to the exports in `src/command/index.ts`:

--- a/packages/cad-simple-viewer/src/command/AcApLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApLineCmd.ts
@@ -52,9 +52,21 @@ export class AcApLineJig extends AcEdPreviewJig<AcGePoint3dLike> {
 }
 
 /**
- * Command to create one line.
+ * Command to create chained line segments.
+ *
+ * Behavior is aligned with AutoCAD LINE:
+ * - After the first point, each confirmed next point immediately creates one segment.
+ * - `Undo` removes the last created segment.
+ * - `Close` creates the closing segment to the first point and ends command.
  */
 export class AcApLineCmd extends AcEdCommand {
+  /**
+   * Last endpoint created by LINE command.
+   *
+   * Used by "Continue" option at next LINE start.
+   */
+  private static _lastEndpoint?: AcGePoint3d
+
   /**
    * Creates LINE command instance.
    */
@@ -71,24 +83,74 @@ export class AcApLineCmd extends AcEdCommand {
    * @param context - Current application/document context.
    */
   async execute(context: AcApContext) {
+    const db = context.doc.database
     const points: AcGePoint3d[] = []
-    let closed = false
+    const createdSegments: AcDbLine[] = []
+    const hasContinuePoint = () => !!AcApLineCmd._lastEndpoint
+    const getContinuePoint = () =>
+      AcApLineCmd._lastEndpoint
+        ? new AcGePoint3d(AcApLineCmd._lastEndpoint)
+        : undefined
+    const syncLastEndpoint = () => {
+      const current = getCurrentPoint()
+      if (current) {
+        AcApLineCmd._lastEndpoint = new AcGePoint3d(current)
+      }
+    }
     const appendPoint = (point: AcGePoint3dLike) => {
       points.push(new AcGePoint3d(point))
     }
-    const undoLast = () => {
-      if (points.length <= 1) return
+    const getCurrentPoint = () => points[points.length - 1]
+    const appendSegment = (endPoint: AcGePoint3dLike) => {
+      const startPoint = getCurrentPoint()
+      if (!startPoint) return
+      const segment = new AcDbLine(new AcGePoint3d(startPoint), endPoint)
+      db.tables.blockTable.modelSpace.appendEntity(segment)
+      createdSegments.push(segment)
+      appendPoint(endPoint)
+    }
+    const undoLastSegment = () => {
+      if (createdSegments.length <= 0 || points.length <= 1) return
+      createdSegments.pop()?.erase()
       points.pop()
     }
-    const getCurrentPoint = () => points[points.length - 1]
+    const closeSegment = () => {
+      if (points.length <= 1) return
+      const first = points[0]
+      const current = getCurrentPoint()
+      if (!current) return
+      const isSamePoint =
+        first.x === current.x && first.y === current.y && first.z === current.z
+      if (!isSamePoint) {
+        appendSegment(first)
+      }
+    }
 
     const startPointPrompt = new AcEdPromptPointOptions(
-      AcApI18n.t('jig.line.firstPoint')
+      hasContinuePoint()
+        ? AcApI18n.t('jig.line.firstPointOrContinue')
+        : AcApI18n.t('jig.line.firstPoint')
     )
+    if (hasContinuePoint()) {
+      startPointPrompt.keywords.add(
+        AcApI18n.t('jig.line.keywords.continue.display'),
+        AcApI18n.t('jig.line.keywords.continue.global'),
+        AcApI18n.t('jig.line.keywords.continue.local')
+      )
+    }
     const startPointResult =
       await AcApDocManager.instance.editor.getPoint(startPointPrompt)
-    if (startPointResult.status !== AcEdPromptStatus.OK) return
-    appendPoint(startPointResult.value!)
+    if (startPointResult.status === AcEdPromptStatus.OK) {
+      appendPoint(startPointResult.value!)
+    } else if (
+      startPointResult.status === AcEdPromptStatus.Keyword &&
+      startPointResult.stringResult === 'Continue' &&
+      hasContinuePoint()
+    ) {
+      appendPoint(getContinuePoint()!)
+    } else {
+      return
+    }
 
     type LineState = AcEdPromptState<
       AcEdPromptPointOptions,
@@ -138,17 +200,17 @@ export class AcApLineCmd extends AcEdCommand {
        */
       async handleResult(result: AcEdPromptPointResult): Promise<StepResult> {
         if (result.status === AcEdPromptStatus.OK) {
-          appendPoint(result.value!)
+          appendSegment(result.value!)
           return 'continue'
         }
         if (result.status === AcEdPromptStatus.Keyword) {
           const keyword = result.stringResult ?? ''
           if (keyword === 'Undo') {
-            undoLast()
+            undoLastSegment()
             return 'continue'
           }
           if (keyword === 'Close' && points.length > 1) {
-            closed = true
+            closeSegment()
             return 'finish'
           }
           return 'continue'
@@ -163,18 +225,6 @@ export class AcApLineCmd extends AcEdCommand {
     >()
     machine.setState(new NextPointState())
     await machine.run(prompt => AcApDocManager.instance.editor.getPoint(prompt))
-
-    const db = context.doc.database
-    if (closed && points.length > 1) {
-      appendPoint(points[0])
-    }
-
-    for (let index = 0; index < points.length - 1; index++) {
-      const startPoint = points[index]
-      const endPoint = points[index + 1]
-      db.tables.blockTable.modelSpace.appendEntity(
-        new AcDbLine(startPoint, endPoint)
-      )
-    }
+    syncLastEndpoint()
   }
 }

--- a/packages/cad-simple-viewer/src/editor/command/AcEdCommandStack.ts
+++ b/packages/cad-simple-viewer/src/editor/command/AcEdCommandStack.ts
@@ -16,6 +16,21 @@ export interface AcEdCommandGroup {
   commandsByGlobalName: Map<string, AcEdCommand>
   /** Map of commands indexed by their local names */
   commandsByLocalName: Map<string, AcEdCommand>
+  /**
+   * Map of commands indexed by alias names.
+   *
+   * Key is normalized alias (uppercase), value is the registered command object.
+   * Used for direct lookup by alias and conflict checks during registration.
+   */
+  commandsByAlias: Map<string, AcEdCommand>
+  /**
+   * Reverse index of aliases by command instance.
+   *
+   * This map allows:
+   * - Efficient cleanup of all aliases when a command is removed
+   * - Efficient alias listing in command UI (auto-complete display)
+   */
+  aliasesByCommand: Map<AcEdCommand, Set<string>>
 }
 
 /**
@@ -54,12 +69,16 @@ export class AcEdCommandStack {
     this._systemCommandGroup = {
       groupName: AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
       commandsByGlobalName: new Map(),
-      commandsByLocalName: new Map()
+      commandsByLocalName: new Map(),
+      commandsByAlias: new Map(),
+      aliasesByCommand: new Map()
     }
     this._defaultCommandGroup = {
       groupName: AcEdCommandStack.DEFAUT_COMMAND_GROUP_NAME,
       commandsByGlobalName: new Map(),
-      commandsByLocalName: new Map()
+      commandsByLocalName: new Map(),
+      commandsByAlias: new Map(),
+      aliasesByCommand: new Map()
     }
     this._commandsByGroup.push(this._systemCommandGroup)
     this._commandsByGroup.push(this._defaultCommandGroup)
@@ -72,6 +91,8 @@ export class AcEdCommandStack {
    * @param cmdGlobalName - The global (untranslated) name of the command. Must be unique within the group.
    * @param cmdLocalName - The local (translated) name of the command. Defaults to global name if empty.
    * @param cmd - The command object to add to the stack.
+   * @param cmdAlias - Optional command alias or alias list. Aliases are case-insensitive and
+   * normalized to uppercase during registration.
    *
    * @throws {Error} When the global name is empty or when a command with the same name already exists
    *
@@ -84,7 +105,8 @@ export class AcEdCommandStack {
     cmdGroupName: string,
     cmdGlobalName: string,
     cmdLocalName: string,
-    cmd: AcEdCommand
+    cmd: AcEdCommand,
+    cmdAlias?: string | string[]
   ) {
     cmdGroupName = cmdGroupName.toUpperCase()
     cmdGlobalName = cmdGlobalName.toUpperCase()
@@ -108,8 +130,11 @@ export class AcEdCommandStack {
         commandGroup = {
           groupName: cmdGroupName,
           commandsByGlobalName: new Map(),
-          commandsByLocalName: new Map()
+          commandsByLocalName: new Map(),
+          commandsByAlias: new Map(),
+          aliasesByCommand: new Map()
         }
+        this._commandsByGroup.push(commandGroup)
       } else {
         commandGroup = tmp
       }
@@ -124,9 +149,29 @@ export class AcEdCommandStack {
         `[AcEdCommandStack] The command with local name '${cmdLocalName}' already exists!`
       )
     }
+    const aliases = this.normalizeAliases(cmdAlias, cmdGlobalName, cmdLocalName)
+    for (const alias of aliases) {
+      if (commandGroup.commandsByAlias.has(alias)) {
+        throw new Error(
+          `[AcEdCommandStack] The command alias '${alias}' already exists!`
+        )
+      }
+      if (
+        commandGroup.commandsByGlobalName.has(alias) ||
+        commandGroup.commandsByLocalName.has(alias)
+      ) {
+        throw new Error(
+          `[AcEdCommandStack] The command alias '${alias}' conflicts with existing command name!`
+        )
+      }
+    }
 
     commandGroup.commandsByGlobalName.set(cmdGlobalName, cmd)
     commandGroup.commandsByLocalName.set(cmdLocalName, cmd)
+    aliases.forEach(alias => {
+      commandGroup.commandsByAlias.set(alias, cmd)
+    })
+    commandGroup.aliasesByCommand.set(cmd, new Set(aliases))
     cmd.globalName = cmdGlobalName
     cmd.localName = cmdLocalName
   }
@@ -175,7 +220,8 @@ export class AcEdCommandStack {
       const { command } = item.value
       if (
         command.globalName.startsWith(prefix) ||
-        command.localName.startsWith(prefix)
+        command.localName.startsWith(prefix) ||
+        this.commandAliasStartsWith(item.value.commandGroup, command, prefix)
       ) {
         // Check mode compatibility if mode is specified
         if (mode === undefined || this.isModeCompatible(mode, command.mode)) {
@@ -207,6 +253,9 @@ export class AcEdCommandStack {
     let result: AcEdCommand | undefined = undefined
     for (const group of this._commandsByGroup) {
       result = group.commandsByGlobalName.get(cmdName)
+      if (!result) {
+        result = group.commandsByAlias.get(cmdName)
+      }
       if (result) {
         // Check mode compatibility if mode is specified
         if (mode === undefined || this.isModeCompatible(mode, result.mode)) {
@@ -238,6 +287,9 @@ export class AcEdCommandStack {
     let result: AcEdCommand | undefined = undefined
     for (const group of this._commandsByGroup) {
       result = group.commandsByLocalName.get(cmdName)
+      if (!result) {
+        result = group.commandsByAlias.get(cmdName)
+      }
       if (result) {
         // Check mode compatibility if mode is specified
         if (mode === undefined || this.isModeCompatible(mode, result.mode)) {
@@ -265,7 +317,18 @@ export class AcEdCommandStack {
     cmdGlobalName = cmdGlobalName.toUpperCase()
     for (const group of this._commandsByGroup) {
       if (group.groupName == cmdGroupName) {
-        return group.commandsByGlobalName.delete(cmdGlobalName)
+        const command = group.commandsByGlobalName.get(cmdGlobalName)
+        if (!command) {
+          return false
+        }
+        group.commandsByGlobalName.delete(cmdGlobalName)
+        group.commandsByLocalName.delete(command.localName)
+        const aliases = group.aliasesByCommand.get(command)
+        aliases?.forEach(alias => {
+          group.commandsByAlias.delete(alias)
+        })
+        group.aliasesByCommand.delete(command)
+        return true
       }
     }
     return false
@@ -280,13 +343,11 @@ export class AcEdCommandStack {
    */
   removeGroup(groupName: string) {
     groupName = groupName.toUpperCase()
-    let tmp = -1
-    this._commandsByGroup.some((group, index) => {
-      tmp = index
-      return group.groupName == groupName
-    })
-    if (tmp >= 0) {
-      this._commandsByGroup.splice(tmp, 1)
+    const index = this._commandsByGroup.findIndex(
+      group => group.groupName === groupName
+    )
+    if (index >= 0) {
+      this._commandsByGroup.splice(index, 1)
       return true
     }
     return false
@@ -296,11 +357,113 @@ export class AcEdCommandStack {
    * Removes all of registered commands
    */
   removeAll() {
-    this._commandsByGroup = []
     this._defaultCommandGroup.commandsByGlobalName.clear()
     this._defaultCommandGroup.commandsByLocalName.clear()
+    this._defaultCommandGroup.commandsByAlias.clear()
+    this._defaultCommandGroup.aliasesByCommand.clear()
     this._systemCommandGroup.commandsByGlobalName.clear()
     this._systemCommandGroup.commandsByLocalName.clear()
+    this._systemCommandGroup.commandsByAlias.clear()
+    this._systemCommandGroup.aliasesByCommand.clear()
+    this._commandsByGroup = [
+      this._systemCommandGroup,
+      this._defaultCommandGroup
+    ]
+  }
+
+  /**
+   * Gets all aliases of the specified command in a command group.
+   *
+   * @param command - Target command object
+   * @param commandGroupName - Optional command group name. If omitted, the first matching group is used.
+   * @returns Alias list in registration order
+   */
+  getCommandAliases(command: AcEdCommand, commandGroupName?: string): string[] {
+    const normalizedGroupName = commandGroupName?.trim().toUpperCase()
+
+    const groups = normalizedGroupName
+      ? this._commandsByGroup.filter(
+          group => group.groupName === normalizedGroupName
+        )
+      : this._commandsByGroup
+
+    for (const group of groups) {
+      const aliases = group.aliasesByCommand.get(command)
+      if (aliases) {
+        return [...aliases]
+      }
+    }
+
+    return []
+  }
+
+  /**
+   * Checks whether any alias of the given command starts with the input prefix.
+   *
+   * This helper is used by prefix search so alias names can participate in
+   * command auto-complete matching together with global/local command names.
+   *
+   * @param commandGroupName - Name of the command group containing the command
+   * @param command - Command instance whose aliases are inspected
+   * @param prefix - Uppercase prefix to match
+   * @returns True if any alias starts with the prefix
+   */
+  private commandAliasStartsWith(
+    commandGroupName: string,
+    command: AcEdCommand,
+    prefix: string
+  ) {
+    const group = this._commandsByGroup.find(
+      value => value.groupName === commandGroupName
+    )
+    if (!group) {
+      return false
+    }
+    const aliases = group.aliasesByCommand.get(command)
+    if (!aliases) {
+      return false
+    }
+    for (const alias of aliases) {
+      if (alias.startsWith(prefix)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
+   * Normalizes raw alias input into a validated alias list for registration.
+   *
+   * Processing rules:
+   * - Accepts one alias string or a list of alias strings.
+   * - Trims whitespace and converts aliases to uppercase.
+   * - Removes empty aliases.
+   * - Removes aliases that are identical to command global/local names.
+   * - Removes duplicates while preserving insertion order.
+   *
+   * @param aliases - Raw alias input from caller
+   * @param cmdGlobalName - Command global name in uppercase
+   * @param cmdLocalName - Command local name in uppercase
+   * @returns Normalized alias list
+   */
+  private normalizeAliases(
+    aliases: string | string[] | undefined,
+    cmdGlobalName: string,
+    cmdLocalName: string
+  ) {
+    const values = Array.isArray(aliases) ? aliases : aliases ? [aliases] : []
+    const result = new Set<string>()
+    values.forEach(alias => {
+      const normalized = alias.trim().toUpperCase()
+      if (
+        normalized &&
+        normalized !== cmdGlobalName &&
+        normalized !== cmdLocalName
+      ) {
+        result.add(normalized)
+      }
+    })
+    return [...result]
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
@@ -662,7 +662,13 @@ export class AcEdCommandLine {
           item.commandGroup,
           item.command.globalName
         )
-        div.innerHTML = `<strong>${item.command.globalName} - ${description}</strong>`
+        const aliases =
+          AcApDocManager.instance.commandManager.getCommandAliases(
+            item.command,
+            item.commandGroup
+          )
+        const aliasText = aliases.length ? `(${aliases.join(', ')})` : ''
+        div.innerHTML = `<strong>${item.command.globalName}${aliasText} - ${description}</strong>`
         if (idx === this.autoCompleteIndex) div.classList.add('selected')
         this.cmdPopup.appendChild(div)
       })

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -146,9 +146,15 @@ export default {
   },
   line: {
     firstPoint: 'Specify the first point:',
+    firstPointOrContinue: 'Specify first point or',
     nextPoint: 'Specify the next point:',
     nextPointWithOptions: 'Specify next point or',
     keywords: {
+      continue: {
+        display: 'Continue(C)',
+        local: 'Continue',
+        global: 'Continue'
+      },
       undo: {
         display: 'Undo(U)',
         local: 'Undo',

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -139,9 +139,15 @@ export default {
   },
   line: {
     firstPoint: '指定第一个点：',
+    firstPointOrContinue: '请指定第一个点或',
     nextPoint: '指定下一个点：',
     nextPointWithOptions: '请指定下一个点或',
     keywords: {
+      continue: {
+        display: '继续(C)',
+        local: '继续',
+        global: 'Continue'
+      },
       undo: {
         display: '放弃(U)',
         local: '放弃',


### PR DESCRIPTION
## Summary
- Add command alias support to command registration, lookup, and autocomplete matching.
- Introduce built-in default aliases and user-configurable alias overrides via `AcApDocManager.createInstance({ commandAliases })`.
- Refactor `LINE` behavior to create segments incrementally, support `Undo`/`Close`, and add `Continue` from last endpoint.
- Update command-line suggestion UI to display aliases and add EN/ZH i18n text plus developer docs/example wiring.

## Why
- Improve command discoverability and efficiency with AutoCAD-style short aliases.
- Make `LINE` interaction closer to expected CAD behavior for faster chained drafting.
- Allow app-level customization of aliases without patching core command registrations.

## What Changed
- `AcEdCommandStack`:
- Add alias indexes (`commandsByAlias`, `aliasesByCommand`), alias normalization, conflict checks, alias-aware search/lookup, alias cleanup on remove, and `getCommandAliases`.
- `AcApDocManager`:
- Add built-in alias table, option parsing/normalization for `commandAliases`, alias resolution helper, and register built-in/sysvar commands with resolved aliases.
- `AcEdCommandLine`:
- Show aliases in autocomplete items.
- `AcApLineCmd`:
- Switch to incremental segment creation, implement true segment-level undo, close-to-first-point logic, and start-point `Continue` keyword using last endpoint cache.
- Docs and localization:
- Add alias usage section in `AGENTS.md`, add EN/ZH `Continue` prompt/keyword strings, and wire demo overrides in example app.

## Risks / Notes
- Alias conflicts now throw at registration time; plugin/custom command sets may need alias review.
- `LINE` last-endpoint continuation is static state; behavior across document/session boundaries should be validated.
- Branch-level diff against `main` is currently empty (no commits ahead); this PR text is based on staged workspace changes.
