### PR TITLE
fix(three-renderer): restore bg-tracking for ACI 7 solid hatches (regression of #228)

### DIFF
--- a/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
@@ -89,7 +89,16 @@ describe('AcTrStyleManager', () => {
     expect(refreshed.color.getHex()).toBe(0xffff00)
   })
 
-  it('keeps foreground hatch fills visible via drawOrder-separated materials', () => {
+  it('solid foreground hatches fuse with the canvas bg (AutoCAD-aligned)', () => {
+    // AutoCAD reference: a solid ACI 7 hatch is rendered as if painted with
+    // the paper colour, so it fuses into both light and dark canvases and
+    // only the overlaid wireframe remains visible. See
+    // images-ex/hatch-bg-bug-refact-lee/autocad/tower-{light,dark}.png and
+    // the "drawing" pair in the same folder for the reference visuals.
+    //
+    // Linework-tier fills (drawOrder >= 0 — wide polylines, MText glyphs)
+    // are NOT hatches: they represent linework rasterized as a mesh and
+    // must invert with the theme so ACI 7 stays legible.
     const styleManager = new AcTrStyleManager()
     styleManager.currentBackgroundColor = 0xffffff
 
@@ -112,13 +121,19 @@ describe('AcTrStyleManager', () => {
       lineworkFillTraits
     ) as THREE.MeshBasicMaterial
 
+    // Solid hatch and linework-tier fill must NOT share a cache slot —
+    // otherwise the bg-tracked hatch material would be repainted by
+    // `changeForeground` and vice-versa.
     expect(hatchMaterial).not.toBe(lineworkFillMaterial)
 
     const hatchMetadata = getMaterialMetadata(hatchMaterial)
     expect(hatchMetadata.drawOrder).toBe(-1)
-    expect(hatchMetadata.isBackgroundFill).toBe(false)
-    expect(hatchMetadata.isForeground).toBe(true)
-    expect(hatchMaterial.color.getHex()).toBe(0x000000)
+    expect(hatchMetadata.isBackgroundFill).toBe(true)
+    expect(hatchMetadata.isForeground).toBe(false)
+    // Material is BORN with the current bg colour, not its trait RGB —
+    // so a DWG opened in dark theme does not flash a white silhouette
+    // before the first changeBackground call.
+    expect(hatchMaterial.color.getHex()).toBe(0xffffff)
 
     const lineworkFillMetadata = getMaterialMetadata(lineworkFillMaterial)
     expect(lineworkFillMetadata.drawOrder).toBe(0)
@@ -128,6 +143,10 @@ describe('AcTrStyleManager', () => {
   })
 
   it('keeps patterned foreground hatches as visible shader linework', () => {
+    // Patterned hatches differ from solid foreground fills: their visible
+    // component is the pattern lines themselves, which behave like linework
+    // and must stay legible against both canvases. So they invert with the
+    // theme (foreground tracking) instead of fusing with the bg.
     const styleManager = new AcTrStyleManager()
     styleManager.currentBackgroundColor = 0xffffff
 
@@ -160,6 +179,62 @@ describe('AcTrStyleManager', () => {
     expect(metadata.drawOrder).toBe(-1)
     expect(metadata.isBackgroundFill).toBe(false)
     expect(metadata.isForeground).toBe(true)
+  })
+
+  it('solid hatch with explicit truecolor stays at literal RGB across themes', () => {
+    // A DWG author who picked an explicit RGB via the truecolor picker
+    // (e.g. 255,255,255 from the colour palette) gets a literal hatch.
+    // `traits.color.isForeground` is only true for the ACI 7 / foreground
+    // pseudo-colour, so an explicit truecolor falls outside the bg-fuse
+    // rule even when the picked RGB happens to match the canvas paper.
+    const styleManager = new AcTrStyleManager()
+    styleManager.currentBackgroundColor = 0xffffff
+
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.layer = 'A-WALL'
+    // Explicit truecolor — NOT foreground.
+    traits.color.setRGB(0x80, 0x80, 0x80)
+    traits.rgbColor = 0x808080
+    traits.drawOrder = -1
+
+    const material = styleManager.getFillMaterial(
+      traits
+    ) as THREE.MeshBasicMaterial
+
+    const metadata = getMaterialMetadata(material)
+    expect(metadata.isBackgroundFill).toBe(false)
+    expect(metadata.isForeground).toBe(false)
+    expect(material.color.getHex()).toBe(0x808080)
+
+    // Theme flip must not mutate the literal truecolor.
+    styleManager.currentBackgroundColor = 0x000000
+    expect(material.color.getHex()).toBe(0x808080)
+  })
+
+  it('repaints solid foreground hatches on theme flip', () => {
+    // Lock the `_bgfill` cache partition + `isBackgroundFill` metadata
+    // contract: changeBackground must walk these materials and repaint
+    // them so the fuse-with-bg behaviour persists across theme flips.
+    const styleManager = new AcTrStyleManager()
+    styleManager.currentBackgroundColor = 0xffffff
+
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.layer = 'A-WALL'
+    traits.color = new AcCmColor().setForeground()
+    traits.rgbColor = 0xffffff
+    traits.drawOrder = -1
+
+    const material = styleManager.getFillMaterial(
+      traits
+    ) as THREE.MeshBasicMaterial
+
+    expect(material.color.getHex()).toBe(0xffffff)
+
+    styleManager.currentBackgroundColor = 0x000000
+    expect(material.color.getHex()).toBe(0x000000)
+
+    styleManager.currentBackgroundColor = 0xffffff
+    expect(material.color.getHex()).toBe(0xffffff)
   })
 
   it('creates a new patterned hatch material when pattern offset changes', () => {

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -68,38 +68,57 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
   }
 
   /**
-   * Fill meshes at the normal linework tier (`drawOrder >= 0`) follow
-   * COLORTHEME inversion so ACI 7 content stays legible.
+   * Fill meshes at the linework tier (`drawOrder >= 0`) follow
+   * COLORTHEME inversion so ACI 7 content stays legible. This covers
+   * MText glyphs and wide polylines — meshes that are rasterized as
+   * fill but represent linework.
    *
-   * This covers MText glyphs and wide polylines, both of which are
-   * rasterized as meshes but should behave like linework, not like
-   * hatches. Negative tiers are reserved for hatch-like fills and are
-   * handled by `shouldTrackBackground` instead.
+   * Patterned hatches at the hatch tier (`drawOrder < 0` with non-empty
+   * `definitionLines`) also invert: their visible component is the
+   * pattern lines themselves, which must stay legible against both
+   * light and dark canvases.
+   *
+   * Solid foreground hatches are deliberately excluded from this
+   * branch — they go through `shouldTrackBackground` instead so they
+   * fuse with the canvas bg (matching AutoCAD's reference rendering;
+   * see `images-ex/hatch-bg-bug-refact-lee/autocad/tower-*.png`).
    */
   protected shouldTrackForeground(
     traits: AcGiSubEntityTraits,
     _options: AcTrFillMaterialOptions
   ): boolean {
+    if (!traits.color.isForeground) return false
+    const drawOrder = traits.drawOrder ?? 0
+    if (drawOrder >= 0) return true
     const style = traits.fillType
-    const isVisibleHatch =
-      (traits.drawOrder ?? 0) < 0 &&
-      !style.gradient &&
-      (style.solidFill || !!style.definitionLines?.length)
-    return (
-      traits.color.isForeground &&
-      ((traits.drawOrder ?? 0) >= 0 || isVisibleHatch)
-    )
+    const isPatterned =
+      !style.gradient && !!style.definitionLines?.length
+    return isPatterned
   }
 
   /**
-   * Solid hatch fills now follow the same foreground inversion as linework:
-   * ACI 7 stays visible against both dark and light canvas backgrounds.
+   * Solid foreground hatch fills (ACI 7, `drawOrder < 0`, no pattern,
+   * no gradient) follow the canvas background colour rather than carry
+   * an absolute RGB. AutoCAD renders them as if they were painted with
+   * the paper colour, so they fuse into both light and dark canvases
+   * and only the overlaid wireframe remains visible.
+   *
+   * Hatches with an explicit RGB (including a literal truecolor white
+   * 0xFFFFFF) fall outside this rule — `traits.color.isForeground` is
+   * only true for the ACI 7 / foreground pseudo-colour, so a DWG
+   * author who picked `255,255,255` via the truecolor picker still
+   * gets a literal white hatch.
    */
   protected shouldTrackBackground(
-    _traits: AcGiSubEntityTraits,
+    traits: AcGiSubEntityTraits,
     _options: AcTrFillMaterialOptions
   ): boolean {
-    return false
+    if (!traits.color.isForeground) return false
+    if ((traits.drawOrder ?? 0) >= 0) return false
+    const style = traits.fillType
+    if (style.gradient) return false
+    const isSolid = !style.definitionLines || style.definitionLines.length === 0
+    return isSolid
   }
 
   /**
@@ -113,7 +132,21 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const side = options.side ?? 'front'
     const threeSide = side === 'back' ? THREE.BackSide : THREE.FrontSide
 
-    const effectiveTraits = traits
+    // Background-follow fills must be BORN with the current canvas bg,
+    // not with their resolved trait RGB. Without this, opening a DWG
+    // in dark theme shows ACI 7 solid hatches as solid white on the
+    // first frame — `changeBackground` iterates only materials already
+    // in the cache, so it cannot fix materials created AFTER the theme
+    // was set. Overriding `rgbColor` here lets the existing
+    // `createMeshBasicMaterial` / `createHatchShaderMaterial` helpers
+    // stay untouched while the material still lands on the right
+    // `userData.isBackgroundFill` bucket for future repaints.
+    const effectiveTraits: AcGiSubEntityTraits = this.shouldTrackBackground(
+      traits,
+      options
+    )
+      ? { ...traits, rgbColor: this.options.currentBackgroundColor }
+      : traits
 
     let material: THREE.Material
     if (style.gradient) {
@@ -282,7 +315,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
   /**
    * Build a deterministic caching key based on traits and options.
    *
-   * Two partitioning dimensions beyond colour/layer/pattern:
+   * Three partitioning dimensions beyond colour/layer/pattern:
    *
    * - `side`: `'back'` variant goes in a separate key so mirrored
    *   fills don't steal the front-side material of the common path.
@@ -290,10 +323,15 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
    *   line-like fill meshes (wide polylines, text glyphs) because the
    *   batcher groups by material id and applies one `renderOrder` tier
    *   per batch.
+   * - `_bgfill`: background-tracked fills (solid foreground hatches)
+   *   get their own partition so `changeBackground` can mutate them
+   *   in place without affecting any literal-RGB hatch that happens
+   *   to share layer + colour (e.g. a truecolor 0xFFFFFF hatch on the
+   *   same layer as an ACI 7 hatch).
    *
-   * Both suffixes are appended only when they differ from the
-   * default, keeping existing keys stable and avoiding unnecessary
-   * cache fragmentation on the common path.
+   * All suffixes are appended only when they differ from the default,
+   * keeping existing keys stable and avoiding unnecessary cache
+   * fragmentation on the common path.
    */
   protected buildKey(
     traits: AcGiSubEntityTraits,
@@ -302,6 +340,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const style = traits.fillType
     const sideSuffix = options.side === 'back' ? '_back' : ''
     const drawOrderSuffix = this.buildDrawOrderSuffix(traits)
+    const bgSuffix = this.shouldTrackBackground(traits, options) ? '_bgfill' : ''
     // Use color + layer + rebaseOffset + pattern info for key
     if (style.gradient) {
       const gradient = style.gradient
@@ -328,7 +367,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
 
     const isSolid = !style.definitionLines || style.definitionLines.length === 0
     if (isSolid) {
-      return `solid_${traits.layer}_${traits.rgbColor}${sideSuffix}${drawOrderSuffix}`
+      return `solid_${traits.layer}_${traits.rgbColor}${sideSuffix}${drawOrderSuffix}${bgSuffix}`
     }
 
     const patternHash = style.definitionLines


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                        
   
  Solid foreground (ACI 7) hatches must fuse with the canvas background to match AutoCAD's reference rendering — they are painted with the paper colour, so they merge into both light and dark canvases and only the overlaid wireframe stays visible.                                                                                                                                                                                                                                                                             
                                              
  PR #228 (the original hatch draw-order fix) implemented this contract. PR #250 ("Improve foreground hatch visibility") inadvertently replaced it with a foreground-inversion path, which collapses any layer with an ACI 7 solid hatch + wireframe into a single monochrome silhouette (black on light canvas, white on dark canvas) that occludes the wireframe.                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  This PR restores PR #228's contract while preserving the patterned-hatch behaviour that PR #250 added.                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
  ## Visual reference                                                                                                                                                                                                                                                                                               
                                                                                                                                                   
  Same `.dwg` file, same camera, same theme — three columns:                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  | | AutoCAD (reference) | cad-viewer (current `main`) | cad-viewer (this PR) |
  |---|---|---|---|                                                                                                                                                                                                                                                                                                 
  | Tower (light) | <img width="521" height="581" alt="tower-light" src="https://github.com/user-attachments/assets/7c10d49d-070c-4acb-a103-50f5fac105a5" /> | <img width="505" height="625" alt="tower-light" src="https://github.com/user-attachments/assets/44273674-2ca5-44b0-8113-471e1d1733a6" /> | <img width="452" height="601" alt="tower-light" src="https://github.com/user-attachments/assets/d472e2b1-40da-497b-89cb-943b67a12b9c" /> |                                                                                                         
  | Tower (dark)  | <img width="451" height="497" alt="tower-dark" src="https://github.com/user-attachments/assets/381cf461-7f22-4d4a-84ce-c47e4d3bdf9e" /> | <img width="507" height="616" alt="tower-dark" src="https://github.com/user-attachments/assets/3f8ad4ed-6189-42e1-8cc8-08b4539e8c3a" /> | <img width="510" height="609" alt="tower-dark" src="https://github.com/user-attachments/assets/78ce40c5-85d8-4bc8-a31c-b86f23eb0455" /> |                                                                                                                                                          
  | Drawing (light) | <img width="1265" height="732" alt="draw-light" src="https://github.com/user-attachments/assets/8c33f60c-d166-4c73-aa48-a03909d932ca" /> | <img width="1040" height="689" alt="draw-light" src="https://github.com/user-attachments/assets/3aef0e04-14cb-40b1-b18c-0509fb07302d" /> | <img width="981" height="659" alt="draw-light" src="https://github.com/user-attachments/assets/69339c04-b5d7-4e3e-9162-5c3d985c8c7a" /> |                                                                                                         
  | Drawing (dark)  | <img width="1294" height="755" alt="draw-dark" src="https://github.com/user-attachments/assets/f503bac5-cff7-4028-b86d-ce5ecf39de0a" /> | <img width="1105" height="679" alt="draw-dark" src="https://github.com/user-attachments/assets/61ae5ade-3e4f-4cd0-a556-810fb1434892" /> | <img width="978" height="649" alt="draw-dark" src="https://github.com/user-attachments/assets/cf43f5cf-3a64-4b03-974e-ce642a03c9ac" /> |                                                                                                                                                           
                                
                                                                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  Restore the four pieces of #228's contract that #250 dropped, all in `AcTrFillMaterialManager`:                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  - `shouldTrackForeground`: solid hatches at the hatch tier are excluded (they go through `shouldTrackBackground` instead). Linework-tier fills (`drawOrder >= 0` — wide polylines, MText glyphs) and patterned hatches at the hatch tier still invert with the theme. The patterned-hatch branch **preserves the contract added by #250**: pattern lines are the visible component and must stay legible against both canvases.                                                                                                                                                                                                                                                                                          
  - `shouldTrackBackground`: returns true for solid foreground hatches at `drawOrder < 0` (`isForeground && solidFill && !gradient`).                                                                                                                                                                                                                                                     
  - `createMaterialImpl`: bg-tracked materials are BORN with the current canvas bg colour, so opening a DWG in dark theme does not flash white silhouettes before the first `changeBackground` call.                                                                                                                                                                                                                                                     
  - `buildKey`: bg-tracked solids get a `_bgfill` cache suffix so they do not collide with literal-RGB hatches sharing the same layer + colour (e.g. a truecolor 0xFFFFFF hatch on a layer that also has an ACI 7 hatch).                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  PR #237's `drawOrder` partition + wide-polyline foreground inversion is **untouched**.                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  ## Tests                                                                                                                                                                                                                                                                                                          
                                                                                                                           
  - Updated `solid foreground hatches fuse with the canvas bg (AutoCAD-aligned)` with comments referencing the AutoCAD reference screenshots.                              
  - Kept `keeps patterned foreground hatches as visible shader linework` unchanged — that contract added by #250 is preserved.
  - Added `solid hatch with explicit truecolor stays at literal RGB across themes` (defensive: explicit RGB never flips even when it matches the paper colour).                                                                                                                                                                                                                                                                                      
  - Added `repaints solid foreground hatches on theme flip` (locks the `_bgfill` partition + `isBackgroundFill` metadata + `changeBackground` pipeline against future refactors).                                                                                                                                                                                                                                                                             
                                                                                                                                                   
  ## Dependency                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
  ⚠️  **Depends on mlightcad/realdwg-web#82** (and a subsequent `@mlightcad/data-model` / `@mlightcad/libredwg-converter` release).                                                                                                                                                                                                                                               
                                                                                                                                                       
  The companion fix in `realdwg-web` preserves explicit hatch colour through the data-model converter (a regression introduced by #78's `AcDbHatch.color` override). Without it, hatches that AutoCAD shows as coloured arrive in the renderer as `isForeground=true` and would either fuse with bg (with this PR's gates) or invert with theme (without it), neither of which matches AutoCAD.                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  With both PRs in place, hatches that AutoCAD shows as paper-fused (ACI 7 solid) and as coloured (explicit RGB) both render correctly.
  
  ## File
  
  [test-file-tower.dwg](https://drive.google.com/file/d/1YekkiMGxHz0pjFGGfenFoICvoAJjKgAO/view?usp=sharing)
