### PR TITLE
feat: improve ESM import support

### DIFF
--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -28,9 +28,11 @@
   "module": "./dist/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.umd.cjs"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
   },
   "scripts": {
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1075,9 +1075,8 @@ export class AcApDocManager {
         convertByEntityType: false,
         useWorker: true,
         parserWorkerUrl:
-          webworkerFileUrls && webworkerFileUrls.dxfParser
-            ? webworkerFileUrls.dxfParser
-            : './assets/dxf-parser-worker.js'
+          webworkerFileUrls?.dxfParser ??
+          new URL('./assets/dxf-parser-worker.js', import.meta.url)
       })
       AcDbDatabaseConverterManager.instance.register(
         AcDbFileType.DXF,
@@ -1093,9 +1092,8 @@ export class AcApDocManager {
         convertByEntityType: false,
         useWorker: true,
         parserWorkerUrl:
-          webworkerFileUrls && webworkerFileUrls.dwgParser
-            ? webworkerFileUrls.dwgParser
-            : './assets/libredwg-parser-worker.js'
+          webworkerFileUrls?.dwgParser ??
+          new URL('./assets/libredwg-parser-worker.js', import.meta.url)
       })
       AcDbDatabaseConverterManager.instance.register(
         AcDbFileType.DWG,
@@ -1121,9 +1119,8 @@ export class AcApDocManager {
   private registerWorkers(webworkerFileUrls?: AcApWebworkerFiles) {
     this.registerConverters(webworkerFileUrls)
     AcTrMTextRenderer.getInstance().initialize(
-      webworkerFileUrls && webworkerFileUrls.mtextRender
-        ? webworkerFileUrls.mtextRender
-        : './assets/mtext-renderer-worker.js'
+      webworkerFileUrls?.mtextRender ??
+        new URL('./assets/mtext-renderer-worker.js', import.meta.url)
     )
   }
 

--- a/packages/cad-simple-viewer/src/plugin/AcApPluginManager.ts
+++ b/packages/cad-simple-viewer/src/plugin/AcApPluginManager.ts
@@ -327,7 +327,6 @@ export class AcApPluginManager {
         const importPath = `${basePath}/${pluginFile.replace(/^\//, '')}`
 
         // Dynamically import the plugin module
-        // @ts-expect-error - Dynamic imports are supported at runtime in modern environments
         const module = await import(/* @vite-ignore */ importPath)
 
         // Get the plugin from the module

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -22,8 +22,10 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",

--- a/packages/svg-renderer/package.json
+++ b/packages/svg-renderer/package.json
@@ -18,9 +18,11 @@
   "module": "./dist/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.umd.cjs"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
   },
   "scripts": {
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",

--- a/packages/three-renderer/package.json
+++ b/packages/three-renderer/package.json
@@ -28,9 +28,11 @@
   "module": "./dist/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.umd.cjs"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
   },
   "scripts": {
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "es6",
+    "module": "es2020",
     "declaration": true,
     "declarationMap": true,
     "allowJs": false,


### PR DESCRIPTION
## Summary

Addresses **#140** — makes it possible to use the library via a standard ES module `import` statement without a custom build pipeline.

### Changes

**`tsconfig.base.json`**
- Upgrade `"module": "es6"` → `"module": "es2020"`. Vite handles the actual output format; `tsc` is used only for type-checking and `.d.ts` generation, so this is safe across all packages. This also enables native `import.meta` typing.

**`package.json` → `exports` field (all publishable packages)**
- Wrap the top-level condition shorthand with an explicit `"."` subpath entry — the standards-compliant form required by Node.js ESM, webpack 5, and modern Vite consumers:
  ```json
  // before (shorthand, not always honoured)
  "exports": { "types": "...", "import": "...", "require": "..." }

  // after (explicit subpath map)
  "exports": { ".": { "types": "...", "import": "...", "require": "..." } }
  ```

**`AcApDocManager.ts` — worker URL defaults**
- Replace hardcoded relative string paths (`'./assets/dxf-parser-worker.js'`) with `new URL('./assets/…', import.meta.url)`. Bundlers (Vite, webpack 5) recognise this pattern and resolve the worker asset relative to the **module** rather than the HTML document, which is necessary when the library is imported from `node_modules`. Consumers who already supply `webworkerFileUrls` are unaffected.

**`AcApPluginManager.ts`**
- Remove now-stale `@ts-expect-error` suppression — dynamic `import()` is properly typed under `"module": "es2020"`.

## Test plan

- [ ] `pnpm build` — all 6 packages build without errors.
- [ ] `pnpm test` — all test suites pass.
- [ ] `pnpm lint` — no new errors (pre-existing i18n warnings are unrelated).
- [ ] ESM consumer smoke-test: create a minimal `index.html` that imports `dist/index.js` as an ES module and verifies the viewer mounts without 404s on worker files.

## Scope

All changes are backwards-compatible. No public API surface changes. Worker URL override via `webworkerFileUrls` continues to work as before.

Closes #140