### PR TITLE
feat: add gradient hatch rendering support to three-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@mlightcad/data-model": "^1.7.25",
-      "@mlightcad/libredwg-converter": "^3.5.25",
+      "@mlightcad/data-model": "../../../realdwg-web/packages/data-model",
+      "@mlightcad/libredwg-converter": "../../../realdwg-web/packages/libredwg-converter",
       "@mlightcad/mtext-renderer": "^0.10.7",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@mlightcad/data-model": "../../../realdwg-web/packages/data-model",
-      "@mlightcad/libredwg-converter": "../../../realdwg-web/packages/libredwg-converter",
+      "@mlightcad/data-model": "^1.7.26",
+      "@mlightcad/libredwg-converter": "^3.5.26",
       "@mlightcad/mtext-renderer": "^0.10.7",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",

--- a/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
@@ -126,4 +126,49 @@ describe('AcTrStyleManager', () => {
     expect(lineworkFillMetadata.isBackgroundFill).toBe(false)
     expect(lineworkFillMaterial.color.getHex()).toBe(0x000000)
   })
+
+  it('creates gradient hatch shader materials with per-boundary uniforms', () => {
+    const styleManager = new AcTrStyleManager()
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.layer = 'A-GRAD'
+    traits.rgbColor = 0xff0000
+    traits.drawOrder = -1
+    traits.fillType = {
+      solidFill: false,
+      patternAngle: 0,
+      definitionLines: [],
+      gradient: {
+        name: 'LINEAR',
+        angle: Math.PI / 4,
+        shift: 0.25,
+        oneColorMode: false,
+        shadeTintValue: 0,
+        endColor: 0x0000ff
+      }
+    }
+
+    const material = styleManager.getFillMaterial(traits, new THREE.Vector2(), {
+      minX: 1,
+      minY: 2,
+      maxX: 5,
+      maxY: 8
+    }) as THREE.ShaderMaterial
+    const otherBoundsMaterial = styleManager.getFillMaterial(
+      traits,
+      new THREE.Vector2(),
+      { minX: 0, minY: 0, maxX: 5, maxY: 8 }
+    )
+
+    expect(material).toBeInstanceOf(THREE.ShaderMaterial)
+    expect(material).not.toBe(otherBoundsMaterial)
+    expect(material.vertexShader).toContain('attribute vec2 gradientPosition')
+    expect(material.uniforms.u_startColor.value.getHex()).toBe(0xff0000)
+    expect(material.uniforms.u_endColor.value.getHex()).toBe(0x0000ff)
+    expect(material.uniforms.u_angle.value).toBeCloseTo(Math.PI / 4)
+    expect(material.uniforms.u_shift.value).toBeCloseTo(0.25)
+
+    const metadata = getMaterialMetadata(material)
+    expect(metadata.drawOrder).toBe(-1)
+    expect(metadata.isBackgroundFill).toBe(false)
+  })
 })

--- a/packages/three-renderer/src/object/AcTrPolygon.ts
+++ b/packages/three-renderer/src/object/AcTrPolygon.ts
@@ -39,10 +39,54 @@ export class AcTrPolygon extends AcTrEntity {
       geometry.computeBoundingBox()
       this.box = geometry.boundingBox!
 
-      const material = this.styleManager.getFillMaterial(traits)
+      this.addGradientPositionAttribute(geometry, traits)
+
+      const gradientBounds = {
+        minX: this.box.min.x,
+        minY: this.box.min.y,
+        maxX: this.box.max.x,
+        maxY: this.box.max.y
+      }
+      const material = this.styleManager.getFillMaterial(
+        traits,
+        undefined,
+        gradientBounds
+      )
       this.add(new THREE.Mesh(geometry, material))
     }
   }
