### PR TITLE
fix: fix custom font base URL propagation for MText renderer

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
@@ -217,8 +217,7 @@ import { AcApDocManager } from '../src/app/AcApDocManager'
 
 describe('AcApDocManager font URL configuration', () => {
   beforeEach(() => {
-    ;(AcApDocManager as unknown as { _instance: unknown })._instance =
-      undefined
+    ;(AcApDocManager as unknown as { _instance: unknown })._instance = undefined
     mockFontLoaderInstances.length = 0
     mockInitialize.mockClear()
     mockSetRenderMode.mockClear()

--- a/packages/cad-viewer/src/component/common/MlHatchFillTypePanel.vue
+++ b/packages/cad-viewer/src/component/common/MlHatchFillTypePanel.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { ElOption,ElSelect } from 'element-plus'
+import { ElOption, ElSelect } from 'element-plus'
 
 interface MlHatchFillTypePanelProps {
   modelValue?: string

--- a/packages/three-renderer/__tests__/AcTrMTextRenderer.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMTextRenderer.spec.ts
@@ -43,6 +43,22 @@ describe('AcTrMTextRenderer', () => {
     expect(mockRendererInstances[0].setFontUrl).toHaveBeenCalledWith(fontUrl)
   })
 
+  it('applies a pending custom font URL after restoring the render mode', () => {
+    const renderer = AcTrMTextRenderer.getInstance()
+    const fontUrl = 'https://cdn.example.com/cad/fonts/'
+
+    renderer.setRenderMode('main')
+    renderer.setFontUrl(fontUrl)
+    renderer.initialize('./assets/mtext-renderer-worker.js')
+
+    const rendererInstance = mockRendererInstances[0]
+    expect(rendererInstance.setDefaultMode).toHaveBeenCalledWith('main')
+    expect(rendererInstance.setFontUrl).toHaveBeenCalledWith(fontUrl)
+    expect(
+      rendererInstance.setDefaultMode.mock.invocationCallOrder[0]
+    ).toBeLessThan(rendererInstance.setFontUrl.mock.invocationCallOrder[0])
+  })
+
   it('forwards a custom font URL to an initialized renderer immediately', () => {
     const renderer = AcTrMTextRenderer.getInstance()
     const fontUrl = 'https://cdn.example.com/cad/fonts/'
@@ -50,6 +66,20 @@ describe('AcTrMTextRenderer', () => {
     renderer.initialize('./assets/mtext-renderer-worker.js')
     renderer.setFontUrl(fontUrl)
 
+    expect(mockRendererInstances[0].setFontUrl).toHaveBeenCalledWith(fontUrl)
+  })
+
+  it('reapplies the custom font URL when switching render modes', () => {
+    const renderer = AcTrMTextRenderer.getInstance()
+    const fontUrl = 'https://cdn.example.com/cad/fonts/'
+
+    renderer.initialize('./assets/mtext-renderer-worker.js')
+    renderer.setFontUrl(fontUrl)
+    mockRendererInstances[0].setFontUrl.mockClear()
+
+    renderer.setRenderMode('main')
+
+    expect(mockRendererInstances[0].setDefaultMode).toHaveBeenCalledWith('main')
     expect(mockRendererInstances[0].setFontUrl).toHaveBeenCalledWith(fontUrl)
   })
 })

--- a/packages/three-renderer/src/renderer/AcTrMTextRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrMTextRenderer.ts
@@ -74,10 +74,8 @@ export class AcTrMTextRenderer {
    * @param value - URL to load fonts
    */
   setFontUrl(value: string) {
-    if (this._renderer) {
-      this._renderer.setFontUrl(value)
-    }
     this._fontUrl = value
+    this.applyFontUrl()
   }
 
   /**
@@ -85,10 +83,11 @@ export class AcTrMTextRenderer {
    * @param mode - Render mode
    */
   setRenderMode(mode: RenderMode) {
+    this._renderMode = mode
     if (this._renderer) {
       this._renderer.setDefaultMode(mode)
+      this.applyFontUrl()
     }
-    this._renderMode = mode
   }
 
   /**
@@ -136,17 +135,11 @@ export class AcTrMTextRenderer {
    */
   initialize(workerUrl: string | URL): void {
     this._workerUrl = workerUrl
-    // Notes:
-    // Please don't modify the default rendering mode from 'worker' to 'main'.
-    // Otherwise, web worker renderer will not get 'setFontUrl' message. Call
-    // to 'setFontUrl' in the following code will not take effect.
     this._renderer = new UnifiedRenderer('worker', { workerUrl })
-    if (this._fontUrl) {
-      this._renderer.setFontUrl(this._fontUrl)
-    }
     if (this._renderMode) {
       this._renderer.setDefaultMode(this._renderMode)
     }
+    this.applyFontUrl()
     if (this._styleManager) {
       const styleManager = new AcTrMTextStyleManager(this._styleManager)
       this._renderer.setStyleManager(styleManager)
@@ -167,6 +160,12 @@ export class AcTrMTextRenderer {
   private ensureRendererCreated() {
     if (!this._renderer && this._workerUrl) {
       this.initialize(this._workerUrl)
+    }
+  }
+
+  private applyFontUrl() {
+    if (this._renderer && this._fontUrl) {
+      this._renderer.setFontUrl(this._fontUrl)
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue where MText font loading could still use the default remote font repository even after `baseUrl` was configured with a custom CAD data URL.

The fix ensures `AcTrMTextRenderer` preserves and reapplies the custom font URL when:

- the renderer is initialized after the font URL has already been set
- the render mode is restored during initialization
- the render mode is switched after initialization

## Changes

- Store the configured MText font URL and apply it through a shared helper.
- Reapply the custom font URL after `setDefaultMode()` so the active renderer receives it.
- Add regression coverage for pending font URL application and render mode switching.

## Verification

- `pnpm jest packages/three-renderer/__tests__/AcTrMTextRenderer.spec.ts packages/three-renderer/__tests__/AcTrFontLoader.spec.ts packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts --runInBand`
- `pnpm --filter @mlightcad/three-renderer build`
