### PR TITLE
feat: improve PNG export bounds handling and add export menu entry

### DIFF
--- a/packages/cad-simple-viewer-example/index.html
+++ b/packages/cad-simple-viewer-example/index.html
@@ -212,6 +212,13 @@
           <button
             type="button"
             class="file-list-item"
+            data-file-url="https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/data/block-color.dxf"
+          >
+            block-color.dxf
+          </button>
+          <button
+            type="button"
+            class="file-list-item"
             data-file-url="https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/data/lockers.dwg"
           >
             lockers.dwg

--- a/packages/cad-simple-viewer/src/command/convert/AcApConvertToPngCmd.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApConvertToPngCmd.ts
@@ -8,7 +8,10 @@ import {
   AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { AcTrView2d } from '../../view'
 import { AcApPngConvertor } from './AcApPngConvertor'
+
+const DEFAULT_LONG_SIDE_PX = 1024
 
 /**
  * Command for exporting the current CAD drawing to PNG format.
@@ -16,7 +19,7 @@ import { AcApPngConvertor } from './AcApPngConvertor'
  * This command creates a PNG converter and initiates the conversion
  * process to export the current drawing as a PNG file. The command:
  * - Creates a new PNG converter instance
- * - Prompts for optional bounding box (or press Enter to use drawing extents)
+ * - Prompts for an export bounding box
  * - Prompts for optional long side pixel value (or press Enter for default)
  * - Converts the current view to PNG format
  * - Automatically downloads the PNG file
@@ -35,48 +38,148 @@ export class AcApConvertToPngCmd extends AcEdCommand {
    * Executes the PNG conversion command.
    *
    * Prompts the user for:
-   * 1. Optional bounding box (press Enter to skip and use drawing extents)
-   * 2. Optional long side pixel value (press Enter for default 8000)
+   * 1. Export bounding box
+   * 2. Optional long side pixel value (press Enter for default 1024)
    *
    * @param _context - The application context (unused in this command)
    */
   async execute(_context: AcApContext) {
     const converter = new AcApPngConvertor()
+    const view = AcApDocManager.instance.curView as AcTrView2d
+    this.syncActiveLayoutViewSize(view)
 
-    // Prompt for bounding box (optional - press Enter to skip)
+    // Prompt for export bounds.
     const boxOptions = new AcEdPromptBoxOptions(
-      AcApI18n.t('pngout.boundsFirstCorner'),
-      AcApI18n.t('pngout.boundsSecondCorner')
+      AcApI18n.t('jig.pngout.boundsFirstCorner'),
+      AcApI18n.t('jig.pngout.boundsSecondCorner')
     )
+    // Export window corners should follow exact click positions.
+    boxOptions.disableOSnap = true
     const boxResult = await AcApDocManager.instance.editor.getBox(boxOptions)
 
     let bounds: AcGeBox2d
     if (boxResult.status === AcEdPromptStatus.OK && boxResult.value) {
-      bounds = boxResult.value
-    } else {
-      // fallback - use drawing extents
-      const db = AcApDocManager.instance.curDocument.database
-      const ext = db.extents
-      bounds = new AcGeBox2d(
-        new AcGePoint2d(ext.min.x, ext.min.y),
-        new AcGePoint2d(ext.max.x, ext.max.y)
+      const expandedBounds = this.expandBoundsToEntityExtents(
+        boxResult.value,
+        view
       )
+      bounds = expandedBounds.bounds
+    } else if (boxResult.status === AcEdPromptStatus.None) {
+      bounds = this.getCurrentDrawingBounds()
+    } else {
+      // User canceled or prompt failed: abort command gracefully.
+      return
     }
 
-    // Prompt for long side value (optional - press Enter for default 8000)
+    // Prompt for long side value (optional - press Enter for default 1024)
     const longSidePrompt = new AcEdPromptDoubleOptions(
-      AcApI18n.t('pngout.longSidePrompt')
+      `${AcApI18n.t('jig.pngout.longSidePrompt')} <${DEFAULT_LONG_SIDE_PX}>`
     )
     longSidePrompt.allowNone = true
+    longSidePrompt.allowNegative = false
+    longSidePrompt.allowZero = false
+    longSidePrompt.defaultValue = DEFAULT_LONG_SIDE_PX
+    longSidePrompt.useDefaultValue = true
     const longSideResult =
       await AcApDocManager.instance.editor.getDouble(longSidePrompt)
+
+    if (
+      longSideResult.status === AcEdPromptStatus.Cancel ||
+      longSideResult.status === AcEdPromptStatus.Error
+    ) {
+      return
+    }
 
     const longSide =
       longSideResult.status === AcEdPromptStatus.OK &&
       longSideResult.value !== undefined
         ? longSideResult.value
-        : 8000
+        : DEFAULT_LONG_SIDE_PX
 
     converter.convert(bounds, longSide)
+  }
+
+  /**
+   * Returns the current drawing extents projected to XY bounds.
+   */
+  private getCurrentDrawingBounds(): AcGeBox2d {
+    const db = AcApDocManager.instance.curDocument.database
+    const ext = db.extents
+    return new AcGeBox2d(
+      new AcGePoint2d(ext.min.x, ext.min.y),
+      new AcGePoint2d(ext.max.x, ext.max.y)
+    )
+  }
+
+  /**
+   * Expands user-picked bounds to include extents of intersected entities.
+   *
+   * This avoids cutting entities when the pick box touches their geometry
+   * edges (for example anti-aliased line caps or text glyph overhangs).
+   */
+  private expandBoundsToEntityExtents(
+    userBounds: AcGeBox2d,
+    view: AcTrView2d
+  ): { bounds: AcGeBox2d; expanded: boolean } {
+    const hits = view.search(userBounds)
+    const entityBounds = new AcGeBox2d()
+    let hasEntityBounds = false
+
+    const expandByItem = (item: {
+      minX: number
+      minY: number
+      maxX: number
+      maxY: number
+      children?: Array<{
+        minX: number
+        minY: number
+        maxX: number
+        maxY: number
+      }>
+    }) => {
+      entityBounds.expandByPoint(new AcGePoint2d(item.minX, item.minY))
+      entityBounds.expandByPoint(new AcGePoint2d(item.maxX, item.maxY))
+      hasEntityBounds = true
+
+      item.children?.forEach(child => {
+        entityBounds.expandByPoint(new AcGePoint2d(child.minX, child.minY))
+        entityBounds.expandByPoint(new AcGePoint2d(child.maxX, child.maxY))
+      })
+    }
+
+    hits.forEach(hit => expandByItem(hit))
+
+    if (!hasEntityBounds || entityBounds.isEmpty()) {
+      return { bounds: userBounds, expanded: false }
+    }
+
+    const merged = new AcGeBox2d()
+      .expandByPoint(userBounds.min)
+      .expandByPoint(userBounds.max)
+      .expandByPoint(entityBounds.min)
+      .expandByPoint(entityBounds.max)
+
+    const expanded =
+      merged.min.x !== userBounds.min.x ||
+      merged.min.y !== userBounds.min.y ||
+      merged.max.x !== userBounds.max.x ||
+      merged.max.y !== userBounds.max.y
+
+    return { bounds: merged, expanded }
+  }
+
+  /**
+   * Keeps active layout-view size in sync with current view size.
+   *
+   * This guards against stale screen-to-world mapping after container layout
+   * changes that do not fire a window resize event.
+   */
+  private syncActiveLayoutViewSize(view: AcTrView2d) {
+    const layoutView = view.activeLayoutView
+    if (!layoutView) {
+      return
+    }
+
+    layoutView.resize(view.width, view.height)
   }
 }

--- a/packages/cad-simple-viewer/src/command/convert/AcApPngConvertor.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApPngConvertor.ts
@@ -11,22 +11,6 @@ import { AcTrView2d } from '../../view'
  * to PNG format and download it as a file. It renders the current view
  * using WebGLRenderTarget for optimal performance without requiring
  * preserveDrawingBuffer to be enabled on the renderer.
- *
- * The conversion process:
- * 1. Gets the current view and its associated renderer, scene, and camera
- * 2. Creates an offscreen render target for pixel capture
- * 3. Renders the scene to the render target
- * 4. Reads the pixel data and flips it vertically (WebGL renders upside down)
- * 5. Creates a canvas, draws the pixel data, and exports as PNG
- * 6. Triggers a download of the PNG file
- *
- * @example
- * ```typescript
- * const converter = new AcApPngConvertor();
- *
- * // Convert and download current drawing as PNG
- * converter.convert();
- * ```
  */
 export class AcApPngConvertor {
   /**
@@ -41,26 +25,11 @@ export class AcApPngConvertor {
    * - Exports as PNG and downloads with timestamp-based filename
    *
    * @param bounds - Optional world coordinate bounding box to export.
-   *                  If provided, the camera will zoom to fit this region.
-   *                  If not provided, exports the current view.
-   * @param long_side - Optional maximum dimension (width or height) in pixels for the output PNG.
-   *                    The other dimension is calculated based on the aspect ratio of bounds.
-   *                    If not provided, uses the current view dimensions.
-   * @example
-   * ```typescript
-   * const converter = new AcApPngConvertor();
-   * converter.convert(); // Downloads the drawing as PNG
-   * ```
-   *
-   * @example
-   * ```typescript
-   * // Export a specific region
-   * const bounds = new AcGeBox2d(new AcGePoint2d(0, 0), new AcGePoint2d(100, 100));
-   * const converter = new AcApPngConvertor();
-   * converter.convert(bounds); // Downloads the specified region as PNG
-   * ```
+   *                 If provided, the camera will zoom to fit this region.
+   *                 If not provided, exports the current view.
+   * @param longSide - Optional maximum dimension (width or height) in pixels.
    */
-  convert(bounds?: AcGeBox2d, long_side?: number) {
+  convert(bounds?: AcGeBox2d, longSide?: number) {
     const view = AcApDocManager.instance.curView as AcTrView2d
     const renderer = view.renderer.internalRenderer
     const scene = view.internalScene
@@ -71,29 +40,33 @@ export class AcApPngConvertor {
       return
     }
 
-    let outputWidth = view.width
-    let outputHeight = view.height
+    const viewAspect = view.width / Math.max(view.height, 1)
+    const targetAspect = bounds ? this.getBoundsAspect(bounds) : viewAspect
+    let outputWidth = Math.max(1, Math.round(view.width))
+    let outputHeight = Math.max(1, Math.round(view.height))
 
-    if (long_side && bounds) {
-      const size = new AcGeVector2d()
-      bounds.getSize(size)
-      const boundsWidth = size.x
-      const boundsHeight = size.y
-      const boundsAspect = boundsWidth / boundsHeight
-      if (boundsAspect > 1) {
-        outputWidth = long_side
-        outputHeight = Math.round(long_side / boundsAspect)
-      } else {
-        outputHeight = long_side
-        outputWidth = Math.round(long_side * boundsAspect)
-      }
+    if (longSide && longSide > 0) {
+      const outputSize = this.resolveOutputSize(longSide, targetAspect)
+      outputWidth = outputSize.width
+      outputHeight = outputSize.height
     }
 
-    // Save original camera state for restoration later
+    // Keep stable render path at view aspect, then center-crop to target aspect.
+    const renderSize = this.resolveRenderSizeForCenterCrop(
+      outputWidth,
+      outputHeight,
+      viewAspect
+    )
+    const renderWidth = renderSize.width
+    const renderHeight = renderSize.height
+    const needsCrop =
+      renderWidth !== outputWidth || renderHeight !== outputHeight
+
+    // Save original camera state for restoration later (keep legacy fitting path).
     const originalZoom = camera.zoom
     const originalPosition = camera.position.clone()
 
-    // If bounds provided, calculate zoom and position to fit the specified region
+    // Legacy zoom-based fitting; this path historically produced correct bounds.
     if (bounds) {
       const size = new AcGeVector2d()
       bounds.getSize(size)
@@ -101,8 +74,8 @@ export class AcApPngConvertor {
       const center = new AcGeVector2d()
       bounds.getCenter(center)
 
-      const boundsWidth = size.x
-      const boundsHeight = size.y
+      const boundsWidth = Math.max(Math.abs(size.x), Number.EPSILON)
+      const boundsHeight = Math.max(Math.abs(size.y), Number.EPSILON)
       const widthRatio = view.width / boundsWidth
       const heightRatio = view.height / boundsHeight
       const scale = Math.min(widthRatio, heightRatio)
@@ -113,10 +86,9 @@ export class AcApPngConvertor {
       camera.updateProjectionMatrix()
     }
 
-    // Create a render target for offscreen rendering
     const renderTarget = new THREE.WebGLRenderTarget(
-      outputWidth,
-      outputHeight,
+      renderWidth,
+      renderHeight,
       {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
@@ -125,51 +97,150 @@ export class AcApPngConvertor {
       }
     )
 
-    // Store the original render target
     const originalRenderTarget = renderer.getRenderTarget()
 
-    // Render to the offscreen target
     renderer.setRenderTarget(renderTarget)
+
     renderer.render(scene, camera)
 
-    // Read pixels from the render target
-    const pixels = new Uint8Array(outputWidth * outputHeight * 4)
+    const pixels = new Uint8Array(renderWidth * renderHeight * 4)
     renderer.readRenderTargetPixels(
       renderTarget,
       0,
       0,
-      outputWidth,
-      outputHeight,
+      renderWidth,
+      renderHeight,
       pixels
     )
 
-    // Restore the original render target
     renderer.setRenderTarget(originalRenderTarget)
-
-    // Clean up the render target
     renderTarget.dispose()
 
-    // Restore original camera state
     camera.zoom = originalZoom
     camera.position.copy(originalPosition)
     camera.updateProjectionMatrix()
 
-    // Flip the image vertically (WebGL renders upside down)
     const flippedPixels = this.flipPixelsVertically(
       pixels,
-      outputWidth,
-      outputHeight
+      renderWidth,
+      renderHeight
     )
+    const finalPixels = needsCrop
+      ? this.cropPixelsCentered(
+          flippedPixels,
+          renderWidth,
+          renderHeight,
+          outputWidth,
+          outputHeight
+        )
+      : flippedPixels
 
-    // Create canvas and draw the pixels
     const canvas = this.createCanvasFromPixels(
-      flippedPixels,
+      finalPixels,
       outputWidth,
       outputHeight
     )
 
-    // Export to PNG and download
     this.createFileAndDownloadIt(canvas)
+  }
+
+  /**
+   * Resolves a pixel output size from a long-side target and aspect ratio.
+   */
+  private resolveOutputSize(
+    longSide: number,
+    aspect: number
+  ): { width: number; height: number } {
+    const clampedLongSide = Math.max(1, Math.round(longSide))
+    const safeAspect =
+      Number.isFinite(aspect) && aspect > Number.EPSILON ? aspect : 1
+
+    if (safeAspect >= 1) {
+      return {
+        width: clampedLongSide,
+        height: Math.max(1, Math.round(clampedLongSide / safeAspect))
+      }
+    }
+
+    return {
+      width: Math.max(1, Math.round(clampedLongSide * safeAspect)),
+      height: clampedLongSide
+    }
+  }
+
+  /**
+   * Computes render size using source aspect so final target can be center-cropped.
+   */
+  private resolveRenderSizeForCenterCrop(
+    targetWidth: number,
+    targetHeight: number,
+    sourceAspect: number
+  ) {
+    const safeSourceAspect =
+      Number.isFinite(sourceAspect) && sourceAspect > Number.EPSILON
+        ? sourceAspect
+        : 1
+    const targetAspect = targetWidth / Math.max(targetHeight, 1)
+
+    if (Math.abs(targetAspect - safeSourceAspect) < 1e-6) {
+      return { width: targetWidth, height: targetHeight }
+    }
+
+    if (safeSourceAspect > targetAspect) {
+      // Source is wider; extend width then crop left/right.
+      return {
+        width: Math.max(
+          targetWidth,
+          Math.ceil(targetHeight * safeSourceAspect)
+        ),
+        height: targetHeight
+      }
+    }
+
+    // Source is taller/narrower; extend height then crop top/bottom.
+    return {
+      width: targetWidth,
+      height: Math.max(targetHeight, Math.ceil(targetWidth / safeSourceAspect))
+    }
+  }
+
+  /**
+   * Center-crops an RGBA pixel buffer from source to destination size.
+   */
+  private cropPixelsCentered(
+    pixels: Uint8Array,
+    srcWidth: number,
+    srcHeight: number,
+    dstWidth: number,
+    dstHeight: number
+  ) {
+    if (srcWidth === dstWidth && srcHeight === dstHeight) {
+      return pixels
+    }
+
+    const offsetX = Math.floor((srcWidth - dstWidth) / 2)
+    const offsetY = Math.floor((srcHeight - dstHeight) / 2)
+    const cropped = new Uint8Array(dstWidth * dstHeight * 4)
+
+    for (let y = 0; y < dstHeight; y++) {
+      const srcStart = ((y + offsetY) * srcWidth + offsetX) * 4
+      const srcEnd = srcStart + dstWidth * 4
+      const dstStart = y * dstWidth * 4
+      cropped.set(pixels.subarray(srcStart, srcEnd), dstStart)
+    }
+
+    return cropped
+  }
+
+  /**
+   * Returns the world-space aspect ratio of bounds.
+   */
+  private getBoundsAspect(bounds: AcGeBox2d) {
+    const size = new AcGeVector2d()
+    bounds.getSize(size)
+    const width = Math.max(Math.abs(size.x), Number.EPSILON)
+    const height = Math.max(Math.abs(size.y), Number.EPSILON)
+    return width / height
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptBoxOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptBoxOptions.ts
@@ -9,6 +9,7 @@ export class AcEdPromptBoxOptions extends AcEdPromptOptions<AcGeBox2d> {
   private _secondCornerMessage: string
   private _useBasePoint: boolean = false
   private _useDashedLine: boolean = false
+  private _disableOSnap: boolean = false
 
   constructor(firstCornerMessage: string, secondCornerMessage: string) {
     super(firstCornerMessage)
@@ -52,6 +53,19 @@ export class AcEdPromptBoxOptions extends AcEdPromptOptions<AcGeBox2d> {
   set useDashedLine(flag: boolean) {
     if (!this.isReadOnly) {
       this._useDashedLine = flag
+    }
+  }
+
+  /**
+   * Gets or sets whether object snap should be disabled for both box corners.
+   */
+  get disableOSnap(): boolean {
+    return this._disableOSnap
+  }
+
+  set disableOSnap(flag: boolean) {
+    if (!this.isReadOnly) {
+      this._disableOSnap = flag
     }
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptPointOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptPointOptions.ts
@@ -13,6 +13,7 @@ export class AcEdPromptPointOptions extends AcEdPromptOptions<AcGePoint3d> {
   private _useBasePoint: boolean = false
   private _useDashedLine: boolean = false
   private _allowNone: boolean = false
+  private _disableOSnap: boolean = false
 
   /**
    * Constructs a new `AcEdPromptPointOptions` with a given prompt message.
@@ -79,6 +80,18 @@ export class AcEdPromptPointOptions extends AcEdPromptOptions<AcGePoint3d> {
   set allowNone(flag: boolean) {
     if (!this.isReadOnly) {
       this._allowNone = flag
+    }
+  }
+
+  /**
+   * Gets or sets whether object snap should be disabled for this point prompt.
+   */
+  get disableOSnap(): boolean {
+    return this._disableOSnap
+  }
+  set disableOSnap(flag: boolean) {
+    if (!this.isReadOnly) {
+      this._disableOSnap = flag
     }
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -1285,6 +1285,7 @@ export class AcEdInputManager {
         this.copyKeywords(options, options1)
         options1.useDashedLine = options.useDashedLine
         options1.useBasePoint = options.useBasePoint
+        options1.disableOSnap = options.disableOSnap
         const p1Result = await this.getPoint(options1)
         if (p1Result.status !== AcEdPromptStatus.OK) {
           return new AcEdPromptBoxResult(
@@ -1328,6 +1329,7 @@ export class AcEdInputManager {
         this.copyKeywords(options, options2)
         options2.useDashedLine = options.useDashedLine
         options2.useBasePoint = options.useBasePoint
+        options2.disableOSnap = options.disableOSnap
         const p2 = await this.getPointInternal(options2, cleanup, drawPreview)
 
         const box = new AcGeBox2d().expandByPoint(p1).expandByPoint(p2)
@@ -1376,6 +1378,7 @@ export class AcEdInputManager {
     return this.makeFloatingInputPromise<AcGePoint3dLike>({
       inputCount: 2,
       promptOptions: options,
+      disableOSnap: options.disableOSnap,
       cleanup,
       handler,
       getDynamicValue,

--- a/packages/cad-simple-viewer/src/i18n/en/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/command.ts
@@ -1,10 +1,5 @@
 export default {
   ACAD: {
-    pngout: {
-      boundsFirstCorner: 'Specify first corner of bounds',
-      boundsSecondCorner: 'Specify opposite corner',
-      longSidePrompt: 'Enter long side size in pixels'
-    },
     arc: {
       description: 'Creates an arc'
     },
@@ -114,6 +109,9 @@ export default {
     pickbox: {
       description:
         'Sets the size (in pixels) of the selection box used to pick objects'
+    },
+    pngout: {
+      description: 'Exports to PNG'
     },
     qnew: {
       description: 'Starts a new drawing'

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -88,104 +88,6 @@ export default {
       }
     }
   },
-  ellipse: {
-    axisEndpointOrOptions: 'Specify axis endpoint of ellipse or',
-    arcAxisEndpointOrCenter: 'Specify axis endpoint of elliptical arc or',
-    center: 'Specify center of ellipse:',
-    firstAxisEndpoint: 'Specify endpoint of axis:',
-    secondAxisEndpoint: 'Specify other endpoint of axis:',
-    otherAxisOrRotation: 'Specify distance to other axis or',
-    rotationAngle: 'Specify rotation angle around major axis:',
-    arcStartAngle: 'Specify start angle of elliptical arc:',
-    arcEndAngle: 'Specify end angle of elliptical arc:',
-    keywords: {
-      arc: {
-        display: 'Arc(A)',
-        local: 'Arc',
-        global: 'Arc'
-      },
-      center: {
-        display: 'Center(C)',
-        local: 'Center',
-        global: 'Center'
-      },
-      rotation: {
-        display: 'Rotation(R)',
-        local: 'Rotation',
-        global: 'Rotation'
-      }
-    },
-    invalid: {
-      axis: 'Invalid axis input: axis length must be greater than 0.',
-      otherAxis: 'Invalid other-axis input: distance must be greater than 0.',
-      rotation:
-        'Invalid rotation input: resulting minor axis must be greater than 0.'
-    }
-  },
-  measureDistance: {
-    firstPoint: 'Specify first point:',
-    secondPoint: 'Specify second point:'
-  },
-  measureArea: {
-    firstPoint: 'Specify first point:',
-    nextPoint: 'Specify next point (or press Enter to finish):'
-  },
-  measureAngle: {
-    vertex: 'Specify vertex point:',
-    arm1: 'Specify point on first arm:',
-    arm2: 'Specify point on second arm:'
-  },
-  measureArc: {
-    startPoint: 'Specify arc start point:',
-    throughPoint: 'Specify a point on the arc:',
-    endPoint: 'Specify arc end point:'
-  },
-  dimlinear: {
-    xLine1Point: 'Specify the first extension line origin:',
-    xLine2Point: 'Specify the second extension line origin:',
-    dimLinePoint: 'Specify dimension line location:'
-  },
-  line: {
-    firstPoint: 'Specify the first point:',
-    firstPointOrContinue: 'Specify first point or',
-    nextPoint: 'Specify the next point:',
-    nextPointWithOptions: 'Specify next point or',
-    keywords: {
-      continue: {
-        display: 'Continue(C)',
-        local: 'Continue',
-        global: 'Continue'
-      },
-      undo: {
-        display: 'Undo(U)',
-        local: 'Undo',
-        global: 'Undo'
-      },
-      close: {
-        display: 'Close(C)',
-        local: 'Close',
-        global: 'Close'
-      }
-    }
-  },
-  mtext: {
-    point: 'Specify mtext insertion point:'
-  },
-  point: {
-    point: 'Specify a point'
-  },
-  move: {
-    basePointOrDisplacement: 'Specify base point or',
-    secondPointOrDisplacement: 'Specify second point or',
-    displacement: 'Specify displacement:',
-    keywords: {
-      displacement: {
-        display: 'Displacement(D)',
-        local: 'Displacement',
-        global: 'Displacement'
-      }
-    }
-  },
   copy: {
     basePointOrOptions: 'Specify base point or',
     displacementOrArray: 'Specify displacement or',
@@ -228,232 +130,115 @@ export default {
       }
     }
   },
-  rotate: {
-    basePoint: 'Specify base point:',
-    rotationAngleOrOptions: 'Specify rotation angle or',
-    referenceAngleOrPoints: 'Specify reference angle or',
-    firstReferencePoint: 'Specify first point of reference angle:',
-    secondReferencePoint: 'Specify second point:',
-    newAngle: 'Specify new angle:',
-    keywords: {
-      copy: {
-        display: 'Copy(C)',
-        local: 'Copy',
-        global: 'Copy'
-      },
-      reference: {
-        display: 'Reference(R)',
-        local: 'Reference',
-        global: 'Reference'
-      },
-      points: {
-        display: 'Points(P)',
-        local: 'Points',
-        global: 'Points'
-      }
-    },
-    invalid: {
-      referencePoints: 'Invalid reference points: points must be different.'
-    }
+  dimlinear: {
+    xLine1Point: 'Specify the first extension line origin:',
+    xLine2Point: 'Specify the second extension line origin:',
+    dimLinePoint: 'Specify dimension line location:'
   },
-  rect: {
-    firstPoint: 'Specify first corner point:',
-    nextPoint: 'Specify other corner point:',
-    firstPointWithOptions: 'Specify first corner point or',
-    otherCornerWithOptions: 'Specify other corner point or',
-    chamferFirst: 'Specify first chamfer distance:',
-    chamferSecond: 'Specify second chamfer distance:',
-    filletRadius: 'Specify fillet radius:',
-    segmentWidth: 'Specify rectangle line width:',
-    elevationValue: 'Specify elevation:',
-    thicknessValue: 'Specify thickness:',
-    rotationAngle: 'Specify rectangle rotation angle:',
-    dimensionLength: 'Specify rectangle length:',
-    dimensionWidth: 'Specify rectangle width:',
-    areaValue: 'Specify rectangle area:',
-    areaLengthOrWidth: 'Specify rectangle length',
-    areaSpecifyWidth: 'Specify rectangle width:',
-    invalidPositive: 'Invalid input. Please enter a value greater than 0.',
-    invalidRect:
-      'Unable to create rectangle. Please specify valid corners or dimensions.',
-    thicknessNotSupported:
-      'Rectangle thickness is currently not written to entity data. The thickness setting is ignored.',
-    keywords: {
-      chamfer: {
-        display: 'Chamfer(C)',
-        local: 'Chamfer',
-        global: 'Chamfer'
-      },
-      elevation: {
-        display: 'Elevation(E)',
-        local: 'Elevation',
-        global: 'Elevation'
-      },
-      fillet: {
-        display: 'Fillet(F)',
-        local: 'Fillet',
-        global: 'Fillet'
-      },
-      thickness: {
-        display: 'Thickness(T)',
-        local: 'Thickness',
-        global: 'Thickness'
-      },
-      width: {
-        display: 'Width(W)',
-        local: 'Width',
-        global: 'Width'
-      },
-      area: {
-        display: 'Area(A)',
-        local: 'Area',
-        global: 'Area'
-      },
-      dimensions: {
-        display: 'Dimensions(D)',
-        local: 'Dimensions',
-        global: 'Dimensions'
-      },
-      rotation: {
-        display: 'Rotation(R)',
-        local: 'Rotation',
-        global: 'Rotation'
-      },
-      length: {
-        display: 'Length(L)',
-        local: 'Length',
-        global: 'Length'
-      },
-      rectWidth: {
-        display: 'Width(W)',
-        local: 'Width',
-        global: 'Width'
-      }
-    }
-  },
-  polygon: {
-    numberOfSides: 'Enter number of sides:',
-    centerOrEdge: 'Specify center of polygon or',
-    radiusOrType: 'Enter options',
-    edgeStart: 'Specify first endpoint of edge:',
-    edgeEnd: 'Specify second endpoint of edge:',
-    keywords: {
-      edge: {
-        display: 'Edge(E)',
-        local: 'Edge',
-        global: 'Edge'
-      },
-      inscribed: {
-        display: 'Inscribed in circle(I)',
-        local: 'Inscribed in circle',
-        global: 'Inscribed'
-      },
-      circumscribed: {
-        display: 'Circumscribed about circle(C)',
-        local: 'Circumscribed about circle',
-        global: 'Circumscribed'
-      }
-    },
-    invalid: {
-      sides: 'Invalid number of sides. Enter an integer between 3 and 1024.',
-      radius: 'Invalid radius. Radius must be greater than 0.',
-      edge: 'Invalid edge. The edge length must be greater than 0.'
-    }
-  },
-  sketch: {
-    firstPoint: 'Specify the first point:',
-    nextPoint: 'Specify the end point:'
-  },
-  polyline: {
-    firstPoint: 'Specify the first point:',
-    nextPoint: 'Specify the next point (or press Enter to finish):',
-    nextPointWithOptions: 'Specify next point or',
-    nextPointWithArcOptions: 'Specify next point or',
+  ellipse: {
+    axisEndpointOrOptions: 'Specify axis endpoint of ellipse or',
+    arcAxisEndpointOrCenter: 'Specify axis endpoint of elliptical arc or',
+    center: 'Specify center of ellipse:',
+    firstAxisEndpoint: 'Specify endpoint of axis:',
+    secondAxisEndpoint: 'Specify other endpoint of axis:',
+    otherAxisOrRotation: 'Specify distance to other axis or',
+    rotationAngle: 'Specify rotation angle around major axis:',
+    arcStartAngle: 'Specify start angle of elliptical arc:',
+    arcEndAngle: 'Specify end angle of elliptical arc:',
     keywords: {
       arc: {
         display: 'Arc(A)',
         local: 'Arc',
         global: 'Arc'
       },
-      undo: {
-        display: 'Undo(U)',
-        local: 'Undo',
-        global: 'Undo'
-      },
-      close: {
-        display: 'Close(C)',
-        local: 'Close',
-        global: 'Close'
-      },
-      line: {
-        display: 'Line(L)',
-        local: 'Line',
-        global: 'Line'
-      },
-      angle: {
-        display: 'Angle(A)',
-        local: 'Angle',
-        global: 'Angle'
-      },
       center: {
         display: 'Center(C)',
         local: 'Center',
         global: 'Center'
       },
-      secondPoint: {
-        display: 'Second point(P)',
-        local: 'Second point',
-        global: 'SecondPoint'
-      },
-      radius: {
-        display: 'Radius(R)',
-        local: 'Radius',
-        global: 'Radius'
+      rotation: {
+        display: 'Rotation(R)',
+        local: 'Rotation',
+        global: 'Rotation'
       }
     },
-    arcAngle: 'Specify arc angle:',
-    arcCenter: 'Specify center point:',
-    arcSecondPoint: 'Specify second point on arc:',
-    arcEndPoint: 'Specify arc end point:',
-    arcRadius: 'Specify arc radius:'
+    invalid: {
+      axis: 'Invalid axis input: axis length must be greater than 0.',
+      otherAxis: 'Invalid other-axis input: distance must be greater than 0.',
+      rotation:
+        'Invalid rotation input: resulting minor axis must be greater than 0.'
+    }
   },
-  zoom: {
-    mainPrompt: 'Specify corner of window or',
-    firstCorner: 'Specify first corner:',
-    secondCorner: 'Specify opposite corner:',
-    centerPoint: 'Specify center point:',
-    heightOrScale: 'Enter height or scale factor (nX or nXP):',
-    scaleFactor: 'Enter scale factor (nX or nXP):',
+  hatch: {
+    prompt: 'Select boundary object or',
+    pickPoint: 'Specify internal point (or press Enter to finish):',
+    select: 'Select objects to hatch:',
+    patternName: 'Enter hatch pattern name:',
+    scale: 'Specify hatch pattern scale:',
+    angle: 'Specify hatch pattern angle:',
+    style: 'Enter hatch style',
+    associative: 'Specify associativity',
+    invalidBoundary: 'Selected objects do not form a closed boundary.',
     keywords: {
-      all: {
-        display: 'All(A)',
-        local: 'All',
-        global: 'All'
+      pick: {
+        display: 'Pick points(P)',
+        local: 'Pick points',
+        global: 'PickPoints'
       },
-      center: {
-        display: 'Center(C)',
-        local: 'Center',
-        global: 'Center'
+      select: {
+        display: 'Select objects(S)',
+        local: 'Select objects',
+        global: 'SelectObjects'
       },
-      extents: {
-        display: 'Extents(E)',
-        local: 'Extents',
-        global: 'Extents'
-      },
-      previous: {
-        display: 'Previous(P)',
-        local: 'Previous',
-        global: 'Previous'
+      pattern: {
+        display: 'Pattern(P)',
+        local: 'Pattern',
+        global: 'Pattern'
       },
       scale: {
         display: 'Scale(S)',
         local: 'Scale',
         global: 'Scale'
       },
-      window: {
-        display: 'Window(W)',
-        local: 'Window',
-        global: 'Window'
+      angle: {
+        display: 'Angle(A)',
+        local: 'Angle',
+        global: 'Angle'
+      },
+      style: {
+        display: 'Style(T)',
+        local: 'Style',
+        global: 'HatchStyle'
+      },
+      associative: {
+        display: 'Associative(AS)',
+        local: 'Associative',
+        global: 'AssociativeMode'
+      },
+      normal: {
+        display: 'Normal(N)',
+        local: 'Normal',
+        global: 'Normal'
+      },
+      outer: {
+        display: 'Outer(O)',
+        local: 'Outer',
+        global: 'Outer'
+      },
+      ignore: {
+        display: 'Ignore(I)',
+        local: 'Ignore',
+        global: 'Ignore'
+      },
+      yes: {
+        display: 'Yes(Y)',
+        local: 'Yes',
+        global: 'Yes'
+      },
+      no: {
+        display: 'No(N)',
+        local: 'No',
+        global: 'No'
       }
     }
   },
@@ -607,78 +392,258 @@ export default {
       }
     }
   },
-  hatch: {
-    prompt: 'Select boundary object or',
-    pickPoint: 'Specify internal point (or press Enter to finish):',
-    select: 'Select objects to hatch:',
-    patternName: 'Enter hatch pattern name:',
-    scale: 'Specify hatch pattern scale:',
-    angle: 'Specify hatch pattern angle:',
-    style: 'Enter hatch style',
-    associative: 'Specify associativity',
-    invalidBoundary: 'Selected objects do not form a closed boundary.',
+  line: {
+    firstPoint: 'Specify the first point:',
+    firstPointOrContinue: 'Specify first point or',
+    nextPoint: 'Specify the next point:',
+    nextPointWithOptions: 'Specify next point or',
     keywords: {
-      pick: {
-        display: 'Pick points(P)',
-        local: 'Pick points',
-        global: 'PickPoints'
+      continue: {
+        display: 'Continue(C)',
+        local: 'Continue',
+        global: 'Continue'
       },
-      select: {
-        display: 'Select objects(S)',
-        local: 'Select objects',
-        global: 'SelectObjects'
+      undo: {
+        display: 'Undo(U)',
+        local: 'Undo',
+        global: 'Undo'
       },
-      pattern: {
-        display: 'Pattern(P)',
-        local: 'Pattern',
-        global: 'Pattern'
+      close: {
+        display: 'Close(C)',
+        local: 'Close',
+        global: 'Close'
+      }
+    }
+  },
+  measureAngle: {
+    vertex: 'Specify vertex point:',
+    arm1: 'Specify point on first arm:',
+    arm2: 'Specify point on second arm:'
+  },
+  measureArc: {
+    startPoint: 'Specify arc start point:',
+    throughPoint: 'Specify a point on the arc:',
+    endPoint: 'Specify arc end point:'
+  },
+  measureArea: {
+    firstPoint: 'Specify first point:',
+    nextPoint: 'Specify next point (or press Enter to finish):'
+  },
+  measureDistance: {
+    firstPoint: 'Specify first point:',
+    secondPoint: 'Specify second point:'
+  },
+  move: {
+    basePointOrDisplacement: 'Specify base point or',
+    secondPointOrDisplacement: 'Specify second point or',
+    displacement: 'Specify displacement:',
+    keywords: {
+      displacement: {
+        display: 'Displacement(D)',
+        local: 'Displacement',
+        global: 'Displacement'
+      }
+    }
+  },
+  mtext: {
+    point: 'Specify mtext insertion point:'
+  },
+  pngout: {
+    boundsFirstCorner: 'Specify first corner of bounds',
+    boundsSecondCorner: 'Specify opposite corner',
+    longSidePrompt: 'Enter long side size in pixels'
+  },
+  point: {
+    point: 'Specify a point'
+  },
+  polygon: {
+    numberOfSides: 'Enter number of sides:',
+    centerOrEdge: 'Specify center of polygon or',
+    radiusOrType: 'Enter options',
+    edgeStart: 'Specify first endpoint of edge:',
+    edgeEnd: 'Specify second endpoint of edge:',
+    keywords: {
+      edge: {
+        display: 'Edge(E)',
+        local: 'Edge',
+        global: 'Edge'
       },
-      scale: {
-        display: 'Scale(S)',
-        local: 'Scale',
-        global: 'Scale'
+      inscribed: {
+        display: 'Inscribed in circle(I)',
+        local: 'Inscribed in circle',
+        global: 'Inscribed'
+      },
+      circumscribed: {
+        display: 'Circumscribed about circle(C)',
+        local: 'Circumscribed about circle',
+        global: 'Circumscribed'
+      }
+    },
+    invalid: {
+      sides: 'Invalid number of sides. Enter an integer between 3 and 1024.',
+      radius: 'Invalid radius. Radius must be greater than 0.',
+      edge: 'Invalid edge. The edge length must be greater than 0.'
+    }
+  },
+  polyline: {
+    firstPoint: 'Specify the first point:',
+    nextPoint: 'Specify the next point (or press Enter to finish):',
+    nextPointWithOptions: 'Specify next point or',
+    nextPointWithArcOptions: 'Specify next point or',
+    keywords: {
+      arc: {
+        display: 'Arc(A)',
+        local: 'Arc',
+        global: 'Arc'
+      },
+      undo: {
+        display: 'Undo(U)',
+        local: 'Undo',
+        global: 'Undo'
+      },
+      close: {
+        display: 'Close(C)',
+        local: 'Close',
+        global: 'Close'
+      },
+      line: {
+        display: 'Line(L)',
+        local: 'Line',
+        global: 'Line'
       },
       angle: {
         display: 'Angle(A)',
         local: 'Angle',
         global: 'Angle'
       },
-      style: {
-        display: 'Style(T)',
-        local: 'Style',
-        global: 'HatchStyle'
+      center: {
+        display: 'Center(C)',
+        local: 'Center',
+        global: 'Center'
       },
-      associative: {
-        display: 'Associative(AS)',
-        local: 'Associative',
-        global: 'AssociativeMode'
+      secondPoint: {
+        display: 'Second point(P)',
+        local: 'Second point',
+        global: 'SecondPoint'
       },
-      normal: {
-        display: 'Normal(N)',
-        local: 'Normal',
-        global: 'Normal'
+      radius: {
+        display: 'Radius(R)',
+        local: 'Radius',
+        global: 'Radius'
+      }
+    },
+    arcAngle: 'Specify arc angle:',
+    arcCenter: 'Specify center point:',
+    arcSecondPoint: 'Specify second point on arc:',
+    arcEndPoint: 'Specify arc end point:',
+    arcRadius: 'Specify arc radius:'
+  },
+  rect: {
+    firstPoint: 'Specify first corner point:',
+    nextPoint: 'Specify other corner point:',
+    firstPointWithOptions: 'Specify first corner point or',
+    otherCornerWithOptions: 'Specify other corner point or',
+    chamferFirst: 'Specify first chamfer distance:',
+    chamferSecond: 'Specify second chamfer distance:',
+    filletRadius: 'Specify fillet radius:',
+    segmentWidth: 'Specify rectangle line width:',
+    elevationValue: 'Specify elevation:',
+    thicknessValue: 'Specify thickness:',
+    rotationAngle: 'Specify rectangle rotation angle:',
+    dimensionLength: 'Specify rectangle length:',
+    dimensionWidth: 'Specify rectangle width:',
+    areaValue: 'Specify rectangle area:',
+    areaLengthOrWidth: 'Specify rectangle length',
+    areaSpecifyWidth: 'Specify rectangle width:',
+    invalidPositive: 'Invalid input. Please enter a value greater than 0.',
+    invalidRect:
+      'Unable to create rectangle. Please specify valid corners or dimensions.',
+    thicknessNotSupported:
+      'Rectangle thickness is currently not written to entity data. The thickness setting is ignored.',
+    keywords: {
+      chamfer: {
+        display: 'Chamfer(C)',
+        local: 'Chamfer',
+        global: 'Chamfer'
       },
-      outer: {
-        display: 'Outer(O)',
-        local: 'Outer',
-        global: 'Outer'
+      elevation: {
+        display: 'Elevation(E)',
+        local: 'Elevation',
+        global: 'Elevation'
       },
-      ignore: {
-        display: 'Ignore(I)',
-        local: 'Ignore',
-        global: 'Ignore'
+      fillet: {
+        display: 'Fillet(F)',
+        local: 'Fillet',
+        global: 'Fillet'
       },
-      yes: {
-        display: 'Yes(Y)',
-        local: 'Yes',
-        global: 'Yes'
+      thickness: {
+        display: 'Thickness(T)',
+        local: 'Thickness',
+        global: 'Thickness'
       },
-      no: {
-        display: 'No(N)',
-        local: 'No',
-        global: 'No'
+      width: {
+        display: 'Width(W)',
+        local: 'Width',
+        global: 'Width'
+      },
+      area: {
+        display: 'Area(A)',
+        local: 'Area',
+        global: 'Area'
+      },
+      dimensions: {
+        display: 'Dimensions(D)',
+        local: 'Dimensions',
+        global: 'Dimensions'
+      },
+      rotation: {
+        display: 'Rotation(R)',
+        local: 'Rotation',
+        global: 'Rotation'
+      },
+      length: {
+        display: 'Length(L)',
+        local: 'Length',
+        global: 'Length'
+      },
+      rectWidth: {
+        display: 'Width(W)',
+        local: 'Width',
+        global: 'Width'
       }
     }
+  },
+  rotate: {
+    basePoint: 'Specify base point:',
+    rotationAngleOrOptions: 'Specify rotation angle or',
+    referenceAngleOrPoints: 'Specify reference angle or',
+    firstReferencePoint: 'Specify first point of reference angle:',
+    secondReferencePoint: 'Specify second point:',
+    newAngle: 'Specify new angle:',
+    keywords: {
+      copy: {
+        display: 'Copy(C)',
+        local: 'Copy',
+        global: 'Copy'
+      },
+      reference: {
+        display: 'Reference(R)',
+        local: 'Reference',
+        global: 'Reference'
+      },
+      points: {
+        display: 'Points(P)',
+        local: 'Points',
+        global: 'Points'
+      }
+    },
+    invalid: {
+      referencePoints: 'Invalid reference points: points must be different.'
+    }
+  },
+  sketch: {
+    firstPoint: 'Specify the first point:',
+    nextPoint: 'Specify the end point:'
   },
   spline: {
     firstPoint: 'Specify the first point:',
@@ -744,5 +709,45 @@ export default {
   },
   sysvar: {
     prompt: 'Please input new value:'
+  },
+  zoom: {
+    mainPrompt: 'Specify corner of window or',
+    firstCorner: 'Specify first corner:',
+    secondCorner: 'Specify opposite corner:',
+    centerPoint: 'Specify center point:',
+    heightOrScale: 'Enter height or scale factor (nX or nXP):',
+    scaleFactor: 'Enter scale factor (nX or nXP):',
+    keywords: {
+      all: {
+        display: 'All(A)',
+        local: 'All',
+        global: 'All'
+      },
+      center: {
+        display: 'Center(C)',
+        local: 'Center',
+        global: 'Center'
+      },
+      extents: {
+        display: 'Extents(E)',
+        local: 'Extents',
+        global: 'Extents'
+      },
+      previous: {
+        display: 'Previous(P)',
+        local: 'Previous',
+        global: 'Previous'
+      },
+      scale: {
+        display: 'Scale(S)',
+        local: 'Scale',
+        global: 'Scale'
+      },
+      window: {
+        display: 'Window(W)',
+        local: 'Window',
+        global: 'Window'
+      }
+    }
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/zh/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/command.ts
@@ -1,10 +1,5 @@
 export default {
   ACAD: {
-    pngout: {
-      boundsFirstCorner: '指定边界的第一个角点',
-      boundsSecondCorner: '指定对角点',
-      longSidePrompt: '输入长边像素大小'
-    },
     arc: {
       description: '创建圆弧'
     },
@@ -106,6 +101,9 @@ export default {
     },
     pickbox: {
       description: '控制用于选择对象的拾取框大小（像素）'
+    },
+    pngout: {
+      description: '导出为 PNG 图片'
     },
     qnew: {
       description: '创建新图纸'

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -82,103 +82,6 @@ export default {
       }
     }
   },
-  ellipse: {
-    axisEndpointOrOptions: '指定椭圆的轴端点或',
-    arcAxisEndpointOrCenter: '指定椭圆弧的轴端点或',
-    center: '指定椭圆中心点：',
-    firstAxisEndpoint: '指定轴的端点：',
-    secondAxisEndpoint: '指定轴的另一个端点：',
-    otherAxisOrRotation: '指定到另一轴的距离或',
-    rotationAngle: '指定绕长轴的旋转角度：',
-    arcStartAngle: '指定椭圆弧起始角：',
-    arcEndAngle: '指定椭圆弧终止角：',
-    keywords: {
-      arc: {
-        display: '圆弧(A)',
-        local: '圆弧',
-        global: 'Arc'
-      },
-      center: {
-        display: '中心点(C)',
-        local: '中心点',
-        global: 'Center'
-      },
-      rotation: {
-        display: '旋转(R)',
-        local: '旋转',
-        global: 'Rotation'
-      }
-    },
-    invalid: {
-      axis: '轴输入无效：轴长必须大于 0。',
-      otherAxis: '另一轴输入无效：距离必须大于 0。',
-      rotation: '旋转输入无效：计算得到的短轴必须大于 0。'
-    }
-  },
-  measureDistance: {
-    firstPoint: '指定第一个点：',
-    secondPoint: '指定第二个点：'
-  },
-  measureArea: {
-    firstPoint: '指定第一个点：',
-    nextPoint: '指定下一个点（或按 Enter 完成）：'
-  },
-  measureAngle: {
-    vertex: '指定顶点：',
-    arm1: '指定第一条边上的点：',
-    arm2: '指定第二条边上的点：'
-  },
-  measureArc: {
-    startPoint: '指定弧的起点：',
-    throughPoint: '指定弧上的一个点：',
-    endPoint: '指定弧的终点：'
-  },
-  dimlinear: {
-    xLine1Point: '指定第一条尺寸界限原点：',
-    xLine2Point: '指定第二条尺寸界限原点：',
-    dimLinePoint: '指定尺寸线位置：'
-  },
-  line: {
-    firstPoint: '指定第一个点：',
-    firstPointOrContinue: '请指定第一个点或',
-    nextPoint: '指定下一个点：',
-    nextPointWithOptions: '请指定下一个点或',
-    keywords: {
-      continue: {
-        display: '继续(C)',
-        local: '继续',
-        global: 'Continue'
-      },
-      undo: {
-        display: '放弃(U)',
-        local: '放弃',
-        global: 'Undo'
-      },
-      close: {
-        display: '闭合(C)',
-        local: '闭合',
-        global: 'Close'
-      }
-    }
-  },
-  mtext: {
-    point: '指定多行文本插入点：'
-  },
-  point: {
-    point: '指定点'
-  },
-  move: {
-    basePointOrDisplacement: '指定基点或',
-    secondPointOrDisplacement: '指定第二个点或',
-    displacement: '指定位移：',
-    keywords: {
-      displacement: {
-        display: '位移(D)',
-        local: '位移',
-        global: 'Displacement'
-      }
-    }
-  },
   copy: {
     basePointOrOptions: '指定基点或',
     displacementOrArray: '指定位移或',
@@ -220,231 +123,114 @@ export default {
       }
     }
   },
-  rotate: {
-    basePoint: '指定基点：',
-    rotationAngleOrOptions: '指定旋转角度或',
-    referenceAngleOrPoints: '指定参考角或',
-    firstReferencePoint: '指定参考角的第一点：',
-    secondReferencePoint: '指定第二点：',
-    newAngle: '指定新角度：',
-    keywords: {
-      copy: {
-        display: '复制(C)',
-        local: '复制',
-        global: 'Copy'
-      },
-      reference: {
-        display: '参照(R)',
-        local: '参照',
-        global: 'Reference'
-      },
-      points: {
-        display: '点(P)',
-        local: '点',
-        global: 'Points'
-      }
-    },
-    invalid: {
-      referencePoints: '参考点输入无效：两点必须不同。'
-    }
+  dimlinear: {
+    xLine1Point: '指定第一条尺寸界限原点：',
+    xLine2Point: '指定第二条尺寸界限原点：',
+    dimLinePoint: '指定尺寸线位置：'
   },
-  rect: {
-    firstPoint: '指定第一个角点：',
-    nextPoint: '指定另一个角点：',
-    firstPointWithOptions: '指定第一个角点或者',
-    otherCornerWithOptions: '指定另一个角点或者',
-    chamferFirst: '指定第一个倒角距离：',
-    chamferSecond: '指定第二个倒角距离：',
-    filletRadius: '指定圆角半径：',
-    segmentWidth: '指定矩形线宽：',
-    elevationValue: '指定标高：',
-    thicknessValue: '指定厚度：',
-    rotationAngle: '指定矩形旋转角度：',
-    dimensionLength: '指定矩形长度：',
-    dimensionWidth: '指定矩形宽度：',
-    areaValue: '指定矩形面积：',
-    areaLengthOrWidth: '指定矩形长度',
-    areaSpecifyWidth: '指定矩形宽度：',
-    invalidPositive: '输入无效：请输入大于 0 的数值。',
-    invalidRect: '无法创建矩形：请输入有效的角点或尺寸。',
-    thicknessNotSupported:
-      '当前版本暂不支持将矩形厚度写入图元，已忽略厚度设置。',
-    keywords: {
-      chamfer: {
-        display: '倒角(C)',
-        local: '倒角',
-        global: 'Chamfer'
-      },
-      elevation: {
-        display: '标高(E)',
-        local: '标高',
-        global: 'Elevation'
-      },
-      fillet: {
-        display: '圆角(F)',
-        local: '圆角',
-        global: 'Fillet'
-      },
-      thickness: {
-        display: '厚度(T)',
-        local: '厚度',
-        global: 'Thickness'
-      },
-      width: {
-        display: '宽度(W)',
-        local: '宽度',
-        global: 'Width'
-      },
-      area: {
-        display: '面积(A)',
-        local: '面积',
-        global: 'Area'
-      },
-      dimensions: {
-        display: '尺寸(D)',
-        local: '尺寸',
-        global: 'Dimensions'
-      },
-      rotation: {
-        display: '旋转(R)',
-        local: '旋转',
-        global: 'Rotation'
-      },
-      length: {
-        display: '长度(L)',
-        local: '长度',
-        global: 'Length'
-      },
-      rectWidth: {
-        display: '宽度(W)',
-        local: '宽度',
-        global: 'Width'
-      }
-    }
-  },
-  polygon: {
-    numberOfSides: '输入边数：',
-    centerOrEdge: '指定多边形中心点或',
-    radiusOrType: '输入选项',
-    edgeStart: '指定边的第一个端点：',
-    edgeEnd: '指定边的第二个端点：',
-    keywords: {
-      edge: {
-        display: '边(E)',
-        local: '边',
-        global: 'Edge'
-      },
-      inscribed: {
-        display: '内接于圆(I)',
-        local: '内接于圆',
-        global: 'Inscribed'
-      },
-      circumscribed: {
-        display: '外切于圆(C)',
-        local: '外切于圆',
-        global: 'Circumscribed'
-      }
-    },
-    invalid: {
-      sides: '边数无效：请输入 3 到 1024 之间的整数。',
-      radius: '半径无效：半径必须大于 0。',
-      edge: '边无效：边长必须大于 0。'
-    }
-  },
-  sketch: {
-    firstPoint: '指定第一个点：',
-    nextPoint: '指定结束点：'
-  },
-  polyline: {
-    firstPoint: '指定第一个点：',
-    nextPoint: '指定下一个点（或按 Enter 完成）：',
-    nextPointWithOptions: '请指定下一个点或',
-    nextPointWithArcOptions: '请指定下一个点或',
+  ellipse: {
+    axisEndpointOrOptions: '指定椭圆的轴端点或',
+    arcAxisEndpointOrCenter: '指定椭圆弧的轴端点或',
+    center: '指定椭圆中心点：',
+    firstAxisEndpoint: '指定轴的端点：',
+    secondAxisEndpoint: '指定轴的另一个端点：',
+    otherAxisOrRotation: '指定到另一轴的距离或',
+    rotationAngle: '指定绕长轴的旋转角度：',
+    arcStartAngle: '指定椭圆弧起始角：',
+    arcEndAngle: '指定椭圆弧终止角：',
     keywords: {
       arc: {
         display: '圆弧(A)',
         local: '圆弧',
         global: 'Arc'
       },
-      undo: {
-        display: '放弃(U)',
-        local: '放弃',
-        global: 'Undo'
-      },
-      close: {
-        display: '闭合(C)',
-        local: '闭合',
-        global: 'Close'
-      },
-      line: {
-        display: '直线(L)',
-        local: '直线',
-        global: 'Line'
-      },
-      angle: {
-        display: '角度(A)',
-        local: '角度',
-        global: 'Angle'
-      },
       center: {
-        display: '圆心(C)',
-        local: '圆心',
+        display: '中心点(C)',
+        local: '中心点',
         global: 'Center'
       },
-      secondPoint: {
-        display: '第二点(P)',
-        local: '第二点',
-        global: 'SecondPoint'
-      },
-      radius: {
-        display: '半径(R)',
-        local: '半径',
-        global: 'Radius'
+      rotation: {
+        display: '旋转(R)',
+        local: '旋转',
+        global: 'Rotation'
       }
     },
-    arcAngle: '指定弧角度：',
-    arcCenter: '指定圆心：',
-    arcSecondPoint: '指定弧上的第二点：',
-    arcEndPoint: '指定弧的终点：',
-    arcRadius: '指定弧半径：'
+    invalid: {
+      axis: '轴输入无效：轴长必须大于 0。',
+      otherAxis: '另一轴输入无效：距离必须大于 0。',
+      rotation: '旋转输入无效：计算得到的短轴必须大于 0。'
+    }
   },
-  zoom: {
-    mainPrompt: '指定窗口角点或',
-    firstCorner: '指定第一个角点：',
-    secondCorner: '指定对角点：',
-    centerPoint: '指定缩放中心点：',
-    heightOrScale: '输入高度或比例因子（nX 或 nXP）：',
-    scaleFactor: '输入比例因子（nX 或 nXP）：',
+  hatch: {
+    prompt: '选择边界对象或',
+    pickPoint: '指定内部点（或按 Enter 结束）：',
+    select: '选择要填充的对象：',
+    patternName: '输入填充图案名称：',
+    scale: '指定填充图案比例：',
+    angle: '指定填充图案角度：',
+    style: '输入填充样式',
+    associative: '指定关联性',
+    invalidBoundary: '所选对象无法构成闭合边界。',
     keywords: {
-      all: {
-        display: '全部(A)',
-        local: '全部',
-        global: 'All'
+      pick: {
+        display: '拾取点(P)',
+        local: '拾取点',
+        global: 'PickPoints'
       },
-      center: {
-        display: '中心(C)',
-        local: '中心',
-        global: 'Center'
+      select: {
+        display: '选择对象(S)',
+        local: '选择对象',
+        global: 'SelectObjects'
       },
-      extents: {
-        display: '范围(E)',
-        local: '范围',
-        global: 'Extents'
-      },
-      previous: {
-        display: '上一个(P)',
-        local: '上一个',
-        global: 'Previous'
+      pattern: {
+        display: '图案(P)',
+        local: '图案',
+        global: 'Pattern'
       },
       scale: {
         display: '比例(S)',
         local: '比例',
         global: 'Scale'
       },
-      window: {
-        display: '窗口(W)',
-        local: '窗口',
-        global: 'Window'
+      angle: {
+        display: '角度(A)',
+        local: '角度',
+        global: 'Angle'
+      },
+      style: {
+        display: '样式(T)',
+        local: '样式',
+        global: 'HatchStyle'
+      },
+      associative: {
+        display: '关联(AS)',
+        local: '关联',
+        global: 'AssociativeMode'
+      },
+      normal: {
+        display: '普通(N)',
+        local: '普通',
+        global: 'Normal'
+      },
+      outer: {
+        display: '外部(O)',
+        local: '外部',
+        global: 'Outer'
+      },
+      ignore: {
+        display: '忽略(I)',
+        local: '忽略',
+        global: 'Ignore'
+      },
+      yes: {
+        display: '是(Y)',
+        local: '是',
+        global: 'Yes'
+      },
+      no: {
+        display: '否(N)',
+        local: '否',
+        global: 'No'
       }
     }
   },
@@ -597,78 +383,257 @@ export default {
       }
     }
   },
-  hatch: {
-    prompt: '选择边界对象或',
-    pickPoint: '指定内部点（或按 Enter 结束）：',
-    select: '选择要填充的对象：',
-    patternName: '输入填充图案名称：',
-    scale: '指定填充图案比例：',
-    angle: '指定填充图案角度：',
-    style: '输入填充样式',
-    associative: '指定关联性',
-    invalidBoundary: '所选对象无法构成闭合边界。',
+  line: {
+    firstPoint: '指定第一个点：',
+    firstPointOrContinue: '请指定第一个点或',
+    nextPoint: '指定下一个点：',
+    nextPointWithOptions: '请指定下一个点或',
     keywords: {
-      pick: {
-        display: '拾取点(P)',
-        local: '拾取点',
-        global: 'PickPoints'
+      continue: {
+        display: '继续(C)',
+        local: '继续',
+        global: 'Continue'
       },
-      select: {
-        display: '选择对象(S)',
-        local: '选择对象',
-        global: 'SelectObjects'
+      undo: {
+        display: '放弃(U)',
+        local: '放弃',
+        global: 'Undo'
       },
-      pattern: {
-        display: '图案(P)',
-        local: '图案',
-        global: 'Pattern'
+      close: {
+        display: '闭合(C)',
+        local: '闭合',
+        global: 'Close'
+      }
+    }
+  },
+  measureArc: {
+    startPoint: '指定弧的起点：',
+    throughPoint: '指定弧上的一个点：',
+    endPoint: '指定弧的终点：'
+  },
+  measureAngle: {
+    vertex: '指定顶点：',
+    arm1: '指定第一条边上的点：',
+    arm2: '指定第二条边上的点：'
+  },
+  measureArea: {
+    firstPoint: '指定第一个点：',
+    nextPoint: '指定下一个点（或按 Enter 完成）：'
+  },
+  measureDistance: {
+    firstPoint: '指定第一个点：',
+    secondPoint: '指定第二个点：'
+  },
+  move: {
+    basePointOrDisplacement: '指定基点或',
+    secondPointOrDisplacement: '指定第二个点或',
+    displacement: '指定位移：',
+    keywords: {
+      displacement: {
+        display: '位移(D)',
+        local: '位移',
+        global: 'Displacement'
+      }
+    }
+  },
+  mtext: {
+    point: '指定多行文本插入点：'
+  },
+  pngout: {
+    boundsFirstCorner: '指定边界的第一个角点',
+    boundsSecondCorner: '指定对角点',
+    longSidePrompt: '输入长边像素大小'
+  },
+  point: {
+    point: '指定点'
+  },
+  polygon: {
+    numberOfSides: '输入边数：',
+    centerOrEdge: '指定多边形中心点或',
+    radiusOrType: '输入选项',
+    edgeStart: '指定边的第一个端点：',
+    edgeEnd: '指定边的第二个端点：',
+    keywords: {
+      edge: {
+        display: '边(E)',
+        local: '边',
+        global: 'Edge'
       },
-      scale: {
-        display: '比例(S)',
-        local: '比例',
-        global: 'Scale'
+      inscribed: {
+        display: '内接于圆(I)',
+        local: '内接于圆',
+        global: 'Inscribed'
+      },
+      circumscribed: {
+        display: '外切于圆(C)',
+        local: '外切于圆',
+        global: 'Circumscribed'
+      }
+    },
+    invalid: {
+      sides: '边数无效：请输入 3 到 1024 之间的整数。',
+      radius: '半径无效：半径必须大于 0。',
+      edge: '边无效：边长必须大于 0。'
+    }
+  },
+  polyline: {
+    firstPoint: '指定第一个点：',
+    nextPoint: '指定下一个点（或按 Enter 完成）：',
+    nextPointWithOptions: '请指定下一个点或',
+    nextPointWithArcOptions: '请指定下一个点或',
+    keywords: {
+      arc: {
+        display: '圆弧(A)',
+        local: '圆弧',
+        global: 'Arc'
+      },
+      undo: {
+        display: '放弃(U)',
+        local: '放弃',
+        global: 'Undo'
+      },
+      close: {
+        display: '闭合(C)',
+        local: '闭合',
+        global: 'Close'
+      },
+      line: {
+        display: '直线(L)',
+        local: '直线',
+        global: 'Line'
       },
       angle: {
         display: '角度(A)',
         local: '角度',
         global: 'Angle'
       },
-      style: {
-        display: '样式(T)',
-        local: '样式',
-        global: 'HatchStyle'
+      center: {
+        display: '圆心(C)',
+        local: '圆心',
+        global: 'Center'
       },
-      associative: {
-        display: '关联(AS)',
-        local: '关联',
-        global: 'AssociativeMode'
+      secondPoint: {
+        display: '第二点(P)',
+        local: '第二点',
+        global: 'SecondPoint'
       },
-      normal: {
-        display: '普通(N)',
-        local: '普通',
-        global: 'Normal'
+      radius: {
+        display: '半径(R)',
+        local: '半径',
+        global: 'Radius'
+      }
+    },
+    arcAngle: '指定弧角度：',
+    arcCenter: '指定圆心：',
+    arcSecondPoint: '指定弧上的第二点：',
+    arcEndPoint: '指定弧的终点：',
+    arcRadius: '指定弧半径：'
+  },
+  rotate: {
+    basePoint: '指定基点：',
+    rotationAngleOrOptions: '指定旋转角度或',
+    referenceAngleOrPoints: '指定参考角或',
+    firstReferencePoint: '指定参考角的第一点：',
+    secondReferencePoint: '指定第二点：',
+    newAngle: '指定新角度：',
+    keywords: {
+      copy: {
+        display: '复制(C)',
+        local: '复制',
+        global: 'Copy'
       },
-      outer: {
-        display: '外部(O)',
-        local: '外部',
-        global: 'Outer'
+      reference: {
+        display: '参照(R)',
+        local: '参照',
+        global: 'Reference'
       },
-      ignore: {
-        display: '忽略(I)',
-        local: '忽略',
-        global: 'Ignore'
+      points: {
+        display: '点(P)',
+        local: '点',
+        global: 'Points'
+      }
+    },
+    invalid: {
+      referencePoints: '参考点输入无效：两点必须不同。'
+    }
+  },
+  rect: {
+    firstPoint: '指定第一个角点：',
+    nextPoint: '指定另一个角点：',
+    firstPointWithOptions: '指定第一个角点或者',
+    otherCornerWithOptions: '指定另一个角点或者',
+    chamferFirst: '指定第一个倒角距离：',
+    chamferSecond: '指定第二个倒角距离：',
+    filletRadius: '指定圆角半径：',
+    segmentWidth: '指定矩形线宽：',
+    elevationValue: '指定标高：',
+    thicknessValue: '指定厚度：',
+    rotationAngle: '指定矩形旋转角度：',
+    dimensionLength: '指定矩形长度：',
+    dimensionWidth: '指定矩形宽度：',
+    areaValue: '指定矩形面积：',
+    areaLengthOrWidth: '指定矩形长度',
+    areaSpecifyWidth: '指定矩形宽度：',
+    invalidPositive: '输入无效：请输入大于 0 的数值。',
+    invalidRect: '无法创建矩形：请输入有效的角点或尺寸。',
+    thicknessNotSupported:
+      '当前版本暂不支持将矩形厚度写入图元，已忽略厚度设置。',
+    keywords: {
+      chamfer: {
+        display: '倒角(C)',
+        local: '倒角',
+        global: 'Chamfer'
       },
-      yes: {
-        display: '是(Y)',
-        local: '是',
-        global: 'Yes'
+      elevation: {
+        display: '标高(E)',
+        local: '标高',
+        global: 'Elevation'
       },
-      no: {
-        display: '否(N)',
-        local: '否',
-        global: 'No'
+      fillet: {
+        display: '圆角(F)',
+        local: '圆角',
+        global: 'Fillet'
+      },
+      thickness: {
+        display: '厚度(T)',
+        local: '厚度',
+        global: 'Thickness'
+      },
+      width: {
+        display: '宽度(W)',
+        local: '宽度',
+        global: 'Width'
+      },
+      area: {
+        display: '面积(A)',
+        local: '面积',
+        global: 'Area'
+      },
+      dimensions: {
+        display: '尺寸(D)',
+        local: '尺寸',
+        global: 'Dimensions'
+      },
+      rotation: {
+        display: '旋转(R)',
+        local: '旋转',
+        global: 'Rotation'
+      },
+      length: {
+        display: '长度(L)',
+        local: '长度',
+        global: 'Length'
+      },
+      rectWidth: {
+        display: '宽度(W)',
+        local: '宽度',
+        global: 'Width'
       }
     }
+  },
+  sketch: {
+    firstPoint: '指定第一个点：',
+    nextPoint: '指定结束点：'
   },
   spline: {
     firstPoint: '指定第一个点：',
@@ -734,5 +699,45 @@ export default {
   },
   sysvar: {
     prompt: '请输入新的值：'
+  },
+  zoom: {
+    mainPrompt: '指定窗口角点或',
+    firstCorner: '指定第一个角点：',
+    secondCorner: '指定对角点：',
+    centerPoint: '指定缩放中心点：',
+    heightOrScale: '输入高度或比例因子（nX 或 nXP）：',
+    scaleFactor: '输入比例因子（nX 或 nXP）：',
+    keywords: {
+      all: {
+        display: '全部(A)',
+        local: '全部',
+        global: 'All'
+      },
+      center: {
+        display: '中心(C)',
+        local: '中心',
+        global: 'Center'
+      },
+      extents: {
+        display: '范围(E)',
+        local: '范围',
+        global: 'Extents'
+      },
+      previous: {
+        display: '上一个(P)',
+        local: '上一个',
+        global: 'Previous'
+      },
+      scale: {
+        display: '比例(S)',
+        local: '比例',
+        global: 'Scale'
+      },
+      window: {
+        display: '窗口(W)',
+        local: '窗口',
+        global: 'Window'
+      }
+    }
   }
 }

--- a/packages/cad-viewer/src/component/layout/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/layout/MlRibbonCommands.vue
@@ -1254,6 +1254,10 @@ const fileMenuItems = computed<FileMenuItemModel[]>(() => {
     {
       id: 'Convert',
       label: t('main.mainMenu.export')
+    },
+    {
+      id: 'PngOut',
+      label: t('main.mainMenu.exportImage')
     }
   ]
 })
@@ -1292,6 +1296,8 @@ const handleFileMenuSelect = (command: string) => {
   if (command === 'Convert') {
     const cmd = new AcApConvertToDxfCmd()
     cmd.trigger(AcApDocManager.instance.context)
+  } else if (command === 'PngOut') {
+    AcApDocManager.instance.sendStringToExecute('pngout')
   } else if (command === 'QNew') {
     const cmd = new AcApQNewCmd()
     cmd.trigger(AcApDocManager.instance.context)

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -2,7 +2,8 @@ export default {
   mainMenu: {
     new: 'New Drawing',
     open: 'Open Drawing',
-    export: 'Export to DXF'
+    export: 'Export to DXF',
+    exportImage: 'Export to Image'
   },
   ribbon: {
     tab: {

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -2,7 +2,8 @@ export default {
   mainMenu: {
     new: '新建图纸',
     open: '打开图纸',
-    export: '导出为DXF'
+    export: '导出为DXF',
+    exportImage: '导出图片'
   },
   ribbon: {
     tab: {


### PR DESCRIPTION
## Summary
- Improve `pngout` export flow with stricter prompt handling, better bounds selection, and safer defaults.
- Update PNG rendering logic to compute output size/aspect more robustly and center-crop when needed.
- Expose image export in the viewer file menu and add corresponding locale entries.
- Add prompt-option plumbing to support disabling object snap during box/point input.
- Refresh command/jig i18n mappings, including moving `pngout` prompt strings into `jig` translations.

## Why
- Users need more predictable PNG export results (less clipping, clearer prompts, and sensible default image size).
- Export-to-image should be discoverable from the UI, not only via command line input.
- Box-corner picking for export should follow exact cursor picks without OSnap interference.

## What Changed
- `AcApConvertToPngCmd`:
- Switched prompt keys to `jig.pngout.*`.
- Added `DEFAULT_LONG_SIDE_PX = 1024` and configured numeric prompt defaults/validation.
- Treats `Enter` on bounds prompt as “use drawing extents”; exits early on cancel/error.
- Disables OSnap for export bounds picking.
- Expands user-selected bounds to intersected entity extents to reduce cut-off geometry.
- Syncs active layout view size before exporting.
- `AcApPngConvertor`:
- Refactored `convert(bounds?, longSide?)` sizing pipeline.
- Added helpers for output-size resolution, bounds aspect computation, center-crop render sizing, and pixel cropping.
- Preserved existing camera-fit path while improving render-target/output handling.
- Input prompt infrastructure:
- Added `disableOSnap` to `AcEdPromptBoxOptions` and `AcEdPromptPointOptions`.
- Propagated `disableOSnap` through `AcEdInputManager` box/point prompt paths.
- UI/i18n:
- Added `PngOut` file-menu action in `MlRibbonCommands.vue` (`sendStringToExecute('pngout')`).
- Added `exportImage` labels in viewer locales (`en`/`zh`).
- Updated command locales (`en`/`zh`) with `pngout` description entries.
- Updated jig locales (`en`/`zh`) with `pngout` prompt strings and reordered prompt blocks.
- Example:
- Added `block-color.dxf` quick-open button in `packages/cad-simple-viewer-example/index.html`.

## Risks / Notes
- Default long-side export value changed from `8000` to `1024`, which may alter output resolution expectations.
- New center-crop path may trim edges when target aspect differs from render aspect.
- Large i18n jig-file reshuffle can make review harder and may hide accidental key/mapping regressions.