+
+  private addGradientPositionAttribute(
+    geometry: THREE.BufferGeometry,
+    traits: AcGiSubEntityTraits
+  ) {
+    if (!traits.fillType.gradient || !geometry.boundingBox) {
+      return
+    }
+
+    const position = geometry.getAttribute('position')
+    if (!position) {
+      return
+    }
+
+    const box = geometry.boundingBox
+    const centerX = (box.min.x + box.max.x) * 0.5
+    const centerY = (box.min.y + box.max.y) * 0.5
+    const halfWidth = Math.max((box.max.x - box.min.x) * 0.5, 1e-9)
+    const halfHeight = Math.max((box.max.y - box.min.y) * 0.5, 1e-9)
+    const values = new Float32Array(position.count * 2)
+
+    for (let index = 0; index < position.count; index++) {
+      values[index * 2] = (position.getX(index) - centerX) / halfWidth
+      values[index * 2 + 1] = (position.getY(index) - centerY) / halfHeight
+    }
+
+    geometry.setAttribute(
+      'gradientPosition',
+      new THREE.BufferAttribute(values, 2)
+    )
+  }
+
   private buildHatchGeometry(
     pointBoundaries: AcGePoint2d[][],
     node: AcGeIndexNode,

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -6,14 +6,14 @@ import {
 import * as THREE from 'three'
 
 import {
-  AcTrPatternLine,
-  createHatchPatternShaderMaterial
-} from './AcTrHatchPatternShaders'
-import {
   AcTrGradientBounds,
   createGradientHatchShaderMaterial,
   normalizeGradientBounds
 } from './AcTrGradientHatchShaders'
+import {
+  AcTrPatternLine,
+  createHatchPatternShaderMaterial
+} from './AcTrHatchPatternShaders'
 import { AcTrMaterialManager, AcTrMaterialSide } from './AcTrMaterialManager'
 import {
   getMaterialMetadata,

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -9,6 +9,11 @@ import {
   AcTrPatternLine,
   createHatchPatternShaderMaterial
 } from './AcTrHatchPatternShaders'
+import {
+  AcTrGradientBounds,
+  createGradientHatchShaderMaterial,
+  normalizeGradientBounds
+} from './AcTrGradientHatchShaders'
 import { AcTrMaterialManager, AcTrMaterialSide } from './AcTrMaterialManager'
 import {
   getMaterialMetadata,
@@ -17,6 +22,7 @@ import {
 
 export interface AcTrFillMaterialOptions {
   rebaseOffset: THREE.Vector2
+  gradientBounds?: AcTrGradientBounds
   /**
    * Which face the rasteriser keeps.  Defaults to `'front'`.
    *
@@ -33,8 +39,8 @@ export interface AcTrFillMaterialOptions {
  *
  * Responsibilities:
  * - Returns THREE.MeshBasicMaterial for solid fills or empty/unsupported hatches.
- * - Returns custom shader materials for patterned hatches.
- * - Caches both MeshBasicMaterials and hatch shader materials.
+ * - Returns custom shader materials for patterned and gradient hatches.
+ * - Caches MeshBasicMaterials and hatch shader materials.
  * - Provides `clear()` method to dispose of all cached materials.
  */
 export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMaterialOptions> {
@@ -94,7 +100,11 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     traits: AcGiSubEntityTraits,
     _options: AcTrFillMaterialOptions
   ): boolean {
-    return (traits.drawOrder ?? 0) < 0 && traits.color.isForeground
+    return (
+      (traits.drawOrder ?? 0) < 0 &&
+      traits.color.isForeground &&
+      !traits.fillType.gradient
+    )
   }
 
   /**
@@ -125,7 +135,13 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
       : traits
 
     let material: THREE.Material
-    if (!style.definitionLines || style.definitionLines.length < 1) {
+    if (style.gradient) {
+      material = this.createGradientShaderMaterial(
+        effectiveTraits,
+        options,
+        threeSide
+      )
+    } else if (!style.definitionLines || style.definitionLines.length < 1) {
       material = this.createMeshBasicMaterial(effectiveTraits, threeSide)
     } else if (
       style.definitionLines.some(line => !this.isValidDefinitionLine(line))
@@ -150,6 +166,19 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
       side
     })
     return material
+  }
+
+  private createGradientShaderMaterial(
+    traits: AcGiSubEntityTraits,
+    options: AcTrFillMaterialOptions,
+    threeSide: THREE.Side
+  ): THREE.Material {
+    return createGradientHatchShaderMaterial(
+      traits.fillType.gradient!,
+      normalizeGradientBounds(options.gradientBounds),
+      new THREE.Color(traits.rgbColor),
+      threeSide
+    )
   }
 
   /**
@@ -300,9 +329,36 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     // layer + colour.  The suffix is appended only when the condition
     // matches, keeping the common path's keys bit-identical.
     const bgSuffix =
-      (traits.drawOrder ?? 0) < 0 && traits.color.isForeground ? '_bgfill' : ''
+      (traits.drawOrder ?? 0) < 0 &&
+      traits.color.isForeground &&
+      !style.gradient
+        ? '_bgfill'
+        : ''
 
     // Use color + layer + rebaseOffset + pattern info for key
+    if (style.gradient) {
+      const gradient = style.gradient
+      const bounds = normalizeGradientBounds(options.gradientBounds)
+      return [
+        'gradient',
+        traits.layer,
+        traits.rgbColor,
+        gradient.name || 'LINEAR',
+        gradient.angle ?? 0,
+        gradient.shift ?? 0,
+        gradient.oneColorMode ? 1 : 0,
+        gradient.shadeTintValue ?? 0,
+        gradient.startColor ?? '',
+        gradient.endColor ?? '',
+        bounds.minX,
+        bounds.minY,
+        bounds.maxX,
+        bounds.maxY,
+        sideSuffix,
+        drawOrderSuffix
+      ].join('_')
+    }
+
     const isSolid = !style.definitionLines || style.definitionLines.length === 0
     if (isSolid) {
       return `solid_${traits.layer}_${traits.rgbColor}${sideSuffix}${drawOrderSuffix}${bgSuffix}`

--- a/packages/three-renderer/src/style/AcTrGradientHatchShaders.ts
+++ b/packages/three-renderer/src/style/AcTrGradientHatchShaders.ts
@@ -1,0 +1,201 @@
+import * as THREE from 'three'
+
+export interface AcTrGradientBounds {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+export interface AcTrGradientHatchStyle {
+  name?: string
+  angle?: number
+  shift?: number
+  oneColorMode?: boolean
+  shadeTintValue?: number
+  startColor?: number
+  endColor?: number
+}
+
+enum AcTrGradientType {
+  Linear = 0,
+  Cylinder = 1,
+  InvCylinder = 2,
+  Spherical = 3,
+  InvSpherical = 4,
+  Hemispherical = 5,
+  InvHemispherical = 6,
+  Curved = 7,
+  InvCurved = 8
+}
+
+const GradientTypes: Record<string, AcTrGradientType> = {
+  LINEAR: AcTrGradientType.Linear,
+  CYLINDER: AcTrGradientType.Cylinder,
+  INVCYLINDER: AcTrGradientType.InvCylinder,
+  SPHERICAL: AcTrGradientType.Spherical,
+  INVSPHERICAL: AcTrGradientType.InvSpherical,
+  HEMISPHERICAL: AcTrGradientType.Hemispherical,
+  INVHEMISPHERICAL: AcTrGradientType.InvHemispherical,
+  CURVED: AcTrGradientType.Curved,
+  INVCURVED: AcTrGradientType.InvCurved
+}
+
+export function createGradientHatchShaderMaterial(
+  gradient: AcTrGradientHatchStyle,
+  _bounds: AcTrGradientBounds,
+  fallbackColor: THREE.Color,
+  side: THREE.Side = THREE.FrontSide
+): THREE.Material {
+  const startColor = new THREE.Color(
+    gradient.startColor ?? fallbackColor.getHex()
+  )
+  const endColor = new THREE.Color(
+    gradient.endColor ??
+      getOneColorGradientEndColor(
+        startColor,
+        gradient.oneColorMode,
+        gradient.shadeTintValue
+      )
+  )
+  const type =
+    GradientTypes[(gradient.name || 'LINEAR').trim().toUpperCase()] ??
+    AcTrGradientType.Linear
+
+  const uniforms = {
+    u_startColor: { value: startColor },
+    u_endColor: { value: endColor },
+    u_angle: { value: gradient.angle ?? 0 },
+    u_shift: { value: gradient.shift ?? 0 },
+    u_gradientType: { value: type }
+  }
+
+  const vertexShader = /* glsl */ `
+    attribute vec2 gradientPosition;
+
+    varying vec2 v_gradientPosition;
+
+    #include <clipping_planes_pars_vertex>
+    void main() {
+      v_gradientPosition = gradientPosition;
+
+      #include <begin_vertex>
+      #include <project_vertex>
+      #include <clipping_planes_vertex>
+    }`
+
+  const fragmentShader = /* glsl */ `
+    precision highp float;
+
+    uniform vec3 u_startColor;
+    uniform vec3 u_endColor;
+    uniform float u_angle;
+    uniform float u_shift;
+    uniform int u_gradientType;
+
+    varying vec2 v_gradientPosition;
+
+    #include <clipping_planes_pars_fragment>
+
+    const float EPSILON = 1e-6;
+
+    vec2 rotate(vec2 samplePos, float angle) {
+      float s = sin(angle);
+      float c = cos(angle);
+      return vec2(c * samplePos.x - s * samplePos.y, c * samplePos.y + s * samplePos.x);
+    }
+
+    float saturate(float value) {
+      return clamp(value, 0.0, 1.0);
+    }
+
+    float getGradientFactor(vec2 localPos) {
+      vec2 shiftedPos = localPos - vec2(clamp(u_shift, -1.0, 1.0), 0.0);
+      float linear = saturate(shiftedPos.x * 0.5 + 0.5);
+      float cylinder = saturate(1.0 - abs(shiftedPos.x));
+      float radial = saturate(length(shiftedPos));
+      float curved = smoothstep(0.0, 1.0, linear);
+      float hemi = saturate(1.0 - length(shiftedPos - vec2(0.0, -1.0)) * 0.5);
+
+      if (u_gradientType == 1) {
+        return cylinder;
+      }
+      if (u_gradientType == 2) {
+        return 1.0 - cylinder;
+      }
+      if (u_gradientType == 3) {
+        return 1.0 - radial;
+      }
+      if (u_gradientType == 4) {
+        return radial;
+      }
+      if (u_gradientType == 5) {
+        return hemi;
+      }
+      if (u_gradientType == 6) {
+        return 1.0 - hemi;
+      }
+      if (u_gradientType == 7) {
+        return curved;
+      }
+      if (u_gradientType == 8) {
+        return 1.0 - curved;
+      }
+      return linear;
+    }
+
+    void main() {
+      #include <clipping_planes_fragment>
+
+      vec2 localPos = rotate(v_gradientPosition, -u_angle);
+      float factor = saturate(getGradientFactor(localPos));
+
+      gl_FragColor = vec4(mix(u_startColor, u_endColor, factor), 1.0);
+      #include <colorspace_fragment>
+    }`
+
+  return new THREE.ShaderMaterial({
+    uniforms,
+    vertexShader,
+    fragmentShader,
+    side
+  })
+}
+
+function getOneColorGradientEndColor(
+  startColor: THREE.Color,
+  oneColorMode = false,
+  shadeTintValue = 0
+) {
+  if (!oneColorMode) {
+    return 0xffffff
+  }
+
+  const amount = Math.abs(THREE.MathUtils.clamp(shadeTintValue, -1, 1)) || 0.5
+  const target =
+    shadeTintValue < 0 ? new THREE.Color(0x000000) : new THREE.Color(0xffffff)
+  return startColor.clone().lerp(target, amount).getHex()
+}
+
+export function normalizeGradientBounds(
+  bounds?: AcTrGradientBounds
+): AcTrGradientBounds {
+  if (!bounds) {
+    return {
+      minX: 0,
+      minY: 0,
+      maxX: 1,
+      maxY: 1
+    }
+  }
+  return {
+    minX: toFiniteNumber(bounds.minX, 0),
+    minY: toFiniteNumber(bounds.minY, 0),
+    maxX: toFiniteNumber(bounds.maxX, 1),
+    maxY: toFiniteNumber(bounds.maxY, 1)
+  }
+}
+
+function toFiniteNumber(value: unknown, fallback: number) {
+  return Number.isFinite(value) ? (value as number) : fallback
+}

--- a/packages/three-renderer/src/style/AcTrStyleManager.ts
+++ b/packages/three-renderer/src/style/AcTrStyleManager.ts
@@ -134,10 +134,17 @@ export class AcTrStyleManager {
    */
   getFillMaterial(
     traits: AcGiSubEntityTraits,
-    rebaseOffset: THREE.Vector2 = _rebaseOffset
+    rebaseOffset: THREE.Vector2 = _rebaseOffset,
+    gradientBounds?: {
+      minX: number
+      minY: number
+      maxX: number
+      maxY: number
+    }
   ): THREE.Material {
     return this.fillMgr.getMaterial(traits, {
-      rebaseOffset
+      rebaseOffset,
+      gradientBounds
     })
   }
 

--- a/packages/three-renderer/src/util/AcTrMaterialUtil.ts
+++ b/packages/three-renderer/src/util/AcTrMaterialUtil.ts
@@ -67,6 +67,12 @@ export class AcTrMaterialUtil {
       if (material.uniforms.u_color) {
         material.uniforms.u_color.value.set(color)
       }
+      if (material.uniforms.u_startColor) {
+        material.uniforms.u_startColor.value.set(color)
+      }
+      if (material.uniforms.u_endColor) {
+        material.uniforms.u_endColor.value.set(color)
+      }
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.7.25
-  '@mlightcad/libredwg-converter': ^3.5.25
+  '@mlightcad/data-model': ../../../realdwg-web/packages/data-model
+  '@mlightcad/libredwg-converter': ../../../realdwg-web/packages/libredwg-converter
   '@mlightcad/mtext-renderer': ^0.10.7
   element-plus: ^2.12.0
   three: ^0.172.0
@@ -105,11 +105,11 @@ importers:
   packages/cad-simple-viewer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.25
-        version: 1.7.25
+        specifier: ../../../realdwg-web/packages/data-model
+        version: link:../../../realdwg-web/packages/data-model
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.25
-        version: 3.5.25(@mlightcad/data-model@1.7.25)
+        specifier: ../../../realdwg-web/packages/libredwg-converter
+        version: link:../../../realdwg-web/packages/libredwg-converter
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -154,8 +154,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.25
-        version: 1.7.25
+        specifier: ../../../realdwg-web/packages/data-model
+        version: link:../../../realdwg-web/packages/data-model
 
   packages/cad-viewer:
     dependencies:
@@ -166,8 +166,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.25
-        version: 1.7.25
+        specifier: ../../../realdwg-web/packages/data-model
+        version: link:../../../realdwg-web/packages/data-model
       '@vueuse/core':
         specifier: ^11.1.0
         version: 11.3.0(vue@3.5.31(typescript@5.9.3))
@@ -239,8 +239,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.25
-        version: 1.7.25
+        specifier: ../../../realdwg-web/packages/data-model
+        version: link:../../../realdwg-web/packages/data-model
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -294,14 +294,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.25
-        version: 1.7.25
+        specifier: ../../../realdwg-web/packages/data-model
+        version: link:../../../realdwg-web/packages/data-model
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.25
-        version: 1.7.25
+        specifier: ../../../realdwg-web/packages/data-model
+        version: link:../../../realdwg-web/packages/data-model
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.7
         version: 0.10.7(three@0.172.0)
@@ -1184,9 +1184,6 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fxts/core@1.26.0':
-    resolution: {integrity: sha512-ONaza1CGr8dLKmJ0HQgi0h4XuyDJMr0P70M7o/My/YeeRxuYoSANHjE2nSY7xO4WHgxUD5ojd5dpxlFOzAEJsA==}
-
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
@@ -1342,10 +1339,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@lukeed/csprng@1.1.0':
-    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
-    engines: {node: '>=8'}
-
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -1364,34 +1357,6 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
-
-  '@mlightcad/common@1.4.25':
-    resolution: {integrity: sha512-Lowyt6cHJn7sX1+zreiOgMPokMBrfQBKUTrAUvTpRiNd6aMQtgVGpgjG70WllDGLCXi5M9xEopRff7JUYZCe5g==}
-
-  '@mlightcad/data-model@1.7.25':
-    resolution: {integrity: sha512-3BFTrQ53sWcp9lS4KVZ7n8TGJfF3NqrIGKwt2F5+6phJHSDvqyCbVZh4dAgncbgnE3e2SvjkQX9Ck46G9e0h+Q==}
-
-  '@mlightcad/dxf-json@1.1.3':
-    resolution: {integrity: sha512-XslMIrowLI9VOs84/x4SmcsKSdNxSSGyEVrhJTFiSsB3CghtU2tzOmvDoCHCPa4jYCmYkQ1GK/rgQ+89wXXPgw==}
-
-  '@mlightcad/geometry-engine@3.2.25':
-    resolution: {integrity: sha512-NCockKrpUJTtJRNJCnK1RP2CXYRl4R1aPUiUTHCc1EQlK3j1Yds+zBp7P1XwMWuJIlD8YdhbgXtwTWY+/3mUOA==}
-    peerDependencies:
-      '@mlightcad/common': 1.4.25
-
-  '@mlightcad/graphic-interface@3.3.25':
-    resolution: {integrity: sha512-v5lGzaox1DImnMoJSgfPxrEW/hUWOgCQxJ4U9LNax3IEHuSZFq9uDdd5eVj7KgWcrLUkPAykS9jvFSeAkSTZCg==}
-    peerDependencies:
-      '@mlightcad/common': 1.4.25
-      '@mlightcad/geometry-engine': 3.2.25
-
-  '@mlightcad/libredwg-converter@3.5.25':
-    resolution: {integrity: sha512-zD+xxZRj8oVQ0BYbWAp1gfITYVYqSCuvP6Nj318PkXCknfzOzNyghvqSeq3ghoZ+VP37WHw1QUracQnZjbx1/w==}
-    peerDependencies:
-      '@mlightcad/data-model': ^1.7.25
-
-  '@mlightcad/libredwg-web@0.7.0':
-    resolution: {integrity: sha512-x58HIOaRGskAk143hhJwuT8Gw2Gker7qLfrHFJZsNrSSpD7wLwuuZIdfGD0VZMlzq2/PmQoTJFKqIM4Qp+ptJw==}
 
   '@mlightcad/mtext-input-box@0.2.3':
     resolution: {integrity: sha512-+PMrtMKS96yAI7FKc4xuwIyljQ2Uqg8+ccg7QiyIbY56CcTrOCLQQqt/6EHMQADIcZYobf21+9PkoBaGndgfHg==}
@@ -3577,10 +3542,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  loglevel@1.9.2:
-    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
-    engines: {node: '>= 0.6.0'}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -4480,10 +4441,6 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
-
-  uid@2.0.2:
-    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
-    engines: {node: '>=8'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5791,10 +5748,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fxts/core@1.26.0':
-    dependencies:
-      tslib: 2.8.1
-
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
       '@shikijs/engine-oniguruma': 3.23.0
@@ -6075,8 +6028,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lukeed/csprng@1.1.0': {}
-
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -6128,39 +6079,6 @@ snapshots:
       resolve: 1.22.11
 
   '@microsoft/tsdoc@0.16.0': {}
-
-  '@mlightcad/common@1.4.25':
-    dependencies:
-      loglevel: 1.9.2
-
-  '@mlightcad/data-model@1.7.25':
-    dependencies:
-      '@mlightcad/common': 1.4.25
-      '@mlightcad/dxf-json': 1.1.3
-      '@mlightcad/geometry-engine': 3.2.25(@mlightcad/common@1.4.25)
-      '@mlightcad/graphic-interface': 3.3.25(@mlightcad/common@1.4.25)(@mlightcad/geometry-engine@3.2.25(@mlightcad/common@1.4.25))
-      iconv-lite: 0.7.2
-      uid: 2.0.2
-
-  '@mlightcad/dxf-json@1.1.3':
-    dependencies:
-      '@fxts/core': 1.26.0
-
-  '@mlightcad/geometry-engine@3.2.25(@mlightcad/common@1.4.25)':
-    dependencies:
-      '@mlightcad/common': 1.4.25
-
-  '@mlightcad/graphic-interface@3.3.25(@mlightcad/common@1.4.25)(@mlightcad/geometry-engine@3.2.25(@mlightcad/common@1.4.25))':
-    dependencies:
-      '@mlightcad/common': 1.4.25
-      '@mlightcad/geometry-engine': 3.2.25(@mlightcad/common@1.4.25)
-
-  '@mlightcad/libredwg-converter@3.5.25(@mlightcad/data-model@1.7.25)':
-    dependencies:
-      '@mlightcad/data-model': 1.7.25
-      '@mlightcad/libredwg-web': 0.7.0
-
-  '@mlightcad/libredwg-web@0.7.0': {}
 
   '@mlightcad/mtext-input-box@0.2.3(@mlightcad/mtext-renderer@0.10.7(three@0.172.0))(three@0.172.0)':
     dependencies:
@@ -8630,8 +8548,6 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
-  loglevel@1.9.2: {}
-
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
@@ -9520,10 +9436,6 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
-
-  uid@2.0.2:
-    dependencies:
-      '@lukeed/csprng': 1.1.0
 
   undici-types@6.21.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ../../../realdwg-web/packages/data-model
-  '@mlightcad/libredwg-converter': ../../../realdwg-web/packages/libredwg-converter
+  '@mlightcad/data-model': ^1.7.26
+  '@mlightcad/libredwg-converter': ^3.5.26
   '@mlightcad/mtext-renderer': ^0.10.7
   element-plus: ^2.12.0
   three: ^0.172.0
@@ -105,11 +105,11 @@ importers:
   packages/cad-simple-viewer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ../../../realdwg-web/packages/data-model
-        version: link:../../../realdwg-web/packages/data-model
+        specifier: ^1.7.26
+        version: 1.7.26
       '@mlightcad/libredwg-converter':
-        specifier: ../../../realdwg-web/packages/libredwg-converter
-        version: link:../../../realdwg-web/packages/libredwg-converter
+        specifier: ^3.5.26
+        version: 3.5.26(@mlightcad/data-model@1.7.26)
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -154,8 +154,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ../../../realdwg-web/packages/data-model
-        version: link:../../../realdwg-web/packages/data-model
+        specifier: ^1.7.26
+        version: 1.7.26
 
   packages/cad-viewer:
     dependencies:
@@ -166,8 +166,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ../../../realdwg-web/packages/data-model
-        version: link:../../../realdwg-web/packages/data-model
+        specifier: ^1.7.26
+        version: 1.7.26
       '@vueuse/core':
         specifier: ^11.1.0
         version: 11.3.0(vue@3.5.31(typescript@5.9.3))
@@ -239,8 +239,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ../../../realdwg-web/packages/data-model
-        version: link:../../../realdwg-web/packages/data-model
+        specifier: ^1.7.26
+        version: 1.7.26
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -294,14 +294,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ../../../realdwg-web/packages/data-model
-        version: link:../../../realdwg-web/packages/data-model
+        specifier: ^1.7.26
+        version: 1.7.26
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ../../../realdwg-web/packages/data-model
-        version: link:../../../realdwg-web/packages/data-model
+        specifier: ^1.7.26
+        version: 1.7.26
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.7
         version: 0.10.7(three@0.172.0)
@@ -1184,6 +1184,9 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@fxts/core@1.26.0':
+    resolution: {integrity: sha512-ONaza1CGr8dLKmJ0HQgi0h4XuyDJMr0P70M7o/My/YeeRxuYoSANHjE2nSY7xO4WHgxUD5ojd5dpxlFOzAEJsA==}
+
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
@@ -1339,6 +1342,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -1357,6 +1364,34 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@mlightcad/common@1.4.26':
+    resolution: {integrity: sha512-xOBxX5VIU+9BGyr40jLEphR7O2oR2vLNq+0q7IhV369QyA7iNESbYyzu8FhZDxT9tMDNfNm8yjUgQtncGZp3UQ==}
+
+  '@mlightcad/data-model@1.7.26':
+    resolution: {integrity: sha512-qiLCp/+UsyzsHKxiKFaEos8RccKMMqImmFn8LpovrmnvCgVwOOvXn4hdqHqKFZMcjtFAG8sb9O5HvrNdrTXnfw==}
+
+  '@mlightcad/dxf-json@1.1.4':
+    resolution: {integrity: sha512-1Vo0g5La4JEHEyA3ayZx/5fHMIGYbcc6FM/4plNP9nF7803IdcvAzXrNHN/ddnv41mRqPy8awF0TvJBqRTe1xg==}
+
+  '@mlightcad/geometry-engine@3.2.26':
+    resolution: {integrity: sha512-ifsyfKB6dTOgWhdwE2yFlHVsB4A++RUIDwXP4HGoY+AOsXq2W6yKqMCTDDZPNnmzIUtymUhNmNymNhFHqmxXvg==}
+    peerDependencies:
+      '@mlightcad/common': 1.4.26
+
+  '@mlightcad/graphic-interface@3.3.26':
+    resolution: {integrity: sha512-R0JjcN7ldhanqIYsJJsnStDi60zHnkCrtdb/XJ4q0B9cLvqk/5NRudAEj6+oIYmvtZKAVgCFU9ALuJuhqZlMNw==}
+    peerDependencies:
+      '@mlightcad/common': 1.4.26
+      '@mlightcad/geometry-engine': 3.2.26
+
+  '@mlightcad/libredwg-converter@3.5.26':
+    resolution: {integrity: sha512-pd9JmD4C42F/owkXML0TaFoEeFYaRSSSTydI7lNlzpqSH8oeToPznQea0MXQn/ywXYs/+G5DCeLJD+pFWH5ADA==}
+    peerDependencies:
+      '@mlightcad/data-model': ^1.7.26
+
+  '@mlightcad/libredwg-web@0.7.1':
+    resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
   '@mlightcad/mtext-input-box@0.2.3':
     resolution: {integrity: sha512-+PMrtMKS96yAI7FKc4xuwIyljQ2Uqg8+ccg7QiyIbY56CcTrOCLQQqt/6EHMQADIcZYobf21+9PkoBaGndgfHg==}
@@ -3542,6 +3577,10 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -4441,6 +4480,10 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uid@2.0.2:
+    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
+    engines: {node: '>=8'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5748,6 +5791,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@fxts/core@1.26.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
       '@shikijs/engine-oniguruma': 3.23.0
@@ -6028,6 +6075,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lukeed/csprng@1.1.0': {}
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -6079,6 +6128,39 @@ snapshots:
       resolve: 1.22.11
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@mlightcad/common@1.4.26':
+    dependencies:
+      loglevel: 1.9.2
+
+  '@mlightcad/data-model@1.7.26':
+    dependencies:
+      '@mlightcad/common': 1.4.26
+      '@mlightcad/dxf-json': 1.1.4
+      '@mlightcad/geometry-engine': 3.2.26(@mlightcad/common@1.4.26)
+      '@mlightcad/graphic-interface': 3.3.26(@mlightcad/common@1.4.26)(@mlightcad/geometry-engine@3.2.26(@mlightcad/common@1.4.26))
+      iconv-lite: 0.7.2
+      uid: 2.0.2
+
+  '@mlightcad/dxf-json@1.1.4':
+    dependencies:
+      '@fxts/core': 1.26.0
+
+  '@mlightcad/geometry-engine@3.2.26(@mlightcad/common@1.4.26)':
+    dependencies:
+      '@mlightcad/common': 1.4.26
+
+  '@mlightcad/graphic-interface@3.3.26(@mlightcad/common@1.4.26)(@mlightcad/geometry-engine@3.2.26(@mlightcad/common@1.4.26))':
+    dependencies:
+      '@mlightcad/common': 1.4.26
+      '@mlightcad/geometry-engine': 3.2.26(@mlightcad/common@1.4.26)
+
+  '@mlightcad/libredwg-converter@3.5.26(@mlightcad/data-model@1.7.26)':
+    dependencies:
+      '@mlightcad/data-model': 1.7.26
+      '@mlightcad/libredwg-web': 0.7.1
+
+  '@mlightcad/libredwg-web@0.7.1': {}
 
   '@mlightcad/mtext-input-box@0.2.3(@mlightcad/mtext-renderer@0.10.7(three@0.172.0))(three@0.172.0)':
     dependencies:
@@ -8548,6 +8630,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  loglevel@1.9.2: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
@@ -9436,6 +9520,10 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  uid@2.0.2:
+    dependencies:
+      '@lukeed/csprng': 1.1.0
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary

- Add gradient hatch style data to the graphics hatch style contract.
- Pass `AcDbHatch` gradient properties through `subWorldDraw()`.
- Add a Three.js shader material for AutoCAD-style gradient hatch fills.
- Support predefined gradient names including `LINEAR`, `CYLINDER`, `SPHERICAL`, `HEMISPHERICAL`, `CURVED`, and inverse variants.
- Store per-vertex gradient sample coordinates so batched mesh rebasing does not collapse gradients into solid colors.
- Add coverage for gradient hatch material creation.

## Validation

- `pnpm --filter @mlightcad/three-renderer build`
- `pnpm jest packages/three-renderer/__tests__/AcTrStyleManager.spec.ts --runInBand`
- `pnpm --dir ../realdwg-web --filter @mlightcad/data-model build`
- `pnpm --dir ../realdwg-web exec jest packages/data-model/__tests__/AcDbHatch.spec.ts --runInBand`
