### PR TITLE
feat: refine prompt default/none flow and right-click behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@mlightcad/data-model": "^1.7.16",
-      "@mlightcad/libredwg-converter": "^3.5.16",
+      "@mlightcad/data-model": "^1.7.18",
+      "@mlightcad/libredwg-converter": "^3.5.18",
       "@mlightcad/mtext-renderer": "^0.10.7",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",

--- a/packages/cad-simple-viewer/__tests__/AcEdKeywordCollection.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdKeywordCollection.spec.ts
@@ -1,0 +1,36 @@
+import { AcEdKeywordCollection } from '../src/editor/input/prompt/AcEdKeywordCollection'
+import { AcEdPromptKeywordOptions } from '../src/editor/input/prompt/AcEdPromptKeywordOptions'
+
+describe('AcEdKeywordCollection prompt format', () => {
+  test('formats as [Keywords] <Default>:', () => {
+    const keywords = new AcEdKeywordCollection()
+    const yes = keywords.add('Yes', 'Yes', 'Yes')
+    keywords.add('No', 'No', 'No')
+    keywords.default = yes
+
+    const format = keywords.getPromptFormat()
+    expect(format.visibleKeywords).toEqual(['Yes', 'No'])
+    expect(format.defaultKeyword).toBe('Yes')
+    expect(format.formattedTail).toBe('[Yes/No] <Yes>:')
+  })
+
+  test('omits default segment when no default is set', () => {
+    const keywords = new AcEdKeywordCollection()
+    keywords.add('Yes', 'Yes', 'Yes')
+    keywords.add('No', 'No', 'No')
+
+    const format = keywords.getPromptFormat()
+    expect(format.defaultKeyword).toBeUndefined()
+    expect(format.formattedTail).toBe('[Yes/No]:')
+  })
+
+  test('PromptOptions delegates format through getKeywordPromptFormat()', () => {
+    const options = new AcEdPromptKeywordOptions('Specify option')
+    const yes = options.keywords.add('Yes', 'Yes', 'Yes')
+    options.keywords.add('No', 'No', 'No')
+    options.keywords.default = yes
+
+    const format = options.getKeywordPromptFormat()
+    expect(format.formattedTail).toBe('[Yes/No] <Yes>:')
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcEdKeywordSession.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdKeywordSession.spec.ts
@@ -1,0 +1,57 @@
+import { AcEdPromptKeywordOptions } from '../src/editor/input/prompt/AcEdPromptKeywordOptions'
+import { AcEdKeywordSession } from '../src/editor/input/session/AcEdKeywordSession'
+
+describe('KeywordSession Enter behavior', () => {
+  const createCliStub = () =>
+    ({
+      clearInput: jest.fn(),
+      setInputReadOnly: jest.fn(),
+      renderKeywordPrompt: jest.fn(),
+      focusInput: jest.fn(),
+      clear: jest.fn()
+    }) as any
+
+  const createSession = (options: AcEdPromptKeywordOptions) => {
+    const session = new AcEdKeywordSession(createCliStub(), options, true)
+    const resolved: string[] = []
+    ;(session as any).resolve = (value: string) => resolved.push(value)
+    return { session, resolved }
+  }
+
+  test('Enter with default keyword returns default keyword', () => {
+    const options = new AcEdPromptKeywordOptions('pick')
+    const kw = options.keywords.add('First', 'First', 'First')
+    options.keywords.default = kw
+    options.allowNone = false
+
+    const { session, resolved } = createSession(options)
+    const handled = session.handleEnter('')
+
+    expect(handled).toBe(true)
+    expect(resolved).toEqual(['First'])
+  })
+
+  test('Enter with no default and allowNone=true returns none token', () => {
+    const options = new AcEdPromptKeywordOptions('pick')
+    options.keywords.add('First', 'First', 'First')
+    options.allowNone = true
+
+    const { session, resolved } = createSession(options)
+    const handled = session.handleEnter('')
+
+    expect(handled).toBe(true)
+    expect(resolved).toEqual([''])
+  })
+
+  test('Enter with no default and allowNone=false is invalid', () => {
+    const options = new AcEdPromptKeywordOptions('pick')
+    options.keywords.add('First', 'First', 'First')
+    options.allowNone = false
+
+    const { session, resolved } = createSession(options)
+    const handled = session.handleEnter('')
+
+    expect(handled).toBe(false)
+    expect(resolved).toEqual([])
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcEdPromptOptionsBehavior.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdPromptOptionsBehavior.spec.ts
@@ -1,0 +1,191 @@
+import { AcEdPromptNumericalOptions } from '../src/editor/input/prompt/AcEdPromptNumericalOptions'
+import { AcEdPromptStringOptions } from '../src/editor/input/prompt/AcEdPromptStringOptions'
+import { AcEdPromptDoubleOptions } from '../src/editor/input/prompt/AcEdPromptDoubleOptions'
+import { AcEdPromptIntegerOptions } from '../src/editor/input/prompt/AcEdPromptIntegerOptions'
+import { AcEdPromptDistanceOptions } from '../src/editor/input/prompt/AcEdPromptDistanceOptions'
+import { AcEdFloatingInputBoxes } from '../src/editor/input/ui/AcEdFloatingInputBoxes'
+
+describe('FloatingInputBoxes Enter priority', () => {
+  type InputStub = {
+    userTyped: boolean
+    value: string
+    focused: boolean
+    markValid: jest.Mock
+    markInvalid: jest.Mock
+    focus: jest.Mock
+    select: jest.Mock
+    isEventTarget: (e: KeyboardEvent) => boolean
+  }
+
+  const createInputStub = (userTyped: boolean): InputStub => ({
+    userTyped,
+    value: '',
+    focused: true,
+    markValid: jest.fn(),
+    markInvalid: jest.fn(),
+    focus: jest.fn(),
+    select: jest.fn(),
+    isEventTarget: () => false
+  })
+
+  const createBoxes = (opts: {
+    userTyped: boolean
+    useDefaultValue?: boolean
+    defaultValue?: unknown
+    allowNone?: boolean
+  }) => {
+    const boxes = Object.create(AcEdFloatingInputBoxes.prototype) as any
+    boxes.twoInputs = false
+    boxes.xInput = createInputStub(opts.userTyped)
+    boxes.yInput = undefined
+    boxes.useDefaultValue = !!opts.useDefaultValue
+    boxes.defaultValue = opts.defaultValue
+    boxes.allowNone = !!opts.allowNone
+    boxes.onCommit = jest.fn(() => true)
+    boxes.onNone = jest.fn()
+    boxes.onCancel = jest.fn()
+    boxes.validateFn = jest.fn(() => ({ isValid: false }))
+    return boxes
+  }
+
+  const createEnterEvent = () =>
+    ({
+      key: 'Enter',
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn()
+    }) as any as KeyboardEvent
+
+  test('defaultValue takes precedence over allowNone', () => {
+    const boxes = createBoxes({
+      userTyped: false,
+      useDefaultValue: true,
+      defaultValue: 42,
+      allowNone: true
+    })
+    const e = createEnterEvent()
+
+    ;(boxes as any).handleKeyDown(e)
+
+    expect(boxes.onCommit).toHaveBeenCalledWith(42)
+    expect(boxes.onNone).not.toHaveBeenCalled()
+  })
+
+  test('no default and allowNone=true returns None', () => {
+    const boxes = createBoxes({
+      userTyped: false,
+      useDefaultValue: false,
+      allowNone: true
+    })
+    const e = createEnterEvent()
+
+    ;(boxes as any).handleKeyDown(e)
+
+    expect(boxes.onNone).toHaveBeenCalledTimes(1)
+    expect(boxes.onCommit).not.toHaveBeenCalled()
+  })
+
+  test('no default and allowNone=false keeps prompting (invalid)', () => {
+    const boxes = createBoxes({
+      userTyped: false,
+      useDefaultValue: false,
+      allowNone: false
+    })
+    const e = createEnterEvent()
+
+    ;(boxes as any).handleKeyDown(e)
+
+    expect(boxes.onCommit).not.toHaveBeenCalled()
+    expect(boxes.onNone).not.toHaveBeenCalled()
+    expect(boxes.xInput.markInvalid).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Prompt option classes behavior matrix', () => {
+  type Outcome = 'default' | 'none' | 'invalid'
+
+  const simulateEnterByPromptOptions = (promptOptions: {
+    useDefaultValue?: boolean
+    defaultValue?: unknown
+    allowNone?: boolean
+  }): Outcome => {
+    const boxes = Object.create(AcEdFloatingInputBoxes.prototype) as any
+    boxes.twoInputs = false
+    boxes.xInput = {
+      userTyped: false,
+      value: '',
+      focused: true,
+      markValid: jest.fn(),
+      markInvalid: jest.fn(),
+      focus: jest.fn(),
+      select: jest.fn(),
+      isEventTarget: () => false
+    }
+    boxes.yInput = undefined
+    boxes.useDefaultValue = !!promptOptions.useDefaultValue
+    boxes.defaultValue = promptOptions.defaultValue
+    boxes.allowNone = !!promptOptions.allowNone
+    boxes.onCommit = jest.fn(() => true)
+    boxes.onNone = jest.fn()
+    boxes.onCancel = jest.fn()
+    boxes.validateFn = jest.fn(() => ({ isValid: false }))
+
+    const e = {
+      key: 'Enter',
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn()
+    } as any as KeyboardEvent
+
+    ;(boxes as any).handleKeyDown(e)
+
+    if (boxes.onCommit.mock.calls.length > 0) return 'default'
+    if (boxes.onNone.mock.calls.length > 0) return 'none'
+    return 'invalid'
+  }
+
+  test('AcEdPromptNumericalOptions: default > none > invalid', () => {
+    const opt = new AcEdPromptNumericalOptions('num')
+    opt.useDefaultValue = true
+    opt.defaultValue = 7
+    opt.allowNone = true
+    expect(simulateEnterByPromptOptions(opt as any)).toBe('default')
+
+    opt.useDefaultValue = false
+    opt.allowNone = true
+    expect(simulateEnterByPromptOptions(opt as any)).toBe('none')
+
+    opt.allowNone = false
+    expect(simulateEnterByPromptOptions(opt as any)).toBe('invalid')
+  })
+
+  test('AcEdPromptStringOptions: supports default on Enter', () => {
+    const opt = new AcEdPromptStringOptions('str')
+    opt.useDefaultValue = true
+    opt.defaultValue = 'abc'
+    expect(simulateEnterByPromptOptions(opt as any)).toBe('default')
+
+    opt.useDefaultValue = false
+    expect(simulateEnterByPromptOptions(opt as any)).toBe('invalid')
+  })
+
+  test('AcEdPromptNumericalOptions subclasses share same Enter priority', () => {
+    const subclasses = [
+      new AcEdPromptDoubleOptions('dbl'),
+      new AcEdPromptIntegerOptions('int'),
+      new AcEdPromptDistanceOptions('dist')
+    ]
+
+    subclasses.forEach(opt => {
+      opt.useDefaultValue = true
+      opt.defaultValue = 9
+      opt.allowNone = true
+      expect(simulateEnterByPromptOptions(opt as any)).toBe('default')
+
+      opt.useDefaultValue = false
+      opt.allowNone = true
+      expect(simulateEnterByPromptOptions(opt as any)).toBe('none')
+
+      opt.allowNone = false
+      expect(simulateEnterByPromptOptions(opt as any)).toBe('invalid')
+    })
+  })
+})

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdKeywordCollection.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdKeywordCollection.ts
@@ -1,6 +1,51 @@
 import { AcEdKeyword } from './AcEdKeyword'
 
 /**
+ * Structured keyword-prompt render payload used by command-line UI.
+ *
+ * This interface captures the canonical AutoCAD-style keyword section that
+ * appears after the prompt message, including:
+ * - visible keyword labels inside `[...]`
+ * - optional default keyword inside `<...>`
+ * - the fully composed tail text ending with `:`
+ *
+ * Typical rendered form:
+ * `Specify option [Yes/No] <Yes>:`
+ */
+export interface AcEdKeywordPromptFormat {
+  /**
+   * Ordered list of visible keyword display names.
+   *
+   * Notes:
+   * - The order matches prompt-rendering order in the command line.
+   * - Hidden keywords are excluded.
+   * - Values are display strings (localized UI labels), not global tokens.
+   */
+  visibleKeywords: string[]
+
+  /**
+   * Display name of the default keyword, when one is configured and visible.
+   *
+   * The value corresponds to what should be shown inside angle brackets in the
+   * prompt tail, e.g. `<Yes>`. When no default keyword is active (or when the
+   * default is hidden), this field is `undefined`.
+   */
+  defaultKeyword?: string
+
+  /**
+   * Canonical AutoCAD-style keyword suffix for prompt rendering.
+   *
+   * Standard form:
+   * - `[K1/K2]:` when no default keyword exists
+   * - `[K1/K2] <K1>:` when a default keyword exists
+   *
+   * This string is intended to be appended after the prompt message, e.g.:
+   * `Specify option [Yes/No] <Yes>:`
+   */
+  formattedTail: string
+}
+
+/**
  * A collection of `AcEdKeyword` objects, mirroring `Autodesk.AutoCAD.EditorInput.KeywordCollection`.
  * Represents the set of valid keywords for a prompt.
  */
@@ -225,6 +270,30 @@ export class AcEdKeywordCollection {
       })
 
     return parts.join('/')
+  }
+
+  /**
+   * Builds canonical AutoCAD-style keyword tail:
+   * [K1/K2] <Default>:
+   */
+  getPromptFormat(): AcEdKeywordPromptFormat {
+    const visibleKeywords = this._keywords
+      .filter(kw => kw.visible)
+      .map(kw => kw.displayName)
+
+    const defaultKeyword =
+      this._defaultKeyword && this._defaultKeyword.visible
+        ? this._defaultKeyword.displayName
+        : undefined
+
+    const keywordsText = `[${visibleKeywords.join('/')}]`
+    const defaultText = defaultKeyword ? ` <${defaultKeyword}>` : ''
+
+    return {
+      visibleKeywords,
+      defaultKeyword,
+      formattedTail: `${keywordsText}${defaultText}:`
+    }
   }
 
   /** Returns an iterator over the `AcEdKeyword` objects in this collection. */

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptOptions.ts
@@ -1,7 +1,10 @@
 import { AcGePoint3d } from '@mlightcad/data-model'
 
 import { AcEdPreviewJig } from '../AcEdPreviewJig'
-import { AcEdKeywordCollection } from './AcEdKeywordCollection'
+import {
+  AcEdKeywordCollection,
+  AcEdKeywordPromptFormat
+} from './AcEdKeywordCollection'
 
 /**
  * Represents the base class for prompt options in the Editor, similar to `Autodesk.AutoCAD.EditorInput.PromptOptions`.
@@ -87,6 +90,14 @@ export class AcEdPromptOptions<T = number | string | AcGePoint3d> {
    */
   get keywords(): AcEdKeywordCollection {
     return this._keywords
+  }
+
+  /**
+   * Returns AutoCAD-style keyword prompt format data:
+   * [Keywords] <Default>:
+   */
+  getKeywordPromptFormat(): AcEdKeywordPromptFormat {
+    return this._keywords.getPromptFormat()
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/input/session/AcEdKeywordSession.ts
+++ b/packages/cad-simple-viewer/src/editor/input/session/AcEdKeywordSession.ts
@@ -3,9 +3,35 @@ import { AcEdPromptKeywordOptions } from '../prompt/AcEdPromptKeywordOptions'
 import { AcEdCommandLine } from '../ui/AcEdCommandLine'
 import { AcEdInputSession } from './AcEdInputSession'
 
+/**
+ * Interactive keyword-input session bound to the command line.
+ *
+ * This session is responsible for:
+ * - Rendering the keyword prompt UI
+ * - Applying Enter/Escape behavior for keyword picking
+ * - Handling default-keyword and `AllowNone` semantics on empty Enter
+ * - Restoring command-line input state when the session ends
+ *
+ * The resolved session value is always a string:
+ * - keyword global name when a keyword is selected
+ * - empty string when the prompt ends as "none"/cancel path
+ */
 export class AcEdKeywordSession extends AcEdInputSession<string> {
+  /**
+   * Keyword parser/validator shared by Enter handling.
+   *
+   * It maps user input (display/local/global/alias) to canonical
+   * global keyword names and rejects invalid text.
+   */
   private handler: AcEdKeywordHandler
 
+  /**
+   * Creates a keyword session instance.
+   *
+   * @param cli - Command-line UI adapter used to render prompt and control input state
+   * @param options - Keyword prompt options (message, keyword set, default, `allowNone`)
+   * @param allowTyping - When false, typed input is disabled and only clickable keywords are accepted
+   */
   constructor(
     private cli: AcEdCommandLine,
     private options: AcEdPromptKeywordOptions,
@@ -15,6 +41,15 @@ export class AcEdKeywordSession extends AcEdInputSession<string> {
     this.handler = new AcEdKeywordHandler(options)
   }
 
+  /**
+   * Initializes session UI state.
+   *
+   * Behavior:
+   * - Clears any stale command-line input text
+   * - Sets input read-only depending on `allowTyping`
+   * - Renders clickable keyword prompt
+   * - Focuses command-line input for immediate interaction
+   */
   protected onStart(): void {
     this.cli.clearInput()
     this.cli.setInputReadOnly(!this.allowTyping)
@@ -22,8 +57,37 @@ export class AcEdKeywordSession extends AcEdInputSession<string> {
     this.cli.focusInput()
   }
 
+  /**
+   * Handles Enter key input for this keyword session.
+   *
+   * Resolution order:
+   * 1. If typing is disabled, Enter is treated as consumed.
+   * 2. Empty input:
+   *    - use default keyword when present and enabled
+   *    - otherwise resolve empty string when `allowNone` is true
+   *    - otherwise reject as invalid (session remains active)
+   * 3. Non-empty input:
+   *    - parse as keyword via {@link AcEdKeywordHandler}
+   *    - resolve parsed global keyword when valid
+   *    - reject when invalid
+   *
+   * @param value - Raw text currently typed in command-line input
+   * @returns `true` when Enter is consumed; `false` when input is invalid
+   */
   handleEnter(value: string): boolean {
     if (!this.allowTyping) return true
+    if (!value.trim()) {
+      const defaultKeyword = this.options.keywords.default
+      if (defaultKeyword?.enabled) {
+        this.finish(defaultKeyword.globalName)
+        return true
+      }
+      if (this.options.allowNone) {
+        this.finish('')
+        return true
+      }
+      return false
+    }
     const parsed = this.handler.parse(value)
     if (parsed !== null) {
       this.finish(parsed)
@@ -32,10 +96,23 @@ export class AcEdKeywordSession extends AcEdInputSession<string> {
     return false
   }
 
+  /**
+   * Handles Escape key for this session.
+   *
+   * Escape resolves the session with an empty string, which the caller
+   * interprets as cancel/none depending on prompt context.
+   */
   handleEscape(): void {
     this.finish('')
   }
 
+  /**
+   * Restores command-line state after session completion.
+   *
+   * This always:
+   * - Re-enables input editing
+   * - Clears prompt/input visuals from command line
+   */
   protected cleanup(): void {
     this.cli.setInputReadOnly(false)
     this.cli.clear()

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
@@ -741,8 +741,10 @@ export class AcEdCommandLine {
       this.promptEl.append(options.message.trim() + ' ')
     }
 
-    const keywords = options.keywords?.toArray().filter(k => k.visible) ?? []
-    if (!keywords.length) return
+    const promptFormat = options.getKeywordPromptFormat()
+    if (!promptFormat.visibleKeywords.length) return
+    const keywords = options.keywords?.toArray().filter(k => k.visible)
+    if (!keywords?.length) return
 
     this.promptEl.append('[')
 
@@ -763,7 +765,13 @@ export class AcEdCommandLine {
       this.promptEl.append(span)
     })
 
-    this.promptEl.append(']: ')
+    this.promptEl.append(']')
+
+    if (promptFormat.defaultKeyword) {
+      this.promptEl.append(` <${promptFormat.defaultKeyword}>`)
+    }
+
+    this.promptEl.append(': ')
   }
 
   /** Resolve command name */

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -21,6 +21,7 @@ import {
   AcEdFloatingInputCommitCallback,
   AcEdFloatingInputDrawPreviewCallback,
   AcEdFloatingInputDynamicValueCallback,
+  AcEdFloatingInputNoneCallback,
   AcEdFloatingInputOptions,
   AcEdFloatingInputValidationCallback
 } from './AcEdFloatingInputTypes'
@@ -72,6 +73,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   private onCommit?: AcEdFloatingInputCommitCallback<T>
   private onChange?: AcEdFloatingInputChangeCallback<T>
   private onCancel?: AcEdFloatingInputCancelCallback
+  private onNone?: AcEdFloatingInputNoneCallback
 
   /** Validation and dynamic value providers */
   private validateFn: AcEdFloatingInputValidationCallback<T>
@@ -134,6 +136,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     this.onCommit = options.onCommit
     this.onChange = options.onChange
     this.onCancel = options.onCancel
+    this.onNone = options.onNone
 
     // -----------------------------
     // Input boxes
@@ -144,10 +147,13 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
         twoInputs: options.inputCount === 2,
         validate: this.validateFn,
         onCancel: this.onCancel,
+        onNone: this.onNone,
         onCommit: this.onCommit,
         onChange: this.onChange,
         autoFocus: this.isDynamicInputEnabled(),
-        allowNone: options.allowNone
+        allowNone: options.allowNone,
+        useDefaultValue: options.useDefaultValue,
+        defaultValue: options.defaultValue
       })
     }
 

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBoxes.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBoxes.ts
@@ -3,6 +3,7 @@ import {
   AcEdFloatingInputCancelCallback,
   AcEdFloatingInputChangeCallback,
   AcEdFloatingInputCommitCallback,
+  AcEdFloatingInputNoneCallback,
   AcEdFloatingInputRawData,
   AcEdFloatingInputValidationCallback,
   AcEdFloatingInputValidationResult
@@ -46,6 +47,11 @@ export interface AcEdFloatingInputBoxesOptions<T> {
   onCancel?: AcEdFloatingInputCancelCallback
 
   /**
+   * Callback invoked when Enter submits "none" (AllowNone + empty typed input).
+   */
+  onNone?: AcEdFloatingInputNoneCallback
+
+  /**
    * Whether to autofocus/select inputs after mount.
    * Default: true
    */
@@ -57,6 +63,16 @@ export interface AcEdFloatingInputBoxesOptions<T> {
    * current dynamic-preview value.  Mirrors AutoCAD's AllowNone behaviour.
    */
   allowNone?: boolean
+
+  /**
+   * Whether Enter with no manual input should submit defaultValue.
+   */
+  useDefaultValue?: boolean
+
+  /**
+   * Default value submitted when useDefaultValue is true.
+   */
+  defaultValue?: T
 }
 
 /**
@@ -96,8 +112,11 @@ export class AcEdFloatingInputBoxes<T> {
   private onCommit?: AcEdFloatingInputCommitCallback<T>
   private onChange?: AcEdFloatingInputChangeCallback<T>
   private onCancel?: AcEdFloatingInputCancelCallback
+  private onNone?: AcEdFloatingInputNoneCallback
   private validateFn: AcEdFloatingInputValidationCallback<T>
   private allowNone: boolean
+  private useDefaultValue: boolean
+  private defaultValue?: T
 
   /**
    * Constructs one instance of this class
@@ -125,7 +144,10 @@ export class AcEdFloatingInputBoxes<T> {
     this.onCommit = options.onCommit
     this.onChange = options.onChange
     this.onCancel = options.onCancel
+    this.onNone = options.onNone
     this.allowNone = options.allowNone ?? false
+    this.useDefaultValue = options.useDefaultValue ?? false
+    this.defaultValue = options.defaultValue
 
     // Focus/select after mount
     if (options.autoFocus !== false) {
@@ -139,7 +161,7 @@ export class AcEdFloatingInputBoxes<T> {
 
   /** Returns true if user typed in ANY input box */
   get userTyped(): boolean {
-    return this.xInput.userTyped || !!this.xInput?.userTyped
+    return this.xInput.userTyped || !!this.yInput?.userTyped
   }
 
   /** Return one flag to indicate whether one of inputs is focused. */
@@ -209,11 +231,23 @@ export class AcEdFloatingInputBoxes<T> {
     }
 
     if (e.key === 'Enter') {
+      if (this.useDefaultValue && !this.userTyped) {
+        const committed =
+          !this.onCommit || this.onCommit(this.defaultValue as T)
+        if (committed) {
+          currentInput.markValid()
+        } else {
+          currentInput.markInvalid()
+        }
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
+
       // When allowNone is set and the user has not manually typed coordinates,
-      // treat Enter as a cancel (finish the prompt without adding a point) so
-      // that commands like MeasureArea can use Enter-to-finish naturally.
+      // treat Enter as PromptStatus.None so commands can finish naturally.
       if (this.allowNone && !this.userTyped) {
-        this.onCancel?.()
+        this.onNone?.()
       } else {
         const state = this.validate()
         if (state.isValid && state.value != null) {

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputTypes.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputTypes.ts
@@ -71,6 +71,11 @@ export type AcEdFloatingInputChangeCallback<T> = (
 export type AcEdFloatingInputCancelCallback = () => void
 
 /**
+ * Callback invoked when user confirms "no input" (Enter with AllowNone).
+ */
+export type AcEdFloatingInputNoneCallback = () => void
+
+/**
  * Callback invoked on mousemove to update the preview geometry.
  */
 export type AcEdFloatingInputDrawPreviewCallback = (
@@ -174,6 +179,22 @@ export interface AcEdFloatingInputOptions<T> {
    * Callback invoked on cancellation (Escape or hide()).
    */
   onCancel?: AcEdFloatingInputCancelCallback
+
+  /**
+   * Callback invoked when user enters no value and prompt allows none.
+   */
+  onNone?: AcEdFloatingInputNoneCallback
+
+  /**
+   * Whether pressing Enter with no manual input should submit defaultValue.
+   */
+  useDefaultValue?: boolean
+
+  /**
+   * Default value submitted when Enter is pressed with no manual input and
+   * useDefaultValue is true.
+   */
+  defaultValue?: T
 
   /**
    * When true, pressing Enter without having manually typed coordinates

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -1,5 +1,8 @@
 import {
   AcDbEntity,
+  acdbHostApplicationServices,
+  AcDbSystemVariables,
+  AcDbSysVarManager,
   AcGeBox2d,
   AcGePoint2dLike,
   AcGePoint3dLike
@@ -76,6 +79,15 @@ class AcEdKeywordInputError extends Error {
   constructor(keyword: string) {
     super('keyword')
     this.keyword = keyword
+  }
+}
+
+/**
+ * Internal control-flow error used to represent Enter/RightClick None input.
+ */
+class AcEdNoneInputError extends Error {
+  constructor() {
+    super('none')
   }
 }
 
@@ -441,6 +453,126 @@ export class AcEdInputManager {
   }
 
   /**
+   * Converts internal prompt control-flow errors to typed prompt results.
+   *
+   * @typeParam T - Prompt result type to construct
+   * @param error - Unknown error thrown from prompt workflow
+   * @param handlers - Result factories for mapped prompt statuses
+   * @returns Mapped prompt result when recognized; otherwise `undefined`
+   */
+  private mapPromptError<T>(
+    error: unknown,
+    handlers: {
+      none?: () => T
+      cancel?: () => T
+      keyword?: (keyword: string) => T
+    }
+  ): T | undefined {
+    if (handlers.none && this.isPromptNone(error)) {
+      return handlers.none()
+    }
+    if (handlers.cancel && this.isPromptCancelled(error)) {
+      return handlers.cancel()
+    }
+    if (handlers.keyword && this.isPromptKeyword(error)) {
+      return handlers.keyword(error.keyword)
+    }
+    return undefined
+  }
+
+  /**
+   * Attaches keyword text to a prompt result and returns it.
+   */
+  private withKeywordResult<T extends AcEdPromptResult>(
+    result: T,
+    keyword: string
+  ): T {
+    result.stringResult = keyword
+    return result
+  }
+
+  /**
+   * Maps internal control-flow errors to prompt results by status constructor.
+   *
+   * @typeParam T - Prompt result type
+   * @param error - Unknown error thrown from prompt workflow
+   * @param create - Factory creating a result from target status
+   * @param options - Toggles for supported mapped statuses
+   */
+  private mapPromptErrorToResult<T extends AcEdPromptResult>(
+    error: unknown,
+    create: (status: AcEdPromptStatus) => T,
+    options?: {
+      none?: boolean
+      cancel?: boolean
+      keyword?: boolean
+    }
+  ): T | undefined {
+    const includeNone = options?.none ?? true
+    const includeCancel = options?.cancel ?? true
+    const includeKeyword = options?.keyword ?? true
+
+    return this.mapPromptError(error, {
+      none: includeNone ? () => create(AcEdPromptStatus.None) : undefined,
+      cancel: includeCancel ? () => create(AcEdPromptStatus.Cancel) : undefined,
+      keyword: includeKeyword
+        ? keyword =>
+            this.withKeywordResult(create(AcEdPromptStatus.Keyword), keyword)
+        : undefined
+    })
+  }
+
+  /**
+   * Executes prompt workflow with centralized try/catch mapping.
+   *
+   * @typeParam T - Raw successful value from prompt workflow
+   * @typeParam R - Prompt result type
+   * @param run - Async prompt workflow that may throw control-flow errors
+   * @param onOk - Maps successful workflow value to result object
+   * @param create - Creates a result object from mapped prompt status
+   * @param options - Toggles for supported mapped statuses
+   */
+  private async executePrompt<T, R extends AcEdPromptResult>(
+    run: () => Promise<T>,
+    onOk: (value: T) => R,
+    create: (status: AcEdPromptStatus) => R,
+    options?: {
+      none?: boolean
+      cancel?: boolean
+      keyword?: boolean
+    }
+  ): Promise<R> {
+    try {
+      const value = await run()
+      return onOk(value)
+    } catch (error) {
+      const mapped = this.mapPromptErrorToResult(error, create, options)
+      if (mapped) return mapped
+      throw error
+    }
+  }
+
+  /**
+   * Extracts default-value behavior from prompt options when supported.
+   */
+  private resolvePromptDefaultValue<T>(promptOptions: AcEdPromptOptions<T>): {
+    useDefaultValue: boolean
+    defaultValue?: T
+  } {
+    if (
+      'useDefaultValue' in promptOptions &&
+      'defaultValue' in promptOptions &&
+      (promptOptions as { useDefaultValue: boolean }).useDefaultValue
+    ) {
+      return {
+        useDefaultValue: true,
+        defaultValue: (promptOptions as { defaultValue: T }).defaultValue
+      }
+    }
+    return { useDefaultValue: false }
+  }
+
+  /**
    * Prompts the user to specify a point.
    *
    * The point may be supplied by clicking in the view, typing coordinates into
@@ -454,20 +586,11 @@ export class AcEdInputManager {
   async getPoint(
     options: AcEdPromptPointOptions
   ): Promise<AcEdPromptPointResult> {
-    try {
-      const value = await this.getPointInternal(options)
-      return new AcEdPromptPointResult(AcEdPromptStatus.OK, value)
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptPointResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        const result = new AcEdPromptPointResult(AcEdPromptStatus.Keyword)
-        result.stringResult = error.keyword
-        return result
-      }
-      throw error
-    }
+    return this.executePrompt(
+      () => this.getPointInternal(options),
+      value => new AcEdPromptPointResult(AcEdPromptStatus.OK, value),
+      status => new AcEdPromptPointResult(status)
+    )
   }
 
   /**
@@ -521,41 +644,33 @@ export class AcEdInputManager {
       return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, scriptedValue)
     }
 
-    try {
-      // If no base point defined → fall back to typed numeric input
-      if (!this.lastPoint) {
-        const value = await this.getNumberTyped(options, handler)
-        return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value)
-      }
-
-      const getDynamicValue = (pos: AcGePoint2dLike) => {
-        const dx = pos.x - this.lastPoint!.x
-        const dy = pos.y - this.lastPoint!.y
-        const dist = Math.sqrt(dx * dx + dy * dy)
-        return {
-          value: dist,
-          raw: { x: this.formatNumber(dist, 'distance') }
+    return this.executePrompt(
+      async () => {
+        // If no base point defined → fall back to typed numeric input
+        if (!this.lastPoint) {
+          return await this.getNumberTyped(options, handler)
         }
-      }
 
-      const value = await this.makeFloatingInputPromise<number>({
-        inputCount: 1,
-        promptOptions: options,
-        handler,
-        getDynamicValue
-      })
-      return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value)
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptDoubleResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        const result = new AcEdPromptDoubleResult(AcEdPromptStatus.Keyword)
-        result.stringResult = error.keyword
-        return result
-      }
-      throw error
-    }
+        const getDynamicValue = (pos: AcGePoint2dLike) => {
+          const dx = pos.x - this.lastPoint!.x
+          const dy = pos.y - this.lastPoint!.y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          return {
+            value: dist,
+            raw: { x: this.formatNumber(dist, 'distance') }
+          }
+        }
+
+        return await this.makeFloatingInputPromise<number>({
+          inputCount: 1,
+          promptOptions: options,
+          handler,
+          getDynamicValue
+        })
+      },
+      value => new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value),
+      status => new AcEdPromptDoubleResult(status)
+    )
   }
 
   /**
@@ -584,20 +699,11 @@ export class AcEdInputManager {
 
     // No reference point available: fallback to typed angle input only.
     if (!basePoint) {
-      try {
-        const value = await this.getNumberTyped(options, handler)
-        return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value)
-      } catch (error) {
-        if (this.isPromptCancelled(error)) {
-          return new AcEdPromptDoubleResult(AcEdPromptStatus.Cancel)
-        }
-        if (this.isPromptKeyword(error)) {
-          const result = new AcEdPromptDoubleResult(AcEdPromptStatus.Keyword)
-          result.stringResult = error.keyword
-          return result
-        }
-        throw error
-      }
+      return this.executePrompt(
+        () => this.getNumberTyped(options, handler),
+        value => new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value),
+        status => new AcEdPromptDoubleResult(status)
+      )
     }
 
     const getDynamicValue = (pos: AcGePoint2dLike) => {
@@ -615,25 +721,17 @@ export class AcEdInputManager {
       }
     }
 
-    try {
-      const value = await this.makeFloatingInputPromise<number>({
-        inputCount: 1,
-        promptOptions: options,
-        handler,
-        getDynamicValue
-      })
-      return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value)
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptDoubleResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        const result = new AcEdPromptDoubleResult(AcEdPromptStatus.Keyword)
-        result.stringResult = error.keyword
-        return result
-      }
-      throw error
-    }
+    return this.executePrompt(
+      () =>
+        this.makeFloatingInputPromise<number>({
+          inputCount: 1,
+          promptOptions: options,
+          handler,
+          getDynamicValue
+        }),
+      value => new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value),
+      status => new AcEdPromptDoubleResult(status)
+    )
   }
 
   /**
@@ -654,20 +752,11 @@ export class AcEdInputManager {
       return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, scriptedValue)
     }
 
-    try {
-      const value = await this.getNumberTyped(options, handler)
-      return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value)
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptDoubleResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        const result = new AcEdPromptDoubleResult(AcEdPromptStatus.Keyword)
-        result.stringResult = error.keyword
-        return result
-      }
-      throw error
-    }
+    return this.executePrompt(
+      () => this.getNumberTyped(options, handler),
+      value => new AcEdPromptDoubleResult(AcEdPromptStatus.OK, value),
+      status => new AcEdPromptDoubleResult(status)
+    )
   }
 
   /**
@@ -689,23 +778,11 @@ export class AcEdInputManager {
       return new AcEdPromptIntegerResult(AcEdPromptStatus.OK, scriptedValue)
     }
 
-    try {
-      const value = await this.getNumberTyped(
-        options,
-        new AcEdIntegerHandler(options)
-      )
-      return new AcEdPromptIntegerResult(AcEdPromptStatus.OK, value)
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptIntegerResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        const result = new AcEdPromptIntegerResult(AcEdPromptStatus.Keyword)
-        result.stringResult = error.keyword
-        return result
-      }
-      throw error
-    }
+    return this.executePrompt(
+      () => this.getNumberTyped(options, new AcEdIntegerHandler(options)),
+      value => new AcEdPromptIntegerResult(AcEdPromptStatus.OK, value),
+      status => new AcEdPromptIntegerResult(status)
+    )
   }
 
   /**
@@ -726,31 +803,26 @@ export class AcEdInputManager {
       return new AcEdPromptResult(AcEdPromptStatus.OK, scriptedValue)
     }
 
-    try {
-      const getDynamicValue = () => {
-        return {
-          value: '',
-          raw: { x: '' }
+    return this.executePrompt(
+      async () => {
+        const getDynamicValue = () => {
+          return {
+            value: '',
+            raw: { x: '' }
+          }
         }
-      }
 
-      const handler = new AcEdStringHandler(options)
-      const value = await this.makeFloatingInputPromise<string>({
-        inputCount: 1,
-        promptOptions: options,
-        handler,
-        getDynamicValue
-      })
-      return new AcEdPromptResult(AcEdPromptStatus.OK, value)
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        return new AcEdPromptResult(AcEdPromptStatus.Keyword, error.keyword)
-      }
-      throw error
-    }
+        const handler = new AcEdStringHandler(options)
+        return await this.makeFloatingInputPromise<string>({
+          inputCount: 1,
+          promptOptions: options,
+          handler,
+          getDynamicValue
+        })
+      },
+      value => new AcEdPromptResult(AcEdPromptStatus.OK, value),
+      status => new AcEdPromptResult(status)
+    )
   }
 
   /**
@@ -773,18 +845,21 @@ export class AcEdInputManager {
       return new AcEdPromptResult(AcEdPromptStatus.OK, scriptedValue)
     }
 
-    try {
-      const result = await this._commandLine.getKeywords(options, true)
-      if (!result) {
-        return new AcEdPromptResult(AcEdPromptStatus.Cancel)
-      }
-      return new AcEdPromptResult(AcEdPromptStatus.OK, result)
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptResult(AcEdPromptStatus.Cancel)
-      }
-      throw error
-    }
+    return this.executePrompt(
+      async () => {
+        const result = await this._commandLine.getKeywords(options, true)
+        if (!result) {
+          if (options.allowNone) {
+            throw new AcEdNoneInputError()
+          }
+          throw new Error('cancelled')
+        }
+        return result
+      },
+      value => new AcEdPromptResult(AcEdPromptStatus.OK, value),
+      status => new AcEdPromptResult(status),
+      { keyword: false }
+    )
   }
 
   /**
@@ -818,184 +893,198 @@ export class AcEdInputManager {
   async getSelection(
     options: AcEdPromptSelectionOptions
   ): Promise<AcEdPromptSelectionResult> {
-    try {
-      const value = await new Promise<string[]>((resolve, reject) => {
-        this.active = true
-        this.entitySelectionActive = true
-        const keywordSession = this.startKeywordSession(options, true)
-        if (!keywordSession) {
-          this._commandLine.setPrompt(options.message)
-        }
-
-        const floatingMessage = new AcEdFloatingMessage(this.view, {
-          parent: this.view.canvas,
-          message: options.message
-        })
-
-        const selected = new Set<string>()
-        let startWcs: AcGePoint2dLike | null = null
-        let startCanvas: AcGePoint2dLike | null = null
-        let previewEl: HTMLDivElement | null = null
-
-        let settled = false
-        const cleanup = () => {
-          if (settled) return
-          settled = true
-          this.active = false
-          this.entitySelectionActive = false
-          floatingMessage?.dispose()
-          previewEl?.remove()
-          keywordSession?.cancel()
-          this._commandLine.clear()
-
-          document.removeEventListener('keydown', keyHandler)
-          this.view.canvas.removeEventListener('mousedown', mouseDown)
-          this.view.canvas.removeEventListener('mousemove', mouseMove)
-          this.view.canvas.removeEventListener('mouseup', mouseUp)
-        }
-
-        keywordSession?.promise.then(keyword => {
-          if (settled) return
-          if (!keyword) {
-            cleanup()
-            reject(new Error('cancelled'))
-            return
-          }
-          cleanup()
-          reject(new AcEdKeywordInputError(keyword))
-        })
-
-        /** ---------- Keyboard ---------- */
-
-        const keyHandler = (e: KeyboardEvent) => {
-          if (e.key === 'Escape') {
-            cleanup()
-            reject(new Error('cancelled'))
-            return
+    return this.executePrompt(
+      () =>
+        new Promise<string[]>((resolve, reject) => {
+          this.active = true
+          this.entitySelectionActive = true
+          const keywordSession = this.startKeywordSession(options, true)
+          if (!keywordSession) {
+            this._commandLine.setPrompt(options.message)
           }
 
-          if (e.key === 'Enter') {
-            cleanup()
-            resolve([...selected])
+          const floatingMessage = new AcEdFloatingMessage(this.view, {
+            parent: this.view.canvas,
+            message: options.message
+          })
+
+          const selected = new Set<string>()
+          let startWcs: AcGePoint2dLike | null = null
+          let startCanvas: AcGePoint2dLike | null = null
+          let previewEl: HTMLDivElement | null = null
+
+          let settled = false
+          const cleanup = () => {
+            if (settled) return
+            settled = true
+            this.active = false
+            this.entitySelectionActive = false
+            floatingMessage?.dispose()
+            previewEl?.remove()
+            keywordSession?.cancel()
+            this._commandLine.clear()
+
+            document.removeEventListener('keydown', keyHandler)
+            this.view.canvas.removeEventListener('mousedown', mouseDown)
+            this.view.canvas.removeEventListener('mousemove', mouseMove)
+            this.view.canvas.removeEventListener('mouseup', mouseUp)
+            this.view.canvas.removeEventListener(
+              'contextmenu',
+              contextMenuHandler
+            )
           }
-        }
 
-        /** ---------- Mouse ---------- */
-
-        const mouseDown = (e: MouseEvent) => {
-          startCanvas = this.view.viewportToCanvas({
-            x: e.clientX,
-            y: e.clientY
-          })
-          startWcs = this.view.screenToWorld(startCanvas)
-
-          previewEl = document.createElement('div')
-          previewEl.className = 'ml-jig-preview-rect'
-          this.view.container.appendChild(previewEl)
-        }
-
-        const mouseMove = (e: MouseEvent) => {
-          if (!startWcs || !previewEl || !startCanvas) return
-
-          const curWcs = this.view.screenToWorld(
-            this.view.viewportToCanvas({ x: e.clientX, y: e.clientY })
-          )
-          const curCanvas = this.view.viewportToCanvas({
-            x: e.clientX,
-            y: e.clientY
-          })
-          const p1 = this.view.worldToScreen(startWcs)
-          const p2 = this.view.worldToScreen(curWcs)
-
-          const left = Math.min(p1.x, p2.x)
-          const top = Math.min(p1.y, p2.y)
-          const width = Math.abs(p1.x - p2.x)
-          const height = Math.abs(p1.y - p2.y)
-          const mode = this.view.getSelectionMode(startCanvas, curCanvas)
-          const action = this.view.getSelectionActionFromEvent(e, 'add')
-          const style = this.view.getSelectionPreviewStyle(mode, action)
-
-          Object.assign(previewEl.style, {
-            left: `${left}px`,
-            top: `${top}px`,
-            width: `${width}px`,
-            height: `${height}px`,
-            borderStyle: style.borderStyle,
-            background: style.background
-          })
-          previewEl.style.setProperty('--line-color', style.lineColor)
-        }
-
-        const mouseUp = (e: MouseEvent) => {
-          if (!startWcs || !startCanvas) return
-
-          const endWcs = this.view.screenToWorld(
-            this.view.viewportToCanvas({ x: e.clientX, y: e.clientY })
-          )
-          const endCanvas = this.view.viewportToCanvas({
-            x: e.clientX,
-            y: e.clientY
-          })
-          previewEl?.remove()
-          previewEl = null
-
-          // Click selection
-          const action = this.view.getSelectionActionFromEvent(e, 'add')
-
-          if (this.view.isSelectionClick(startCanvas, endCanvas)) {
-            const picked = this.view.pick(endWcs)
-            if (picked.length > 0) {
-              this.view.applySelection([picked[0].id], action)
-            } else if (action === 'replace') {
-              this.view.selectionSet.clear()
+          keywordSession?.promise.then(keyword => {
+            if (settled) return
+            if (!keyword) {
+              cleanup()
+              reject(new Error('cancelled'))
+              return
             }
-          } else {
-            // Box selection
-            const box = new AcGeBox2d()
-              .expandByPoint(startWcs)
-              .expandByPoint(endWcs)
-            const mode = this.view.getSelectionMode(startCanvas, endCanvas)
-            this.view.selectByBoxWithMode(box, mode, action)
-          }
+            cleanup()
+            reject(new AcEdKeywordInputError(keyword))
+          })
 
-          selected.clear()
-          for (const id of this.view.selectionSet.ids) {
-            selected.add(id)
-          }
+          /** ---------- Keyboard ---------- */
 
-          if (options.singleOnly && action !== 'remove') {
-            if (selected.size > 0) {
+          const keyHandler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+              cleanup()
+              reject(new Error('cancelled'))
+              return
+            }
+
+            if (e.key === 'Enter') {
               cleanup()
               resolve([...selected])
             }
           }
 
-          startWcs = null
-          startCanvas = null
-        }
+          /** ---------- Mouse ---------- */
+          const contextMenuHandler = (e: MouseEvent) => {
+            if (this.shouldUseRightClickEnter()) {
+              e.preventDefault()
+            }
+          }
 
-        document.addEventListener('keydown', keyHandler)
-        this.view.canvas.addEventListener('mousedown', mouseDown)
-        this.view.canvas.addEventListener('mousemove', mouseMove)
-        this.view.canvas.addEventListener('mouseup', mouseUp)
-      })
-      return new AcEdPromptSelectionResult(
-        AcEdPromptStatus.OK,
-        new AcEdSelectionSet(value)
-      )
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptSelectionResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        return new AcEdPromptSelectionResult(
-          AcEdPromptStatus.Keyword,
-          undefined,
-          error.keyword
-        )
-      }
-      throw error
-    }
+          const mouseDown = (e: MouseEvent) => {
+            if (e.button === 2) {
+              if (this.shouldUseRightClickEnter()) {
+                e.preventDefault()
+                cleanup()
+                resolve([...selected])
+              }
+              return
+            }
+            if (e.button !== 0) return
+
+            startCanvas = this.view.viewportToCanvas({
+              x: e.clientX,
+              y: e.clientY
+            })
+            startWcs = this.view.screenToWorld(startCanvas)
+
+            previewEl = document.createElement('div')
+            previewEl.className = 'ml-jig-preview-rect'
+            this.view.container.appendChild(previewEl)
+          }
+
+          const mouseMove = (e: MouseEvent) => {
+            if (e.buttons !== 1) return
+            if (!startWcs || !previewEl || !startCanvas) return
+
+            const curWcs = this.view.screenToWorld(
+              this.view.viewportToCanvas({ x: e.clientX, y: e.clientY })
+            )
+            const curCanvas = this.view.viewportToCanvas({
+              x: e.clientX,
+              y: e.clientY
+            })
+            const p1 = this.view.worldToScreen(startWcs)
+            const p2 = this.view.worldToScreen(curWcs)
+
+            const left = Math.min(p1.x, p2.x)
+            const top = Math.min(p1.y, p2.y)
+            const width = Math.abs(p1.x - p2.x)
+            const height = Math.abs(p1.y - p2.y)
+            const mode = this.view.getSelectionMode(startCanvas, curCanvas)
+            const action = this.view.getSelectionActionFromEvent(e, 'add')
+            const style = this.view.getSelectionPreviewStyle(mode, action)
+
+            Object.assign(previewEl.style, {
+              left: `${left}px`,
+              top: `${top}px`,
+              width: `${width}px`,
+              height: `${height}px`,
+              borderStyle: style.borderStyle,
+              background: style.background
+            })
+            previewEl.style.setProperty('--line-color', style.lineColor)
+          }
+
+          const mouseUp = (e: MouseEvent) => {
+            if (e.button !== 0) return
+            if (!startWcs || !startCanvas) return
+
+            const endWcs = this.view.screenToWorld(
+              this.view.viewportToCanvas({ x: e.clientX, y: e.clientY })
+            )
+            const endCanvas = this.view.viewportToCanvas({
+              x: e.clientX,
+              y: e.clientY
+            })
+            previewEl?.remove()
+            previewEl = null
+
+            // Click selection
+            const action = this.view.getSelectionActionFromEvent(e, 'add')
+
+            if (this.view.isSelectionClick(startCanvas, endCanvas)) {
+              const picked = this.view.pick(endWcs)
+              if (picked.length > 0) {
+                this.view.applySelection([picked[0].id], action)
+              } else if (action === 'replace') {
+                this.view.selectionSet.clear()
+              }
+            } else {
+              // Box selection
+              const box = new AcGeBox2d()
+                .expandByPoint(startWcs)
+                .expandByPoint(endWcs)
+              const mode = this.view.getSelectionMode(startCanvas, endCanvas)
+              this.view.selectByBoxWithMode(box, mode, action)
+            }
+
+            selected.clear()
+            for (const id of this.view.selectionSet.ids) {
+              selected.add(id)
+            }
+
+            if (options.singleOnly && action !== 'remove') {
+              if (selected.size > 0) {
+                cleanup()
+                resolve([...selected])
+              }
+            }
+
+            startWcs = null
+            startCanvas = null
+          }
+
+          document.addEventListener('keydown', keyHandler)
+          this.view.canvas.addEventListener('mousedown', mouseDown)
+          this.view.canvas.addEventListener('mousemove', mouseMove)
+          this.view.canvas.addEventListener('mouseup', mouseUp)
+          this.view.canvas.addEventListener('contextmenu', contextMenuHandler)
+        }),
+      value =>
+        new AcEdPromptSelectionResult(
+          AcEdPromptStatus.OK,
+          new AcEdSelectionSet(value)
+        ),
+      status => new AcEdPromptSelectionResult(status),
+      { none: false }
+    )
   }
 
   /**
@@ -1014,114 +1103,129 @@ export class AcEdInputManager {
   async getEntity(
     options: AcEdPromptEntityOptions
   ): Promise<AcEdPromptEntityResult> {
-    try {
-      let pickedPoint: AcGePoint3dLike | undefined
-      const value = await new Promise<string | null>((resolve, reject) => {
-        this.active = true
-        this.entitySelectionActive = true
-        const keywordSession = this.startKeywordSession(options, true)
-        const floatingMessage = new AcEdFloatingMessage(this.view, {
-          parent: this.view.canvas,
-          message: options.message
-        })
-        if (!keywordSession) {
-          this._commandLine.setPrompt(options.message)
-        }
-        let settled = false
-        const cleanup = () => {
-          if (settled) return
-          settled = true
-          this.active = false
-          this.entitySelectionActive = false
-          options.jig?.end()
-          document.removeEventListener('keydown', keyHandler)
-          this.view.canvas.removeEventListener('mousedown', clickHandler)
-          floatingMessage?.dispose()
-          keywordSession?.cancel()
-          this._commandLine.clear()
-        }
+    let pickedPoint: AcGePoint3dLike | undefined
+    return this.executePrompt(
+      () =>
+        new Promise<string | null>((resolve, reject) => {
+          this.active = true
+          this.entitySelectionActive = true
+          const keywordSession = this.startKeywordSession(options, true)
+          const floatingMessage = new AcEdFloatingMessage(this.view, {
+            parent: this.view.canvas,
+            message: options.message
+          })
+          if (!keywordSession) {
+            this._commandLine.setPrompt(options.message)
+          }
+          let settled = false
+          const cleanup = () => {
+            if (settled) return
+            settled = true
+            this.active = false
+            this.entitySelectionActive = false
+            options.jig?.end()
+            document.removeEventListener('keydown', keyHandler)
+            this.view.canvas.removeEventListener('mousedown', clickHandler)
+            this.view.canvas.removeEventListener(
+              'contextmenu',
+              contextMenuHandler
+            )
+            floatingMessage?.dispose()
+            keywordSession?.cancel()
+            this._commandLine.clear()
+          }
 
-        keywordSession?.promise.then(keyword => {
-          if (settled) return
-          if (!keyword) {
+          keywordSession?.promise.then(keyword => {
+            if (settled) return
+            if (!keyword) {
+              cleanup()
+              reject(new Error('cancelled'))
+              return
+            }
             cleanup()
-            reject(new Error('cancelled'))
-            return
-          }
-          cleanup()
-          reject(new AcEdKeywordInputError(keyword))
-        })
+            reject(new AcEdKeywordInputError(keyword))
+          })
 
-        /** Mouse click → try select entity */
-        const clickHandler = (e: MouseEvent) => {
-          const pos = this.view.screenToWorld(
-            this.view.viewportToCanvas({ x: e.clientX, y: e.clientY })
-          )
-          const picked = this.view.pick(pos, undefined, true)
+          /** Mouse click → try select entity */
+          const clickHandler = (e: MouseEvent) => {
+            if (e.button === 2) {
+              if (this.shouldUseRightClickEnter() && options.allowNone) {
+                e.preventDefault()
+                cleanup()
+                resolve(null)
+              }
+              return
+            }
+            if (e.button !== 0) return
 
-          // Clicked empty space
-          if (picked.length == 0) {
-            this._commandLine.showError(options.rejectMessage)
-            return
-          }
+            const pos = this.view.screenToWorld(
+              this.view.viewportToCanvas({ x: e.clientX, y: e.clientY })
+            )
+            const picked = this.view.pick(pos, undefined, true)
 
-          const entity = this.getEntityById(picked[0].id)
-          if (!entity) {
-            this._commandLine.showError(options.rejectMessage)
-            return
-          }
+            // Clicked empty space
+            if (picked.length == 0) {
+              this._commandLine.showError(options.rejectMessage)
+              return
+            }
 
-          if (
-            !options.allowObjectOnLockedLayer &&
-            this.isEntityOnLockedLayer(entity)
-          ) {
-            this._commandLine.showError(options.rejectMessage)
-            return
-          }
+            const entity = this.getEntityById(picked[0].id)
+            if (!entity) {
+              this._commandLine.showError(options.rejectMessage)
+              return
+            }
 
-          if (!this.isEntityClassAllowed(entity, options)) {
-            this._commandLine.showError(options.rejectMessage)
-            return
-          }
+            if (
+              !options.allowObjectOnLockedLayer &&
+              this.isEntityOnLockedLayer(entity)
+            ) {
+              this._commandLine.showError(options.rejectMessage)
+              return
+            }
 
-          pickedPoint = { x: pos.x, y: pos.y, z: 0 }
-          cleanup()
-          resolve(picked[0].id)
-        }
+            if (!this.isEntityClassAllowed(entity, options)) {
+              this._commandLine.showError(options.rejectMessage)
+              return
+            }
 
-        /** Keyboard handling */
-        const keyHandler = (e: KeyboardEvent) => {
-          if (e.key === 'Escape') {
+            pickedPoint = { x: pos.x, y: pos.y, z: 0 }
             cleanup()
-            reject(new Error('cancelled'))
-            return
+            resolve(picked[0].id)
           }
 
-          if (e.key === 'Enter' && options.allowNone) {
-            cleanup()
-            resolve(null)
-          }
-        }
+          /** Keyboard handling */
+          const keyHandler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+              cleanup()
+              reject(new Error('cancelled'))
+              return
+            }
 
-        document.addEventListener('keydown', keyHandler)
-        this.view.canvas.addEventListener('mousedown', clickHandler)
-      })
-      return new AcEdPromptEntityResult(
-        AcEdPromptStatus.OK,
-        value || undefined,
-        pickedPoint
-      )
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptEntityResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        const result = new AcEdPromptEntityResult(AcEdPromptStatus.Keyword)
-        result.stringResult = error.keyword
-        return result
-      }
-      throw error
-    }
+            if (e.key === 'Enter' && options.allowNone) {
+              cleanup()
+              resolve(null)
+            }
+          }
+
+          const contextMenuHandler = (e: MouseEvent) => {
+            if (this.shouldUseRightClickEnter()) {
+              e.preventDefault()
+            }
+          }
+
+          document.addEventListener('keydown', keyHandler)
+          this.view.canvas.addEventListener('mousedown', clickHandler)
+          this.view.canvas.addEventListener('contextmenu', contextMenuHandler)
+        }),
+      value =>
+        new AcEdPromptEntityResult(
+          AcEdPromptStatus.OK,
+          value || undefined,
+          pickedPoint
+        ),
+      status => new AcEdPromptEntityResult(status),
+      { none: false }
+    )
   }
 
   /**
@@ -1137,75 +1241,67 @@ export class AcEdInputManager {
    * @returns A prompt result containing the final 2D box, cancel status, or keyword
    */
   async getBox(options: AcEdPromptBoxOptions): Promise<AcEdPromptBoxResult> {
-    try {
-      // Get first point
-      const message1 =
-        options.firstCornerMessage ||
-        AcApI18n.t('main.inputManager.firstCorner')
-      const options1 = new AcEdPromptPointOptions(message1)
-      this.copyKeywords(options, options1)
-      options1.useDashedLine = options.useDashedLine
-      options1.useBasePoint = options.useBasePoint
-      const p1Result = await this.getPoint(options1)
-      if (p1Result.status !== AcEdPromptStatus.OK) {
-        return new AcEdPromptBoxResult(
-          p1Result.status,
-          undefined,
-          p1Result.stringResult
-        )
-      }
-      const p1 = p1Result.value!
-      const cwcsP1 = this.view.worldToScreen(p1)
+    return this.executePrompt(
+      async () => {
+        // Get first point
+        const message1 =
+          options.firstCornerMessage ||
+          AcApI18n.t('main.inputManager.firstCorner')
+        const options1 = new AcEdPromptPointOptions(message1)
+        this.copyKeywords(options, options1)
+        options1.useDashedLine = options.useDashedLine
+        options1.useBasePoint = options.useBasePoint
+        const p1Result = await this.getPoint(options1)
+        if (p1Result.status !== AcEdPromptStatus.OK) {
+          return new AcEdPromptBoxResult(
+            p1Result.status,
+            undefined,
+            p1Result.stringResult
+          )
+        }
+        const p1 = p1Result.value!
+        const cwcsP1 = this.view.worldToScreen(p1)
 
-      // Create preview rectangle
-      const previewEl = document.createElement('div')
-      previewEl.className = 'ml-jig-preview-rect'
-      this.view.container.appendChild(previewEl)
+        // Create preview rectangle
+        const previewEl = document.createElement('div')
+        previewEl.className = 'ml-jig-preview-rect'
+        this.view.container.appendChild(previewEl)
 
-      const cleanup = () => {
-        previewEl.remove()
-      }
+        const cleanup = () => {
+          previewEl.remove()
+        }
 
-      const drawPreview = (pos: AcGePoint2dLike) => {
-        const cwcsP2 = this.view.worldToScreen(pos)
-        const left = Math.min(cwcsP2.x, cwcsP1.x)
-        const top = Math.min(cwcsP2.y, cwcsP1.y)
-        const width = Math.abs(cwcsP2.x - cwcsP1.x)
-        const height = Math.abs(cwcsP2.y - cwcsP1.y)
+        const drawPreview = (pos: AcGePoint2dLike) => {
+          const cwcsP2 = this.view.worldToScreen(pos)
+          const left = Math.min(cwcsP2.x, cwcsP1.x)
+          const top = Math.min(cwcsP2.y, cwcsP1.y)
+          const width = Math.abs(cwcsP2.x - cwcsP1.x)
+          const height = Math.abs(cwcsP2.y - cwcsP1.y)
 
-        Object.assign(previewEl.style, {
-          left: `${left}px`,
-          top: `${top}px`,
-          width: `${width}px`,
-          height: `${height}px`
-        })
-      }
+          Object.assign(previewEl.style, {
+            left: `${left}px`,
+            top: `${top}px`,
+            width: `${width}px`,
+            height: `${height}px`
+          })
+        }
 
-      // Second point
-      const message2 =
-        options.secondCornerMessage ||
-        AcApI18n.t('main.inputManager.secondCorner')
-      const options2 = new AcEdPromptPointOptions(message2)
-      this.copyKeywords(options, options2)
-      options2.useDashedLine = options.useDashedLine
-      options2.useBasePoint = options.useBasePoint
-      const p2 = await this.getPointInternal(options2, cleanup, drawPreview)
+        // Second point
+        const message2 =
+          options.secondCornerMessage ||
+          AcApI18n.t('main.inputManager.secondCorner')
+        const options2 = new AcEdPromptPointOptions(message2)
+        this.copyKeywords(options, options2)
+        options2.useDashedLine = options.useDashedLine
+        options2.useBasePoint = options.useBasePoint
+        const p2 = await this.getPointInternal(options2, cleanup, drawPreview)
 
-      const box = new AcGeBox2d().expandByPoint(p1).expandByPoint(p2)
-      return new AcEdPromptBoxResult(AcEdPromptStatus.OK, box)
-    } catch (error) {
-      if (this.isPromptCancelled(error)) {
-        return new AcEdPromptBoxResult(AcEdPromptStatus.Cancel)
-      }
-      if (this.isPromptKeyword(error)) {
-        return new AcEdPromptBoxResult(
-          AcEdPromptStatus.Keyword,
-          undefined,
-          error.keyword
-        )
-      }
-      throw error
-    }
+        const box = new AcGeBox2d().expandByPoint(p1).expandByPoint(p2)
+        return new AcEdPromptBoxResult(AcEdPromptStatus.OK, box)
+      },
+      value => value,
+      status => new AcEdPromptBoxResult(status)
+    )
   }
 
   /**
@@ -1378,6 +1474,49 @@ export class AcEdInputManager {
   }
 
   /**
+   * Returns whether an unknown error value represents PromptStatus.None.
+   *
+   * @param error - Unknown error value thrown from an input workflow
+   * @returns `true` if the error represents "no input" confirmation
+   */
+  private isPromptNone(error: unknown): boolean {
+    return error instanceof AcEdNoneInputError
+  }
+
+  /**
+   * Reads SHORTCUTMENU value from current working database.
+   *
+   * @returns Normalized 0..3 shortcut-menu mode
+   */
+  private getShortcutMenuMode(): number {
+    const db = acdbHostApplicationServices().workingDatabase
+    const raw = AcDbSysVarManager.instance().getVar(
+      AcDbSystemVariables.SHORTCUTMENU,
+      db
+    )
+    const value = Math.trunc(Number(raw))
+    if (Number.isNaN(value)) return 0
+    const normalized = value & 0x3
+    return normalized
+  }
+
+  /**
+   * Resolves right-click behavior for current prompt session.
+   *
+   * SHORTCUTMENU:
+   * 0 => always Enter
+   * 1 => Enter in command, menu when idle
+   * 2 => menu in command
+   * 3 => always menu
+   */
+  private shouldUseRightClickEnter() {
+    const mode = this.getShortcutMenuMode()
+    if (mode === 0) return true
+    if (mode === 1) return this.active
+    return false
+  }
+
+  /**
    * Synchronizes the stored modifier-key snapshot with a DOM keyboard event.
    *
    * Floating preview rendering depends on modifier state for behaviors such as
@@ -1527,6 +1666,9 @@ export class AcEdInputManager {
         'allowNone' in options.promptOptions
           ? (options.promptOptions as { allowNone: boolean }).allowNone
           : false
+      const defaultBehavior = this.resolvePromptDefaultValue(
+        options.promptOptions
+      )
       const floatingInput = new AcEdFloatingInput(this.view, {
         parent: this.view.canvas,
         inputCount: options.inputCount,
@@ -1537,6 +1679,8 @@ export class AcEdInputManager {
         baseAngle: promptDefaults.baseAngle,
         allowPrompt: options.allowPrompt !== false,
         allowNone,
+        useDefaultValue: defaultBehavior.useDefaultValue,
+        defaultValue: defaultBehavior.defaultValue,
         validate: validate,
         getDynamicValue: options.getDynamicValue,
         drawPreview: (pos: AcGePoint2dLike) => {
@@ -1561,7 +1705,8 @@ export class AcEdInputManager {
           }
           return result
         },
-        onCancel: () => rejector()
+        onCancel: () => rejector(),
+        onNone: () => noneRejector()
       })
       const cleanup = () => {
         if (settled) return
@@ -1573,6 +1718,7 @@ export class AcEdInputManager {
         document.removeEventListener('keydown', escHandler)
         document.removeEventListener('keydown', modifierHandler)
         document.removeEventListener('keyup', modifierHandler)
+        this.view.canvas.removeEventListener('contextmenu', contextMenuHandler)
         floatingInput.dispose()
         keywordSession?.cancel()
         this._commandLine.clear()
@@ -1586,6 +1732,10 @@ export class AcEdInputManager {
       const rejector = (err?: Error) => {
         cleanup()
         reject(err ?? new Error('cancelled'))
+      }
+
+      const noneRejector = () => {
+        rejector(new AcEdNoneInputError())
       }
 
       const keywordRejector = (keyword: string) => {
@@ -1604,9 +1754,15 @@ export class AcEdInputManager {
           floatingInput.requestPreviewRefresh()
         }
       }
+      const contextMenuHandler = (e: MouseEvent) => {
+        if (!this.shouldUseRightClickEnter()) return
+        e.preventDefault()
+        noneRejector()
+      }
       document.addEventListener('keydown', escHandler)
       document.addEventListener('keydown', modifierHandler)
       document.addEventListener('keyup', modifierHandler)
+      this.view.canvas.addEventListener('contextmenu', contextMenuHandler)
       // showAt() expects viewport coordinates; curMousePos is canvas-local.
       floatingInput.showAt(this.view.canvasToViewport(this.view.curMousePos))
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.7.16
-  '@mlightcad/libredwg-converter': ^3.5.16
+  '@mlightcad/data-model': ^1.7.18
+  '@mlightcad/libredwg-converter': ^3.5.18
   '@mlightcad/mtext-renderer': ^0.10.7
   element-plus: ^2.12.0
   three: ^0.172.0
@@ -105,11 +105,11 @@ importers:
   packages/cad-simple-viewer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.16
-        version: 1.7.16
+        specifier: ^1.7.18
+        version: 1.7.18
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.16
-        version: 3.5.16(@mlightcad/data-model@1.7.16)
+        specifier: ^3.5.18
+        version: 3.5.18(@mlightcad/data-model@1.7.18)
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -154,8 +154,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.16
-        version: 1.7.16
+        specifier: ^1.7.18
+        version: 1.7.18
 
   packages/cad-viewer:
     dependencies:
@@ -166,8 +166,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.16
-        version: 1.7.16
+        specifier: ^1.7.18
+        version: 1.7.18
       '@vueuse/core':
         specifier: ^11.1.0
         version: 11.3.0(vue@3.5.31(typescript@5.9.3))
@@ -236,8 +236,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.16
-        version: 1.7.16
+        specifier: ^1.7.18
+        version: 1.7.18
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -288,14 +288,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.16
-        version: 1.7.16
+        specifier: ^1.7.18
+        version: 1.7.18
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.16
-        version: 1.7.16
+        specifier: ^1.7.18
+        version: 1.7.18
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.7
         version: 0.10.7(three@0.172.0)
@@ -1359,33 +1359,33 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.4.16':
-    resolution: {integrity: sha512-0ApgFI11z2yywADawtOf94WvZYJEIN1K0Vw9qqXrHjFKFhwpvx4c2JD3JV1Y3D0D3wwhvFuU4IvPzKGpjffKUA==}
+  '@mlightcad/common@1.4.18':
+    resolution: {integrity: sha512-CYfNOvGv9v/k+DsUJ7niaDKEIxuQG5yu1EbqXn7webj+eWoaMoY5rv/v0IhAuy89Tb+bkdJ0YcPBTXRDWw+hLg==}
 
-  '@mlightcad/data-model@1.7.16':
-    resolution: {integrity: sha512-7Vruaii8z4pVtG3MSqQynkbdealGgyZypYLQbUbmf3tzU7XS/WRz1yVtCdVPbDU4RKHPBffOUVmSz/6pYaJMUA==}
+  '@mlightcad/data-model@1.7.18':
+    resolution: {integrity: sha512-MnWUpXvNPMXwWN5qewuOoMU3JIxIl4Dv1ED3wzycs613qAc0vo9iydQ6qrdnz5fYludv8wssvuVHnqJIyNKIsw==}
 
   '@mlightcad/dxf-json@1.1.3':
     resolution: {integrity: sha512-XslMIrowLI9VOs84/x4SmcsKSdNxSSGyEVrhJTFiSsB3CghtU2tzOmvDoCHCPa4jYCmYkQ1GK/rgQ+89wXXPgw==}
 
-  '@mlightcad/geometry-engine@3.2.16':
-    resolution: {integrity: sha512-xDOTNJZ78j6POyKdIGKXoK23o01jM97A2F6kRNtsFUD8r8wWA0nA4itS0OdUoDI4EI5/4bZZx8RKQ/g2nSO3kQ==}
+  '@mlightcad/geometry-engine@3.2.18':
+    resolution: {integrity: sha512-HFK+TFEkHfottSVQtLXfKGou88LikSrSdv0KShX6K94QLmjI3t6MdN9JoD3l6g0X/O8VzmLiQJuREuO8wAASCQ==}
     peerDependencies:
-      '@mlightcad/common': 1.4.16
+      '@mlightcad/common': 1.4.18
 
-  '@mlightcad/graphic-interface@3.3.16':
-    resolution: {integrity: sha512-1v30K/wKp0RBMCsRlq++xiTpPdszWAcFZppyGUFziVkgdIqLu7Zc0kHq6DY705C8VFCY5rt8LOt7a5tPz1ZfqQ==}
+  '@mlightcad/graphic-interface@3.3.18':
+    resolution: {integrity: sha512-sRHCEfyRrrn8+F6s/+pbecHN7aZoyDArpwpLKrAE922NcoOTMpEmmsP5J/FiRUOy4YAApULnESHlcVGtYloXQg==}
     peerDependencies:
-      '@mlightcad/common': 1.4.16
-      '@mlightcad/geometry-engine': 3.2.16
+      '@mlightcad/common': 1.4.18
+      '@mlightcad/geometry-engine': 3.2.18
 
-  '@mlightcad/libredwg-converter@3.5.16':
-    resolution: {integrity: sha512-JYubImkEBDQJRRT2zsAUfMsyvaMQnrX7koZsXah1iP5Mei9qvvr0F+RIdX/oMJ+AIlDLNuYWcIChO+CYpnvkzA==}
+  '@mlightcad/libredwg-converter@3.5.18':
+    resolution: {integrity: sha512-Mya0OgIt6uK2tJUM+SJ1hAF1lg1Esy//9gnaD2hAkTprTyoVTcUNkVWk+ix21StXLaul9zOBcwqIyAONWX2c7Q==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.16
+      '@mlightcad/data-model': ^1.7.18
 
-  '@mlightcad/libredwg-web@0.6.9':
-    resolution: {integrity: sha512-BZ713nAwuMcWUcbHuDYOqxrQTHBvT8lw3Eu6UedRYHo/UuxcZQloppJTV+uXtoJLFCtFJI5Evv4gLHmzjeDNIA==}
+  '@mlightcad/libredwg-web@0.6.10':
+    resolution: {integrity: sha512-yJ9bTyuKWTst2vEaYmWjW36bIM5xkfTPg3QhpbexdG+bqi7/UY/Jyp3X7tovcOv0HJ/gnDXV9RaeAs+IzUxJ5w==}
 
   '@mlightcad/mtext-input-box@0.2.3':
     resolution: {integrity: sha512-+PMrtMKS96yAI7FKc4xuwIyljQ2Uqg8+ccg7QiyIbY56CcTrOCLQQqt/6EHMQADIcZYobf21+9PkoBaGndgfHg==}
@@ -6119,16 +6119,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.4.16':
+  '@mlightcad/common@1.4.18':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.7.16':
+  '@mlightcad/data-model@1.7.18':
     dependencies:
-      '@mlightcad/common': 1.4.16
+      '@mlightcad/common': 1.4.18
       '@mlightcad/dxf-json': 1.1.3
-      '@mlightcad/geometry-engine': 3.2.16(@mlightcad/common@1.4.16)
-      '@mlightcad/graphic-interface': 3.3.16(@mlightcad/common@1.4.16)(@mlightcad/geometry-engine@3.2.16(@mlightcad/common@1.4.16))
+      '@mlightcad/geometry-engine': 3.2.18(@mlightcad/common@1.4.18)
+      '@mlightcad/graphic-interface': 3.3.18(@mlightcad/common@1.4.18)(@mlightcad/geometry-engine@3.2.18(@mlightcad/common@1.4.18))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
@@ -6136,21 +6136,21 @@ snapshots:
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.2.16(@mlightcad/common@1.4.16)':
+  '@mlightcad/geometry-engine@3.2.18(@mlightcad/common@1.4.18)':
     dependencies:
-      '@mlightcad/common': 1.4.16
+      '@mlightcad/common': 1.4.18
 
-  '@mlightcad/graphic-interface@3.3.16(@mlightcad/common@1.4.16)(@mlightcad/geometry-engine@3.2.16(@mlightcad/common@1.4.16))':
+  '@mlightcad/graphic-interface@3.3.18(@mlightcad/common@1.4.18)(@mlightcad/geometry-engine@3.2.18(@mlightcad/common@1.4.18))':
     dependencies:
-      '@mlightcad/common': 1.4.16
-      '@mlightcad/geometry-engine': 3.2.16(@mlightcad/common@1.4.16)
+      '@mlightcad/common': 1.4.18
+      '@mlightcad/geometry-engine': 3.2.18(@mlightcad/common@1.4.18)
 
-  '@mlightcad/libredwg-converter@3.5.16(@mlightcad/data-model@1.7.16)':
+  '@mlightcad/libredwg-converter@3.5.18(@mlightcad/data-model@1.7.18)':
     dependencies:
-      '@mlightcad/data-model': 1.7.16
-      '@mlightcad/libredwg-web': 0.6.9
+      '@mlightcad/data-model': 1.7.18
+      '@mlightcad/libredwg-web': 0.6.10
 
-  '@mlightcad/libredwg-web@0.6.9': {}
+  '@mlightcad/libredwg-web@0.6.10': {}
 
   '@mlightcad/mtext-input-box@0.2.3(@mlightcad/mtext-renderer@0.10.7(three@0.172.0))(three@0.172.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- Align prompt input behavior across command-line and floating input flows for default values, `AllowNone`, and keyword handling.
- Add AutoCAD-style keyword prompt formatting with explicit default keyword rendering (e.g. `[Yes/No] <Yes>:`).
- Introduce focused tests for keyword formatting/session behavior and Enter-priority behavior in floating input boxes.

## Why
- Prompt interactions had inconsistent outcomes for empty Enter across sessions/components.
- Right-click Enter behavior needed to respect `SHORTCUTMENU` semantics during active prompts.
- The input manager’s repeated error-to-status mapping logic was hard to maintain and easy to diverge.

## What Changed
- `AcEdKeywordCollection` / `AcEdPromptOptions`:
- Added structured keyword prompt formatting (`getPromptFormat` / `getKeywordPromptFormat`) including visible keywords, optional default, and final tail string.
- `AcEdCommandLine`:
- Updated keyword prompt rendering to include default keyword segment and canonical suffix formatting.
- `AcEdKeywordSession`:
- Implemented empty-Enter resolution order: default keyword -> none (when `allowNone`) -> invalid.
- `AcEdFloatingInputTypes` / `AcEdFloatingInput` / `AcEdFloatingInputBoxes`:
- Added `onNone`, `useDefaultValue`, and `defaultValue` plumbing.
- Updated Enter handling priority to submit default first, then none (if allowed), otherwise validate/invalid.
- `AcEdInputManager`:
- Added centralized prompt execution/error mapping helpers.
- Added internal `None` control flow (`AcEdNoneInputError`) and mapping to `PromptStatus.None`.
- Wired floating input `onNone` path and default-value extraction from prompt options.
- Added right-click handling gated by `SHORTCUTMENU` (`0/1 => Enter-like during command`).
- Applied centralized prompt execution pattern across prompt APIs (`getPoint`, numeric/string prompts, selection/entity/box, etc.).
- Dependencies:
- Bumped `@mlightcad/data-model` to `^1.7.18` and `@mlightcad/libredwg-converter` to `^3.5.18` (with lockfile updates).

## Testing
- [ ] Not run (PR text drafted from staged diff only; no test execution performed in this step)
- [x] Added unit tests for:
- Keyword prompt format + `PromptOptions` delegation
- Keyword session empty-Enter behavior matrix
- Floating input Enter priority and prompt option behavior matrix

## Risks / Notes
- `AcEdInputManager` was heavily refactored; status-mapping regressions are possible in less common prompt paths.
- Right-click behavior now depends on runtime `SHORTCUTMENU`; verify expected UX in environments with customized sysvar values.
- New default/none precedence may change command behavior where previous flows implicitly canceled on empty Enter.
