### PR TITLE
fix: fix MTEXT selection bounds for aligned text

### DIFF
--- a/packages/three-renderer/__tests__/AcTrMText.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMText.spec.ts
@@ -1,0 +1,183 @@
+import type { MTextObject } from '@mlightcad/mtext-renderer'
+import * as THREE from 'three'
+
+jest.mock('../src/renderer', () => ({
+  AcTrMTextRenderer: {
+    getInstance: jest.fn()
+  }
+}))
+
+import { AcTrMText } from '../src/object/AcTrMText'
+
+type GeometryHost = THREE.Object3D & {
+  box: THREE.Box3
+  computeGeometryBox: () => THREE.Box3
+  hasGeometry: (object: THREE.Object3D) => boolean
+}
+
+type RaycastHost = THREE.Object3D & {
+  _mtext?: Pick<MTextObject, 'raycast'>
+  box: THREE.Box3
+}
+
+const privateMethods = AcTrMText.prototype as unknown as {
+  computeGeometryBox(this: GeometryHost): THREE.Box3
+  updateSelectionBox(this: GeometryHost, mtext: MTextObject): void
+  hasGeometry(object: THREE.Object3D): boolean
+  raycast(
+    this: RaycastHost,
+    raycaster: THREE.Raycaster,
+    intersects: THREE.Intersection[]
+  ): void
+}
+
+describe('AcTrMText selection geometry', () => {
+  it('computes the selection box from transformed rendered child geometry', () => {
+    const host = createGeometryHost()
+    host.add(createBoxMesh({ x: 10, y: 20, z: 0 }))
+
+    const box = host.computeGeometryBox()
+
+    expect(box.min.toArray()).toEqual([10, 20, 0])
+    expect(box.max.toArray()).toEqual([14, 22, 0])
+  })
+
+  it('prefers rendered geometry over an offset renderer-provided mtext box', () => {
+    const host = createGeometryHost()
+    host.add(createBoxMesh({ x: 10, y: 20, z: 0 }))
+    const offsetMTextBox = new THREE.Box3(
+      new THREE.Vector3(100, 100, 0),
+      new THREE.Vector3(101, 101, 0)
+    )
+
+    privateMethods.updateSelectionBox.call(
+      host,
+      createMTextObject(offsetMTextBox)
+    )
+
+    expect(host.box.min.toArray()).toEqual([10, 20, 0])
+    expect(host.box.max.toArray()).toEqual([14, 22, 0])
+  })
+
+  it('falls back to the renderer-provided mtext box when there is no child geometry', () => {
+    const host = createGeometryHost()
+    const fallbackBox = new THREE.Box3(
+      new THREE.Vector3(100, 100, 0),
+      new THREE.Vector3(101, 101, 0)
+    )
+
+    privateMethods.updateSelectionBox.call(host, createMTextObject(fallbackBox))
+
+    expect(host.box.min.toArray()).toEqual([100, 100, 0])
+    expect(host.box.max.toArray()).toEqual([101, 101, 0])
+  })
+
+  it('keeps precise mtext raycast hits when the renderer reports an intersection', () => {
+    const raycaster = createRaycaster()
+    const hitPoint = new THREE.Vector3(0, 0, 0)
+    const rendererHit: THREE.Intersection = {
+      distance: 10,
+      point: hitPoint,
+      object: new THREE.Object3D()
+    }
+    const host = createRaycastHost({
+      box: createSelectableBox(),
+      mtextRaycast: (_raycaster, intersects) => {
+        intersects.push(rendererHit)
+      }
+    })
+    const intersects: THREE.Intersection[] = []
+
+    privateMethods.raycast.call(host, raycaster, intersects)
+
+    expect(intersects).toEqual([rendererHit])
+  })
+
+  it('uses the entity selection box as a raycast fallback when mtext layout misses', () => {
+    const raycaster = createRaycaster()
+    const host = createRaycastHost({
+      box: createSelectableBox(),
+      mtextRaycast: jest.fn()
+    })
+    const intersects: THREE.Intersection[] = []
+
+    privateMethods.raycast.call(host, raycaster, intersects)
+
+    expect(intersects).toHaveLength(1)
+    expect(intersects[0].object).toBe(host)
+    expect(intersects[0].point.x).toBeCloseTo(0)
+    expect(intersects[0].point.y).toBeCloseTo(0)
+    expect(intersects[0].point.z).toBeCloseTo(0.1)
+  })
+
+  it('does not report a fallback raycast hit when the selection box is empty', () => {
+    const raycaster = createRaycaster()
+    const host = createRaycastHost({
+      box: new THREE.Box3(),
+      mtextRaycast: jest.fn()
+    })
+    const intersects: THREE.Intersection[] = []
+
+    privateMethods.raycast.call(host, raycaster, intersects)
+
+    expect(intersects).toHaveLength(0)
+  })
+})
+
+function createGeometryHost(): GeometryHost {
+  const host = new THREE.Object3D() as GeometryHost
+  host.box = new THREE.Box3()
+  host.computeGeometryBox = privateMethods.computeGeometryBox
+  host.hasGeometry = privateMethods.hasGeometry
+  return host
+}
+
+function createRaycastHost(options: {
+  box: THREE.Box3
+  mtextRaycast: Pick<MTextObject, 'raycast'>['raycast']
+}): RaycastHost {
+  const host = new THREE.Object3D() as RaycastHost
+  host.box = options.box
+  host._mtext = {
+    raycast: options.mtextRaycast
+  }
+  host.updateMatrixWorld(true)
+  return host
+}
+
+function createMTextObject(box: THREE.Box3): MTextObject {
+  const mtext = new THREE.Object3D() as MTextObject
+  mtext.box = box
+  mtext.createLayoutData = () => ({ lines: [], chars: [] })
+  return mtext
+}
+
+function createBoxMesh(position: THREE.Vector3Like) {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(
+      [0, 0, 0, 4, 0, 0, 4, 2, 0, 0, 2, 0],
+      3
+    )
+  )
+  geometry.setIndex([0, 1, 2, 0, 2, 3])
+
+  const mesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial())
+  mesh.position.copy(position)
+  return mesh
+}
+
+function createRaycaster() {
+  return new THREE.Raycaster(
+    new THREE.Vector3(0, 0, 10),
+    new THREE.Vector3(0, 0, -1)
+  )
+}
+
+function createSelectableBox() {
+  return new THREE.Box3(
+    new THREE.Vector3(-1, -1, -0.1),
+    new THREE.Vector3(1, 1, 0.1)
+  )
+}

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -16,6 +16,12 @@ import { AcTrStyleManager } from '../style/AcTrStyleManager'
 import { AcTrMTextColorUtil } from '../util'
 import { AcTrEntity } from './AcTrEntity'
 
