### PR TITLE
fix: use side-aware material cache to render mirrored block fills

### DIFF
--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -4,6 +4,7 @@ import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeome
 
 import { AcTrPointSymbolCreator } from '../geometry/AcTrPointSymbolCreator'
 import { AcTrEntity } from '../object'
+import { AcTrStyleManager } from '../style/AcTrStyleManager'
 import { AcTrMaterialUtil } from '../util'
 import { AcTrBatchGeometryUserData } from './AcTrBatchedGeometryInfo'
 import { AcTrBatchedLine } from './AcTrBatchedLine'
@@ -340,6 +341,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     this._unbatchedEntities.delete(objectId)
     const unbatchedObjects: THREE.Object3D[] = []
     let hasUnbatched = false
+    const styleManager = entity.styleManager
 
     entity.updateMatrixWorld(true)
     entity.traverse(object => {
@@ -376,7 +378,7 @@ export class AcTrBatchedGroup extends THREE.Group {
           this.addMesh(object, {
             objectId,
             bboxIntersectionCheck: bboxIntersectionCheck
-          })
+          }, styleManager)
         )
       } else if (object instanceof THREE.Points) {
         entityInfo.push(
@@ -648,12 +650,35 @@ export class AcTrBatchedGroup extends THREE.Group {
 
   /**
    * Adds one `THREE.Mesh` object into matching mesh batch.
+   *
+   * When the mesh's world transform has a negative determinant (mirrored
+   * block reference), the triangle winding is reversed and `FrontSide`
+   * culling would discard the fill.  In that case we swap to a
+   * `BackSide` variant of the same material — zero fillrate overhead,
+   * and the mesh lands in a separate batch keyed by the variant's id.
+   *
+   * Lines and points are unaffected by face culling and do not need
+   * this treatment.
+   *
+   * **Static-transform assumption:** this check runs once when the mesh
+   * enters the batch.  If a future feature mutates transforms after
+   * batching (live edit, animation), this check will not re-run.
    */
   private addMesh(
     object: THREE.Mesh,
-    userData: AcTrBatchGeometryUserData
+    userData: AcTrBatchGeometryUserData,
+    styleManager: AcTrStyleManager
   ): AcTrEntityInBatchedObject {
-    const material = object.material as THREE.Material
+    let material = object.material as THREE.Material
+
+    // Detect mirrored transforms: a negative determinant means the
+    // transform reversed triangle winding (odd number of negative scale
+    // factors).  Swap to BackSide so the culler keeps these triangles.
+    // det === 0 is a singular (collapsed) matrix — nothing renders, skip.
+    if (object.matrixWorld.determinant() < 0) {
+      material = styleManager.getBackSideVariant(material)
+      object.material = material
+    }
 
     const batches = this.getMatchedMeshBatches(object)
     let batchedMesh = batches.get(material.id)

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -5,10 +5,19 @@ import {
   AcTrPatternLine,
   createHatchPatternShaderMaterial
 } from './AcTrHatchPatternShaders'
-import { AcTrMaterialManager } from './AcTrMaterialManager'
+import { AcTrMaterialManager, AcTrMaterialSide } from './AcTrMaterialManager'
 
 export interface AcTrFillMaterialOptions {
   rebaseOffset: THREE.Vector2
+  /**
+   * Which face the rasteriser keeps.  Defaults to `'front'`.
+   *
+   * Mirrored block references (negative-determinant transforms) reverse
+   * triangle winding, causing `FrontSide` fills to be culled.  The
+   * batching layer requests `'back'` for those meshes so the culler
+   * keeps the (now CW-wound) triangles — with zero fillrate overhead.
+   */
+  side?: AcTrMaterialSide
 }
 
 /**
@@ -22,6 +31,26 @@ export interface AcTrFillMaterialOptions {
  */
 export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMaterialOptions> {
   /**
+   * Returns a `BackSide` variant of the given fill material.
+   *
+   * The variant is cached under a separate key so that mirrored and
+   * non-mirrored fills land in different batches (same draw-call cost
+   * per fragment, no `DoubleSide` overhead).
+   */
+  getBackSideVariant(material: THREE.Material): THREE.Material {
+    const key = material.userData.materialKey as string | undefined
+    if (!key) return material
+
+    // Already a back-side material — return as-is (idempotent).
+    if (material.userData.side === 'back') return material
+
+    const traits = this.keyToTraits[key]
+    if (!traits) return material
+
+    return this.getMaterial(traits, { ...traits, side: 'back' })
+  }
+
+  /**
    * Create either MeshBasicMaterial or hatch shader material
    */
   protected createMaterialImpl(
@@ -29,18 +58,22 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     options: AcTrFillMaterialOptions
   ): THREE.Material {
     const style = traits.fillType
+    const side = options.side ?? 'front'
+    const threeSide = side === 'back' ? THREE.BackSide : THREE.FrontSide
+
+    let material: THREE.Material
     if (!style.definitionLines || style.definitionLines.length < 1) {
-      return this.createMeshBasicMaterial(traits)
-    }
-
-    // Validate pattern lines
-    if (style.definitionLines.some(line => !line.dashLengths)) {
+      material = this.createMeshBasicMaterial(traits, threeSide)
+    } else if (style.definitionLines.some(line => !line.dashLengths)) {
       log.warn('Invalid dash pattern', style)
-      return this.createMeshBasicMaterial(traits)
+      material = this.createMeshBasicMaterial(traits, threeSide)
+    } else {
+      material = this.createHatchShaderMaterial(traits, options, threeSide)
     }
 
-    // Otherwise create new hatch shader material
-    return this.createHatchShaderMaterial(traits, options)
+    // Store side in userData so getBackSideVariant can check idempotency
+    material.userData.side = side
+    return material
   }
 
   /**
@@ -48,7 +81,8 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
    */
   private createHatchShaderMaterial(
     traits: AcGiSubEntityTraits,
-    options: AcTrFillMaterialOptions
+    options: AcTrFillMaterialOptions,
+    threeSide: THREE.Side
   ): THREE.Material {
     const style = traits.fillType
     const RATIO_FOR_NONDOT_PATTERN = 0.005
@@ -144,7 +178,9 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
       patternLines,
       style.patternAngle,
       AcTrMaterialManager.CameraZoomUniform,
-      new THREE.Color(traits.rgbColor)
+      new THREE.Color(traits.rgbColor),
+      0,
+      threeSide
     )
     material.defines = {
       MAX_PATTERN_SEGMENT_COUNT: maxPatternSegmentCount
@@ -152,23 +188,31 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     return material
   }
 
-  private createMeshBasicMaterial(traits: AcGiSubEntityTraits): THREE.Material {
-    return new THREE.MeshBasicMaterial({ color: traits.rgbColor })
+  private createMeshBasicMaterial(
+    traits: AcGiSubEntityTraits,
+    side: THREE.Side
+  ): THREE.Material {
+    return new THREE.MeshBasicMaterial({ color: traits.rgbColor, side })
   }
 
   /**
-   * Build a deterministic caching key based on traits and options
+   * Build a deterministic caching key based on traits and options.
+   *
+   * The `side` dimension is appended only when it differs from the
+   * default (`'front'`), keeping existing keys stable and avoiding
+   * unnecessary cache fragmentation for the common non-mirrored path.
    */
   protected buildKey(
     traits: AcGiSubEntityTraits,
-    _options: AcTrFillMaterialOptions
+    options: AcTrFillMaterialOptions
   ): string {
     const style = traits.fillType
+    const sideSuffix = options.side === 'back' ? '_back' : ''
 
     // Use color + layer + rebaseOffset + pattern info for key
     const isSolid = !style.definitionLines || style.definitionLines.length === 0
     if (isSolid) {
-      return `solid_${traits.layer}_${traits.rgbColor}`
+      return `solid_${traits.layer}_${traits.rgbColor}${sideSuffix}`
     }
 
     const patternHash = style.definitionLines
@@ -178,6 +222,6 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
       )
       .join('|')
 
-    return `hatch_${traits.layer}_${traits.rgbColor}_${style.patternAngle}_${patternHash}`
+    return `hatch_${traits.layer}_${traits.rgbColor}_${style.patternAngle}_${patternHash}${sideSuffix}`
   }
 }

--- a/packages/three-renderer/src/style/AcTrHatchPatternShaders.ts
+++ b/packages/three-renderer/src/style/AcTrHatchPatternShaders.ts
@@ -36,7 +36,8 @@ export function createHatchPatternShaderMaterial(
   patternAngle: number, // in radians
   cameraZoomUniform: { value: number },
   color: THREE.Color,
-  fixedThicknessInWorldCoord = 0
+  fixedThicknessInWorldCoord = 0,
+  side: THREE.Side = THREE.FrontSide
 ): THREE.Material {
   const uniforms = {
     u_cameraZoom: cameraZoomUniform,
@@ -261,6 +262,7 @@ export function createHatchPatternShaderMaterial(
     uniforms,
     vertexShader,
     fragmentShader,
-    clipping: true
+    clipping: true,
+    side
   })
 }

--- a/packages/three-renderer/src/style/AcTrMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrMaterialManager.ts
@@ -5,6 +5,19 @@ import { AcTrMaterialUtil } from '../util'
 import { AcTrStyleManagerOptions } from './AcTrStyleManagerOptions'
 
 /**
+ * Valid material side values for cache partitioning.
+ *
+ * - `'front'` — default; culls back-faces (CW winding after CCW input).
+ * - `'back'`  — culls front-faces; used for meshes whose winding was
+ *   reversed by a mirrored transform (negative determinant).
+ *
+ * `DoubleSide` is intentionally excluded: in 2-D CAD every fill has a
+ * deterministic winding after the matrix bake, so one of the two
+ * single-side values always suffices with zero fillrate overhead.
+ */
+export type AcTrMaterialSide = 'front' | 'back'
+
+/**
  * Base class for all material managers (line, fill, point).
  *
  * This class implements:
@@ -150,9 +163,23 @@ export abstract class AcTrMaterialManager<T> {
   }
 
   /**
+   * Returns a `BackSide` variant of the given material.
+   *
+   * The default implementation returns the material unchanged — only
+   * subclasses whose primitives are affected by face culling (i.e.
+   * meshes / fills) override this to produce a cached `BackSide` clone.
+   *
+   * @param material - A material previously obtained from this manager.
+   */
+  getBackSideVariant(material: THREE.Material): THREE.Material {
+    return material
+  }
+
+  /**
    * Creates a THREE.js material and stores metadata in userData:
    *   - layer
    *   - isByLayer
+   *   - materialKey (cache key, used by getBackSideVariant for reverse lookup)
    */
   protected createMaterial(
     key: string,
@@ -161,10 +188,11 @@ export abstract class AcTrMaterialManager<T> {
   ): THREE.Material {
     const material = this.createMaterialImpl(traits, options)
 
-    // Attach metadata required for layer updates
+    // Attach metadata required for layer updates and side-variant lookups
     material.userData.layer = traits.layer
     material.userData.isByLayer = this.isByLayer(traits)
     material.userData.isForeground = traits.color.isForeground
+    material.userData.materialKey = key
 
     this.cache[key] = material
     return material

--- a/packages/three-renderer/src/style/AcTrStyleManager.ts
+++ b/packages/three-renderer/src/style/AcTrStyleManager.ts
@@ -104,6 +104,22 @@ export class AcTrStyleManager {
   }
 
   /**
+   * Returns a `BackSide` variant of the given fill material.
+   *
+   * Mirrored block references (transforms with negative determinant)
+   * reverse triangle winding.  Instead of paying `DoubleSide` for every
+   * fill in the scene, the batching layer calls this method only for
+   * meshes that actually need it.  The variant is cached so repeated
+   * calls for the same material are free.
+   *
+   * For non-fill materials (lines, points) this is a no-op — those
+   * primitives are unaffected by face culling.
+   */
+  getBackSideVariant(material: THREE.Material): THREE.Material {
+    return this.fillMgr.getBackSideVariant(material)
+  }
+
+  /**
    * Forces all materials that belong to the given layer to update,
    * for traits that use ByLayer color or ByLayer lineType.
    *


### PR DESCRIPTION
## Summary
                                                                                                                                                            
  Fixes #183 — mirrored INSERTs (`PISO TATIL ALERTA` with Scale X=-1, `1558-BASE$0$ALERTA` with Scale Z=-0.625) were invisible because `FrontSide` culling discarded fills whose triangle winding was reversed by negative-determinant transforms.                                                                   
                                                                                                                                                            
  **Approach (replaces rejected DoubleSide from first attempt):**                                                                                           
                                                                                                                                                            
  - `addMesh` detects `matrixWorld.determinant() < 0` and requests a `BackSide` variant of the fill material                                                
  - `side` is a new dimension in the fill material cache key — mirrored and non-mirrored fills land in separate batches                                     
  - `BackSide` renders each fragment exactly once (same cost as `FrontSide`), unlike `DoubleSide` which disables culling fast-paths                         
  - Non-mirrored fills are completely unaffected — their cache keys and batches don't change                                                                
  - Lines and points skip the check (unaffected by face culling)                                                                                            
                                                                                                                                                            
  ## Files changed                                                                                                                                          
                                                                                                                                                            
  | File | Change |                                                                                                                                         
  |---|---|                                                                                                                                                 
  | `AcTrMaterialManager.ts` | `AcTrMaterialSide` type, `getBackSideVariant()` (no-op base), `materialKey` in userData |                                    
  | `AcTrFillMaterialManager.ts` | `side` in options/key, `BackSide` in `createMaterialImpl`, `getBackSideVariant()` override |                             
  | `AcTrHatchPatternShaders.ts` | `createHatchPatternShaderMaterial` accepts `side` param |                                                                
  | `AcTrStyleManager.ts` | `getBackSideVariant()` delegates to fill manager |                                                                              
  | `AcTrBatchedGroup.ts` | `addMesh` detects negative determinant and swaps material |                                                                     
                                                                                                                                                            
  ## Test plan                                                                                                                                              
                                                                                                                                                            
  - [x] 4 `PISO TATIL ALERTA` INSERTs render (including 2 with Scale X=-1)                                                                                  
  - [x] `1558-BASE$0$ALERTA` INSERT renders (Scale Z=-0.625)
  - [x] Non-mirrored fills unchanged (no extra batches for non-mirrored layers)                                                                             
  - [x] No visual regression on standard DWG files                                                                                                          
  - [x] Build passes, all tests pass, lint clean 