### PR TITLE
fix: fix nested block reference osnap transforms and insertion points

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@mlightcad/data-model": "^1.7.22",
-      "@mlightcad/libredwg-converter": "^3.5.22",
+      "@mlightcad/data-model": "^1.7.23",
+      "@mlightcad/libredwg-converter": "^3.5.23",
       "@mlightcad/mtext-renderer": "^0.10.7",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",

--- a/packages/cad-simple-viewer/__tests__/AcTrHierarchicalSpatialIndex.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrHierarchicalSpatialIndex.spec.ts
@@ -1,0 +1,94 @@
+jest.mock('rbush', () => {
+  class RBushMock<
+    T extends { minX: number; minY: number; maxX: number; maxY: number }
+  > {
+    private items: T[] = []
+
+    insert(item: T) {
+      this.items.push(item)
+    }
+
+    load(items: readonly T[]) {
+      this.items.push(...items)
+    }
+
+    remove(item: T, equals?: (a: T, b: T) => boolean) {
+      if (equals) {
+        const index = this.items.findIndex(entry => equals(entry, item))
+        if (index >= 0) this.items.splice(index, 1)
+        return
+      }
+      const index = this.items.indexOf(item)
+      if (index >= 0) this.items.splice(index, 1)
+    }
+
+    clear() {
+      this.items = []
+    }
+
+    search(bbox: { minX: number; minY: number; maxX: number; maxY: number }) {
+      return this.items.filter(
+        item =>
+          !(
+            item.maxX < bbox.minX ||
+            item.minX > bbox.maxX ||
+            item.maxY < bbox.minY ||
+            item.minY > bbox.maxY
+          )
+      )
+    }
+
+    collides(bbox: { minX: number; minY: number; maxX: number; maxY: number }) {
+      return this.search(bbox).length > 0
+    }
+
+    all() {
+      return [...this.items]
+    }
+  }
+
+  return {
+    __esModule: true,
+    default: RBushMock
+  }
+})
+
+import { AcTrHierarchicalSpatialIndex } from '../src/spatialIndex/AcTrHierarchicalSpatialIndex'
+
+describe('AcTrHierarchicalSpatialIndex', () => {
+  test('does not pollute child index with root item when objectId is reused', () => {
+    const spatialIndex = new AcTrHierarchicalSpatialIndex()
+    const insertId = 'INSERT_ID'
+
+    spatialIndex.ensureChildIndex(insertId, [
+      {
+        minX: 1,
+        minY: 1,
+        maxX: 2,
+        maxY: 2,
+        id: 'SUB_ENTITY_ID'
+      }
+    ])
+
+    spatialIndex.insert({
+      minX: 0,
+      minY: 0,
+      maxX: 10,
+      maxY: 10,
+      id: insertId
+    })
+
+    const hits = spatialIndex.search({
+      minX: 0,
+      minY: 0,
+      maxX: 3,
+      maxY: 3
+    })
+
+    expect(hits).toHaveLength(1)
+    expect(hits[0].id).toBe(insertId)
+    expect(hits[0].children?.map((item: { id: string }) => item.id)).toEqual([
+      'SUB_ENTITY_ID'
+    ])
+  })
+})

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -481,10 +481,12 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     gsMark?: AcDbObjectId
   ) {
     const start = osnapPoints.length
+    const pickPoint = { ...this.view.curPos, z: 0 }
+    const lastPoint = this.lastPoint ? { ...this.lastPoint, z: 0 } : pickPoint
     entity.subGetOsnapPoints(
       osnapMode,
-      { ...this.view.curPos, z: 0 },
-      this.lastPoint,
+      pickPoint,
+      lastPoint,
       osnapPoints,
       gsMark
     )

--- a/packages/cad-simple-viewer/src/spatialIndex/AcTrHierarchicalSpatialIndex.ts
+++ b/packages/cad-simple-viewer/src/spatialIndex/AcTrHierarchicalSpatialIndex.ts
@@ -44,29 +44,74 @@ export class AcTrHierarchicalSpatialIndex implements AcTrSpatialIndex {
   private readonly rootIndex: AcTrSpatialIndex<AcEdSpatialQueryResultItem>
   private readonly childIndexes = new Map<string, AcTrSpatialIndex>()
 
+  /**
+   * Creates a hierarchical spatial index instance.
+   *
+   * The provided root index stores first-level, coarse-grained items. When no
+   * index is provided, an R-tree based implementation is used by default to
+   * balance insertion and query performance on typical CAD datasets.
+   *
+   * @param rootIndex Optional first-level spatial index implementation.
+   */
   constructor(rootIndex?: AcTrSpatialIndex<AcEdSpatialQueryResultItem>) {
     this.rootIndex = rootIndex ?? new AcTrRBushSpatialIndex()
   }
 
-  /** Register second-level index for an id */
+  /**
+   * Registers or replaces a second-level spatial index for a root item id.
+   *
+   * This only updates the child index map; it does not insert or update the
+   * corresponding first-level item in the root index.
+   *
+   * @param id Root item id that owns the child index.
+   * @param index Child index containing fine-grained geometry/items for `id`.
+   */
   setChildIndex(id: string, index: AcTrSpatialIndex): void {
     this.childIndexes.set(id, index)
   }
 
-  /** Remove second-level index */
+  /**
+   * Removes a registered second-level index by root item id.
+   *
+   * If no child index is registered for the id, this method is a no-op.
+   *
+   * @param id Root item id whose child index should be removed.
+   */
   removeChildIndex(id: string): void {
     this.childIndexes.delete(id)
   }
 
+  /**
+   * Inserts one first-level item into the root spatial index.
+   *
+   * This method does not create or update any child index automatically.
+   *
+   * @param item The coarse-grained item to insert.
+   */
   insert(item: AcEdSpatialQueryResultItem): void {
     this.rootIndex.insert(item)
-    this.childIndexes.get(item.id)?.insert(item)
   }
 
+  /**
+   * Bulk-loads first-level items into the root spatial index.
+   *
+   * Existing child indexes are not modified by this operation.
+   *
+   * @param items First-level items to be loaded.
+   */
   load(items: readonly AcEdSpatialQueryResultItem[]): void {
     this.rootIndex.load(items)
   }
 
+  /**
+   * Removes one first-level item from the root index and clears its child index.
+   *
+   * The child index bound to `item.id` is always deleted to avoid stale
+   * second-level data even when custom equality logic is used.
+   *
+   * @param item The root item to remove.
+   * @param equals Optional custom equality function used by the root index.
+   */
   remove(
     item: AcEdSpatialQueryResultItem,
     equals?: (
@@ -78,17 +123,41 @@ export class AcTrHierarchicalSpatialIndex implements AcTrSpatialIndex {
     this.childIndexes.delete(item.id)
   }
 
+  /**
+   * Removes one first-level item by id and clears its child index.
+   *
+   * @param id Id of the root item to remove.
+   */
   removeById(id: AcDbObjectId): void {
     this.rootIndex.removeById(id)
     this.childIndexes.delete(id)
   }
 
+  /**
+   * Clears all indexed data from both hierarchy levels.
+   *
+   * This method clears the root index, then clears each child index instance,
+   * and finally removes all child index references from the map.
+   */
   clear(): void {
     this.rootIndex.clear()
     this.childIndexes.forEach(i => i.clear())
     this.childIndexes.clear()
   }
 
+  /**
+   * Performs a hierarchical search against the given bounding box.
+   *
+   * Query flow:
+   * 1. Search the root index for candidate hits.
+   * 2. For each hit:
+   *    - if no child index exists, return the root-level hit directly;
+   *    - if a child index exists, search the child and attach results under
+   *      `children`.
+   *
+   * @param bbox Query bounding box.
+   * @returns Aggregated search results from both levels.
+   */
   search(bbox: AcTrSpatialIndexBBox): AcEdSpatialQueryResultItemEx[] {
     const level1 = this.rootIndex.search(bbox)
     const result: AcEdSpatialQueryResultItemEx[] = []
@@ -110,6 +179,17 @@ export class AcTrHierarchicalSpatialIndex implements AcTrSpatialIndex {
     return result
   }
 
+  /**
+   * Tests whether any indexed item collides with the given bounding box.
+   *
+   * A fast root-level rejection is performed first. If root-level candidates
+   * exist, each candidate is checked as follows:
+   * - without child index: treated as colliding immediately;
+   * - with child index: delegated to child-level `collides`.
+   *
+   * @param bbox Query bounding box.
+   * @returns `true` if at least one collision is found; otherwise `false`.
+   */
   collides(bbox: AcTrSpatialIndexBBox): boolean {
     if (!this.rootIndex.collides(bbox)) return false
 
@@ -120,6 +200,15 @@ export class AcTrHierarchicalSpatialIndex implements AcTrSpatialIndex {
     })
   }
 
+  /**
+   * Returns all indexed items in a flattened form.
+   *
+   * For each root-level hit:
+   * - if a child index exists, all child items are appended;
+   * - otherwise the root-level item itself is appended.
+   *
+   * @returns Flattened list of all available items across both levels.
+   */
   all(): AcEdSpatialQueryResultItem[] {
     const result: AcEdSpatialQueryResultItem[] = []
 
@@ -132,21 +221,78 @@ export class AcTrHierarchicalSpatialIndex implements AcTrSpatialIndex {
     return result
   }
 
-  createChildIndex(group: AcTrGroup) {
-    const size = group.boxes.length
-    let spatialIndex: AcTrSpatialIndex | undefined = undefined
-    if (size > AcTrHierarchicalSpatialIndex.THRESHOLD) {
-      spatialIndex = new AcTrRBushSpatialIndex()
-    } else if (size > 0) {
-      spatialIndex = new AcTrLinearSpatialIndex()
+  /**
+   * Checks whether a second-level index exists for the specified id.
+   *
+   * @param id Root item id.
+   * @returns `true` if a child index is registered for `id`.
+   */
+  hasChildIndex(id: AcDbObjectId) {
+    return this.childIndexes.has(id)
+  }
+
+  /**
+   * Ensures a second-level index exists for a root id and optionally initializes it.
+   *
+   * Behavior:
+   * - if a child index already exists, it is returned as-is;
+   * - otherwise an index type is selected by `items.length`;
+   * - selected index is populated with `items`, stored, and returned.
+   *
+   * No index is created for empty input (`items.length === 0`), and `undefined`
+   * is returned in that case.
+   *
+   * @param id Root object id that owns the child index.
+   * @param items Child items used to initialize a newly created index.
+   * @returns Existing or newly created child index, or `undefined` for empty input.
+   */
+  ensureChildIndex(
+    id: AcDbObjectId,
+    items: readonly AcEdSpatialQueryResultItem[]
+  ) {
+    if (this.hasChildIndex(id)) {
+      return this.childIndexes.get(id)
     }
 
-    if (spatialIndex) {
-      group.boxes.forEach(box => {
-        spatialIndex.insert(box)
-      })
-      this.setChildIndex(group.objectId, spatialIndex)
-    }
+    const spatialIndex = this.createIndexBySize(items.length)
+    if (!spatialIndex) return undefined
+
+    items.forEach(item => spatialIndex.insert(item))
+    this.setChildIndex(id, spatialIndex)
     return spatialIndex
+  }
+
+  /**
+   * Creates or retrieves the child index for a group object.
+   *
+   * This is a convenience wrapper around `ensureChildIndex`, using the group's
+   * `objectId` and `boxes` as id and initialization data.
+   *
+   * @param group Group providing id and child box items.
+   * @returns Existing or newly created child index, or `undefined` when empty.
+   */
+  createChildIndex(group: AcTrGroup) {
+    return this.ensureChildIndex(group.objectId, group.boxes)
+  }
+
+  /**
+   * Chooses a child index implementation by item count.
+   *
+   * Selection strategy:
+   * - `size > THRESHOLD`: use R-tree index for better large-set query performance;
+   * - `0 < size <= THRESHOLD`: use linear index to minimize setup overhead;
+   * - `size <= 0`: return `undefined` (no index required).
+   *
+   * @param size Number of child items.
+   * @returns A child index instance or `undefined` for empty datasets.
+   */
+  private createIndexBySize(size: number) {
+    if (size > AcTrHierarchicalSpatialIndex.THRESHOLD) {
+      return new AcTrRBushSpatialIndex()
+    }
+    if (size > 0) {
+      return new AcTrLinearSpatialIndex()
+    }
+    return undefined
   }
 }

--- a/packages/cad-simple-viewer/src/view/AcTrLayout.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayout.ts
@@ -2,7 +2,7 @@ import { AcDbObjectId, AcGeBox2d, AcGeBox3d } from '@mlightcad/data-model'
 import { AcTrEntity, AcTrGroup } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 
-import { AcEdLayerInfo } from '../editor'
+import { AcEdLayerInfo, AcEdSpatialQueryResultItem } from '../editor'
 import { AcTrHierarchicalSpatialIndex } from '../spatialIndex'
 import { AcTrLayer, AcTrLayerStats } from './AcTrLayer'
 
@@ -293,8 +293,18 @@ export class AcTrLayout {
       maxY: box.max.y,
       id: entity.objectId
     })
-    // If it is one block, we need to build spatial index for entities in this block
-    if (entity instanceof AcTrGroup) {
+
+    // Some INSERT rendering paths split one block reference into multiple layer
+    // groups (AcTrEntity instead of AcTrGroup). Keep child-box index via userData
+    // so object snap can still resolve gsMark to sub-entities.
+    const spatialIndexChildBoxes = this.getSpatialIndexChildBoxes(entity)
+    if (spatialIndexChildBoxes) {
+      this._spatialIndex.ensureChildIndex(
+        entity.objectId,
+        spatialIndexChildBoxes
+      )
+    } else if (entity instanceof AcTrGroup) {
+      // If it is one block group, build spatial index for entities in this block.
       this._spatialIndex.createChildIndex(entity)
     }
 
@@ -465,5 +475,34 @@ export class AcTrLayout {
       }
     }
     return layers
+  }
+
+  /**
+   * Gets optional child bounding boxes used to build a child-level spatial index
+   * for one render entity.
+   *
+   * Some rendering paths (for example INSERT decomposition across layers) cannot
+   * provide a single `AcTrGroup` hierarchy for child indexing. In these cases,
+   * precomputed child query items are attached to `entity.userData` and consumed
+   * here so snapping and fine-grained spatial queries can still resolve
+   * sub-entities correctly.
+   *
+   * @param entity - The render entity that may carry `spatialIndexChildBoxes` in
+   *                 its `userData`.
+   * @returns The child query boxes when available and non-empty; otherwise
+   *          `undefined`.
+   */
+  private getSpatialIndexChildBoxes(entity: AcTrEntity) {
+    const boxes = (
+      entity.userData as {
+        spatialIndexChildBoxes?: AcEdSpatialQueryResultItem[]
+      }
+    ).spatialIndexChildBoxes
+
+    if (!boxes || boxes.length === 0) {
+      return undefined
+    }
+
+    return boxes
   }
 }

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -34,6 +34,7 @@ import {
   AcEdCalculateSizeCallback,
   AcEdConditionWaiter,
   AcEdCorsorType,
+  AcEdSpatialQueryResultItem,
   AcEdSpatialQueryResultItemEx,
   AcEdViewMode,
   applyUiThemeFromBackground,
@@ -1053,6 +1054,11 @@ export class AcTrView2d extends AcEdBaseView {
     const groupObjectId = group.objectId
     const groupLayerName = group.layerName
     const groupBox = group.box
+    const groupChildBoxes: AcEdSpatialQueryResultItem[] = group.boxes.map(
+      box => ({
+        ...box
+      })
+    )
     objectsGroupByLayer.forEach((objects, layerName) => {
       // In AutoCAD, an INSERT entity may reference multiple child entities that
       // reside on different layers. During rendering, this engine groups entities
@@ -1068,6 +1074,10 @@ export class AcTrView2d extends AcEdBaseView {
       // definition is '0', it should be put on layer where the group exist.
       entity.layerName = layerName === '0' ? groupLayerName : layerName
       entity.box = groupBox
+      const entityUserData = entity.userData as {
+        spatialIndexChildBoxes?: AcEdSpatialQueryResultItem[]
+      }
+      entityUserData.spatialIndexChildBoxes = groupChildBoxes
 
       // Important:
       // DO NOT USE spread operator when adding objects because it may be one very large array

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.7.22
-  '@mlightcad/libredwg-converter': ^3.5.22
+  '@mlightcad/data-model': ^1.7.23
+  '@mlightcad/libredwg-converter': ^3.5.23
   '@mlightcad/mtext-renderer': ^0.10.7
   element-plus: ^2.12.0
   three: ^0.172.0
@@ -105,11 +105,11 @@ importers:
   packages/cad-simple-viewer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.22
-        version: 1.7.22
+        specifier: ^1.7.23
+        version: 1.7.23
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.22
-        version: 3.5.22(@mlightcad/data-model@1.7.22)
+        specifier: ^3.5.23
+        version: 3.5.23(@mlightcad/data-model@1.7.23)
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -154,8 +154,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.22
-        version: 1.7.22
+        specifier: ^1.7.23
+        version: 1.7.23
 
   packages/cad-viewer:
     dependencies:
@@ -166,8 +166,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.22
-        version: 1.7.22
+        specifier: ^1.7.23
+        version: 1.7.23
       '@vueuse/core':
         specifier: ^11.1.0
         version: 11.3.0(vue@3.5.31(typescript@5.9.3))
@@ -239,8 +239,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.22
-        version: 1.7.22
+        specifier: ^1.7.23
+        version: 1.7.23
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -294,14 +294,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.22
-        version: 1.7.22
+        specifier: ^1.7.23
+        version: 1.7.23
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.22
-        version: 1.7.22
+        specifier: ^1.7.23
+        version: 1.7.23
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.7
         version: 0.10.7(three@0.172.0)
@@ -1365,30 +1365,30 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.4.22':
-    resolution: {integrity: sha512-3yjAUhRiU4RW0LDnZG/+0yWbHsq/UizVm0koWKilF5EXFivjv+oOnizBjF5BEfrp3W3s2rc5cleS118xNIm6Ag==}
+  '@mlightcad/common@1.4.23':
+    resolution: {integrity: sha512-QV+QRJDi4sS8COk/JinK+UWC3a+c8ZEzWzxjkpTWN4NAgogipB39QXHj7v1Gw4CuxI0QBRiJVdBnJWefi4C3gg==}
 
-  '@mlightcad/data-model@1.7.22':
-    resolution: {integrity: sha512-MLs2jeWPzPHiYiteNO40J9H5xHua2Gx/sCYZK+sSkqLTnetQLVPHunbbzE7nd1BpdrF3Qb+5j4PqZWuaH9278A==}
+  '@mlightcad/data-model@1.7.23':
+    resolution: {integrity: sha512-KFW7UIIBu1JTIGt0lr9dvwS/2H17UWiNmM7WFONtlSNILu/Fm9gZEJk6vY8dmJQE4RHyqLNkQLMivzwC+gaB/A==}
 
   '@mlightcad/dxf-json@1.1.3':
     resolution: {integrity: sha512-XslMIrowLI9VOs84/x4SmcsKSdNxSSGyEVrhJTFiSsB3CghtU2tzOmvDoCHCPa4jYCmYkQ1GK/rgQ+89wXXPgw==}
 
-  '@mlightcad/geometry-engine@3.2.22':
-    resolution: {integrity: sha512-kCp/2zKj4207ZbbpYU5MHwpX/hX6c9f2yM9sbDU4em2goUvaLvzY2bk5W1MlzGGFDOysVlypjR0YEWlZdeoplA==}
+  '@mlightcad/geometry-engine@3.2.23':
+    resolution: {integrity: sha512-P8RlpOKZW/2M2Uvk7vp1/6qDQalaSR//J4AvsIHZCbyK4td4M3N2pZw9ph1urZ3YymqScUYujPY7UEvVilgifw==}
     peerDependencies:
-      '@mlightcad/common': 1.4.22
+      '@mlightcad/common': 1.4.23
 
-  '@mlightcad/graphic-interface@3.3.22':
-    resolution: {integrity: sha512-RIyXIzHOv+FKI4Xh9tIt1aN88yo6PJ7xFof+FRxlXI6SO/qu2UQ3B11BeCowaiAl1B1D5fYCwwSRZL+1lJnKxQ==}
+  '@mlightcad/graphic-interface@3.3.23':
+    resolution: {integrity: sha512-I2ejwO8xgNeX/K72Dxl1COTJuaclXmzHdVHlXcMGH6xr8oCQulTnWFstk4OjCieEZUMlPNiNZNcUEAGEHR2NwQ==}
     peerDependencies:
-      '@mlightcad/common': 1.4.22
-      '@mlightcad/geometry-engine': 3.2.22
+      '@mlightcad/common': 1.4.23
+      '@mlightcad/geometry-engine': 3.2.23
 
-  '@mlightcad/libredwg-converter@3.5.22':
-    resolution: {integrity: sha512-8jHTsZvSDuJlbChQcN4YCgx/m4UuEBnui4RQ+1XCrdd6Fil7qB/LTnxXR5KDwCPcZXQ0qtvf6t5q5XZLM+M97g==}
+  '@mlightcad/libredwg-converter@3.5.23':
+    resolution: {integrity: sha512-EgY05ZmxtXJ/fLFTb1Oq4H7bAPheil7Idu8DsNDQZ/sh6BySy2kRaS26GiE6s/gnmohRJKiKbobxIRrixuLQ1A==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.22
+      '@mlightcad/data-model': ^1.7.23
 
   '@mlightcad/libredwg-web@0.6.10':
     resolution: {integrity: sha512-yJ9bTyuKWTst2vEaYmWjW36bIM5xkfTPg3QhpbexdG+bqi7/UY/Jyp3X7tovcOv0HJ/gnDXV9RaeAs+IzUxJ5w==}
@@ -6152,16 +6152,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.4.22':
+  '@mlightcad/common@1.4.23':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.7.22':
+  '@mlightcad/data-model@1.7.23':
     dependencies:
-      '@mlightcad/common': 1.4.22
+      '@mlightcad/common': 1.4.23
       '@mlightcad/dxf-json': 1.1.3
-      '@mlightcad/geometry-engine': 3.2.22(@mlightcad/common@1.4.22)
-      '@mlightcad/graphic-interface': 3.3.22(@mlightcad/common@1.4.22)(@mlightcad/geometry-engine@3.2.22(@mlightcad/common@1.4.22))
+      '@mlightcad/geometry-engine': 3.2.23(@mlightcad/common@1.4.23)
+      '@mlightcad/graphic-interface': 3.3.23(@mlightcad/common@1.4.23)(@mlightcad/geometry-engine@3.2.23(@mlightcad/common@1.4.23))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
@@ -6169,18 +6169,18 @@ snapshots:
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.2.22(@mlightcad/common@1.4.22)':
+  '@mlightcad/geometry-engine@3.2.23(@mlightcad/common@1.4.23)':
     dependencies:
-      '@mlightcad/common': 1.4.22
+      '@mlightcad/common': 1.4.23
 
-  '@mlightcad/graphic-interface@3.3.22(@mlightcad/common@1.4.22)(@mlightcad/geometry-engine@3.2.22(@mlightcad/common@1.4.22))':
+  '@mlightcad/graphic-interface@3.3.23(@mlightcad/common@1.4.23)(@mlightcad/geometry-engine@3.2.23(@mlightcad/common@1.4.23))':
     dependencies:
-      '@mlightcad/common': 1.4.22
-      '@mlightcad/geometry-engine': 3.2.22(@mlightcad/common@1.4.22)
+      '@mlightcad/common': 1.4.23
+      '@mlightcad/geometry-engine': 3.2.23(@mlightcad/common@1.4.23)
 
-  '@mlightcad/libredwg-converter@3.5.22(@mlightcad/data-model@1.7.22)':
+  '@mlightcad/libredwg-converter@3.5.23(@mlightcad/data-model@1.7.23)':
     dependencies:
-      '@mlightcad/data-model': 1.7.22
+      '@mlightcad/data-model': 1.7.23
       '@mlightcad/libredwg-web': 0.6.10
 
   '@mlightcad/libredwg-web@0.6.10': {}


### PR DESCRIPTION
## PR Description
## Summary
- Correct object snap resolution in `AcDbBlockReference` by propagating cumulative insertion transforms through nested block references.
- Transform pick/last points into block-local space before querying sub-entity osnap points.
- Return insertion snap points in world space using block base point + full insertion transform.
- Add regression tests for transformed pick-point snapping and nested block-reference osnap traversal.

## Why
- Osnap queries against sub-entities in transformed/nested block references could return incorrect coordinates because world/local transforms were not consistently applied.
- Insertion osnap behavior needed to honor parent insertion context and block origin in nested scenarios.

## What Changed
- Extended `subGetOsnapPoints(...)` with an optional cumulative `insertionMat` parameter.
- Reworked `subEntityGetOsnapPoints(...)` to:
- Track visited block references to prevent recursion loops.
- Build cumulative transforms per nesting level.
- Query sub-entities in local space and map results back to world space correctly.
- Added helpers for insertion-point and full insertion-transform computation.
- Updated base `AcDbEntity.subGetOsnapPoints(...)` signature/docs to include the optional insertion matrix.
- Added tests in `AcDbBlockReference.spec.ts` for:
- Pick-point transformation before nearest osnap query.
- End-point osnap resolution through nested block references.

## Testing
- [x] Added/updated unit tests in `packages/data-model/__tests__/AcDbBlockReference.spec.ts`
- [ ] Not run (drafted from git diff context only)

## Risks / Notes
- Method signature change (`subGetOsnapPoints` adds optional parameter) is backward-compatible at call sites but may require attention for custom overrides/implementations.
- Nested traversal now depends on recursion with visited-set guards; edge cases with unusual reference graphs should continue to be monitored.
