### PR TITLE
feat: harden batched rendering and hatch material handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@mlightcad/data-model": "^1.7.23",
-      "@mlightcad/libredwg-converter": "^3.5.23",
+      "@mlightcad/data-model": "^1.7.24",
+      "@mlightcad/libredwg-converter": "^3.5.24",
       "@mlightcad/mtext-renderer": "^0.10.7",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -451,7 +451,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
       const entity = modelSpace.getIdAt(item.id)
       if (!entity) return
 
-      if (item.children) {
+      if (item.children && item.children.length > 0) {
         item.children.forEach(child =>
           this.getOsnapPointsInAvailableModes(entity, osnapPoints, child.id)
         )

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -1046,8 +1046,10 @@ export class AcTrView2d extends AcEdBaseView {
   private async batchConvert(entities: AcDbEntity[]) {
     for (let i = 0; i < entities.length; ++i) {
       const entity = entities[i]
-      const threeEntity: AcTrEntity | null = this.drawEntity(entity, true)
-      if (threeEntity) {
+      try {
+        const threeEntity: AcTrEntity | null = this.drawEntity(entity, true)
+        if (!threeEntity) continue
+
         threeEntity.objectId = entity.objectId
         threeEntity.ownerId = entity.ownerId
         threeEntity.layerName = entity.layer
@@ -1069,23 +1071,16 @@ export class AcTrView2d extends AcEdBaseView {
           !(threeEntity as AcTrGroup).isOnTheSameLayer
         ) {
           this.handleGroup(threeEntity as AcTrGroup)
-          this.decreaseNumOfEntitiesToProcess()
         } else {
           const isExtendBbox = !(
             entity instanceof AcDbRay || entity instanceof AcDbXline
           )
 
-          await threeEntity
-            .draw()
-            .then(() => {
-              this._scene.addEntity(threeEntity, isExtendBbox)
-              // Release memory occupied by this entity
-              threeEntity.dispose()
-              this._isDirty = true
-            })
-            .finally(() => {
-              this.decreaseNumOfEntitiesToProcess()
-            })
+          await threeEntity.draw()
+          this._scene.addEntity(threeEntity, isExtendBbox)
+          // Release memory occupied by this entity
+          threeEntity.dispose()
+          this._isDirty = true
         }
 
         if (entity instanceof AcDbViewport) {
@@ -1107,7 +1102,12 @@ export class AcTrView2d extends AcEdBaseView {
           const fileName = entity.imageFileName
           if (fileName) this._missedImages.set(entity.objectId, fileName)
         }
-      } else {
+      } catch (error) {
+        log.error(
+          `[AcTrView2d] Failed to convert entity ${entity.objectId} (${entity.type}):`,
+          error
+        )
+      } finally {
         this.decreaseNumOfEntitiesToProcess()
       }
     }

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -336,10 +336,17 @@ export class AcTrBatchedGroup extends THREE.Group {
    */
   addEntity(entity: AcTrEntity) {
     const objectId = entity.objectId
-    const entityInfo: AcTrEntityInBatchedObject[] = []
-    this._entitiesMap.set(objectId, entityInfo)
-    this._unbatchedEntities.delete(objectId)
-    const unbatchedObjects: THREE.Object3D[] = []
+    // One logical entity (same objectId) can be appended in multiple passes
+    // (e.g. INSERT decomposition by source layer and inherited layer-0 bucket).
+    // Keep accumulating geometry mappings instead of overwriting previous ones.
+    let entityInfo = this._entitiesMap.get(objectId)
+    if (!entityInfo) {
+      entityInfo = []
+      this._entitiesMap.set(objectId, entityInfo)
+    }
+
+    const existingUnbatched = this._unbatchedEntities.get(objectId)
+    const unbatchedObjects: THREE.Object3D[] = existingUnbatched ?? []
     let hasUnbatched = false
     const styleManager = entity.styleManager
 

--- a/packages/three-renderer/src/batch/AcTrBatchedLine.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine.ts
@@ -579,6 +579,7 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     // Fast path: entities flagged for bbox-only intersection check
     if (geometryInfo.bboxIntersectionCheck) {
       this.getBoundingBoxAt(geometryId, this._box)
+      this._box.applyMatrix4(this.matrixWorld)
       if (raycaster.ray.intersectBox(this._box, this._vector)) {
         const distance = raycaster.ray.origin.distanceTo(this._vector)
         ;(
@@ -622,26 +623,27 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     // bounding box expanded by the Line threshold.
     if (this._batchIntersects.length === 0) {
       this.getBoundingBoxAt(geometryId, _box)
-      if (raycaster.ray.intersectBox(_box, _vector)) {
-        const threshold = raycaster.params.Line.threshold
+      _box.applyMatrix4(this.matrixWorld)
+      const threshold = raycaster.params.Line.threshold
+      if (threshold > 0) {
         _box.expandByScalar(threshold)
-        if (raycaster.ray.intersectBox(_box, _vector2)) {
-          const distance = raycaster.ray.origin.distanceTo(_vector2)
-          ;(
-            intersects as Array<
-              THREE.Intersection & { batchId?: number; objectId?: string }
-            >
-          ).push({
-            distance,
-            point: _vector2.clone(),
-            object: this,
-            face: null,
-            faceIndex: undefined,
-            uv: undefined,
-            batchId: geometryId,
-            objectId: geometryInfo.objectId
-          })
-        }
+      }
+      if (raycaster.ray.intersectBox(_box, _vector2)) {
+        const distance = raycaster.ray.origin.distanceTo(_vector2)
+        ;(
+          intersects as Array<
+            THREE.Intersection & { batchId?: number; objectId?: string }
+          >
+        ).push({
+          distance,
+          point: _vector2.clone(),
+          object: this,
+          face: null,
+          faceIndex: undefined,
+          uv: undefined,
+          batchId: geometryId,
+          objectId: geometryInfo.objectId
+        })
       }
       return
     }

--- a/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
@@ -543,27 +543,26 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     if (_batchIntersects.length === 0) {
       this.getBoundingBoxAt(geometryId, _box)
       _box.applyMatrix4(this.matrixWorld)
-      if (raycaster.ray.intersectBox(_box, _vector)) {
-        // Verify the intersection point is within the Line threshold
-        const threshold = raycaster.params.Line.threshold
+      const threshold = raycaster.params.Line.threshold
+      if (threshold > 0) {
         _box.expandByScalar(threshold)
-        if (raycaster.ray.intersectBox(_box, _vector2)) {
-          const distance = raycaster.ray.origin.distanceTo(_vector2)
-          ;(
-            intersects as Array<
-              THREE.Intersection & { batchId?: number; objectId?: string }
-            >
-          ).push({
-            distance,
-            point: _vector2.clone(),
-            object: this,
-            face: null,
-            faceIndex: undefined,
-            uv: undefined,
-            batchId: geometryId,
-            objectId: geometryInfo.objectId
-          })
-        }
+      }
+      if (raycaster.ray.intersectBox(_box, _vector2)) {
+        const distance = raycaster.ray.origin.distanceTo(_vector2)
+        ;(
+          intersects as Array<
+            THREE.Intersection & { batchId?: number; objectId?: string }
+          >
+        ).push({
+          distance,
+          point: _vector2.clone(),
+          object: this,
+          face: null,
+          faceIndex: undefined,
+          uv: undefined,
+          batchId: geometryId,
+          objectId: geometryInfo.objectId
+        })
       }
       geometry.dispose()
       return

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -1,4 +1,8 @@
-import { AcGiSubEntityTraits, log } from '@mlightcad/data-model'
+import {
+  type AcGiHatchPatternLine,
+  AcGiSubEntityTraits,
+  log
+} from '@mlightcad/data-model'
 import * as THREE from 'three'
 
 import {
@@ -154,8 +158,13 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     let material: THREE.Material
     if (!style.definitionLines || style.definitionLines.length < 1) {
       material = this.createMeshBasicMaterial(effectiveTraits, threeSide)
-    } else if (style.definitionLines.some(line => !line.dashLengths)) {
-      log.warn('Invalid dash pattern', style)
+    } else if (
+      style.definitionLines.some(line => !this.isValidDefinitionLine(line))
+    ) {
+      log.warn(
+        'Invalid hatch pattern definition line, fallback to solid fill',
+        style
+      )
       material = this.createMeshBasicMaterial(effectiveTraits, threeSide)
     } else {
       material = this.createHatchShaderMaterial(
@@ -339,12 +348,65 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     }
 
     const patternHash = style.definitionLines
-      .map(
-        pl =>
-          pl.dashLengths.join(',') + `@${pl.angle},${pl.base.x},${pl.base.y}`
-      )
+      .map(pl => {
+        if (!this.isValidDefinitionLine(pl)) {
+          return 'invalid'
+        }
+
+        const dash = pl.dashLengths!.join(',')
+        const angle = Number.isFinite(pl.angle) ? pl.angle : 0
+        const baseX = pl.base!.x!
+        const baseY = pl.base!.y!
+        return `${dash}@${angle},${baseX},${baseY}`
+      })
       .join('|')
 
     return `hatch_${traits.layer}_${traits.rgbColor}_${style.patternAngle}_${patternHash}${sideSuffix}${textSuffix}${bgSuffix}`
+  }
+
+  /**
+   * Normalizes one hatch pattern definition line in-place and validates it.
+   *
+   * DXF payloads occasionally contain partial pattern-line records. To keep
+   * hatch rendering resilient, this method applies fallback defaults:
+   * - `base` missing  -> `{ x: 0, y: 0 }`
+   * - `offset` missing -> `{ x: 0, y: 0 }`
+   * - `angle` missing  -> `0`
+   *
+   * `dashLengths` must still be an array; when absent or malformed, the line is
+   * considered invalid and the caller can fall back to solid fill rendering.
+   *
+   * @param line Candidate value read from hatch pattern data.
+   * @returns `true` when the line is usable for hatch shader generation.
+   */
+  private isValidDefinitionLine(line: AcGiHatchPatternLine) {
+    if (!line || typeof line !== 'object') return false
+    const mutable = line as AcGiHatchPatternLine & {
+      angle?: unknown
+      dashLengths?: unknown
+      base?: { x?: unknown; y?: unknown } | null
+      offset?: { x?: unknown; y?: unknown } | null
+    }
+
+    if (!Array.isArray(mutable.dashLengths)) return false
+
+    mutable.base = {
+      x: this.toFiniteNumber(mutable.base?.x, 0),
+      y: this.toFiniteNumber(mutable.base?.y, 0)
+    }
+    mutable.offset = {
+      x: this.toFiniteNumber(mutable.offset?.x, 0),
+      y: this.toFiniteNumber(mutable.offset?.y, 0)
+    }
+    mutable.angle = this.toFiniteNumber(mutable.angle, 0)
+    mutable.dashLengths = mutable.dashLengths.map(item =>
+      this.toFiniteNumber(item, 0)
+    )
+
+    return true
+  }
+
+  private toFiniteNumber(value: unknown, fallback = 0): number {
+    return Number.isFinite(value) ? (value as number) : fallback
   }
 }

--- a/packages/three-renderer/src/style/AcTrMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrMaterialManager.ts
@@ -373,6 +373,22 @@ export abstract class AcTrMaterialManager<T> {
     byLayerBindings?: AcTrByLayerBindingFlags
   ): THREE.Material {
     const material = this.createMaterialImpl(traits, options)
+    const isForeground = this.shouldTrackForeground(traits, options)
+    const isBackgroundFill = this.shouldTrackBackground(traits, options)
+
+    // Foreground-follow materials (typically ACI 7 lines/text) must be
+    // initialized against the current canvas background color, otherwise
+    // they can be created with stale white color on a light background
+    // before any theme-change repaint occurs.
+    if (isForeground) {
+      const foregroundColor =
+        this.options.currentBackgroundColor === 0 ? 0xffffff : 0x000000
+      AcTrMaterialUtil.setMaterialColor(
+        material,
+        new THREE.Color(foregroundColor)
+      )
+    }
+
     const resolvedByLayerBindings =
       byLayerBindings ?? this.resolveByLayerBindings(traits)
 
@@ -383,8 +399,8 @@ export abstract class AcTrMaterialManager<T> {
       isByLayerLineType: resolvedByLayerBindings.isByLayerLineType,
       isByLayerLineWeight: resolvedByLayerBindings.isByLayerLineWeight,
       isByLayerTransparency: resolvedByLayerBindings.isByLayerTransparency,
-      isForeground: this.shouldTrackForeground(traits, options),
-      isBackgroundFill: this.shouldTrackBackground(traits, options),
+      isForeground,
+      isBackgroundFill,
       materialKey: key
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.7.23
-  '@mlightcad/libredwg-converter': ^3.5.23
+  '@mlightcad/data-model': ^1.7.24
+  '@mlightcad/libredwg-converter': ^3.5.24
   '@mlightcad/mtext-renderer': ^0.10.7
   element-plus: ^2.12.0
   three: ^0.172.0
@@ -105,11 +105,11 @@ importers:
   packages/cad-simple-viewer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.23
-        version: 1.7.23
+        specifier: ^1.7.24
+        version: 1.7.24
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.23
-        version: 3.5.23(@mlightcad/data-model@1.7.23)
+        specifier: ^3.5.24
+        version: 3.5.24(@mlightcad/data-model@1.7.24)
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -154,8 +154,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.23
-        version: 1.7.23
+        specifier: ^1.7.24
+        version: 1.7.24
 
   packages/cad-viewer:
     dependencies:
@@ -166,8 +166,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.23
-        version: 1.7.23
+        specifier: ^1.7.24
+        version: 1.7.24
       '@vueuse/core':
         specifier: ^11.1.0
         version: 11.3.0(vue@3.5.31(typescript@5.9.3))
@@ -239,8 +239,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.23
-        version: 1.7.23
+        specifier: ^1.7.24
+        version: 1.7.24
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -294,14 +294,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.23
-        version: 1.7.23
+        specifier: ^1.7.24
+        version: 1.7.24
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.23
-        version: 1.7.23
+        specifier: ^1.7.24
+        version: 1.7.24
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.7
         version: 0.10.7(three@0.172.0)
@@ -1365,33 +1365,33 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.4.23':
-    resolution: {integrity: sha512-QV+QRJDi4sS8COk/JinK+UWC3a+c8ZEzWzxjkpTWN4NAgogipB39QXHj7v1Gw4CuxI0QBRiJVdBnJWefi4C3gg==}
+  '@mlightcad/common@1.4.24':
+    resolution: {integrity: sha512-PWlSxdBWEne/wSz43jibEIJ8/uj40XDum9TZjQ1HWPeD2zp/xv63sr9PblZFhNEUnuQ3bSnnQjcD99z5+oZJVQ==}
 
-  '@mlightcad/data-model@1.7.23':
-    resolution: {integrity: sha512-KFW7UIIBu1JTIGt0lr9dvwS/2H17UWiNmM7WFONtlSNILu/Fm9gZEJk6vY8dmJQE4RHyqLNkQLMivzwC+gaB/A==}
+  '@mlightcad/data-model@1.7.24':
+    resolution: {integrity: sha512-sp/zxSFqeVvbNLL9St2LKxf25yqa2z4rZRPb8m73gI0DoWVuanKJpsVG9dO4BuQddBhBUbbHCMBbS3KFma7y9Q==}
 
   '@mlightcad/dxf-json@1.1.3':
     resolution: {integrity: sha512-XslMIrowLI9VOs84/x4SmcsKSdNxSSGyEVrhJTFiSsB3CghtU2tzOmvDoCHCPa4jYCmYkQ1GK/rgQ+89wXXPgw==}
 
-  '@mlightcad/geometry-engine@3.2.23':
-    resolution: {integrity: sha512-P8RlpOKZW/2M2Uvk7vp1/6qDQalaSR//J4AvsIHZCbyK4td4M3N2pZw9ph1urZ3YymqScUYujPY7UEvVilgifw==}
+  '@mlightcad/geometry-engine@3.2.24':
+    resolution: {integrity: sha512-/q0//UwMFsjzYfh4DQ+MMI65hWJ0Zn6zLTe706XyIHw43d8g3YyENu5mGoXkv7FIkoz7UIW+G2vAY/23Exhfbg==}
     peerDependencies:
-      '@mlightcad/common': 1.4.23
+      '@mlightcad/common': 1.4.24
 
-  '@mlightcad/graphic-interface@3.3.23':
-    resolution: {integrity: sha512-I2ejwO8xgNeX/K72Dxl1COTJuaclXmzHdVHlXcMGH6xr8oCQulTnWFstk4OjCieEZUMlPNiNZNcUEAGEHR2NwQ==}
+  '@mlightcad/graphic-interface@3.3.24':
+    resolution: {integrity: sha512-aLhBKQlPlVs8qvyK+MCV1qVcGM0SNlwMzr1qzRgb7fcul33Jk94NMlwB5Z3MAXtXfcfMTY8g0g84i3x+ZsV4cQ==}
     peerDependencies:
-      '@mlightcad/common': 1.4.23
-      '@mlightcad/geometry-engine': 3.2.23
+      '@mlightcad/common': 1.4.24
+      '@mlightcad/geometry-engine': 3.2.24
 
-  '@mlightcad/libredwg-converter@3.5.23':
-    resolution: {integrity: sha512-EgY05ZmxtXJ/fLFTb1Oq4H7bAPheil7Idu8DsNDQZ/sh6BySy2kRaS26GiE6s/gnmohRJKiKbobxIRrixuLQ1A==}
+  '@mlightcad/libredwg-converter@3.5.24':
+    resolution: {integrity: sha512-hMzYvMrwCdvQeilKZJ12HSZhPf2ruLI++rTsErKnQ7+zpw4exhAC/g01N4OTaFEgvkiTziosZq3Gbl2qGzt+Tg==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.23
+      '@mlightcad/data-model': ^1.7.24
 
-  '@mlightcad/libredwg-web@0.6.10':
-    resolution: {integrity: sha512-yJ9bTyuKWTst2vEaYmWjW36bIM5xkfTPg3QhpbexdG+bqi7/UY/Jyp3X7tovcOv0HJ/gnDXV9RaeAs+IzUxJ5w==}
+  '@mlightcad/libredwg-web@0.7.0':
+    resolution: {integrity: sha512-x58HIOaRGskAk143hhJwuT8Gw2Gker7qLfrHFJZsNrSSpD7wLwuuZIdfGD0VZMlzq2/PmQoTJFKqIM4Qp+ptJw==}
 
   '@mlightcad/mtext-input-box@0.2.3':
     resolution: {integrity: sha512-+PMrtMKS96yAI7FKc4xuwIyljQ2Uqg8+ccg7QiyIbY56CcTrOCLQQqt/6EHMQADIcZYobf21+9PkoBaGndgfHg==}
@@ -6152,16 +6152,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.4.23':
+  '@mlightcad/common@1.4.24':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.7.23':
+  '@mlightcad/data-model@1.7.24':
     dependencies:
-      '@mlightcad/common': 1.4.23
+      '@mlightcad/common': 1.4.24
       '@mlightcad/dxf-json': 1.1.3
-      '@mlightcad/geometry-engine': 3.2.23(@mlightcad/common@1.4.23)
-      '@mlightcad/graphic-interface': 3.3.23(@mlightcad/common@1.4.23)(@mlightcad/geometry-engine@3.2.23(@mlightcad/common@1.4.23))
+      '@mlightcad/geometry-engine': 3.2.24(@mlightcad/common@1.4.24)
+      '@mlightcad/graphic-interface': 3.3.24(@mlightcad/common@1.4.24)(@mlightcad/geometry-engine@3.2.24(@mlightcad/common@1.4.24))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
@@ -6169,21 +6169,21 @@ snapshots:
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.2.23(@mlightcad/common@1.4.23)':
+  '@mlightcad/geometry-engine@3.2.24(@mlightcad/common@1.4.24)':
     dependencies:
-      '@mlightcad/common': 1.4.23
+      '@mlightcad/common': 1.4.24
 
-  '@mlightcad/graphic-interface@3.3.23(@mlightcad/common@1.4.23)(@mlightcad/geometry-engine@3.2.23(@mlightcad/common@1.4.23))':
+  '@mlightcad/graphic-interface@3.3.24(@mlightcad/common@1.4.24)(@mlightcad/geometry-engine@3.2.24(@mlightcad/common@1.4.24))':
     dependencies:
-      '@mlightcad/common': 1.4.23
-      '@mlightcad/geometry-engine': 3.2.23(@mlightcad/common@1.4.23)
+      '@mlightcad/common': 1.4.24
+      '@mlightcad/geometry-engine': 3.2.24(@mlightcad/common@1.4.24)
 
-  '@mlightcad/libredwg-converter@3.5.23(@mlightcad/data-model@1.7.23)':
+  '@mlightcad/libredwg-converter@3.5.24(@mlightcad/data-model@1.7.24)':
     dependencies:
-      '@mlightcad/data-model': 1.7.23
-      '@mlightcad/libredwg-web': 0.6.10
+      '@mlightcad/data-model': 1.7.24
+      '@mlightcad/libredwg-web': 0.7.0
 
-  '@mlightcad/libredwg-web@0.6.10': {}
+  '@mlightcad/libredwg-web@0.7.0': {}
 
   '@mlightcad/mtext-input-box@0.2.3(@mlightcad/mtext-renderer@0.10.7(three@0.172.0))(three@0.172.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- Improve resilience of 2D entity batch conversion by wrapping per-entity conversion/draw flow in `try/catch/finally`, preserving progress accounting even on conversion failures.
- Fix multiple batched rendering edge cases across group mapping and line raycast fallback logic.
- Strengthen hatch material creation by validating and normalizing pattern definition lines, with safe fallback to solid fill when data is malformed.
- Initialize foreground-follow materials against current background color to avoid stale contrast on first render.
- Upgrade `@mlightcad/data-model` and `@mlightcad/libredwg-converter` (and lockfile-resolved transitive package versions).

## Why
- DXF/graphics payloads can contain partial or inconsistent data, and current flows could fail hard or render incorrectly.
- Batched geometry and fallback hit-testing behavior needed better consistency for world transforms and multi-pass entity aggregation.
- Material initialization needed to match active background immediately, not only after later theme updates.

## What Changed
- `AcTrView2d.batchConvert` now:
  - wraps each entity conversion in `try/catch/finally`
  - logs failed entity conversions with object/type context
  - guarantees `decreaseNumOfEntitiesToProcess()` execution
  - simplifies async draw path by removing nested `then/finally`
- `AcTrBatchedGroup.addEntity` now accumulates entity mappings for repeated `objectId` additions and preserves/extends existing unbatched object tracking.
- `AcTrBatchedLine` and `AcTrBatchedLine2` raycast fallback now:
  - applies `matrixWorld` to bbox before intersection checks
  - handles `Line.threshold` expansion only when threshold is positive
  - keeps bbox-based fallback intersection push behavior consistent
- `AcEdFloatingInput` avoids iterating empty child collections by requiring `item.children.length > 0`.
- `AcTrFillMaterialManager` now:
  - validates hatch definition lines via `isValidDefinitionLine`
  - normalizes missing/invalid `base`, `offset`, `angle`, and dash values
  - falls back to solid fill and warns when pattern lines are invalid
  - generates safer hatch pattern cache keys from normalized values
- `AcTrMaterialManager.createMaterial` now pre-initializes foreground material color based on current background before binding tracking metadata.
- Dependency overrides and lockfile updated:
  - `@mlightcad/data-model` `^1.7.23 -> ^1.7.24`
  - `@mlightcad/libredwg-converter` `^3.5.23 -> ^3.5.24`

## Risks / Notes
- Hatch definition normalization mutates line objects in place; this is intentional for resilience but may affect downstream assumptions about raw input immutability.
- Bbox fallback hit-testing now consistently uses world-space boxes; interaction behavior may shift for previously mis-transformed cases.
- Branch-level committed diff against `main` is currently empty; this PR text is based on staged workspace changes.
