### PR TITLE
fix: correct ESM exports subpath map and upgrade module target to es2020

### DIFF
--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -28,9 +28,11 @@
   "module": "./dist/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.umd.cjs"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
   },
   "scripts": {
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",

--- a/packages/cad-simple-viewer/src/plugin/AcApPluginManager.ts
+++ b/packages/cad-simple-viewer/src/plugin/AcApPluginManager.ts
@@ -327,7 +327,6 @@ export class AcApPluginManager {
         const importPath = `${basePath}/${pluginFile.replace(/^\//, '')}`
 
         // Dynamically import the plugin module
-        // @ts-expect-error - Dynamic imports are supported at runtime in modern environments
         const module = await import(/* @vite-ignore */ importPath)
 
         // Get the plugin from the module

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -22,8 +22,10 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",

--- a/packages/svg-renderer/package.json
+++ b/packages/svg-renderer/package.json
@@ -18,9 +18,11 @@
   "module": "./dist/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.umd.cjs"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
   },
   "scripts": {
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",

--- a/packages/three-renderer/package.json
+++ b/packages/three-renderer/package.json
@@ -28,9 +28,11 @@
   "module": "./dist/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.umd.cjs"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
   },
   "scripts": {
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "es6",
+    "module": "es2020",
     "declaration": true,
     "declarationMap": true,
     "allowJs": false,


### PR DESCRIPTION
## Summary

This is a revised version of #215, which was reverted because it broke the dev server.

**Root cause of the previous PR's failure:** The previous version changed worker URL defaults from plain strings to `new URL('./assets/worker.js', import.meta.url)`. This broke dev/preview because `import.meta.url` inside the library module resolves relative to the library file, not the app's HTML root — causing the worker fetches to 404.

**This PR removes that change entirely.** Worker URL defaults are left as plain relative strings, which is correct: they are resolved by the browser against the HTML page root, where the app's static-copy plugin places the worker files.

## Changes

**`tsconfig.base.json`**
- `"module": "es6"` → `"module": "es2020"`. `tsc` is used only for type-checking and `.d.ts` generation; Vite controls the actual output format, so this is safe for all packages. This also enables proper `import.meta` typing and removes a now-stale `@ts-expect-error`.

**`package.json` → `exports` (all publishable packages)**
- Wrap top-level condition shorthand with an explicit `"."` subpath entry — required by the Node.js ESM resolution spec and webpack 5:
  ```json
  // before (shorthand — not always honoured by spec-compliant resolvers)
  "exports": { "types": "...", "import": "...", "require": "..." }

  // after (explicit subpath map — required form)
  "exports": {
    ".": { "types": "...", "import": "...", "require": "..." }
  }
  ```

**`AcApPluginManager.ts`**
- Remove stale `@ts-expect-error` comment above the `import()` call — it is no longer needed after the `es2020` module upgrade.

## Verified

- `pnpm build` — all 6 packages compile without errors
- `pnpm dev` — dev server starts, `/assets/dxf-parser-worker.js` returns **200** (not 404)
- Worker URL defaults in `AcApDocManager` are **unchanged**

Closes #140