### PR TITLE
fix: correct hatch draw order and COLORTHEME-aware fill colors

### DIFF
--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -165,10 +165,43 @@ export class AcTrView2d extends AcEdBaseView {
     this.backgroundColor = mergedOptions.background || 0x000000
     this._stats = this.createStats(AcApSettingManager.instance.isShowStats)
 
+    // Two sysvars can drive the canvas background:
+    //
+    // - WHITEBKCOLOR (boolean): the low-level "is the paper white?" flag
+    //   that the View has always honoured.
+    // - COLORTHEME (number): the AutoCAD-standard theme selector where
+    //   0 = dark theme (black bg) and 1 = light theme (white bg).
+    //
+    // The Vue composable `useDark` (cad-viewer) toggles only COLORTHEME
+    // when the user flips the theme.  Without this bridge, toggling the
+    // UI theme left WHITEBKCOLOR stale and the canvas kept its previous
+    // background even though `changeForeground` had been fired through
+    // MTEXT/line inversion — producing e.g. a black canvas in light mode
+    // or a white canvas in dark mode.
+    //
+    // Listening to both sysvars keeps either entry point working.  The
+    // two remain independent (settable in isolation) because setting
+    // `this.backgroundColor` is idempotent and the handler for each
+    // sysvar only fires when that specific variable changes.
     AcDbSysVarManager.instance().events.sysVarChanged.addEventListener(args => {
-      if (args.name === AcDbSystemVariables.WHITEBKCOLOR.toLowerCase()) {
+      const nameLower = args.name.toLowerCase()
+      if (nameLower === AcDbSystemVariables.WHITEBKCOLOR.toLowerCase()) {
         const useWhiteBackgroundColor = args.newVal as boolean
         this.backgroundColor = useWhiteBackgroundColor ? 0xffffff : 0
+      } else if (nameLower === AcDbSystemVariables.COLORTHEME.toLowerCase()) {
+        // COLORTHEME is registered with type 'number' in the data-model
+        // (0 = dark, 1 = light), but the sysvar bus does not strictly
+        // coerce values.  Normalise defensively so plugins setting the
+        // value as a string or boolean still behave correctly.
+        const newVal = args.newVal
+        const isLight =
+          typeof newVal === 'number'
+            ? newVal === 1
+            : typeof newVal === 'boolean'
+              ? newVal
+              : String(newVal).toLowerCase() === 'light' ||
+                String(newVal) === '1'
+        this.backgroundColor = isLight ? 0xffffff : 0
       }
     })
 
@@ -425,6 +458,28 @@ export class AcTrView2d extends AcEdBaseView {
   set backgroundColor(value: number) {
     this._renderer.setClearColor(value)
     this._renderer.changeForeground(value == 0 ? 0xffffff : 0)
+    // Keep solid ACI 7 hatches fused with the canvas background in
+    // both themes (matches AutoCAD, where such hatches vanish into
+    // the paper and only the overlaid wireframe stays visible).
+    //
+    // Setting `currentBackgroundColor` (instead of calling
+    // `changeBackground` directly) covers BOTH phases of the lifecycle:
+    //
+    // 1. Mid-session theme flip: every background-follow material
+    //    already in the material manager's cache is repainted to the
+    //    new bg — same as `changeBackground` alone would have done.
+    // 2. Initial boot (e.g. `useDark` sets dark theme before the DWG
+    //    finishes loading): the style manager stores the bg on its
+    //    options so hatch materials created LATER during `batchConvert`
+    //    are BORN with the correct bg colour.  Without this, the first
+    //    frame after load showed ACI 7 hatches as solid white on a
+    //    black canvas until the user manually toggled the theme.
+    //
+    // `changeForeground` above already handles the inverse flip for
+    // lines/text/MText; `currentBackgroundColor` is the symmetric
+    // counterpart for fills opted into `isBackgroundFill` by
+    // `AcTrFillMaterialManager.shouldTrackBackground`.
+    this._renderer.currentBackgroundColor = value
     this.editor.setCursorColor(value == 0 ? 'white' : 'black')
     applyUiThemeFromBackground(value)
     this._isDirty = true

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -692,6 +692,28 @@ export class AcTrBatchedGroup extends THREE.Group {
         AcTrBatchedGroup.INITIAL_MESH_INDEX_CAPACITY,
         material
       )
+      // Draw-order tiering by primitive type, matching AutoCAD's
+      // default SortentsTable behaviour:
+      //
+      //   renderOrder = -1  → hatch / solid area fills
+      //   renderOrder =  0  → lines, points, text glyph meshes (default)
+      //
+      // All CAD geometry lives on the same Z plane, so depth test alone
+      // cannot decide which primitive wins on a shared pixel.  Without
+      // explicit `renderOrder`, THREE sorts opaque objects by material
+      // id — effectively random — and white HATCH fills end up painted
+      // over BYLAYER outlines (tower DWG: interior floor divisions were
+      // invisible in both light and dark themes because the fills were
+      // drawn after the lines).
+      //
+      // Text glyphs are meshes too but must stay ABOVE lines, so they
+      // keep the default `0`.  They are distinguished from hatches via
+      // `material.userData.isTextFill`, stamped by
+      // `AcTrFillMaterialManager.createMaterialImpl` when the MText
+      // renderer requests a fill material via `getMTextFillMaterial`.
+      if (!material.userData.isTextFill) {
+        batchedMesh.renderOrder = -1
+      }
       batches.set(material.id, batchedMesh)
       this.add(batchedMesh)
     }

--- a/packages/three-renderer/src/renderer/AcTrMTextRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrMTextRenderer.ts
@@ -23,7 +23,15 @@ class AcTrMTextStyleManager implements StyleManager {
 
   getMeshBasicMaterial(traits: ColorSettings): THREE.Material {
     const entityTraits = AcTrSubEntityTraitsUtil.createTraitsForMText(traits)
-    return this._styleManager.getFillMaterial(entityTraits)
+    // Route MText glyph fills through `getMTextFillMaterial` so they
+    // keep COLORTHEME inversion (ACI 7 text must stay legible) while
+    // hatch / solid area fills go through `getFillMaterial` and skip
+    // the inversion (AutoCAD keeps ACI 7 hatches at their resolved
+    // RGB regardless of theme).  Using the dedicated method also
+    // partitions the material cache so text glyphs never share a
+    // material with a hatch that happens to have matching colour and
+    // layer.
+    return this._styleManager.getMTextFillMaterial(entityTraits)
   }
 
   getLineBasicMaterial(traits: ColorSettings): THREE.Material {

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -106,6 +106,48 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
   }
 
   /**
+   * Repaints every material that was registered as a background-follow
+   * fill (currently: solid hatches whose resolved colour is ACI 7).
+   *
+   * This is the symmetric counterpart of `changeForeground`: foreground
+   * materials take the *opposite* of the canvas colour (so lines/text
+   * stay legible), while background-fill materials take the canvas
+   * colour itself (so ACI 7 hatches vanish into the paper and only the
+   * wireframe remains visible).  Callers should invoke both after a
+   * theme flip — typically inside `AcTrView2d.backgroundColor`.
+   *
+   * Prefer setting `currentBackgroundColor` instead of calling this
+   * directly: the setter writes the colour into the style manager
+   * options BEFORE firing the repaint, so materials created AFTER the
+   * setter runs (e.g. hatches from a DWG still being parsed) are born
+   * with the correct colour.  Calling `changeBackground` on its own
+   * only repaints materials that already exist in the cache.
+   *
+   * @param color - New background color (typically the canvas bg).
+   */
+  changeBackground(color: number) {
+    this._styleManager.changeBackground(color)
+  }
+
+  /**
+   * The canvas background colour tracked by the style manager.
+   *
+   * Reading returns the value last written here (or the default
+   * `0x000000`).  Writing both stores the colour on the style manager
+   * options (so materials created LATER inherit it) and repaints every
+   * background-follow material already in the cache (so materials
+   * created EARLIER track the new colour).  This is the correct entry
+   * point for `AcTrView2d.backgroundColor` — `changeBackground` on its
+   * own only covers the second half.
+   */
+  get currentBackgroundColor(): number {
+    return this._styleManager.currentBackgroundColor
+  }
+  set currentBackgroundColor(value: number) {
+    this._styleManager.currentBackgroundColor = value
+  }
+
+  /**
    * Sets the clear color used when clearing the canvas.
    *
    * @param color - Background color as 24-bit hexadecimal RGB number

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -18,6 +18,19 @@ export interface AcTrFillMaterialOptions {
    * keeps the (now CW-wound) triangles — with zero fillrate overhead.
    */
   side?: AcTrMaterialSide
+  /**
+   * Whether this fill material is for a text glyph (MText renderer)
+   * rather than a hatch / solid area fill.  Defaults to `false`.
+   *
+   * Text glyph fills must follow COLORTHEME inversion so that ACI 7
+   * text stays legible against both light and dark backgrounds.
+   * Hatch / solid area fills do NOT invert — AutoCAD keeps them on
+   * their resolved RGB regardless of theme.  This flag partitions
+   * the two into separate cache keys so that an MText glyph sharing
+   * colour + layer with a nearby hatch does not end up in the same
+   * material (their `userData.isForeground` values must differ).
+   */
+  isTextFill?: boolean
 }
 
 /**
@@ -47,7 +60,63 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const traits = this.keyToTraits[key]
     if (!traits) return material
 
+    // Propagate `isTextFill` into the back-side variant so mirrored
+    // text glyphs keep their draw-order tier (above lines / hatches).
+    // `keyToTraits` stores the full options alongside traits, so we
+    // preserve that payload and only override `side`.
     return this.getMaterial(traits, { ...traits, side: 'back' })
+  }
+
+  /**
+   * Only text glyph fills follow COLORTHEME inversion (i.e. get their
+   * colour flipped to the *opposite* of the canvas bg so that ACI 7
+   * text stays legible on both light and dark themes).
+   *
+   * Hatch / solid area fills never invert — when their resolved colour
+   * is the foreground (ACI 7) they follow the bg instead via
+   * `shouldTrackBackground`, so they fuse with the paper and leave
+   * the wireframe visible.  Inverting hatch fills the same way we
+   * invert lines produced the pre-fix bug where ACI 7 hatches became
+   * solid black rectangles in light mode, covering the wireframe.
+   *
+   * Text glyphs rendered through `AcTrMTextRenderer` share this
+   * manager (MText glyph geometry is a mesh fill), but their
+   * contract is the opposite of hatches: they must stay legible
+   * against the theme bg.  The `isTextFill` option — set exclusively
+   * by `AcTrStyleManager.getMTextFillMaterial` — routes text fills
+   * through `shouldTrackForeground` and hatches through
+   * `shouldTrackBackground`, without leaking the distinction into
+   * consumer code.
+   */
+  protected shouldTrackForeground(
+    traits: AcGiSubEntityTraits,
+    options: AcTrFillMaterialOptions
+  ): boolean {
+    return options.isTextFill === true && traits.color.isForeground
+  }
+
+  /**
+   * Solid hatch fills whose resolved colour is the foreground (ACI 7)
+   * must follow the canvas background colour rather than keep an
+   * absolute RGB — AutoCAD renders them as if they were painted with
+   * the paper colour, so they fuse into both light and dark bgs and
+   * only the overlaid wireframe remains visible.
+   *
+   * Text glyph fills (`isTextFill: true`) are explicitly excluded:
+   * they go through `changeForeground` instead (ACI 7 text flips to
+   * the *opposite* of the bg so it stays legible).
+   *
+   * Hatches with an explicit RGB (including truecolor white) fall
+   * outside this rule — `traits.color.isForeground` is only true for
+   * the ACI 7 / foreground pseudo-colour, so a DWG author who picked
+   * `255,255,255` via the truecolor picker still gets a literal white
+   * hatch.
+   */
+  protected shouldTrackBackground(
+    traits: AcGiSubEntityTraits,
+    options: AcTrFillMaterialOptions
+  ): boolean {
+    return options.isTextFill !== true && traits.color.isForeground
   }
 
   /**
@@ -61,18 +130,48 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const side = options.side ?? 'front'
     const threeSide = side === 'back' ? THREE.BackSide : THREE.FrontSide
 
+    // Background-follow fills must be BORN with the current canvas
+    // bg, not with their resolved trait RGB.  Without this, opening a
+    // DWG in dark theme shows ACI 7 hatches as solid white on the
+    // first frame — `changeBackground` iterates only materials already
+    // in the cache, so it cannot fix materials created AFTER the theme
+    // was set.  Overriding `rgbColor` here lets the existing
+    // `createMeshBasicMaterial` / `createHatchShaderMaterial` helpers
+    // stay untouched while the material still lands on the right
+    // `userData.isBackgroundFill` bucket for future repaints.
+    const effectiveTraits: AcGiSubEntityTraits = this.shouldTrackBackground(
+      traits,
+      options
+    )
+      ? { ...traits, rgbColor: this.options.currentBackgroundColor }
+      : traits
+
     let material: THREE.Material
     if (!style.definitionLines || style.definitionLines.length < 1) {
-      material = this.createMeshBasicMaterial(traits, threeSide)
+      material = this.createMeshBasicMaterial(effectiveTraits, threeSide)
     } else if (style.definitionLines.some(line => !line.dashLengths)) {
       log.warn('Invalid dash pattern', style)
-      material = this.createMeshBasicMaterial(traits, threeSide)
+      material = this.createMeshBasicMaterial(effectiveTraits, threeSide)
     } else {
-      material = this.createHatchShaderMaterial(traits, options, threeSide)
+      material = this.createHatchShaderMaterial(
+        effectiveTraits,
+        options,
+        threeSide
+      )
     }
 
     // Store side in userData so getBackSideVariant can check idempotency
     material.userData.side = side
+    // Stamp `isTextFill` so downstream consumers (notably
+    // `AcTrBatchedGroup.addMesh`) can differentiate text glyph meshes
+    // from hatch/solid area fills when deciding draw order.  AutoCAD's
+    // default `SortentsTable` puts hatches BELOW linework and text
+    // ABOVE it; without this marker both would be batched as generic
+    // meshes and end up in the same THREE render queue slot, causing
+    // hatches to occlude BYLAYER outlines (see tower DWG where interior
+    // floor divisions disappear because white hatches paint over the
+    // dark BYLAYER lines).
+    material.userData.isTextFill = options.isTextFill === true
     return material
   }
 
@@ -198,9 +297,18 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
   /**
    * Build a deterministic caching key based on traits and options.
    *
-   * The `side` dimension is appended only when it differs from the
-   * default (`'front'`), keeping existing keys stable and avoiding
-   * unnecessary cache fragmentation for the common non-mirrored path.
+   * Two partitioning dimensions beyond colour/layer/pattern:
+   *
+   * - `side`: `'back'` variant goes in a separate key so mirrored
+   *   fills don't steal the front-side material of the common path.
+   * - `isTextFill`: text glyph fills (from `AcTrMTextRenderer`) must
+   *   not share a material instance with hatch/solid area fills even
+   *   when colour + layer match, because their `userData.isForeground`
+   *   values differ (text inverts with COLORTHEME, hatch does not).
+   *
+   * Both suffixes are appended only when they differ from the
+   * default, keeping existing keys stable and avoiding unnecessary
+   * cache fragmentation on the common path.
    */
   protected buildKey(
     traits: AcGiSubEntityTraits,
@@ -208,11 +316,19 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
   ): string {
     const style = traits.fillType
     const sideSuffix = options.side === 'back' ? '_back' : ''
+    const textSuffix = options.isTextFill ? '_text' : ''
+    // Foreground-tracking fills (solid hatches with ACI 7) get their
+    // own partition so `changeBackground` can mutate them in place
+    // without affecting any literal-RGB hatch that happens to share
+    // layer + colour.  The suffix is appended only when the condition
+    // matches, keeping the common path's keys bit-identical.
+    const bgSuffix =
+      options.isTextFill !== true && traits.color.isForeground ? '_bgfill' : ''
 
     // Use color + layer + rebaseOffset + pattern info for key
     const isSolid = !style.definitionLines || style.definitionLines.length === 0
     if (isSolid) {
-      return `solid_${traits.layer}_${traits.rgbColor}${sideSuffix}`
+      return `solid_${traits.layer}_${traits.rgbColor}${sideSuffix}${textSuffix}${bgSuffix}`
     }
 
     const patternHash = style.definitionLines
@@ -222,6 +338,6 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
       )
       .join('|')
 
-    return `hatch_${traits.layer}_${traits.rgbColor}_${style.patternAngle}_${patternHash}${sideSuffix}`
+    return `hatch_${traits.layer}_${traits.rgbColor}_${style.patternAngle}_${patternHash}${sideSuffix}${textSuffix}${bgSuffix}`
   }
 }

--- a/packages/three-renderer/src/style/AcTrMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrMaterialManager.ts
@@ -154,6 +154,41 @@ export abstract class AcTrMaterialManager<T> {
   }
 
   /**
+   * Changes material color to the specified color if its userData
+   * 'isBackgroundFill' is true — i.e. fills that should fuse with the
+   * canvas background instead of carrying an absolute RGB.
+   *
+   * AutoCAD renders solid hatches whose colour resolves to the
+   * foreground (ACI 7) by painting them with the **background** colour,
+   * so they vanish against the paper in both light and dark themes and
+   * only the overlaid wireframe remains visible.  `changeForeground`
+   * handles the inverse flip (lines/text stay legible); this method is
+   * the symmetric counterpart for fills that must follow the canvas
+   * colour rather than its inverse.
+   *
+   * Only the fill material manager opts materials into this behaviour
+   * (see `AcTrFillMaterialManager.shouldTrackBackground`); managers for
+   * lines, points and text glyphs return `false` by default, so their
+   * caches are a no-op here.
+   *
+   * @param color - New rendering color (typically the canvas background).
+   */
+  changeBackground(color: number) {
+    for (const oldKey of Object.keys(this.cache)) {
+      const oldMaterial = this.cache[oldKey]
+      const data = oldMaterial.userData || {}
+
+      const isTarget = data.isBackgroundFill
+      if (!isTarget) continue
+
+      const oldTraits = this.keyToTraits[oldKey]
+      if (!oldTraits) continue
+
+      AcTrMaterialUtil.setMaterialColor(oldMaterial, new THREE.Color(color))
+    }
+  }
+
+  /**
    * Clears all cached materials.
    */
   dispose(): void {
@@ -179,7 +214,16 @@ export abstract class AcTrMaterialManager<T> {
    * Creates a THREE.js material and stores metadata in userData:
    *   - layer
    *   - isByLayer
+   *   - isForeground      (inverts with COLORTHEME — lines/text/MText)
+   *   - isBackgroundFill  (follows canvas bg — solid ACI 7 hatches)
    *   - materialKey (cache key, used by getBackSideVariant for reverse lookup)
+   *
+   * `isForeground` and `isBackgroundFill` are mutually exclusive in
+   * practice: the former flips a material to the colour *opposite* the
+   * canvas bg (so ACI 7 text stays legible), whereas the latter paints
+   * the material with the canvas bg itself (so ACI 7 hatches fuse with
+   * the paper and leave the wireframe visible).  Subclasses enforce the
+   * split via `shouldTrackForeground` and `shouldTrackBackground`.
    */
   protected createMaterial(
     key: string,
@@ -191,7 +235,11 @@ export abstract class AcTrMaterialManager<T> {
     // Attach metadata required for layer updates and side-variant lookups
     material.userData.layer = traits.layer
     material.userData.isByLayer = this.isByLayer(traits)
-    material.userData.isForeground = traits.color.isForeground
+    material.userData.isForeground = this.shouldTrackForeground(traits, options)
+    material.userData.isBackgroundFill = this.shouldTrackBackground(
+      traits,
+      options
+    )
     material.userData.materialKey = key
 
     this.cache[key] = material
@@ -201,6 +249,49 @@ export abstract class AcTrMaterialManager<T> {
   /** Returns true if either color or linetype is ByLayer. */
   protected isByLayer(traits: AcGiSubEntityTraits): boolean {
     return traits.color.isByLayer || traits.lineType.type === 'ByLayer'
+  }
+
+  /**
+   * Whether materials from this manager should follow COLORTHEME
+   * inversion (i.e. be flipped by `changeForeground`).
+   *
+   * The default implementation delegates to `AcCmColor.isForeground`,
+   * so lines, points and text glyph fills keep inverting ACI 7 with
+   * the theme to preserve legibility (dark stroke on light background
+   * / light stroke on dark background).
+   *
+   * Subclasses can override this to opt a primitive type out of the
+   * inversion — `AcTrFillMaterialManager` uses `options.isTextFill`
+   * to distinguish text glyph fills (invert) from hatch/solid area
+   * fills (do NOT invert — AutoCAD keeps ACI 7 hatches at their
+   * resolved RGB in both themes).
+   */
+  protected shouldTrackForeground(
+    traits: AcGiSubEntityTraits,
+    _options: T
+  ): boolean {
+    return traits.color.isForeground
+  }
+
+  /**
+   * Whether materials from this manager should follow the canvas
+   * background colour — i.e. be repainted by `changeBackground` when
+   * the theme flips.
+   *
+   * Default is `false`: lines, points and text glyph fills never fuse
+   * with the background — they need to stay visible against it.
+   *
+   * `AcTrFillMaterialManager` overrides this to opt solid hatch fills
+   * whose resolved colour is the foreground (ACI 7) into the
+   * background-follow behaviour, matching AutoCAD's rendering where
+   * such hatches vanish into the paper in both light and dark themes
+   * and only the overlaid wireframe remains visible.
+   */
+  protected shouldTrackBackground(
+    _traits: AcGiSubEntityTraits,
+    _options: T
+  ): boolean {
+    return false
   }
 
   /** Subclass must build stable key. */

--- a/packages/three-renderer/src/style/AcTrStyleManager.ts
+++ b/packages/three-renderer/src/style/AcTrStyleManager.ts
@@ -28,7 +28,11 @@ export class AcTrStyleManager {
     viewportScaleUniform: 1.0,
     maxFragmentUniforms: 1024,
     resolution: new THREE.Vector2(1, 1),
-    showLineWeight: false
+    showLineWeight: false,
+    // Matches DEFAULT_VIEW_2D_OPTIONS.background in cad-simple-viewer.
+    // The setter below keeps this in sync with the canvas bg and fires
+    // `changeBackground` so existing materials are repainted on a flip.
+    currentBackgroundColor: 0x000000
   }
   private pointMgr: AcTrPointMaterialManager
   private lineMgr: AcTrLineMaterialManager
@@ -89,6 +93,40 @@ export class AcTrStyleManager {
   }
 
   /**
+   * Current canvas background colour tracked by the style manager.
+   *
+   * See `AcTrStyleManagerOptions.currentBackgroundColor` for the full
+   * contract.  In short: this is the single source of truth that the
+   * fill material manager consults when creating a background-follow
+   * material so it is born with the right colour, and it is also what
+   * `changeBackground` repaints existing materials to when the theme
+   * flips mid-session.
+   */
+  get currentBackgroundColor(): number {
+    return this.options.currentBackgroundColor
+  }
+
+  /**
+   * Updates the canvas background colour and repaints existing
+   * background-follow materials so they track the new colour.
+   *
+   * Order matters:
+   * 1. Write to `options.currentBackgroundColor` first, so any material
+   *    created AFTER this point (e.g. hatches from a DWG that finishes
+   *    loading later in the boot sequence) is born with the new colour.
+   * 2. Fire `changeBackground(value)` so materials already in the
+   *    cache (created BEFORE the flip) are repainted in place.
+   *
+   * Together these cover both the mid-session theme toggle (step 2
+   * alone) and the initial boot-in-dark edge case where the theme is
+   * set before the DWG finishes parsing (step 1 alone).
+   */
+  set currentBackgroundColor(value: number) {
+    this.options.currentBackgroundColor = value
+    this.changeBackground(value)
+  }
+
+  /**
    * Returns the shader hatch material or a mesh fallback.
    *
    * @param traits - Current entity traits.
@@ -100,6 +138,35 @@ export class AcTrStyleManager {
   ): THREE.Material {
     return this.fillMgr.getMaterial(traits, {
       rebaseOffset
+    })
+  }
+
+  /**
+   * Returns a fill material for MText glyph geometry.
+   *
+   * MText glyphs are rendered as mesh fills, so they share the
+   * `AcTrFillMaterialManager` with hatches — but the two have
+   * opposite COLORTHEME semantics: text must stay legible against
+   * the theme background (invert ACI 7 with the theme), whereas
+   * hatches keep their resolved RGB in both themes.  This method
+   * sets the `isTextFill` option so the fill manager opts the
+   * resulting material into `changeForeground` inversion AND
+   * keeps it in a separate cache slot from any hatch that happens
+   * to share colour + layer.
+   *
+   * @param traits - Current entity traits (built via
+   *                 `AcTrSubEntityTraitsUtil.createTraitsForMText`).
+   * @param rebaseOffset - Offset used to transform pattern origins
+   *                       (unused for solid glyph fills, kept for
+   *                       API symmetry with `getFillMaterial`).
+   */
+  getMTextFillMaterial(
+    traits: AcGiSubEntityTraits,
+    rebaseOffset: THREE.Vector2 = _rebaseOffset
+  ): THREE.Material {
+    return this.fillMgr.getMaterial(traits, {
+      rebaseOffset,
+      isTextFill: true
     })
   }
 
@@ -148,6 +215,24 @@ export class AcTrStyleManager {
     this.lineMgr.changeForeground(color)
     this.pointMgr.changeForeground(color)
     this.fillMgr.changeForeground(color)
+  }
+
+  /**
+   * Repaints every material marked as `isBackgroundFill` with the
+   * given colour — used to keep ACI 7 solid hatches fused with the
+   * canvas bg as the theme flips (see `AcTrFillMaterialManager`).
+   *
+   * Point and line managers currently never opt materials into this
+   * behaviour, so their delegation is a no-op; keeping it symmetric
+   * with `changeForeground` allows future managers to opt in without
+   * touching the callers.
+   *
+   * @param color - New rendering color (typically the canvas bg).
+   */
+  changeBackground(color: number) {
+    this.lineMgr.changeBackground(color)
+    this.pointMgr.changeBackground(color)
+    this.fillMgr.changeBackground(color)
   }
 
   /**

--- a/packages/three-renderer/src/style/AcTrStyleManagerOptions.ts
+++ b/packages/three-renderer/src/style/AcTrStyleManagerOptions.ts
@@ -34,4 +34,23 @@ export interface AcTrStyleManagerOptions {
    * - `false`: force basic line materials with 1px width
    */
   showLineWeight: boolean
+
+  /**
+   * Current canvas background colour, as a 24-bit RGB number.
+   *
+   * Used by `AcTrFillMaterialManager` when a solid hatch is opted into
+   * background-follow behaviour (`shouldTrackBackground === true`): the
+   * material is *born* with this colour instead of its resolved trait
+   * colour, so it fuses with the paper on the very first frame — even
+   * when the DWG is loaded AFTER the theme has already been set.
+   *
+   * Kept in sync with `AcTrView2d.backgroundColor` via
+   * `AcTrStyleManager.currentBackgroundColor` (whose setter also fires
+   * `changeBackground(value)` on every manager so materials created
+   * before the flip are repainted).
+   *
+   * Default is `0x000000` (matches the default view bg in
+   * `DEFAULT_VIEW_2D_OPTIONS`).
+   */
+  currentBackgroundColor: number
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                            
                                                                                                                                                                                                      
  Fixes a family of rendering bugs around solid hatches resolved to the foreground pseudo-colour (ACI 7):
                                                                                                                                                                                                        
  1. **Draw order** — ACI 7 solid hatches covered BYLAYER outlines because all meshes ended up in the same THREE render queue slot with sorting by material id (effectively random). On a tower DWG, interior floor divisions vanished behind white rectangles in light mode and dark rectangles in dark mode.                                                                                             
  2. **Theme tracking** — solid ACI 7 hatches kept an absolute RGB regardless of the canvas theme, so toggling light/dark left the fills painted in the previous theme's background colour.           
  3. **Boot-in-dark** — hatches created during `batchConvert` rendered with the default trait RGB on the first frame even when the theme was already flipped, only correcting themselves after a manual re-toggle.                                                                                                                                                                                            
                                                                                                                                                                                                        
  ## What changes                                                                                                                                                                                       
                                                                                                                                                                                                        
  - **`AcTrBatchedGroup`** — tag hatch / solid-fill meshes with `renderOrder = -1` so they draw below linework and text (matches AutoCAD's default `SortentsTable` ordering). Text glyph meshes go through the same batch path but keep the default tier via `material.userData.isTextFill`.                                                                                                             
  - **`AcTrFillMaterialManager`** — new `isTextFill` option partitions text glyph fills from hatch fills. Text glyphs follow COLORTHEME inversion (stay legible); hatches follow the canvas background (fuse with the paper). Cache keys gain `_text` / `_bgfill` suffixes **only** when applicable, so the common non-ACI-7 path stays bit-identical.                                                       
  - **`AcTrMaterialManager`** — new `shouldTrackForeground` / `shouldTrackBackground` hooks plus a `changeBackground(color)` method symmetric to the existing `changeForeground`. Defaults preserve current behaviour; only the fill manager opts materials in.                                                                                                                                      
  - **`AcTrStyleManager` / `AcTrStyleManagerOptions` / `AcTrRenderer`** — new `currentBackgroundColor` tracked field. Setter both stores the bg on the style manager options (so materials created later are born with it) and fires `changeBackground` (so cached materials are repainted). Closes the boot-in-dark edge case.                                                                               
  - **`AcTrView2d`** — react to the `COLORTHEME` sysvar as well. Previously only `WHITEBKCOLOR` was bridged, but the Vue-side theme toggle (`useDark`) only flips `COLORTHEME`, so flipping the UI theme left the canvas background stale. Both sysvars remain independently settable.                                                                                                                        
  - **`AcTrMTextRenderer`** — route MText glyph fills through the new `AcTrStyleManager.getMTextFillMaterial` so they land in the `isTextFill` partition and never share a material instance with a hatch of the same colour + layer.                                                                                                                                                                   
                                                                                                                                                                                                        
  ## Performance                                                                                                                                                                                      
                                                                                                                                                                                                        
  Cache fragmentation is opt-in. The `_text` and `_bgfill` suffixes only attach when the relevant conditions match, so drawings without ACI 7 hatches or MText produce the exact same cache keys (and therefore the same batch count and draw calls) as before this PR.                                                                                                                                     
                                                                   
  ## Depends on                                                                                                                                                                                         
                                                                                                                                                                                                      
  [mlightcad/realdwg-web#59](https://github.com/mlightcad/realdwg-web/pull/59) — preserves the DWG's truecolor when the entity carries both RGB and ACI index, so ACI 254 with a custom palette doesn't fall through to the ACI 7 path. The fix in this PR is correct on its own but only takes full effect once that upstream PR is released and bumped here.                                        
                                                                                                                                                                
  ## Test plan                                                                                                                                                                                          
                                                                                                                                                                                                      
  - [ ] Open a DWG whose tower / interior layout uses BYLAYER outlines with ACI 7 solid hatches. Interior floor divisions are visible in both light and dark themes (hatches fuse with the paper).
  - [ ] Open any DWG with ACI 7 MText over a hatch. Glyphs remain legible against both theme backgrounds.                                                                                               
  - [ ] Toggle COLORTHEME via the theme button in the UI. Hatches flip colour with the paper on the same frame; MText and linework flip the opposite way and stay legible.
  - [ ] Start the app in dark theme (persisted via `useDark`) and open a DWG with ACI 7 hatches. First frame renders correctly — no manual re-toggle required.                                          
  - [ ] Open a drawing with only linework / points / no hatches. No visual regression; batch count unchanged.