+// Reuse scratch objects during hover/pick hit-testing; raycast can run very
+// often while the pointer moves, so keeping these allocations out of the hot
+// path avoids needless garbage collection pressure.
+const _raycastBox = /*@__PURE__*/ new THREE.Box3()
+const _raycastPoint = /*@__PURE__*/ new THREE.Vector3()
+
 export class AcTrMText extends AcTrEntity {
   private _mtext?: MTextObject
   private _text: AcGiMTextData
@@ -56,13 +62,7 @@ export class AcTrMText extends AcTrEntity {
         style,
         this._colorSettings
       )
-      this.add(this._mtext)
-      this.flatten()
-      this.traverse(object => {
-        // Add the flag to check intersection using bounding box of the mesh
-        object.userData.bboxIntersectionCheck = true
-      })
-      this.box = this._mtext.box
+      this.attachMText(this._mtext)
     } catch (error) {
       log.info(
         `Failed to render mtext '${this._text.text}' with the following error:\n`,
@@ -85,13 +85,7 @@ export class AcTrMText extends AcTrEntity {
         this._colorSettings
       )
       this._mtext = mtext
-      this.add(this._mtext)
-      this.flatten()
-      this.traverse(object => {
-        // Add the flag to check intersection using bounding box of the mesh
-        object.userData.bboxIntersectionCheck = true
-      })
-      this.box = this._mtext.box
+      this.attachMText(this._mtext)
     } catch (error) {
       log.info(
         `Failed to render mtext '${this._text.text}' with the following error:\n`,
@@ -101,10 +95,145 @@ export class AcTrMText extends AcTrEntity {
   }
 
   /**
-   * Get intersections between a casted ray and this object. Override this method
-   * to calculate intersection using the bounding box of texts.
+   * Gets intersections between a casted ray and this MTEXT entity.
+   *
+   * The mtext renderer provides a logical, per-character raycast that is useful
+   * when its cached layout is still available.  After this entity is flattened
+   * for batching, however, that logical hierarchy may no longer be able to
+   * report a hit.  In that case we fall back to the entity selection box, which
+   * is rebuilt from the actual rendered child geometry in
+   * {@link updateSelectionBox}.
+   *
+   * This two-step approach keeps precise text picking when possible while still
+   * making point selection robust for MTEXT whose renderer-provided logical box
+   * is offset from the visible glyph geometry.
+   *
+   * @param raycaster Raycaster configured by the active view.
+   * @param intersects Output array populated with any detected intersections.
    */
   raycast(raycaster: THREE.Raycaster, intersects: THREE.Intersection[]) {
+    const previousLength = intersects.length
+
+    // Prefer the mtext renderer's own character/layout hit-test.  If it reports
+    // a hit, keep that result because it is usually more precise than the
+    // entity-level fallback below.
     this._mtext?.raycast(raycaster, intersects)
+    if (intersects.length > previousLength || this.box.isEmpty()) return
+
+    // Fallback path: use the selection box derived from rendered geometry.  This
+    // is what protects point selection when the renderer's logical MTEXT box is
+    // shifted by attachment/alignment handling.
+    _raycastBox.copy(this.box).applyMatrix4(this.matrixWorld)
+    if (raycaster.ray.intersectBox(_raycastBox, _raycastPoint)) {
+      intersects.push({
+        distance: raycaster.ray.origin.distanceTo(_raycastPoint),
+        point: _raycastPoint.clone(),
+        object: this,
+        face: null,
+        faceIndex: undefined,
+        uv: undefined
+      })
+    }
+  }
+
+  /**
+   * Attaches a rendered MTEXT object to this entity and prepares it for viewer
+   * batching and selection.
+   *
+   * The mtext renderer can return a nested hierarchy of meshes and line objects.
+   * The CAD renderer flattens that hierarchy so each renderable leaf becomes a
+   * direct child of the entity, which keeps batching simple and preserves the
+   * visual transforms.  After flattening, every leaf is marked for
+   * bounding-box-based intersection because text glyph outlines are often too
+   * thin or fragmented for pleasant CAD-style point selection.
+   *
+   * @param mtext Rendered MTEXT object returned by the shared MTEXT renderer.
+   */
+  private attachMText(mtext: MTextObject) {
+    this.add(mtext)
+    this.flatten()
+    this.traverse(object => {
+      // Text picking should behave like CAD object picking: the visible glyph
+      // area should be selectable even when the pointer lands inside a hollow
+      // glyph or between tiny outline segments.
+      object.userData.bboxIntersectionCheck = true
+    })
+    this.updateSelectionBox(mtext)
+  }
+
+  /**
+   * Rebuilds the entity selection box used by the scene spatial index.
+   *
+   * The box exposed by the mtext renderer describes its logical MTEXT layout.
+   * For some aligned text, especially middle/center attachment points, that box
+   * can be offset from the glyph geometry that actually appears on screen.  The
+   * scene performs a small spatial-index query before it ever calls raycast, so
+   * an offset box can prevent point selection from even considering the entity.
+   *
+   * To keep the spatial index aligned with what the user sees, prefer a box
+   * computed from the rendered children.  If rendering produced no geometry,
+   * keep the renderer-provided box as a conservative fallback.
+   *
+   * @param mtext Rendered MTEXT object whose logical box is used as fallback.
+   */
+  private updateSelectionBox(mtext: MTextObject) {
+    const geometryBox = this.computeGeometryBox()
+    this.box = geometryBox.isEmpty() ? mtext.box : geometryBox
+  }
+
+  /**
+   * Computes a bounding box from all renderable child geometry.
+   *
+   * Each child geometry owns a local bounding box.  After MTEXT flattening,
+   * child transforms carry the placement that used to live in intermediate
+   * groups, so each child box is transformed by the child's matrix before being
+   * unioned into the result.  The returned box is the selection extent that best
+   * matches the visible MTEXT glyph/decoration geometry at attachment time.
+   *
+   * @returns Bounding box containing all child meshes, lines, and points.
+   */
+  private computeGeometryBox() {
+    const box = new THREE.Box3()
+    const childBox = new THREE.Box3()
+
+    this.updateMatrixWorld(true)
+    this.traverse(object => {
+      if (!this.hasGeometry(object)) return
+
+      const geometry = object.geometry
+      // Some renderer outputs already have bounds; compute lazily for those
+      // that do not so custom/generated geometries still contribute.
+      if (geometry.boundingBox == null) {
+        geometry.computeBoundingBox()
+      }
+      if (geometry.boundingBox == null) return
+
+      object.updateMatrixWorld(true)
+      // Move the child's local geometry box into the entity's current coordinate
+      // frame before unioning.  This preserves translation/rotation/scale left on
+      // the child by flattening.
+      childBox.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld)
+      box.union(childBox)
+    })
+
+    return box
+  }
+
+  /**
+   * Type guard for Three.js objects that expose buffer geometry.
+   *
+   * MTEXT render trees may contain plain grouping nodes as well as renderable
+   * leaves.  This guard keeps bounding-box collection focused on the leaves that
+   * can actually contribute visible geometry.
+   *
+   * @param object Object in the MTEXT render subtree.
+   * @returns True when the object is a mesh, line, or point-like render leaf.
+   */
+  private hasGeometry(
+    object: THREE.Object3D
+  ): object is THREE.Mesh | THREE.Line | THREE.Points {
+    return (
+      'geometry' in object && object.geometry instanceof THREE.BufferGeometry
+    )
   }
 }


### PR DESCRIPTION
## Summary

- Rebuild `AcTrMText` selection bounds from rendered child geometry instead of relying only on the MTEXT renderer’s logical box.
- Add a raycast fallback that uses the entity selection box when the renderer’s layout hit-test misses.
- Keep MTEXT render setup shared between sync and async paths via `attachMText`.
- Add TypeDoc and inline comments explaining the selection-box and raycast fallback logic.
- Add focused tests for MTEXT geometry bounds and raycast fallback behavior.

## Testing

- `pnpm jest packages/three-renderer/__tests__/AcTrMText.spec.ts --runInBand`
- `pnpm jest packages/three-renderer/__tests__ --runInBand`
- `pnpm --filter @mlightcad/three-renderer lint`
- `pnpm --filter @mlightcad/three-renderer build`
