### PR TITLE
fix: fix MTEXT insertion point persistence

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApMTextCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMTextCmd.spec.ts
@@ -1,0 +1,118 @@
+const mockGetBox = jest.fn()
+const mockOpenMTextEditor = jest.fn()
+
+jest.mock('../src/app', () => ({
+  AcApDocManager: {
+    instance: {
+      avaiableFonts: [],
+      editor: {
+        getBox: mockGetBox
+      }
+    }
+  }
+}))
+
+jest.mock('../src/editor', () => {
+  class AcEdCommand {
+    mode: unknown
+  }
+
+  class AcEdMTextEditor {
+    open = mockOpenMTextEditor
+  }
+
+  class AcEdPromptBoxOptions {
+    useBasePoint = true
+    useDashedLine = true
+
+    constructor(
+      readonly firstCornerMessage: string,
+      readonly secondCornerMessage: string
+    ) {}
+  }
+
+  return {
+    AcEdCommand,
+    AcEdMTextEditor,
+    AcEdOpenMode: {
+      Write: 'Write'
+    },
+    AcEdPromptBoxOptions,
+    AcEdPromptStatus: {
+      OK: 'OK',
+      Cancel: 'Cancel'
+    }
+  }
+})
+
+jest.mock('../src/i18n', () => ({
+  AcApI18n: {
+    t: (key: string) => key
+  }
+}))
+
+jest.mock('../src/view', () => ({
+  AcTrView2d: class AcTrView2d {}
+}))
+
+import { AcApMTextCmd } from '../src/command/draw/AcApMTextCmd'
+
+describe('AcApMTextCmd', () => {
+  beforeEach(() => {
+    mockGetBox.mockReset()
+    mockOpenMTextEditor.mockReset()
+  })
+
+  it('persists the insertion location returned by the mtext editor', async () => {
+    const appendEntity = jest.fn()
+    const context = {
+      view: {
+        screenToWorld: ({ y }: { y: number }) => ({ x: 0, y: y * 0.5 })
+      },
+      doc: {
+        database: {
+          tables: {
+            blockTable: {
+              modelSpace: {
+                appendEntity
+              }
+            }
+          }
+        }
+      }
+    }
+
+    mockGetBox.mockResolvedValue({
+      status: 'OK',
+      value: {
+        min: { x: 10, y: 20 },
+        max: { x: 110, y: 80 }
+      }
+    })
+    mockOpenMTextEditor.mockResolvedValue({
+      contents: 'Hello',
+      location: { x: 10, y: 70, z: 0 },
+      width: 100,
+      height: 24
+    })
+
+    await new AcApMTextCmd().execute(context as never)
+
+    expect(mockOpenMTextEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: { x: 10, y: 80, z: 0 },
+        width: 100,
+        textHeight: 12
+      })
+    )
+    expect(appendEntity).toHaveBeenCalledTimes(1)
+
+    const entity = appendEntity.mock.calls[0][0]
+    expect(entity.contents).toBe('Hello')
+    expect(entity.location.x).toBe(10)
+    expect(entity.location.y).toBe(70)
+    expect(entity.location.z).toBe(0)
+    expect(entity.width).toBe(100)
+    expect(entity.height).toBe(24)
+  })
+})

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -41,7 +41,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
-    "@mlightcad/mtext-input-box": "^0.2.3",
+    "@mlightcad/mtext-input-box": "^0.2.4",
     "@mlightcad/mtext-renderer": "workspace:*",
     "@mlightcad/svg-renderer": "workspace:*",
     "@mlightcad/three-renderer": "workspace:*",

--- a/packages/cad-simple-viewer/src/command/draw/AcApMTextCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApMTextCmd.ts
@@ -58,7 +58,7 @@ export class AcApMTextCmd extends AcEdCommand {
     if (!contents) return
 
     const mtext = new AcDbMText()
-    mtext.location = location
+    mtext.location = result.location
     mtext.contents = result.contents
     mtext.width = result.width
     mtext.height = result.height

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
@@ -20,6 +20,8 @@ import { AcTrView2d } from '../../../view'
 export interface AcEdMTextEditorResult {
   /** Final MTEXT contents (including inline formatting codes). */
   contents: string
+  /** Final MTEXT insertion location in world coordinates. */
+  location: AcGePoint3dLike
   /** Final text box width in world units. */
   width: number
   /** Final text box height in world units. */
@@ -214,10 +216,16 @@ export class AcEdMTextEditor {
       }
 
       const onClose = () => {
+        const insertionPoint = mtextInputBox.getMTextInsertionPoint()
         finish({
           contents: mtextInputBox.getText(),
+          location: {
+            x: insertionPoint.x,
+            y: insertionPoint.y,
+            z: insertionPoint.z
+          },
           width,
-          height: textHeight
+          height: normalizedTextHeight
         })
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         version: 0.172.0
     devDependencies:
       '@mlightcad/mtext-input-box':
-        specifier: ^0.2.3
-        version: 0.2.3(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)
+        specifier: ^0.2.4
+        version: 0.2.4(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.9
         version: 0.10.9(three@0.172.0)
@@ -1393,8 +1393,8 @@ packages:
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
-  '@mlightcad/mtext-input-box@0.2.3':
-    resolution: {integrity: sha512-+PMrtMKS96yAI7FKc4xuwIyljQ2Uqg8+ccg7QiyIbY56CcTrOCLQQqt/6EHMQADIcZYobf21+9PkoBaGndgfHg==}
+  '@mlightcad/mtext-input-box@0.2.4':
+    resolution: {integrity: sha512-4A5LJstZzFV3O05GtOfhYLeO9XKLX6ZGFvQnCo5yToQjPM+bLglmK/OUT0mwfKBZlgdQ438eMWY6xDU/8vRABA==}
     peerDependencies:
       '@mlightcad/mtext-renderer': ^0.10.9
       three: ^0.172.0
@@ -6185,7 +6185,7 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.1': {}
 
-  '@mlightcad/mtext-input-box@0.2.3(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/mtext-input-box@0.2.4(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)':
     dependencies:
       '@mlightcad/mtext-renderer': 0.10.9(three@0.172.0)
       '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)


### PR DESCRIPTION
## Summary

- Update MTEXT creation to persist the final insertion location returned by the editor.
- Include the editor-provided MTEXT location in `AcEdMTextEditorResult`.
- Use the normalized text height when returning editor results.
- Upgrade `@mlightcad/mtext-input-box` to `^0.2.4`.
- Add regression coverage for MTEXT command insertion location, dimensions, and contents.

## Testing

- Added `AcApMTextCmd` unit test covering editor result persistence.
