### PR TITLE
fix: fix hover state updates and entity info positioning

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcEdHoverController.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdHoverController.spec.ts
@@ -1,0 +1,108 @@
+import { AcCmEventManager, AcGePoint2d } from '@mlightcad/data-model'
+
+import {
+  AcEdHoverController,
+  AcEdHoverHost
+} from '../src/editor/view/AcEdHoverController'
+import type { AcEdViewHoverEventArgs } from '../src/editor/view/AcEdBaseView'
+
+class MockHoverHost implements AcEdHoverHost {
+  pick = jest.fn<ReturnType<AcEdHoverHost['pick']>, Parameters<AcEdHoverHost['pick']>>()
+  onHover = jest.fn()
+  onUnhover = jest.fn()
+  curMousePos = new AcGePoint2d(20, 30)
+}
+
+describe('AcEdHoverController', () => {
+  let host: MockHoverHost
+  let hoverEvent: AcCmEventManager<AcEdViewHoverEventArgs>
+  let unhoverEvent: AcCmEventManager<AcEdViewHoverEventArgs>
+  let hoverListener: jest.Mock
+  let unhoverListener: jest.Mock
+  let controller: AcEdHoverController
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    host = new MockHoverHost()
+    hoverEvent = new AcCmEventManager<AcEdViewHoverEventArgs>()
+    unhoverEvent = new AcCmEventManager<AcEdViewHoverEventArgs>()
+    hoverListener = jest.fn()
+    unhoverListener = jest.fn()
+    hoverEvent.addEventListener(hoverListener)
+    unhoverEvent.addEventListener(unhoverListener)
+    controller = new AcEdHoverController(
+      host,
+      hoverEvent,
+      unhoverEvent,
+      500,
+      500
+    )
+  })
+
+  afterEach(() => {
+    controller.dispose()
+    jest.useRealTimers()
+  })
+
+  it('dispatches unhover immediately when the pointer leaves the hovered entity', () => {
+    host.pick.mockReturnValueOnce([{ id: 'entity-1' }])
+
+    controller.handleMouseMove(1, 2)
+    jest.advanceTimersByTime(500)
+
+    expect(host.onHover).toHaveBeenCalledWith('entity-1')
+
+    host.pick.mockReturnValueOnce([])
+    host.curMousePos = new AcGePoint2d(40, 50)
+
+    controller.handleMouseMove(10, 20)
+
+    expect(host.pick).toHaveBeenLastCalledWith({ x: 10, y: 20 })
+    expect(host.onUnhover).toHaveBeenCalledWith('entity-1')
+    expect(unhoverListener).toHaveBeenCalledWith({
+      id: 'entity-1',
+      x: 40,
+      y: 50
+    })
+
+    jest.advanceTimersByTime(500)
+    expect(host.pick).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not unhover and rehover when the pointer remains on the same entity', () => {
+    host.pick.mockReturnValueOnce([{ id: 'entity-1' }])
+
+    controller.handleMouseMove(1, 2)
+    jest.advanceTimersByTime(500)
+
+    host.pick.mockReturnValueOnce([{ id: 'entity-1' }])
+    controller.handleMouseMove(10, 20)
+
+    expect(host.onUnhover).not.toHaveBeenCalled()
+    expect(unhoverListener).not.toHaveBeenCalled()
+    expect(host.onHover).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels pending hover confirmation when the pointer leaves immediately', () => {
+    host.pick.mockReturnValue([])
+    host.pick.mockReturnValueOnce([{ id: 'entity-1' }])
+
+    controller.handleMouseMove(1, 2)
+    jest.advanceTimersByTime(500)
+
+    controller.handleMouseMove(10, 20)
+    jest.advanceTimersByTime(500)
+
+    expect(hoverListener).not.toHaveBeenCalled()
+  })
+
+  it('cancels pending hover detection when cleared', () => {
+    host.pick.mockReturnValueOnce([{ id: 'entity-1' }])
+
+    controller.handleMouseMove(1, 2)
+    controller.clear()
+    jest.advanceTimersByTime(500)
+
+    expect(host.pick).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cad-simple-viewer/src/editor/view/AcEdHoverController.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdHoverController.ts
@@ -1,7 +1,10 @@
-import { AcDbObjectId, AcGePoint2d } from '@mlightcad/data-model'
-import { AcCmEventManager } from '@mlightcad/data-model'
+import {
+  AcCmEventManager,
+  AcDbObjectId,
+  AcGePoint2d
+} from '@mlightcad/data-model'
 
-import { AcEdViewHoverEventArgs } from './AcEdBaseView'
+import type { AcEdViewHoverEventArgs } from './AcEdBaseView'
 
 /**
  * Interface implemented by a view that hosts hover behavior.
@@ -116,6 +119,10 @@ export class AcEdHoverController {
    */
   handleMouseMove(x: number, y: number) {
     this.clearHoverTimer()
+    if (this.hoveredId) {
+      this.hoverAt(x, y)
+      return
+    }
     this.hoverTimer = setTimeout(() => {
       this.hoverAt(x, y)
     }, this.hoverDelay)
@@ -134,6 +141,7 @@ export class AcEdHoverController {
    */
   clear() {
     this.setHoveredId(null)
+    this.clearHoverTimer()
     this.clearPauseTimer()
   }
 
@@ -177,6 +185,8 @@ export class AcEdHoverController {
    * @param newId - New hovered object id, or `null` to clear hover
    */
   private setHoveredId(newId: AcDbObjectId | null) {
+    if (this.hoveredId === newId) return
+
     if (this.hoveredId) {
       this.unhoverEvent.dispatch({
         id: this.hoveredId,

--- a/packages/cad-viewer/__tests__/useHover.spec.ts
+++ b/packages/cad-viewer/__tests__/useHover.spec.ts
@@ -1,0 +1,119 @@
+const unmountCallbacks: Array<() => void> = []
+
+jest.mock('vue', () => {
+  const actual = jest.requireActual<typeof import('vue')>('vue')
+
+  return {
+    ...actual,
+    onMounted: (callback: () => void) => callback(),
+    onUnmounted: (callback: () => void) => unmountCallbacks.push(callback)
+  }
+})
+
+class MockEventManager<T> {
+  private listeners = new Set<(args: T) => void>()
+
+  addEventListener(listener: (args: T) => void) {
+    this.listeners.add(listener)
+  }
+
+  removeEventListener(listener: (args: T) => void) {
+    this.listeners.delete(listener)
+  }
+
+  dispatch(args: T) {
+    this.listeners.forEach(listener => listener(args))
+  }
+
+  get listenerCount() {
+    return this.listeners.size
+  }
+}
+
+const hoverEvent = new MockEventManager<{ id: string; x: number; y: number }>()
+const unhoverEvent = new MockEventManager<{ id: string; x: number; y: number }>()
+const canvasToViewport = jest.fn()
+const getIdAt = jest.fn()
+
+const mockDocManager = {
+  curDocument: {
+    database: {
+      tables: {
+        blockTable: {
+          modelSpace: {
+            getIdAt
+          }
+        }
+      }
+    }
+  },
+  curView: {
+    canvasToViewport,
+    events: {
+      hover: hoverEvent,
+      unhover: unhoverEvent
+    }
+  }
+}
+
+jest.mock('@mlightcad/cad-simple-viewer', () => ({
+  AcApDocManager: {
+    instance: mockDocManager
+  }
+}))
+
+import { useHover } from '../src/composable/useHover'
+
+describe('useHover', () => {
+  afterEach(() => {
+    while (unmountCallbacks.length > 0) {
+      unmountCallbacks.pop()?.()
+    }
+    canvasToViewport.mockReset()
+    getIdAt.mockReset()
+  })
+
+  it('tracks hovered entity and converts canvas-local mouse coordinates to viewport coordinates', () => {
+    const entity = { objectId: 'entity-1', type: 'LINE' }
+    getIdAt.mockReturnValue(entity)
+    canvasToViewport.mockReturnValue({ x: 120, y: 80 })
+
+    const hover = useHover()
+
+    hoverEvent.dispatch({ id: 'entity-1', x: 20, y: 30 })
+
+    expect(getIdAt).toHaveBeenCalledWith('entity-1')
+    expect(canvasToViewport).toHaveBeenCalledWith({ x: 20, y: 30 })
+    expect(hover.hovered.value).toBe(true)
+    expect(hover.entity.value).toEqual(entity)
+    expect(hover.id.value).toBe('entity-1')
+    expect(hover.mouse.value).toEqual({ x: 120, y: 80 })
+  })
+
+  it('clears hover state on unhover', () => {
+    getIdAt.mockReturnValue({ objectId: 'entity-1', type: 'LINE' })
+    canvasToViewport.mockReturnValue({ x: 120, y: 80 })
+
+    const hover = useHover()
+    hoverEvent.dispatch({ id: 'entity-1', x: 20, y: 30 })
+    unhoverEvent.dispatch({ id: 'entity-1', x: 20, y: 30 })
+
+    expect(hover.hovered.value).toBe(false)
+    expect(hover.entity.value).toBeNull()
+    expect(hover.id.value).toBeNull()
+  })
+
+  it('removes event listeners when unmounted', () => {
+    useHover()
+
+    expect(hoverEvent.listenerCount).toBe(1)
+    expect(unhoverEvent.listenerCount).toBe(1)
+
+    while (unmountCallbacks.length > 0) {
+      unmountCallbacks.pop()?.()
+    }
+
+    expect(hoverEvent.listenerCount).toBe(0)
+    expect(unhoverEvent.listenerCount).toBe(0)
+  })
+})

--- a/packages/cad-viewer/src/component/layout/MlEntityInfo.vue
+++ b/packages/cad-viewer/src/component/layout/MlEntityInfo.vue
@@ -35,20 +35,18 @@
 </template>
 
 <script setup lang="ts">
-import {
-  AcApDocManager,
-  AcApSettingManager
-} from '@mlightcad/cad-simple-viewer'
+import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { AcDbEntity } from '@mlightcad/data-model'
 import { ComponentPublicInstance, computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { useHover } from '../../composable'
+import { useHover, useSettings } from '../../composable'
 import { colorName, entityName } from '../../locale'
 
 const { t } = useI18n()
 const cardRef = ref<ComponentPublicInstance<{}, HTMLElement> | null>(null)
 const { hovered, entity, mouse } = useHover()
+const features = useSettings()
 
 const cardWidth = ref(180)
 const cardHeight = ref(120)
@@ -79,7 +77,7 @@ const visible = computed(
   () =>
     hovered.value &&
     info.value.type !== '' &&
-    AcApSettingManager.instance.isShowEntityInfo &&
+    features.isShowEntityInfo &&
     !AcApDocManager.instance.editor.isActive
 )
 
@@ -100,6 +98,7 @@ watch(visible, async val => {
   position: fixed;
   left: v-bind(left);
   top: v-bind(top);
+  z-index: 99999;
   width: 180px;
   margin: 0;
   transition: none !important;

--- a/packages/cad-viewer/src/composable/useHover.ts
+++ b/packages/cad-viewer/src/composable/useHover.ts
@@ -75,13 +75,15 @@ export function useHover() {
   const mouse = ref({ x: -1, y: -1 })
   /** Handler for CAD viewer hover events */
   const updateHoverEntity = (args: AcEdViewHoverEventArgs) => {
+    const view = AcApDocManager.instance.curView
     const db = AcApDocManager.instance.curDocument.database
     const ent = db.tables.blockTable.modelSpace.getIdAt(args.id)
     if (ent) {
       entity.value = ent
       id.value = args.id
       hovered.value = true
-      mouse.value = { x: args.x, y: args.y }
+      const viewportPos = view.canvasToViewport({ x: args.x, y: args.y })
+      mouse.value = { x: viewportPos.x, y: viewportPos.y }
     } else {
       hovered.value = false
       entity.value = null


### PR DESCRIPTION
## Summary

- Update `AcEdHoverController` to immediately re-check hover state while an entity is already hovered, so unhover events are dispatched as soon as the pointer leaves.
- Avoid redundant unhover/rehover dispatches when the hovered entity has not changed.
- Convert hover mouse coordinates from canvas-local space to viewport space before positioning entity info.
- Use the shared settings composable for entity info visibility and raise the entity info panel z-index.
- Add tests for hover controller behavior and the `useHover` composable.

## Test Plan

- Added unit coverage for immediate unhover, same-entity hover stability, and pending hover cancellation.
- Added unit coverage for `useHover` state updates, coordinate conversion, and listener cleanup.
