### PR TITLE
feat: add MTEXT editing functionality with contextual ribbon and double-click editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "workspaces": [
     "packages/*"
   ],
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "analyze": "nx run-many -t analyze",
     "build": "nx run-many -t build",
@@ -27,12 +28,13 @@
     "pre-serve": "nx run @mlightcad/cad-viewer-examples:pre-serve",
     "publish:viewer": "pnpm -r publish --filter cad-viewer --filter cad-simple-viewer --no-git-checks",
     "release": "node tools/release.mjs",
+    "sync:versions": "node tools/sync-workspace-versions.mjs",
     "serve": "nx run @mlightcad/cad-viewer-examples:serve",
     "test": "jest",
     "test:e2e": "pnpm --filter @mlightcad/cad-viewer-example test:e2e"
   },
   "engines": {
-    "pnpm": ">=8"
+    "pnpm": ">=9"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/cad-simple-viewer-example/package.json
+++ b/packages/cad-simple-viewer-example/package.json
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@mlightcad/cad-simple-viewer": "workspace:*",
-    "@mlightcad/data-model": "workspace:*"
+    "@mlightcad/data-model": "^1.7.33"
   }
 }

--- a/packages/cad-simple-viewer/__tests__/AcEdHoverController.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdHoverController.spec.ts
@@ -7,7 +7,10 @@ import {
 import type { AcEdViewHoverEventArgs } from '../src/editor/view/AcEdBaseView'
 
 class MockHoverHost implements AcEdHoverHost {
-  pick = jest.fn<ReturnType<AcEdHoverHost['pick']>, Parameters<AcEdHoverHost['pick']>>()
+  pick = jest.fn<
+    ReturnType<AcEdHoverHost['pick']>,
+    Parameters<AcEdHoverHost['pick']>
+  >()
   onHover = jest.fn()
   onUnhover = jest.fn()
   curMousePos = new AcGePoint2d(20, 30)

--- a/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
@@ -1,0 +1,175 @@
+const mockMTextInputBoxInstances: MockMTextInputBox[] = []
+const mockSysVarChanged = {
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn()
+}
+
+class MockMTextInputBox {
+  readonly handlers = new Map<string, Set<() => void>>()
+  readonly update = jest.fn()
+  readonly dispose = jest.fn()
+  readonly off = jest.fn((event: string, handler: () => void) => {
+    this.handlers.get(event)?.delete(handler)
+  })
+  readonly setToolbarTheme = jest.fn()
+  readonly getText = jest.fn(() => 'typed text')
+  readonly getMTextInsertionPoint = jest.fn(() => ({ x: 1, y: 2, z: 3 }))
+
+  constructor(readonly options: Record<string, unknown>) {
+    mockMTextInputBoxInstances.push(this)
+  }
+
+  on(event: string, handler: () => void) {
+    const handlers = this.handlers.get(event) ?? new Set<() => void>()
+    handlers.add(handler)
+    this.handlers.set(event, handlers)
+  }
+
+  emit(event: string) {
+    this.handlers.get(event)?.forEach(handler => handler())
+  }
+}
+
+jest.mock(
+  '@mlightcad/mtext-input-box',
+  () => ({
+    MTextInputBox: MockMTextInputBox
+  }),
+  { virtual: true }
+)
+
+jest.mock('@mlightcad/mtext-renderer', () => ({
+  MTextColor: class MTextColor {}
+}))
+
+jest.mock('@mlightcad/data-model', () => ({
+  AcDbSystemVariables: {
+    COLORTHEME: 'COLORTHEME'
+  },
+  AcDbSysVarManager: {
+    instance: jest.fn(() => ({
+      getVar: jest.fn(() => 0),
+      events: {
+        sysVarChanged: mockSysVarChanged
+      }
+    }))
+  }
+}))
+
+jest.mock('../src/app', () => ({
+  AcApDocManager: {
+    instance: {
+      curDocument: {
+        database: {
+          clayer: '0',
+          textstyle: 'Standard',
+          tables: {
+            textStyleTable: {
+              getAt: jest.fn(() => undefined)
+            }
+          }
+        }
+      },
+      resolveColors: jest.fn(() => ({ layerColor: 0xffffff }))
+    }
+  }
+}))
+
+jest.mock('../src/view', () => ({
+  AcTrView2d: class AcTrView2d {}
+}))
+
+import { AcEdMTextEditor } from '../src/editor/input/ui/AcEdMTextEditor'
+
+interface FakeElement {
+  ownerDocument: {
+    createElement: jest.Mock
+  }
+  appendChild: jest.Mock
+  remove: jest.Mock
+  setAttribute: jest.Mock
+  style: Record<string, string>
+}
+
+function createFakeElement(ownerDocument?: FakeElement['ownerDocument']) {
+  const documentRef =
+    ownerDocument ??
+    ({
+      createElement: jest.fn()
+    } as FakeElement['ownerDocument'])
+  const element: FakeElement = {
+    ownerDocument: documentRef,
+    appendChild: jest.fn(),
+    remove: jest.fn(),
+    setAttribute: jest.fn(),
+    style: {}
+  }
+  if (!ownerDocument) {
+    documentRef.createElement.mockImplementation(() =>
+      createFakeElement(documentRef)
+    )
+  }
+  return element
+}
+
+function createView() {
+  const container = createFakeElement()
+  return {
+    internalScene: {},
+    internalCamera: {},
+    backgroundColor: 0,
+    canvas: createFakeElement(),
+    container,
+    events: {
+      renderFrame: {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn()
+      }
+    },
+    isDirty: false
+  }
+}
+
+describe('AcEdMTextEditor', () => {
+  beforeEach(() => {
+    mockMTextInputBoxInstances.length = 0
+    mockSysVarChanged.addEventListener.mockClear()
+    mockSysVarChanged.removeEventListener.mockClear()
+    AcEdMTextEditor.setDefaultToolbarEnabled(true)
+  })
+
+  it('keeps the input box toolbar object alive in a hidden host when disabled', async () => {
+    const view = createView()
+    const resultPromise = new AcEdMTextEditor().open({
+      view: view as never,
+      location: { x: 0, y: 0, z: 0 },
+      width: 10,
+      textHeight: 2,
+      toolbarEnabled: false
+    })
+
+    const inputBox = mockMTextInputBoxInstances[0]
+    const options = inputBox.options
+    const toolbar = options.toolbar as {
+      enabled: boolean
+      container: FakeElement
+    }
+
+    expect(options.boundingBoxStyle).toEqual({ padding: 0 })
+    expect(toolbar.enabled).toBe(true)
+    expect(toolbar.container).not.toBe(view.container)
+    expect(toolbar.container.style.display).toBe('none')
+    expect(toolbar.container.style.pointerEvents).toBe('none')
+
+    inputBox.emit('close')
+    await expect(resultPromise).resolves.toEqual({
+      contents: 'typed text',
+      location: { x: 1, y: 2, z: 3 },
+      width: 10,
+      height: 2,
+      lineSpacingFactor: 0.3
+    })
+    expect(inputBox.dispose).toHaveBeenCalled()
+    expect(toolbar.container.remove).toHaveBeenCalled()
+  })
+})

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -41,7 +41,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
-    "@mlightcad/mtext-input-box": "^0.2.4",
+    "@mlightcad/mtext-input-box": "../../../mtext-input-box/packages/mtext-input-box",
     "@mlightcad/mtext-renderer": "workspace:*",
     "@mlightcad/svg-renderer": "workspace:*",
     "@mlightcad/three-renderer": "workspace:*",

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -41,8 +41,8 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
-    "@mlightcad/mtext-input-box": "../../../mtext-input-box/packages/mtext-input-box",
-    "@mlightcad/mtext-renderer": "workspace:*",
+    "@mlightcad/mtext-input-box": "^0.2.5",
+    "@mlightcad/mtext-renderer": "^0.10.9",
     "@mlightcad/svg-renderer": "workspace:*",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",
@@ -51,13 +51,13 @@
     "@types/three": "^0.172.0"
   },
   "dependencies": {
-    "@mlightcad/libredwg-converter": "workspace:*",
+    "@mlightcad/libredwg-converter": "^3.5.33",
     "mitt": "^3.0.1",
     "rbush": "^4.0.1"
   },
   "peerDependencies": {
-    "@mlightcad/data-model": "workspace:*",
-    "three": "workspace:*",
+    "@mlightcad/data-model": "^1.7.33",
+    "three": "^0.172.0",
     "lodash-es": "4.17.21"
   }
 }

--- a/packages/cad-simple-viewer/src/command/draw/AcApMTextCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApMTextCmd.ts
@@ -62,6 +62,7 @@ export class AcApMTextCmd extends AcEdCommand {
     mtext.contents = result.contents
     mtext.width = result.width
     mtext.height = result.height
+    mtext.lineSpacingFactor = result.lineSpacingFactor
 
     context.doc.database.tables.blockTable.modelSpace.appendEntity(mtext)
   }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
@@ -14,6 +14,11 @@ import * as THREE from 'three'
 import { AcApDocManager } from '../../../app'
 import { AcTrView2d } from '../../../view'
 
+export type AcEdMTextEditorActiveInputBox = MTextInputBox
+export type AcEdMTextEditorActiveInputBoxChangeListener = (
+  inputBox: AcEdMTextEditorActiveInputBox | null
+) => void
+
 /**
  * Result payload returned by the MTEXT editor when editing is finished.
  */
@@ -64,6 +69,10 @@ export interface AcEdMTextEditorOptions {
  * render loop and handles lifecycle cleanup when the editor is closed.
  */
 export class AcEdMTextEditor {
+  private static activeInputBox: MTextInputBox | null = null
+  private static readonly activeInputBoxChangeListeners =
+    new Set<AcEdMTextEditorActiveInputBoxChangeListener>()
+
   /**
    * Default toolbar color picker factory used when opening the editor if
    * per-call options do not provide {@link AcEdMTextEditorOptions.toolbarColorPicker}.
@@ -82,6 +91,39 @@ export class AcEdMTextEditor {
     factory: MTextToolbarColorPickerFactory | null
   ): void {
     AcEdMTextEditor.defaultColorPicker = factory
+  }
+
+  /**
+   * Returns the MTEXT input box currently being edited, if any.
+   */
+  static getActiveInputBox(): AcEdMTextEditorActiveInputBox | null {
+    return AcEdMTextEditor.activeInputBox
+  }
+
+  /**
+   * Subscribes to active MTEXT input box changes.
+   */
+  static addActiveInputBoxChangeListener(
+    listener: AcEdMTextEditorActiveInputBoxChangeListener
+  ): void {
+    AcEdMTextEditor.activeInputBoxChangeListeners.add(listener)
+  }
+
+  /**
+   * Removes an active MTEXT input box listener.
+   */
+  static removeActiveInputBoxChangeListener(
+    listener: AcEdMTextEditorActiveInputBoxChangeListener
+  ): void {
+    AcEdMTextEditor.activeInputBoxChangeListeners.delete(listener)
+  }
+
+  private static setActiveInputBox(inputBox: MTextInputBox | null): void {
+    if (AcEdMTextEditor.activeInputBox === inputBox) return
+    AcEdMTextEditor.activeInputBox = inputBox
+    AcEdMTextEditor.activeInputBoxChangeListeners.forEach(listener => {
+      listener(inputBox)
+    })
   }
 
   /**
@@ -177,6 +219,7 @@ export class AcEdMTextEditor {
           toolbarColorPicker ?? AcEdMTextEditor.defaultColorPicker ?? undefined
       }
     })
+    AcEdMTextEditor.setActiveInputBox(mtextInputBox)
 
     return new Promise(resolve => {
       let done = false
@@ -199,6 +242,9 @@ export class AcEdMTextEditor {
       }
 
       const cleanup = () => {
+        if (AcEdMTextEditor.activeInputBox === mtextInputBox) {
+          AcEdMTextEditor.setActiveInputBox(null)
+        }
         mtextInputBox.dispose()
         view.events.renderFrame.removeEventListener(onRenderFrame)
         mtextInputBox.off('close', onClose)

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
@@ -31,6 +31,8 @@ export interface AcEdMTextEditorResult {
   width: number
   /** Final text box height in world units. */
   height: number
+  /** Line spacing factor used by the MTEXT input box renderer. */
+  lineSpacingFactor: number
 }
 
 /**
@@ -60,6 +62,11 @@ export interface AcEdMTextEditorOptions {
    * color input in the MTEXT toolbar.
    */
   toolbarColorPicker?: MTextToolbarColorPickerFactory
+  /**
+   * Controls the built-in MTEXT input box toolbar for this editor instance.
+   * Defaults to {@link AcEdMTextEditor.defaultToolbarEnabled}.
+   */
+  toolbarEnabled?: boolean
 }
 
 /**
@@ -69,6 +76,8 @@ export interface AcEdMTextEditorOptions {
  * render loop and handles lifecycle cleanup when the editor is closed.
  */
 export class AcEdMTextEditor {
+  static readonly defaultLineSpacingFactor = 0.3
+
   private static activeInputBox: MTextInputBox | null = null
   private static readonly activeInputBoxChangeListeners =
     new Set<AcEdMTextEditorActiveInputBoxChangeListener>()
@@ -81,6 +90,13 @@ export class AcEdMTextEditor {
   static defaultColorPicker: MTextToolbarColorPickerFactory | null = null
 
   /**
+   * Default visibility for the built-in MTEXT input box toolbar. Applications
+   * with their own contextual ribbon can disable this while keeping the input
+   * box editor active.
+   */
+  static defaultToolbarEnabled = true
+
+  /**
    * Registers a default toolbar color picker factory. The factory is used for
    * every subsequent {@link open} call unless overridden by
    * {@link AcEdMTextEditorOptions.toolbarColorPicker}.
@@ -91,6 +107,16 @@ export class AcEdMTextEditor {
     factory: MTextToolbarColorPickerFactory | null
   ): void {
     AcEdMTextEditor.defaultColorPicker = factory
+  }
+
+  /**
+   * Registers the default built-in toolbar visibility for subsequent
+   * {@link open} calls.
+   *
+   * @param enabled - `true` to show the MTEXT input box toolbar by default.
+   */
+  static setDefaultToolbarEnabled(enabled: boolean): void {
+    AcEdMTextEditor.defaultToolbarEnabled = enabled
   }
 
   /**
@@ -126,6 +152,19 @@ export class AcEdMTextEditor {
     })
   }
 
+  private static createHiddenToolbarContainer(
+    parent: HTMLElement
+  ): HTMLElement {
+    const container = parent.ownerDocument.createElement('div')
+    container.setAttribute('aria-hidden', 'true')
+    Object.assign(container.style, {
+      display: 'none',
+      pointerEvents: 'none'
+    })
+    parent.appendChild(container)
+    return container
+  }
+
   /**
    * Opens the MTEXT editor and resolves when user closes the editor UI.
    *
@@ -147,7 +186,8 @@ export class AcEdMTextEditor {
       textHeight,
       initialText = '',
       toolbarFontFamilies = [],
-      toolbarColorPicker
+      toolbarColorPicker,
+      toolbarEnabled = AcEdMTextEditor.defaultToolbarEnabled
     } = options
     const origin = new THREE.Vector3(location.x, location.y, location.z ?? 0)
     const isLightBackground = view.backgroundColor === 0xffffff
@@ -190,6 +230,13 @@ export class AcEdMTextEditor {
           lastHeight: normalizedTextHeight
         }
       : undefined
+    // MTextInputBox still uses its shared toolbar object for internal format
+    // sync while editing. Keep that object alive when the app hides the built-in
+    // toolbar, but mount it into a hidden host so only the contextual ribbon is
+    // visible.
+    const hiddenToolbarContainer = toolbarEnabled
+      ? null
+      : AcEdMTextEditor.createHiddenToolbarContainer(view.container)
 
     const mtextInputBox = new MTextInputBox({
       scene: view.internalScene,
@@ -202,6 +249,9 @@ export class AcEdMTextEditor {
         color: cursorColor,
         glowColor: cursorColor
       },
+      boundingBoxStyle: {
+        padding: 0
+      },
       imeTarget: view.canvas,
       colorSettings: {
         layer: database.clayer,
@@ -213,7 +263,7 @@ export class AcEdMTextEditor {
         enabled: true,
         theme: getToolbarTheme(),
         fontFamilies,
-        container: view.container,
+        container: hiddenToolbarContainer ?? view.container,
         offsetY: 10,
         colorPicker:
           toolbarColorPicker ?? AcEdMTextEditor.defaultColorPicker ?? undefined
@@ -246,6 +296,7 @@ export class AcEdMTextEditor {
           AcEdMTextEditor.setActiveInputBox(null)
         }
         mtextInputBox.dispose()
+        hiddenToolbarContainer?.remove()
         view.events.renderFrame.removeEventListener(onRenderFrame)
         mtextInputBox.off('close', onClose)
         AcDbSysVarManager.instance().events.sysVarChanged.removeEventListener(
@@ -271,7 +322,8 @@ export class AcEdMTextEditor {
             z: insertionPoint.z
           },
           width,
-          height: normalizedTextHeight
+          height: normalizedTextHeight,
+          lineSpacingFactor: AcEdMTextEditor.defaultLineSpacingFactor
         })
       }
 

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -4,6 +4,7 @@ import {
   AcDbLayerTableRecord,
   AcDbLayerTableRecordAttrs,
   AcDbLayout,
+  AcDbMText,
   AcDbObjectId,
   AcDbRasterImage,
   AcDbRay,
@@ -38,6 +39,8 @@ import {
   AcEdCalculateSizeCallback,
   AcEdConditionWaiter,
   AcEdCorsorType,
+  AcEdMTextEditor,
+  AcEdOpenMode,
   AcEdSpatialQueryResultItem,
   AcEdSpatialQueryResultItemEx,
   AcEdViewMode,
@@ -223,7 +226,11 @@ export class AcTrView2d extends AcEdBaseView {
     let selectionPreviewEl: HTMLDivElement | null = null
 
     const canHandleSelectionGesture = () => {
-      return this.mode === AcEdViewMode.SELECTION && !this.editor.isActive
+      return (
+        this.mode === AcEdViewMode.SELECTION &&
+        !this.editor.isActive &&
+        !AcEdMTextEditor.getActiveInputBox()
+      )
     }
 
     const clearSelectionPreview = () => {
@@ -306,6 +313,15 @@ export class AcTrView2d extends AcEdBaseView {
 
       selectionStartWcs = null
       selectionStartCanvas = null
+    })
+
+    this.canvas.addEventListener('dblclick', e => {
+      if (e.button !== 0) return
+      if (!canHandleSelectionGesture()) return
+      if (AcApDocManager.instance.curDocument.openMode !== AcEdOpenMode.Write) {
+        return
+      }
+      void this.openPickedMTextEditor(e)
     })
     // When using OrbitControls in THREE.js, it attaches its own event listeners to the DOM elements,
     // such as the canvas or the entire document. This can interfere with other event listeners you
@@ -630,6 +646,79 @@ export class AcTrView2d extends AcEdBaseView {
   flyTo(point: AcGePoint2dLike, scale: number) {
     this.activeLayoutView.flyTo(point, scale)
     this._isDirty = true
+  }
+
+  private async openPickedMTextEditor(e: MouseEvent) {
+    const point = this.viewportToCanvas({
+      x: e.clientX,
+      y: e.clientY
+    })
+    const worldPoint = this.screenToWorld(point)
+    const picked = this.pick(worldPoint, undefined, true)
+    if (!picked.length) return
+
+    const entity =
+      AcApDocManager.instance.curDocument.database.tables.blockTable.getEntityById(
+        picked[0].id
+      )
+    if (!(entity instanceof AcDbMText)) return
+
+    e.preventDefault()
+    await this.editMTextEntity(entity)
+  }
+
+  private async editMTextEntity(mtext: AcDbMText) {
+    if (mtext.lineSpacingFactor !== AcEdMTextEditor.defaultLineSpacingFactor) {
+      mtext.lineSpacingFactor = AcEdMTextEditor.defaultLineSpacingFactor
+      mtext.triggerModifiedEvent()
+    }
+
+    const editor = new AcEdMTextEditor()
+    const result = await editor.open({
+      view: this,
+      location: mtext.location,
+      width: this.resolveMTextEditorWidth(mtext),
+      textHeight: this.resolveMTextEditorTextHeight(mtext),
+      initialText: mtext.contents,
+      toolbarFontFamilies: this.getMTextToolbarFontFamilies()
+    })
+    if (!result) return
+
+    mtext.location = result.location
+    mtext.contents = result.contents
+    mtext.width = result.width
+    mtext.height = result.height
+    mtext.lineSpacingFactor = result.lineSpacingFactor
+    mtext.triggerModifiedEvent()
+  }
+
+  private resolveMTextEditorWidth(mtext: AcDbMText) {
+    const width = Number(mtext.width)
+    if (Number.isFinite(width) && width > 0) return width
+    return 1e-4
+  }
+
+  private resolveMTextEditorTextHeight(mtext: AcDbMText) {
+    const textHeight = Number(mtext.height)
+    if (Number.isFinite(textHeight) && textHeight > 0) return textHeight
+    return this.pixelsToWorldY(24)
+  }
+
+  private pixelsToWorldY(pixels: number) {
+    const p0 = this.screenToWorld({ x: 0, y: 0 })
+    const p1 = this.screenToWorld({ x: 0, y: pixels })
+    return Math.max(Math.abs(p1.y - p0.y), 1e-4)
+  }
+
+  private getMTextToolbarFontFamilies() {
+    return Array.from(
+      new Set(
+        AcApDocManager.instance.avaiableFonts
+          .flatMap(fontInfo => fontInfo.name)
+          .map(fontName => fontName.trim())
+          .filter(fontName => fontName.length > 0)
+      )
+    )
   }
 
   /**

--- a/packages/cad-viewer-example/package.json
+++ b/packages/cad-viewer-example/package.json
@@ -33,9 +33,9 @@
     "@element-plus/icons-vue": "^2.3.1",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/cad-viewer": "workspace:*",
-    "@mlightcad/data-model": "workspace:*",
-    "element-plus": "workspace:*",
-    "vue": "workspace:*",
-    "vue-i18n": "workspace:*"
+    "@mlightcad/data-model": "^1.7.33",
+    "element-plus": "^2.12.0",
+    "vue": "^3.4.21",
+    "vue-i18n": "^10.0.1"
   }
 }

--- a/packages/cad-viewer/__tests__/useHover.spec.ts
+++ b/packages/cad-viewer/__tests__/useHover.spec.ts
@@ -31,7 +31,11 @@ class MockEventManager<T> {
 }
 
 const hoverEvent = new MockEventManager<{ id: string; x: number; y: number }>()
-const unhoverEvent = new MockEventManager<{ id: string; x: number; y: number }>()
+const unhoverEvent = new MockEventManager<{
+  id: string
+  x: number
+  y: number
+}>()
 const canvasToViewport = jest.fn()
 const getIdAt = jest.fn()
 

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -60,14 +60,14 @@
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",
     "lodash-es": "4.17.21",
-    "three": "workspace:*"
+    "three": "^0.172.0"
   },
   "peerDependencies": {
     "@mlightcad/cad-simple-viewer": "workspace:*",
-    "@mlightcad/data-model": "workspace:*",
+    "@mlightcad/data-model": "^1.7.33",
     "@vueuse/core": "^11.1.0",
-    "element-plus": "workspace:*",
-    "vue": "workspace:*",
-    "vue-i18n": "workspace:*"
+    "element-plus": "^2.12.0",
+    "vue": "^3.4.21",
+    "vue-i18n": "^10.0.1"
   }
 }

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -84,6 +84,7 @@
 import {
   AcApDocManager,
   AcApOpenDatabaseOptions,
+  AcEdMTextEditor,
   AcEdOpenMode,
   eventBus
 } from '@mlightcad/cad-simple-viewer'
@@ -205,6 +206,14 @@ const isWriteMode = computed(
   () => effectiveOpenMode.value === AcEdOpenMode.Write
 )
 const headerHeightPx = ref(0)
+
+watch(
+  isWriteMode,
+  value => {
+    AcEdMTextEditor.setDefaultToolbarEnabled(!value)
+  },
+  { immediate: true }
+)
 
 const { isShowToolbar } = useEntityDrawStyle(editor)
 provideViewerRect(containerRef)
@@ -447,6 +456,7 @@ onUnmounted(() => {
   // Notify consumers first
   emit('destroy')
 
+  AcEdMTextEditor.setDefaultToolbarEnabled(true)
   headerResizeObserver?.disconnect()
   AcApDocManager.instance.destroy()
 })

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -105,6 +105,7 @@ import MlRibbonPropertyColorDropdown from './MlRibbonPropertyColorDropdown.vue'
 import MlRibbonPropertyLineTypeSelect from './MlRibbonPropertyLineTypeSelect.vue'
 import MlRibbonPropertyLineWeightSelect from './MlRibbonPropertyLineWeightSelect.vue'
 import { useHatchContextualRibbon } from './useHatchContextualRibbon'
+import { useMTextContextualRibbon } from './useMTextContextualRibbon'
 
 interface Props {
   currentLocale?: LocaleProp
@@ -145,6 +146,14 @@ const {
 } = useHatchContextualRibbon({
   activeTabId: activeRibbonTabId,
   clearSelection: () => getCurrentSelectionSet()?.clear()
+})
+const {
+  handleCommandWillStart: handleMTextCommandWillStart,
+  handleCommandEnded: handleMTextCommandEnded,
+  handleItem: handleMTextItem,
+  buildContextualTab: buildMTextContextualTab
+} = useMTextContextualRibbon({
+  activeTabId: activeRibbonTabId
 })
 const {
   layers: ribbonLayers,
@@ -453,8 +462,14 @@ onMounted(() => {
   AcApDocManager.instance.editor.events.commandWillStart.addEventListener(
     handleHatchCommandWillStart
   )
+  AcApDocManager.instance.editor.events.commandWillStart.addEventListener(
+    handleMTextCommandWillStart
+  )
   AcApDocManager.instance.editor.events.commandEnded.addEventListener(
     handleHatchCommandEnded
+  )
+  AcApDocManager.instance.editor.events.commandEnded.addEventListener(
+    handleMTextCommandEnded
   )
   AcApDocManager.instance.events.documentActivated.addEventListener(
     handleDocumentActivated
@@ -469,8 +484,14 @@ onUnmounted(() => {
   AcApDocManager.instance.editor.events.commandWillStart.removeEventListener(
     handleHatchCommandWillStart
   )
+  AcApDocManager.instance.editor.events.commandWillStart.removeEventListener(
+    handleMTextCommandWillStart
+  )
   AcApDocManager.instance.editor.events.commandEnded.removeEventListener(
     handleHatchCommandEnded
+  )
+  AcApDocManager.instance.editor.events.commandEnded.removeEventListener(
+    handleMTextCommandEnded
   )
   AcApDocManager.instance.events.documentActivated.removeEventListener(
     handleDocumentActivated
@@ -1341,6 +1362,7 @@ const buildBaseTabs = (
       ]
     },
     buildHatchContextualTab(t),
+    buildMTextContextualTab(t),
     {
       id: 'tools',
       title: t('main.ribbon.tab.tools'),
@@ -1465,6 +1487,7 @@ const handleRibbonItemClick = (payload: {
 }) => {
   if (isRibbonDisabled.value) return
   if (handleHatchItem(payload.itemId)) return
+  if (handleMTextItem(payload.itemId)) return
   if (
     payload.groupId === 'home-layer' &&
     ribbonLayerOptions.value.some(item => item.value === payload.itemId)

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonMTextHeightSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonMTextHeightSelect.vue
@@ -1,0 +1,78 @@
+<template>
+  <ml-ribbon-property-field
+    :icon="mtextIcon"
+    :disabled="disabled"
+    :control-width="controlWidth"
+  >
+    <el-select
+      :model-value="selectedValue"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      allow-create
+      default-first-option
+      filterable
+      size="small"
+      @change="handleChange"
+    >
+      <el-option
+        v-for="option in normalizedOptions"
+        :key="option"
+        :label="option"
+        :value="option"
+      />
+    </el-select>
+  </ml-ribbon-property-field>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { mtext as mtextIcon } from '../../svg'
+import MlRibbonPropertyField from './MlRibbonPropertyField.vue'
+
+interface RibbonMTextHeightSelectProps {
+  modelValue?: number
+  options?: number[]
+  disabled?: boolean
+  placeholder?: string
+  controlWidth?: string
+}
+
+const props = withDefaults(defineProps<RibbonMTextHeightSelectProps>(), {
+  modelValue: undefined,
+  options: () => [1, 2.5, 3.5, 5, 7, 10, 12, 24],
+  disabled: false,
+  placeholder: '',
+  controlWidth: '108px'
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: number): void
+}>()
+
+const normalizedOptions = computed(() =>
+  Array.from(
+    new Set(
+      props.options
+        .filter(value => Number.isFinite(value) && value > 0)
+        .map(value => formatHeight(value))
+    )
+  )
+)
+
+const selectedValue = computed(() =>
+  props.modelValue != null && Number.isFinite(props.modelValue)
+    ? formatHeight(props.modelValue)
+    : ''
+)
+
+function formatHeight(value: number) {
+  return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)))
+}
+
+function handleChange(value: string | number) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) return
+  emit('update:modelValue', parsed)
+}
+</script>

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonMTextHeightSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonMTextHeightSelect.vue
@@ -67,7 +67,9 @@ const selectedValue = computed(() =>
 )
 
 function formatHeight(value: number) {
-  return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)))
+  return Number.isInteger(value)
+    ? String(value)
+    : String(Number(value.toFixed(4)))
 }
 
 function handleChange(value: string | number) {

--- a/packages/cad-viewer/src/component/ribbon/index.ts
+++ b/packages/cad-viewer/src/component/ribbon/index.ts
@@ -1,6 +1,7 @@
 export { default as MlRibbonCommands } from './MlRibbonCommands.vue'
 export { default as MlRibbonHatchPatternButton } from './MlRibbonHatchPatternButton.vue'
 export { default as MlRibbonLanguageSelector } from './MlRibbonLanguageSelector.vue'
+export { default as MlRibbonMTextHeightSelect } from './MlRibbonMTextHeightSelect.vue'
 export { default as MlRibbonPropertyColorDropdown } from './MlRibbonPropertyColorDropdown.vue'
 export { default as MlRibbonPropertyField } from './MlRibbonPropertyField.vue'
 export { default as MlRibbonPropertyLineTypeSelect } from './MlRibbonPropertyLineTypeSelect.vue'

--- a/packages/cad-viewer/src/component/ribbon/useHatchContextualRibbon.ts
+++ b/packages/cad-viewer/src/component/ribbon/useHatchContextualRibbon.ts
@@ -23,6 +23,19 @@ const HATCH_COMMAND_GLOBAL_NAME = 'HATCH'
 const hatchPatternOptions: HatchPatternOption[] = [
   ...DEFAULT_HATCH_PATTERN_OPTIONS
 ]
+
+/**
+ * Converts ribbon color payloads into the CAD color model expected by the
+ * hatch color controls.
+ *
+ * The hatch command state can expose colors as existing `AcCmColor` instances,
+ * serialized CAD color strings, or CSS hex values. Values that cannot be
+ * interpreted as a hatch color are ignored so the custom color rows can render
+ * an empty/unchanged selection.
+ *
+ * @param value Raw color value stored in the hatch command state.
+ * @returns A normalized `AcCmColor`, or `undefined` when the value is invalid.
+ */
 const toColorValue = (value: unknown) => {
   if (value instanceof AcCmColor) return value
   if (typeof value !== 'string') return undefined
@@ -34,13 +47,37 @@ const toColorValue = (value: unknown) => {
   return undefined
 }
 
+/**
+ * Options required to coordinate the hatch contextual ribbon with the shared
+ * ribbon tab state.
+ */
 interface UseHatchContextualRibbonOptions {
+  /** Currently active ribbon tab id shared by the main ribbon shell. */
   activeTabId: Ref<string>
+  /**
+   * Optional callback used when the close button exits a selection-driven hatch
+   * context instead of an active HATCH command.
+   */
   clearSelection?: () => void
 }
 
+/**
+ * Minimal translation callback used while constructing ribbon model labels.
+ *
+ * @param key Locale message key.
+ * @returns Localized string for the active locale.
+ */
 type Translate = (key: string) => string
 
+/**
+ * Builds the gallery category model used by the hatch pattern picker.
+ *
+ * Pattern ids are emitted with the `hatch-pattern:` prefix because the ribbon
+ * item dispatcher routes all pattern selections through a single handler.
+ *
+ * @param title Display title for the hatch pattern category.
+ * @returns A ribbon gallery category containing every supported hatch pattern.
+ */
 const buildHatchPatternGalleryCategories = (
   title: string
 ): RibbonGalleryCategoryModel[] => [
@@ -58,6 +95,17 @@ const buildHatchPatternGalleryCategories = (
   }
 ]
 
+/**
+ * Creates the contextual ribbon controller for the HATCH workflow.
+ *
+ * The controller keeps the hatch contextual tab visible while either the HATCH
+ * command is running or the current selection consists of hatch entities. It
+ * also translates ribbon item ids into hatch command mutations and rebuilds the
+ * tab model from the latest command state.
+ *
+ * @param options Shared tab state and optional selection clearing hook.
+ * @returns Handlers and state consumed by the ribbon command host.
+ */
 export function useHatchContextualRibbon({
   activeTabId,
   clearSelection
@@ -77,6 +125,12 @@ export function useHatchContextualRibbon({
   const hatchState = hatchRibbonCommand.state
   const isSelectionContextActive = ref(false)
 
+  /**
+   * Reconciles contextual tab visibility with the command and selection modes.
+   *
+   * Command mode takes effect while HATCH is active; selection mode keeps the
+   * same tab available for editing hatch entities after command completion.
+   */
   const refreshContextTabVisibility = () => {
     if (isCommandActive.value || isSelectionContextActive.value) {
       showContextTab()
@@ -85,17 +139,38 @@ export function useHatchContextualRibbon({
     hideContextTab()
   }
 
+  /**
+   * Handles CAD command completion events for the HATCH contextual tab.
+   *
+   * @param args Command event payload raised by the CAD command manager.
+   */
   const handleCommandEnded = (args: AcEdCommandEventArgs) => {
     if (!isContextCommand(args)) return
     isCommandActive.value = false
     refreshContextTabVisibility()
   }
 
+  /**
+   * Updates whether the contextual tab should stay visible for hatch selection.
+   *
+   * @param active Whether the current selection should expose hatch editing UI.
+   */
   const handleSelectionContextChanged = (active: boolean) => {
     isSelectionContextActive.value = active
     refreshContextTabVisibility()
   }
 
+  /**
+   * Extracts a numeric value from a prefixed hatch ribbon item id.
+   *
+   * Input number controls emit ids such as `hatch-scale:2.5`; this helper keeps
+   * the parsing and invalid-value handling consistent for scale, angle, and
+   * opacity controls.
+   *
+   * @param itemId Ribbon item id emitted by a numeric hatch control.
+   * @param prefix Item id prefix that identifies the target hatch property.
+   * @returns Parsed number, or `undefined` when the id does not match or parse.
+   */
   const parseHatchNumberValue = (itemId: string, prefix: string) => {
     if (!itemId.startsWith(prefix)) return undefined
     const raw = itemId.slice(prefix.length)
@@ -103,6 +178,16 @@ export function useHatchContextualRibbon({
     return Number.isFinite(parsed) ? parsed : undefined
   }
 
+  /**
+   * Routes hatch contextual ribbon item clicks to the hatch command facade.
+   *
+   * The ribbon emits string ids rather than calling command APIs directly. This
+   * dispatcher owns the id contract for boundary picking, pattern/fill changes,
+   * color edits, numeric property edits, associativity, and close behavior.
+   *
+   * @param itemId Ribbon item id emitted by the hatch contextual tab.
+   * @returns `true` when the item id belongs to this contextual tab.
+   */
   const handleItem = (itemId: string) => {
     if (itemId === 'hatch-boundary-pick') {
       hatchRibbonCommand.requestPickPoints()
@@ -186,6 +271,16 @@ export function useHatchContextualRibbon({
     return false
   }
 
+  /**
+   * Builds the current hatch contextual ribbon tab model.
+   *
+   * The hatch command state is refreshed from CAD system variables before the
+   * model is created so defaults such as pattern, color, scale, and opacity are
+   * reflected immediately when the tab is rendered.
+   *
+   * @param t Translation callback used for all user-facing labels.
+   * @returns Ribbon tab model consumed by the ribbon renderer.
+   */
   const buildContextualTab = (t: Translate): RibbonTabModel => {
     hatchRibbonCommand.syncStateFromSysVars()
 

--- a/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
+++ b/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
@@ -1,0 +1,959 @@
+import type { AcEdCommandEventArgs } from '@mlightcad/cad-simple-viewer'
+import { AcApDocManager, AcEdMTextEditor } from '@mlightcad/cad-simple-viewer'
+import { AcCmColor } from '@mlightcad/data-model'
+import type {
+  RibbonGalleryCategoryModel,
+  RibbonItemModel,
+  RibbonTabModel
+} from '@mlightcad/ribbon'
+import {
+  defineComponent,
+  h,
+  onMounted,
+  onUnmounted,
+  type Component,
+  type Ref,
+  ref,
+  shallowRef
+} from 'vue'
+
+import { useRibbonContextualTab } from '../../composable'
+import MlRibbonMTextHeightSelect from './MlRibbonMTextHeightSelect.vue'
+import MlRibbonPropertyColorDropdown from './MlRibbonPropertyColorDropdown.vue'
+
+const MTEXT_CONTEXTUAL_TAB_ID = 'mtext-editor-context'
+const MTEXT_COMMAND_GLOBAL_NAME = 'MTEXT'
+const MTEXT_ITEM_PREFIX = 'mtext-'
+
+type Translate = (key: string) => string
+type MTextRibbonScript = 'normal' | 'superscript' | 'subscript'
+type MTextEditorEvent = 'change' | 'selectionChange' | 'cursorMove' | 'close'
+type ActiveInputBoxChangeListener = (inputBox: unknown | null) => void
+
+interface MTextRibbonFormat {
+  fontFamily: string
+  fontSize: number
+  bold: boolean
+  italic: boolean
+  underline: boolean
+  overline: boolean
+  script: MTextRibbonScript
+  strike: boolean
+  aci: number | null
+  rgb: number | null
+}
+
+interface MTextRibbonEditor {
+  setCurrentFormat: (format: Partial<MTextRibbonFormat>) => void
+  getCurrentFormat: () => MTextRibbonFormat
+  insertText: (text: string) => void
+  closeEditor: () => void
+  getDefaultTextStyle?: () => {
+    font?: string
+    fixedTextHeight?: number
+    lastHeight?: number
+  }
+  on?: (event: MTextEditorEvent, handler: () => void) => void
+  off?: (event: string, handler: () => void) => void
+  toggleStackSelection?: () => void
+  toggleScriptSelection?: (script: Exclude<MTextRibbonScript, 'normal'>) => boolean
+  toggleCase?: () => void
+  setAttachmentPoint?: (attachmentPoint: string) => void
+  setParagraphAlignment?: (alignment: string) => void
+  setLineSpacingFactor?: (factor: number) => void
+  clearLineSpacing?: () => void
+}
+
+interface MTextEditorBridge {
+  getActiveInputBox?: () => MTextRibbonEditor | null
+  addActiveInputBoxChangeListener?: (
+    listener: ActiveInputBoxChangeListener
+  ) => void
+  removeActiveInputBoxChangeListener?: (
+    listener: ActiveInputBoxChangeListener
+  ) => void
+}
+
+interface UseMTextContextualRibbonOptions {
+  activeTabId: Ref<string>
+}
+
+const DEFAULT_MTEXT_FORMAT: MTextRibbonFormat = {
+  fontFamily: 'Arial',
+  fontSize: 1,
+  bold: false,
+  italic: false,
+  underline: false,
+  overline: false,
+  script: 'normal',
+  strike: false,
+  aci: null,
+  rgb: null
+}
+
+const toolbarIcons = {
+  bold:
+    '<svg viewBox="0 0 24 24"><path d="M7.8 19c-.3 0-.5 0-.6-.2l-.2-.5V5.7c0-.2 0-.4.2-.5l.6-.2h5c1.5 0 2.7.3 3.5 1 .7.6 1.1 1.4 1.1 2.5a3 3 0 0 1-.6 1.9c-.4.6-1 1-1.6 1.2.4.1.9.3 1.3.6s.8.7 1 1.2c.4.4.5 1 .5 1.6 0 1.3-.4 2.3-1.3 3-.8.7-2.1 1-3.8 1H7.8Zm5-8.3c.6 0 1.2-.1 1.6-.5.4-.3.6-.7.6-1.3 0-1.1-.8-1.7-2.3-1.7H9.3v3.5h3.4Zm.5 6c.7 0 1.3-.1 1.7-.4.4-.4.6-.9.6-1.5s-.2-1-.7-1.4c-.4-.3-1-.4-2-.4H9.4v3.8h4Z" fill-rule="evenodd"></path></svg>',
+  italic:
+    '<svg viewBox="0 0 24 24"><path d="m16.7 4.7-.1.9h-.3c-.6 0-1 0-1.4.3-.3.3-.4.6-.5 1.1l-2.1 9.8v.6c0 .5.4.8 1.4.8h.2l-.2.8H8l.2-.8h.2c1.1 0 1.8-.5 2-1.5l2-9.8.1-.5c0-.6-.4-.8-1.4-.8h-.3l.2-.9h5.8Z" fill-rule="evenodd"></path></svg>',
+  underline:
+    '<svg viewBox="0 0 24 24"><path d="M16 5c.6 0 1 .4 1 1v5.5a4 4 0 0 1-.4 1.8l-1 1.4a5.3 5.3 0 0 1-5.5 1 5 5 0 0 1-1.6-1c-.5-.4-.8-.9-1.1-1.4a4 4 0 0 1-.4-1.8V6c0-.6.4-1 1-1s1 .4 1 1v5.5c0 .3 0 .6.2 1l.6.7a3.3 3.3 0 0 0 2.2.8 3.4 3.4 0 0 0 2.2-.8c.3-.2.4-.5.6-.8l.2-.9V6c0-.6.4-1 1-1ZM8 17h8c.6 0 1 .4 1 1s-.4 1-1 1H8a1 1 0 0 1 0-2Z" fill-rule="evenodd"></path></svg>',
+  overline:
+    '<svg viewBox="0 0 24 24"><path d="M5 4h14v1.5H5V4zm7 3.5c3.04 0 5.5 2.46 5.5 5.5v4.5h-2.25v-4.5c0-1.79-1.46-3.25-3.25-3.25S8.75 11.21 8.75 13v4.5H6.5V13c0-3.04 2.46-5.5 5.5-5.5z"></path></svg>',
+  strike:
+    '<svg viewBox="0 0 24 24"><g fill-rule="evenodd"><path d="M15.6 8.5c-.5-.7-1-1.1-1.3-1.3-.6-.4-1.3-.6-2-.6-2.7 0-2.8 1.7-2.8 2.1 0 1.6 1.8 2 3.2 2.3 4.4.9 4.6 2.8 4.6 3.9 0 1.4-.7 4.1-5 4.1A6.2 6.2 0 0 1 7 16.4l1.5-1.1c.4.6 1.6 2 3.7 2 1.6 0 2.5-.4 3-1.2.4-.8.3-2-.8-2.6-.7-.4-1.6-.7-2.9-1-1-.2-3.9-.8-3.9-3.6C7.6 6 10.3 5 12.4 5c2.9 0 4.2 1.6 4.7 2.4l-1.5 1.1Z"></path><path d="M5 11h14a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z" fill-rule="nonzero"></path></g></svg>',
+  superscript:
+    '<svg viewBox="0 0 24 24"><path d="M15 9.4 10.4 14l4.6 4.6-1.4 1.4L9 15.4 4.4 20 3 18.6 7.6 14 3 9.4 4.4 8 9 12.6 13.6 8 15 9.4Zm5.9 1.6h-5v-1l1-.8 1.7-1.6c.3-.5.5-.9.5-1.3 0-.3 0-.5-.2-.7-.2-.2-.5-.3-.9-.3l-.8.2-.7.4-.4-1.2c.2-.2.5-.4 1-.5.3-.2.8-.2 1.2-.2.8 0 1.4.2 1.8.6.4.4.6 1 .6 1.6 0 .5-.2 1-.5 1.5l-1.3 1.4-.6.5h2.6V11Z" fill-rule="nonzero"></path></svg>',
+  subscript:
+    '<svg viewBox="0 0 24 24"><path d="m10.4 10 4.6 4.6-1.4 1.4L9 11.4 4.4 16 3 14.6 7.6 10 3 5.4 4.4 4 9 8.6 13.6 4 15 5.4 10.4 10ZM21 19h-5v-1l1-.8 1.7-1.6c.3-.4.5-.8.5-1.2 0-.3 0-.6-.2-.7-.2-.2-.5-.3-.9-.3a2 2 0 0 0-.8.2l-.7.3-.4-1.1 1-.6 1.2-.2c.8 0 1.4.3 1.8.7.4.4.6.9.6 1.5s-.2 1.1-.5 1.6a8 8 0 0 1-1.3 1.3l-.6.6h2.6V19Z" fill-rule="nonzero"></path></svg>',
+  stack:
+    '<svg viewBox="0 0 24 24"><path d="M12.4 5.4c.4 0 .8.1 1.2.4.4.2.7.6.9 1 .2.4.3.9.3 1.5s-.1 1.1-.3 1.6c-.2.4-.5.8-.9 1-.4.2-.8.3-1.2.3-.4 0-.7-.1-1-.3-.3-.2-.6-.4-.8-.8l-.1 1h-.8V3h.9v3.4c.2-.3.5-.6.8-.7.3-.2.6-.3 1-.3Zm-.1 5c.5 0 .8-.2 1.1-.5.3-.4.4-.9.4-1.6 0-.6-.1-1.1-.4-1.5-.3-.3-.6-.5-1.1-.5s-.8.2-1.2.5c-.3.3-.5.8-.5 1.5 0 .5.1.9.2 1.2.2.3.4.5.7.7.2.1.5.2.8.2Z"></path><path d="M12.1 15c.6 0 1.1.1 1.5.5.4.4.6.9.6 1.6v3.5h-.8l-.1-.7c-.2.3-.4.5-.7.6-.3.2-.6.2-.9.2-.4 0-.7-.1-1-.2-.3-.1-.5-.3-.7-.6-.2-.2-.2-.5-.2-.9 0-.5.2-1 .6-1.3.4-.3 1-.5 1.7-.5.4 0 .8.1 1.2.2v-.1c0-.5-.1-.9-.3-1.1-.2-.3-.5-.4-.9-.4-.3 0-.6.1-.8.2-.2.1-.4.3-.5.6l-.7-.4c.2-.4.4-.7.8-.9.4-.2.8-.3 1.2-.3Zm1.2 3.2c-.4-.1-.8-.2-1.2-.2s-.8.1-1 .3c-.3.1-.4.4-.4.7 0 .3.1.5.3.7.2.1.5.2.8.2.4 0 .8-.1 1.1-.4.2-.2.4-.6.4-1v-.3Z"></path><rect x="6" y="12.7" width="12" height=".8"></rect></svg>',
+  case:
+    '<svg viewBox="0 0 24 24"><path d="M4 18h2.1l1-2.8h4.2l1 2.8h2.2L10.5 6H8L4 18Zm3.8-4.6 1.4-4.1 1.4 4.1H7.8Zm8 4.6h1.8v-1.5c.5 1.1 1.4 1.7 2.6 1.7 1.7 0 2.8-1.1 2.8-2.7 0-1.7-1.2-2.6-3.2-2.6h-2v-.3c0-1 .6-1.5 1.6-1.5.8 0 1.4.3 1.8 1l1.4-.9c-.6-1.1-1.7-1.7-3.2-1.7-2.1 0-3.4 1.2-3.4 3.1V18Zm3.9-1.4c-1.1 0-1.8-.5-1.8-1.2 0-.7.6-1.1 1.8-1.1h1.5v.5c0 1.1-.6 1.8-1.5 1.8Z"></path></svg>',
+  align:
+    '<svg viewBox="0 0 24 24"><path d="M4 4h16v2H4V4Zm0 4h12v2H4V8Zm0 4h16v2H4v-2Zm0 4h12v2H4v-2Zm0 4h16v2H4v-2Z"></path></svg>',
+  bullets:
+    '<svg viewBox="0 0 24 24"><path d="M6 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm16-1H9v2h13V6ZM6 12a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm16-1H9v2h13v-2ZM6 17a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm16-1H9v2h13v-2Z"></path></svg>',
+  lineSpacing:
+    '<svg viewBox="0 0 24 24"><path d="M8 5h13v2H8V5Zm0 6h13v2H8v-2Zm0 6h13v2H8v-2ZM3 5l2-2 2 2H5.8v14H7l-2 2-2-2h1.2V5H3Z"></path></svg>',
+  symbol:
+    '<svg viewBox="0 0 24 24"><path d="M12 2a7 7 0 0 1 7 7c0 2.1-.9 4-2.3 5.3l-1.4-1.4A5 5 0 1 0 7 9c0 1.9 1 3.5 2.5 4.4V11h2v7h-2v-2.4A7 7 0 0 1 12 2Zm5 15h2v5h-2v-5Zm-4-2h2v7h-2v-7Z"></path></svg>',
+  paragraphDefault:
+    '<svg viewBox="0 0 24 24"><path d="M5 5h14v2H5V5Zm0 4h10v2H5V9Zm0 4h14v2H5v-2Zm0 4h10v2H5v-2Z"></path></svg>',
+  left:
+    '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm0 4h11v2H4V9Zm0 4h16v2H4v-2Zm0 4h11v2H4v-2Z"></path></svg>',
+  center:
+    '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm3 4h10v2H7V9Zm-3 4h16v2H4v-2Zm3 4h10v2H7v-2Z"></path></svg>',
+  right:
+    '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm5 4h11v2H9V9Zm-5 4h16v2H4v-2Zm5 4h11v2H9v-2Z"></path></svg>',
+  justify:
+    '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm0 4h16v2H4V9Zm0 4h16v2H4v-2Zm0 4h16v2H4v-2Z"></path></svg>',
+  distributed:
+    '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm0 4h16v2H4V9Zm0 4h16v2H4v-2Zm0 4h16v2H4v-2Zm-2-1 2 2-2 2v-4Zm20 0v4l-2-2 2-2Z"></path></svg>'
+} as const
+
+function svgIcon(svg: string): Component {
+  const normalized = svg.replace(
+    '<svg ',
+    '<svg width="1em" height="1em" fill="currentColor" aria-hidden="true" '
+  )
+  return defineComponent({
+    name: 'MTextRibbonSvgIcon',
+    setup() {
+      return () =>
+        h('span', {
+          style:
+            'display:inline-flex;width:1em;height:1em;align-items:center;justify-content:center',
+          innerHTML: normalized
+        })
+    }
+  })
+}
+
+const icons = Object.fromEntries(
+  Object.entries(toolbarIcons).map(([key, svg]) => [key, svgIcon(svg)])
+) as Record<keyof typeof toolbarIcons, Component>
+
+function normalizeNumber(value: unknown) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function uniqueStrings(values: string[]) {
+  const seen = new Set<string>()
+  const unique: string[] = []
+  values.forEach(raw => {
+    const value = raw.trim()
+    if (!value || seen.has(value)) return
+    seen.add(value)
+    unique.push(value)
+  })
+  return unique
+}
+
+function getCurrentDatabase() {
+  return AcApDocManager.instance?.curDocument?.database
+}
+
+function toAcCmColorFromFormat(format: MTextRibbonFormat) {
+  const color = new AcCmColor()
+  if (format.aci === 256) {
+    color.setByLayer()
+    return color
+  }
+  if (format.aci === 0) {
+    color.setByBlock()
+    return color
+  }
+  if (format.aci != null) {
+    color.colorIndex = format.aci
+    return color
+  }
+  if (format.rgb != null) {
+    color.setRGBValue(format.rgb)
+    return color
+  }
+  color.setByLayer()
+  return color
+}
+
+function resolveColorDisplay(color: AcCmColor | undefined) {
+  if (!color) return '#7b8794'
+  if (color.isByLayer) {
+    const db = getCurrentDatabase()
+    const layerName = db?.clayer
+    return layerName
+      ? db?.tables.layerTable.getAt(layerName)?.color.cssColor || '#7b8794'
+      : '#7b8794'
+  }
+  if (color.isByBlock) return '#a0a8b8'
+  return color.cssColor || '#7b8794'
+}
+
+function toFormatColor(color: AcCmColor) {
+  if (color.isByLayer) return { aci: 256, rgb: null }
+  if (color.isByBlock) return { aci: 0, rgb: null }
+  if (color.isByACI && typeof color.colorIndex === 'number') {
+    return { aci: color.colorIndex, rgb: null }
+  }
+  return { aci: null, rgb: color.RGB ?? null }
+}
+
+function getMTextEditorBridge(): MTextEditorBridge {
+  return AcEdMTextEditor as unknown as MTextEditorBridge
+}
+
+function getTextStyleRecords() {
+  const db = getCurrentDatabase()
+  if (!db) return []
+  return Array.from(db.tables.textStyleTable.newIterator())
+}
+
+function buildTextStyleGalleryCategories(
+  title: string
+): RibbonGalleryCategoryModel[] {
+  const records = getTextStyleRecords()
+  return [
+    {
+      id: 'mtext-text-styles',
+      title,
+      items: records.map(record => {
+        const name = record.name || record.textStyle.name
+        const font = record.textStyle.font || name
+        return {
+          id: `mtext-style:${name}`,
+          label: name,
+          preview: name,
+          componentProps: {
+            style: {
+              fontFamily: font
+            }
+          }
+        }
+      })
+    }
+  ]
+}
+
+export function useMTextContextualRibbon({
+  activeTabId
+}: UseMTextContextualRibbonOptions) {
+  const {
+    isVisible,
+    isCommandActive,
+    handleCommandWillStart,
+    handleCommandEnded
+  } = useRibbonContextualTab({
+    activeTabId,
+    tabId: MTEXT_CONTEXTUAL_TAB_ID,
+    commandGlobalNames: MTEXT_COMMAND_GLOBAL_NAME
+  })
+  const currentFormat = ref<MTextRibbonFormat>({ ...DEFAULT_MTEXT_FORMAT })
+  const currentColor = shallowRef<AcCmColor>(
+    toAcCmColorFromFormat(currentFormat.value)
+  )
+  const currentColorDisplay = ref(resolveColorDisplay(currentColor.value))
+  const activeEditor = ref<MTextRibbonEditor | null>(null)
+
+  let observedEditor: MTextRibbonEditor | null = null
+
+  const getActiveEditor = () =>
+    getMTextEditorBridge().getActiveInputBox?.() ?? activeEditor.value
+
+  const syncColorStateFromFormat = (format: MTextRibbonFormat) => {
+    const color = toAcCmColorFromFormat(format)
+    currentColor.value = color
+    currentColorDisplay.value = resolveColorDisplay(color)
+  }
+
+  const syncFormatFromEditor = () => {
+    const editor = getActiveEditor()
+    if (!editor) {
+      activeEditor.value = null
+      currentFormat.value = { ...DEFAULT_MTEXT_FORMAT }
+      syncColorStateFromFormat(currentFormat.value)
+      return
+    }
+
+    activeEditor.value = editor
+    currentFormat.value = { ...DEFAULT_MTEXT_FORMAT, ...editor.getCurrentFormat() }
+    syncColorStateFromFormat(currentFormat.value)
+  }
+
+  const bindEditorEvents = (editor: MTextRibbonEditor | null) => {
+    if (observedEditor === editor) return
+    if (observedEditor?.off) {
+      observedEditor.off('change', syncFormatFromEditor)
+      observedEditor.off('selectionChange', syncFormatFromEditor)
+      observedEditor.off('cursorMove', syncFormatFromEditor)
+      observedEditor.off('close', syncFormatFromEditor)
+    }
+    observedEditor = editor
+    if (observedEditor?.on) {
+      observedEditor.on('change', syncFormatFromEditor)
+      observedEditor.on('selectionChange', syncFormatFromEditor)
+      observedEditor.on('cursorMove', syncFormatFromEditor)
+      observedEditor.on('close', syncFormatFromEditor)
+    }
+    syncFormatFromEditor()
+  }
+
+  const handleActiveInputBoxChanged: ActiveInputBoxChangeListener = inputBox => {
+    bindEditorEvents(inputBox as MTextRibbonEditor | null)
+  }
+
+  onMounted(() => {
+    const bridge = getMTextEditorBridge()
+    bridge.addActiveInputBoxChangeListener?.(handleActiveInputBoxChanged)
+    bindEditorEvents(bridge.getActiveInputBox?.() ?? null)
+  })
+
+  onUnmounted(() => {
+    const bridge = getMTextEditorBridge()
+    bridge.removeActiveInputBoxChangeListener?.(handleActiveInputBoxChanged)
+    bindEditorEvents(null)
+  })
+
+  const applyCurrentFormat = (format: Partial<MTextRibbonFormat>) => {
+    const editor = getActiveEditor()
+    if (!editor) return
+    editor.setCurrentFormat(format)
+    syncFormatFromEditor()
+  }
+
+  const handleFormatToggle = (
+    field: 'bold' | 'italic' | 'underline' | 'overline' | 'strike',
+    value: boolean
+  ) => {
+    applyCurrentFormat({ [field]: value })
+  }
+
+  const handleScriptToggle = (
+    script: Exclude<MTextRibbonScript, 'normal'>,
+    active: boolean
+  ) => {
+    const editor = getActiveEditor()
+    if (!editor) return
+    if (!active) {
+      editor.setCurrentFormat({ script: 'normal' })
+      syncFormatFromEditor()
+      return
+    }
+    const handled = editor.toggleScriptSelection?.(script)
+    if (!handled) {
+      editor.setCurrentFormat({ script })
+    }
+    syncFormatFromEditor()
+  }
+
+  const handleStack = () => {
+    const editor = getActiveEditor()
+    editor?.toggleStackSelection?.()
+    syncFormatFromEditor()
+  }
+
+  const handleMTextColorChange = (color?: AcCmColor) => {
+    if (!color) return
+    applyCurrentFormat(toFormatColor(color))
+  }
+
+  const handleFontHeightChange = (value: number) => {
+    if (!Number.isFinite(value) || value <= 0) return
+    applyCurrentFormat({ fontSize: value })
+  }
+
+  const applyTextStyle = (styleName: string) => {
+    const db = getCurrentDatabase()
+    if (!db || !styleName) return
+    const record = db.tables.textStyleTable.getAt(styleName)
+    if (!record) return
+    db.textstyle = styleName
+    const textStyle = record.textStyle
+    const nextFormat: Partial<MTextRibbonFormat> = {}
+    if (textStyle.font) nextFormat.fontFamily = textStyle.font
+    const height =
+      normalizeNumber(textStyle.fixedTextHeight) ??
+      normalizeNumber(textStyle.lastHeight)
+    if (height != null && height > 0) nextFormat.fontSize = height
+    applyCurrentFormat(nextFormat)
+  }
+
+  const getFontOptions = () => {
+    const availableFonts = AcApDocManager.instance?.avaiableFonts ?? []
+    const fontNames = availableFonts.flatMap(fontInfo => fontInfo.name)
+    const styleFonts = getTextStyleRecords().map(record => record.textStyle.font)
+    return uniqueStrings([
+      currentFormat.value.fontFamily,
+      ...styleFonts,
+      ...fontNames,
+      DEFAULT_MTEXT_FORMAT.fontFamily
+    ])
+  }
+
+  const getHeightOptions = () => {
+    const styleHeights = getTextStyleRecords()
+      .flatMap(record => [
+        record.textStyle.fixedTextHeight,
+        record.textStyle.lastHeight
+      ])
+      .map(normalizeNumber)
+      .filter((value): value is number => value != null && value > 0)
+    return Array.from(
+      new Set([currentFormat.value.fontSize, ...styleHeights, 1, 2.5, 3.5, 5, 7, 10, 12, 24])
+    )
+  }
+
+  const insertText = (text: string) => {
+    const editor = getActiveEditor()
+    if (!editor) return
+    editor.insertText(text)
+    syncFormatFromEditor()
+  }
+
+  const handleParagraphAlignment = (alignment: string) => {
+    getActiveEditor()?.setParagraphAlignment?.(alignment)
+    syncFormatFromEditor()
+  }
+
+  const handleItem = (itemId: string) => {
+    if (!itemId.startsWith(MTEXT_ITEM_PREFIX)) return false
+
+    if (itemId.startsWith('mtext-style:')) {
+      applyTextStyle(itemId.slice('mtext-style:'.length))
+      return true
+    }
+    if (itemId.startsWith('mtext-font:')) {
+      applyCurrentFormat({ fontFamily: itemId.slice('mtext-font:'.length) })
+      return true
+    }
+    if (itemId.startsWith('mtext-format:')) {
+      const [, field, state] = itemId.split(':')
+      const active = state === 'on'
+      if (
+        field === 'bold' ||
+        field === 'italic' ||
+        field === 'underline' ||
+        field === 'overline' ||
+        field === 'strike'
+      ) {
+        handleFormatToggle(field, active)
+        return true
+      }
+      if (field === 'superscript' || field === 'subscript') {
+        handleScriptToggle(field, active)
+        return true
+      }
+    }
+    if (itemId === 'mtext-format:stack') {
+      handleStack()
+      return true
+    }
+    if (itemId === 'mtext-format:case') {
+      getActiveEditor()?.toggleCase?.()
+      syncFormatFromEditor()
+      return true
+    }
+    if (itemId.startsWith('mtext-attachment:')) {
+      getActiveEditor()?.setAttachmentPoint?.(
+        itemId.slice('mtext-attachment:'.length)
+      )
+      return true
+    }
+    if (itemId.startsWith('mtext-list:')) {
+      const value = itemId.slice('mtext-list:'.length)
+      if (value === 'number') insertText('1. ')
+      if (value === 'letter') insertText('a. ')
+      if (value === 'bullet') insertText('\\U+2022 ')
+      return true
+    }
+    if (itemId.startsWith('mtext-line-spacing:')) {
+      const value = itemId.slice('mtext-line-spacing:'.length)
+      if (value === 'clear') {
+        getActiveEditor()?.clearLineSpacing?.()
+      } else {
+        const factor = normalizeNumber(value)
+        if (factor != null) getActiveEditor()?.setLineSpacingFactor?.(factor)
+      }
+      return true
+    }
+    if (itemId.startsWith('mtext-paragraph-align:')) {
+      handleParagraphAlignment(itemId.slice('mtext-paragraph-align:'.length))
+      return true
+    }
+    if (itemId.startsWith('mtext-symbol:')) {
+      const symbol = itemId.slice('mtext-symbol:'.length)
+      if (symbol !== 'other') insertText(symbol)
+      return true
+    }
+    if (itemId === 'mtext-close') {
+      getActiveEditor()?.closeEditor()
+      return true
+    }
+
+    return true
+  }
+
+  const createToggleItem = (
+    id: string,
+    label: string,
+    tooltip: string,
+    icon: Component,
+    modelValue: boolean
+  ): RibbonItemModel => ({
+    id,
+    type: 'toggle',
+    label,
+    tooltip,
+    hideLabel: true,
+    size: 'small',
+    disabled: !activeEditor.value,
+    props: {
+      modelValue,
+      activeIcon: icon,
+      inactiveIcon: icon,
+      activeLabel: label,
+      inactiveLabel: label,
+      activeValue: `${id}:on`,
+      inactiveValue: `${id}:off`
+    }
+  })
+
+  const createButtonItem = (
+    id: string,
+    label: string,
+    tooltip: string,
+    icon: Component
+  ): RibbonItemModel => ({
+    id,
+    type: 'button',
+    label,
+    tooltip,
+    hideLabel: true,
+    size: 'small',
+    disabled: !activeEditor.value,
+    props: { icon }
+  })
+
+  const buildContextualTab = (t: Translate): RibbonTabModel => {
+    syncFormatFromEditor()
+
+    const fontOptions = getFontOptions().map(fontName => ({
+      label: fontName,
+      value: `mtext-font:${fontName}`
+    }))
+    const disabled = !activeEditor.value
+    const format = currentFormat.value
+
+    return {
+      id: MTEXT_CONTEXTUAL_TAB_ID,
+      title: t('main.ribbon.tab.mtextEditorContext'),
+      contextual: true,
+      contextualMode: 'exclusive',
+      contextualColor: '#9a6a22',
+      contextualTitle: t('main.ribbon.mtext.contextTitle'),
+      visible: isVisible.value,
+      groups: [
+        {
+          id: 'mtext-style-group',
+          title: t('main.ribbon.mtext.group.textStyle'),
+          orientation: 'row',
+          collections: [
+            {
+              id: 'mtext-style-main',
+              layout: 'row',
+              items: [
+                {
+                  id: 'mtext-style',
+                  type: 'gallery',
+                  tooltip: t('main.ribbon.mtext.tooltip.textStyle'),
+                  size: 'large',
+                  props: {
+                    modelValue: `mtext-style:${getCurrentDatabase()?.textstyle ?? ''}`,
+                    inlineItemLimit: 3,
+                    categories: buildTextStyleGalleryCategories(
+                      t('main.ribbon.mtext.field.textStyle')
+                    )
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'mtext-format-group',
+          title: t('main.ribbon.mtext.group.format'),
+          orientation: 'row',
+          collections: [
+            {
+              id: 'mtext-format-column1',
+              layout: 'column',
+              rows: 3,
+              items: [
+                createToggleItem(
+                  'mtext-format:bold',
+                  t('main.ribbon.mtext.command.bold'),
+                  t('main.ribbon.mtext.tooltip.bold'),
+                  icons.bold,
+                  format.bold
+                ),
+                createToggleItem(
+                  'mtext-format:underline',
+                  t('main.ribbon.mtext.command.underline'),
+                  t('main.ribbon.mtext.tooltip.underline'),
+                  icons.underline,
+                  format.underline
+                ),
+                createToggleItem(
+                  'mtext-format:superscript',
+                  t('main.ribbon.mtext.command.superscript'),
+                  t('main.ribbon.mtext.tooltip.superscript'),
+                  icons.superscript,
+                  format.script === 'superscript'
+                )
+              ]
+            },
+            {
+              id: 'mtext-format-column2',
+              layout: 'column',
+              rows: 3,
+              items: [
+                createToggleItem(
+                  'mtext-format:italic',
+                  t('main.ribbon.mtext.command.italic'),
+                  t('main.ribbon.mtext.tooltip.italic'),
+                  icons.italic,
+                  format.italic
+                ),
+                createToggleItem(
+                  'mtext-format:overline',
+                  t('main.ribbon.mtext.command.overline'),
+                  t('main.ribbon.mtext.tooltip.overline'),
+                  icons.overline,
+                  format.overline
+                ),
+                createToggleItem(
+                  'mtext-format:subscript',
+                  t('main.ribbon.mtext.command.subscript'),
+                  t('main.ribbon.mtext.tooltip.subscript'),
+                  icons.subscript,
+                  format.script === 'subscript'
+                )
+              ]
+            },
+            {
+              id: 'mtext-format-column3',
+              layout: 'column',
+              rows: 3,
+              items: [
+                createToggleItem(
+                  'mtext-format:strike',
+                  t('main.ribbon.mtext.command.strikethrough'),
+                  t('main.ribbon.mtext.tooltip.strikethrough'),
+                  icons.strike,
+                  format.strike
+                ),
+                createButtonItem(
+                  'mtext-format:stack',
+                  t('main.ribbon.mtext.command.stack'),
+                  t('main.ribbon.mtext.tooltip.stack'),
+                  icons.stack
+                ),
+                createButtonItem(
+                  'mtext-format:case',
+                  t('main.ribbon.mtext.command.toggleCase'),
+                  t('main.ribbon.mtext.tooltip.toggleCase'),
+                  icons.case
+                )
+              ]
+            },
+            {
+              id: 'mtext-format-column4',
+              layout: 'column',
+              rows: 3,
+              items: [
+                {
+                  id: 'mtext-font',
+                  type: 'comboBox',
+                  label: t('main.ribbon.mtext.field.font'),
+                  tooltip: t('main.ribbon.mtext.tooltip.font'),
+                  size: 'small',
+                  disabled,
+                  props: {
+                    width: '154px',
+                    modelValue: `mtext-font:${format.fontFamily}`,
+                    emitValueOnChange: true,
+                    options: fontOptions
+                  }
+                },
+                {
+                  id: 'mtext-color',
+                  type: 'custom',
+                  label: t('main.ribbon.mtext.field.color'),
+                  tooltip: t('main.ribbon.mtext.tooltip.color'),
+                  size: 'small',
+                  disabled,
+                  props: {
+                    component: MlRibbonPropertyColorDropdown,
+                    componentProps: {
+                      modelValue: currentColor.value,
+                      displayColor: currentColorDisplay.value,
+                      placeholder: t('main.ribbon.mtext.field.color'),
+                      controlWidth: '132px',
+                      'onUpdate:modelValue': handleMTextColorChange
+                    }
+                  }
+                },
+                {
+                  id: 'mtext-height',
+                  type: 'custom',
+                  label: t('main.ribbon.mtext.field.height'),
+                  tooltip: t('main.ribbon.mtext.tooltip.height'),
+                  size: 'small',
+                  disabled,
+                  props: {
+                    component: MlRibbonMTextHeightSelect,
+                    componentProps: {
+                      modelValue: format.fontSize,
+                      options: getHeightOptions(),
+                      placeholder: t('main.ribbon.mtext.field.height'),
+                      controlWidth: '132px',
+                      'onUpdate:modelValue': handleFontHeightChange
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'mtext-paragraph-group',
+          title: t('main.ribbon.mtext.group.paragraph'),
+          orientation: 'row',
+          collections: [
+            {
+              id: 'mtext-paragraph-attachment',
+              layout: 'row',
+              items: [
+                {
+                  id: 'mtext-attachment',
+                  type: 'dropdown',
+                  label: t('main.ribbon.mtext.command.attachment'),
+                  tooltip: t('main.ribbon.mtext.tooltip.attachment'),
+                  size: 'large',
+                  disabled,
+                  props: {
+                    icon: icons.align,
+                    options: [
+                      'TL',
+                      'TC',
+                      'TR',
+                      'ML',
+                      'MC',
+                      'MR',
+                      'BL',
+                      'BC',
+                      'BR'
+                    ].map(value => ({
+                      value: `mtext-attachment:${value}`,
+                      label: t(`main.ribbon.mtext.attachment.${value}`)
+                    }))
+                  }
+                }
+              ]
+            },
+            {
+              id: 'mtext-paragraph-tools',
+              layout: 'column',
+              rows: 3,
+              items: [
+                {
+                  id: 'mtext-list',
+                  type: 'dropdown',
+                  label: t('main.ribbon.mtext.command.list'),
+                  tooltip: t('main.ribbon.mtext.tooltip.list'),
+                  hideLabel: true,
+                  size: 'small',
+                  disabled,
+                  props: {
+                    icon: icons.bullets,
+                    options: [
+                      { value: 'mtext-list:off', label: t('main.ribbon.mtext.list.off') },
+                      { value: 'mtext-list:number', label: t('main.ribbon.mtext.list.number') },
+                      { value: 'mtext-list:letter', label: t('main.ribbon.mtext.list.letter') },
+                      { value: 'mtext-list:bullet', label: t('main.ribbon.mtext.list.bullet') },
+                      { value: 'mtext-list:start', label: t('main.ribbon.mtext.list.start') },
+                      { value: 'mtext-list:continue', label: t('main.ribbon.mtext.list.continue') },
+                      { value: 'mtext-list:auto', label: t('main.ribbon.mtext.list.auto') },
+                      { value: 'mtext-list:allow-list', label: t('main.ribbon.mtext.list.allowList') }
+                    ]
+                  }
+                },
+                {
+                  id: 'mtext-line-spacing',
+                  type: 'dropdown',
+                  label: t('main.ribbon.mtext.command.lineSpacing'),
+                  tooltip: t('main.ribbon.mtext.tooltip.lineSpacing'),
+                  hideLabel: true,
+                  size: 'small',
+                  disabled,
+                  props: {
+                    icon: icons.lineSpacing,
+                    options: [
+                      { value: 'mtext-line-spacing:1', label: '1.0x' },
+                      { value: 'mtext-line-spacing:1.5', label: '1.5x' },
+                      { value: 'mtext-line-spacing:2', label: '2.0x' },
+                      { value: 'mtext-line-spacing:2.5', label: '2.5x' },
+                      {
+                        value: 'mtext-line-spacing:more',
+                        label: t('main.ribbon.mtext.lineSpacing.more')
+                      },
+                      {
+                        value: 'mtext-line-spacing:clear',
+                        label: t('main.ribbon.mtext.lineSpacing.clear')
+                      }
+                    ]
+                  }
+                },
+                {
+                  id: 'mtext-paragraph-align',
+                  type: 'buttonGroup',
+                  label: t('main.ribbon.mtext.command.paragraphAlignment'),
+                  tooltip: t('main.ribbon.mtext.tooltip.paragraphAlignment'),
+                  hideLabel: true,
+                  size: 'small',
+                  disabled,
+                  props: {
+                    wrap: false,
+                    buttonSize: 'small',
+                    iconSize: '16px',
+                    options: [
+                      {
+                        value: 'mtext-paragraph-align:default',
+                        label: '',
+                        icon: icons.paragraphDefault,
+                        tooltip: t('main.ribbon.mtext.paragraphAlign.default')
+                      },
+                      {
+                        value: 'mtext-paragraph-align:left',
+                        label: '',
+                        icon: icons.left,
+                        tooltip: t('main.ribbon.mtext.paragraphAlign.left')
+                      },
+                      {
+                        value: 'mtext-paragraph-align:center',
+                        label: '',
+                        icon: icons.center,
+                        tooltip: t('main.ribbon.mtext.paragraphAlign.center')
+                      },
+                      {
+                        value: 'mtext-paragraph-align:right',
+                        label: '',
+                        icon: icons.right,
+                        tooltip: t('main.ribbon.mtext.paragraphAlign.right')
+                      },
+                      {
+                        value: 'mtext-paragraph-align:justified',
+                        label: '',
+                        icon: icons.justify,
+                        tooltip: t('main.ribbon.mtext.paragraphAlign.justified')
+                      },
+                      {
+                        value: 'mtext-paragraph-align:distributed',
+                        label: '',
+                        icon: icons.distributed,
+                        tooltip: t('main.ribbon.mtext.paragraphAlign.distributed')
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'mtext-insert-group',
+          title: t('main.ribbon.mtext.group.insert'),
+          orientation: 'row',
+          collections: [
+            {
+              id: 'mtext-insert-main',
+              layout: 'row',
+              items: [
+                {
+                  id: 'mtext-symbol',
+                  type: 'dropdown',
+                  label: t('main.ribbon.mtext.command.symbol'),
+                  tooltip: t('main.ribbon.mtext.tooltip.symbol'),
+                  size: 'large',
+                  disabled,
+                  props: {
+                    icon: icons.symbol,
+                    options: [
+                      { value: 'mtext-symbol:%%d', label: t('main.ribbon.mtext.symbol.degree') },
+                      { value: 'mtext-symbol:%%p', label: t('main.ribbon.mtext.symbol.plusMinus') },
+                      { value: 'mtext-symbol:%%c', label: t('main.ribbon.mtext.symbol.diameter') },
+                      { value: 'mtext-symbol:\\U+2248', label: t('main.ribbon.mtext.symbol.almostEqual') },
+                      { value: 'mtext-symbol:\\U+2220', label: t('main.ribbon.mtext.symbol.angle') },
+                      { value: 'mtext-symbol:\\U+E100', label: t('main.ribbon.mtext.symbol.boundary') },
+                      { value: 'mtext-symbol:\\U+2104', label: t('main.ribbon.mtext.symbol.centerLine') },
+                      { value: 'mtext-symbol:\\U+0394', label: t('main.ribbon.mtext.symbol.delta') },
+                      { value: 'mtext-symbol:\\U+0278', label: t('main.ribbon.mtext.symbol.electricalPhase') },
+                      { value: 'mtext-symbol:\\U+E101', label: t('main.ribbon.mtext.symbol.flowLine') },
+                      { value: 'mtext-symbol:\\U+2261', label: t('main.ribbon.mtext.symbol.identical') },
+                      { value: 'mtext-symbol:\\U+2260', label: t('main.ribbon.mtext.symbol.notEqual') },
+                      { value: 'mtext-symbol:\\U+2126', label: t('main.ribbon.mtext.symbol.ohm') },
+                      { value: 'mtext-symbol:\\U+03A9', label: t('main.ribbon.mtext.symbol.omega') },
+                      { value: 'mtext-symbol:\\U+214A', label: t('main.ribbon.mtext.symbol.propertyLine') },
+                      { value: 'mtext-symbol:\\U+2082', label: t('main.ribbon.mtext.symbol.subscriptTwo') },
+                      { value: 'mtext-symbol:\\U+00B2', label: t('main.ribbon.mtext.symbol.squared') },
+                      { value: 'mtext-symbol:\\U+00B3', label: t('main.ribbon.mtext.symbol.cubed') },
+                      {
+                        value: 'mtext-symbol:\\~',
+                        label: t('main.ribbon.mtext.symbol.nbsp')
+                      },
+                      { value: 'mtext-symbol:other', label: t('main.ribbon.mtext.symbol.other') }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  return {
+    isVisible,
+    isCommandActive,
+    handleCommandWillStart,
+    handleCommandEnded: (args: AcEdCommandEventArgs) => {
+      handleCommandEnded(args)
+      if (args.command?.globalName === MTEXT_COMMAND_GLOBAL_NAME) {
+        bindEditorEvents(null)
+      }
+    },
+    handleItem,
+    buildContextualTab
+  }
+}

--- a/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
+++ b/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
@@ -1,3 +1,4 @@
+import { CircleClose } from '@element-plus/icons-vue'
 import type { AcEdCommandEventArgs } from '@mlightcad/cad-simple-viewer'
 import { AcApDocManager, AcEdMTextEditor } from '@mlightcad/cad-simple-viewer'
 import { AcCmColor } from '@mlightcad/data-model'
@@ -7,11 +8,11 @@ import type {
   RibbonTabModel
 } from '@mlightcad/ribbon'
 import {
+  type Component,
   defineComponent,
   h,
   onMounted,
   onUnmounted,
-  type Component,
   type Ref,
   ref,
   shallowRef
@@ -25,56 +26,146 @@ const MTEXT_CONTEXTUAL_TAB_ID = 'mtext-editor-context'
 const MTEXT_COMMAND_GLOBAL_NAME = 'MTEXT'
 const MTEXT_ITEM_PREFIX = 'mtext-'
 
+/**
+ * Minimal translation callback used while constructing ribbon model labels.
+ *
+ * @param key Locale message key.
+ * @returns Localized string for the active locale.
+ */
 type Translate = (key: string) => string
+
+/**
+ * Supported character baseline modes surfaced by the MText contextual ribbon.
+ */
 type MTextRibbonScript = 'normal' | 'superscript' | 'subscript'
+
+/**
+ * Editor events that require the ribbon to refresh its displayed MText format.
+ */
 type MTextEditorEvent = 'change' | 'selectionChange' | 'cursorMove' | 'close'
+
+/**
+ * Listener called by the MText editor bridge when the active inline editor
+ * changes.
+ *
+ * @param inputBox Newly active editor-like input box, or `null` when editing ends.
+ */
 type ActiveInputBoxChangeListener = (inputBox: unknown | null) => void
 
+/**
+ * Ribbon-friendly snapshot of the current MText character format.
+ *
+ * The real editor can expose richer formatting internals. This shape keeps only
+ * the properties needed by the contextual ribbon controls and normalizes color
+ * into either an ACI value or an RGB integer.
+ */
 interface MTextRibbonFormat {
+  /** Font family applied at the current cursor position or selected range. */
   fontFamily: string
+  /** Text height in drawing units. */
   fontSize: number
+  /** Whether bold formatting is active. */
   bold: boolean
+  /** Whether italic formatting is active. */
   italic: boolean
+  /** Whether underline formatting is active. */
   underline: boolean
+  /** Whether overline formatting is active. */
   overline: boolean
+  /** Current baseline script mode for the cursor or selected text. */
   script: MTextRibbonScript
+  /** Whether strike-through formatting is active. */
   strike: boolean
+  /**
+   * AutoCAD Color Index value for the current text color.
+   *
+   * `256` means ByLayer, `0` means ByBlock, and `null` means the ribbon should
+   * use the `rgb` value when present.
+   */
   aci: number | null
+  /** Packed RGB color value when the format uses a true color override. */
   rgb: number | null
 }
 
+/**
+ * Narrow editor adapter used by the contextual ribbon.
+ *
+ * `AcEdMTextEditor` is consumed through this structural interface so the ribbon
+ * can call optional editing capabilities when the active input box supports
+ * them, while remaining tolerant of older editor implementations.
+ */
 interface MTextRibbonEditor {
+  /**
+   * Applies a partial character format to the active cursor position or
+   * selection.
+   */
   setCurrentFormat: (format: Partial<MTextRibbonFormat>) => void
+  /** Reads the current character format from the editor. */
   getCurrentFormat: () => MTextRibbonFormat
+  /** Inserts raw MText content at the current cursor position. */
   insertText: (text: string) => void
+  /** Commits or closes the active MText editor. */
   closeEditor: () => void
+  /** Returns the editor's default text style information when available. */
   getDefaultTextStyle?: () => {
+    /** Default font family from the active text style. */
     font?: string
+    /** Fixed text height from the active text style. */
     fixedTextHeight?: number
+    /** Last used text height from the active text style. */
     lastHeight?: number
   }
+  /** Subscribes to editor events that may change the ribbon state. */
   on?: (event: MTextEditorEvent, handler: () => void) => void
+  /** Unsubscribes a previously registered editor event handler. */
   off?: (event: string, handler: () => void) => void
+  /** Toggles stacked-fraction formatting for the current selection. */
   toggleStackSelection?: () => void
-  toggleScriptSelection?: (script: Exclude<MTextRibbonScript, 'normal'>) => boolean
+  /**
+   * Toggles superscript or subscript formatting for the current selection.
+   *
+   * @returns `true` when the editor handled the toggle itself.
+   */
+  toggleScriptSelection?: (
+    script: Exclude<MTextRibbonScript, 'normal'>
+  ) => boolean
+  /** Toggles letter case for the current selection. */
   toggleCase?: () => void
+  /** Updates the MText attachment point, such as `TL`, `MC`, or `BR`. */
   setAttachmentPoint?: (attachmentPoint: string) => void
+  /** Updates paragraph alignment for the active paragraph or selection. */
   setParagraphAlignment?: (alignment: string) => void
+  /** Applies a paragraph line spacing factor such as `1.5` or `2`. */
   setLineSpacingFactor?: (factor: number) => void
+  /** Clears an explicit paragraph line spacing override. */
   clearLineSpacing?: () => void
 }
 
+/**
+ * Static bridge exposed by the MText editor module.
+ *
+ * The bridge lets Vue ribbon code discover and observe the imperative inline
+ * editor without importing a concrete editor instance type.
+ */
 interface MTextEditorBridge {
+  /** Returns the currently active MText input box, if one is open. */
   getActiveInputBox?: () => MTextRibbonEditor | null
+  /** Registers a listener for active input box changes. */
   addActiveInputBoxChangeListener?: (
     listener: ActiveInputBoxChangeListener
   ) => void
+  /** Removes a previously registered active input box listener. */
   removeActiveInputBoxChangeListener?: (
     listener: ActiveInputBoxChangeListener
   ) => void
 }
 
+/**
+ * Options required to coordinate the MText contextual ribbon with the shared
+ * ribbon tab state.
+ */
 interface UseMTextContextualRibbonOptions {
+  /** Currently active ribbon tab id shared by the main ribbon shell. */
   activeTabId: Ref<string>
 }
 
@@ -92,8 +183,7 @@ const DEFAULT_MTEXT_FORMAT: MTextRibbonFormat = {
 }
 
 const toolbarIcons = {
-  bold:
-    '<svg viewBox="0 0 24 24"><path d="M7.8 19c-.3 0-.5 0-.6-.2l-.2-.5V5.7c0-.2 0-.4.2-.5l.6-.2h5c1.5 0 2.7.3 3.5 1 .7.6 1.1 1.4 1.1 2.5a3 3 0 0 1-.6 1.9c-.4.6-1 1-1.6 1.2.4.1.9.3 1.3.6s.8.7 1 1.2c.4.4.5 1 .5 1.6 0 1.3-.4 2.3-1.3 3-.8.7-2.1 1-3.8 1H7.8Zm5-8.3c.6 0 1.2-.1 1.6-.5.4-.3.6-.7.6-1.3 0-1.1-.8-1.7-2.3-1.7H9.3v3.5h3.4Zm.5 6c.7 0 1.3-.1 1.7-.4.4-.4.6-.9.6-1.5s-.2-1-.7-1.4c-.4-.3-1-.4-2-.4H9.4v3.8h4Z" fill-rule="evenodd"></path></svg>',
+  bold: '<svg viewBox="0 0 24 24"><path d="M7.8 19c-.3 0-.5 0-.6-.2l-.2-.5V5.7c0-.2 0-.4.2-.5l.6-.2h5c1.5 0 2.7.3 3.5 1 .7.6 1.1 1.4 1.1 2.5a3 3 0 0 1-.6 1.9c-.4.6-1 1-1.6 1.2.4.1.9.3 1.3.6s.8.7 1 1.2c.4.4.5 1 .5 1.6 0 1.3-.4 2.3-1.3 3-.8.7-2.1 1-3.8 1H7.8Zm5-8.3c.6 0 1.2-.1 1.6-.5.4-.3.6-.7.6-1.3 0-1.1-.8-1.7-2.3-1.7H9.3v3.5h3.4Zm.5 6c.7 0 1.3-.1 1.7-.4.4-.4.6-.9.6-1.5s-.2-1-.7-1.4c-.4-.3-1-.4-2-.4H9.4v3.8h4Z" fill-rule="evenodd"></path></svg>',
   italic:
     '<svg viewBox="0 0 24 24"><path d="m16.7 4.7-.1.9h-.3c-.6 0-1 0-1.4.3-.3.3-.4.6-.5 1.1l-2.1 9.8v.6c0 .5.4.8 1.4.8h.2l-.2.8H8l.2-.8h.2c1.1 0 1.8-.5 2-1.5l2-9.8.1-.5c0-.6-.4-.8-1.4-.8h-.3l.2-.9h5.8Z" fill-rule="evenodd"></path></svg>',
   underline:
@@ -108,8 +198,7 @@ const toolbarIcons = {
     '<svg viewBox="0 0 24 24"><path d="m10.4 10 4.6 4.6-1.4 1.4L9 11.4 4.4 16 3 14.6 7.6 10 3 5.4 4.4 4 9 8.6 13.6 4 15 5.4 10.4 10ZM21 19h-5v-1l1-.8 1.7-1.6c.3-.4.5-.8.5-1.2 0-.3 0-.6-.2-.7-.2-.2-.5-.3-.9-.3a2 2 0 0 0-.8.2l-.7.3-.4-1.1 1-.6 1.2-.2c.8 0 1.4.3 1.8.7.4.4.6.9.6 1.5s-.2 1.1-.5 1.6a8 8 0 0 1-1.3 1.3l-.6.6h2.6V19Z" fill-rule="nonzero"></path></svg>',
   stack:
     '<svg viewBox="0 0 24 24"><path d="M12.4 5.4c.4 0 .8.1 1.2.4.4.2.7.6.9 1 .2.4.3.9.3 1.5s-.1 1.1-.3 1.6c-.2.4-.5.8-.9 1-.4.2-.8.3-1.2.3-.4 0-.7-.1-1-.3-.3-.2-.6-.4-.8-.8l-.1 1h-.8V3h.9v3.4c.2-.3.5-.6.8-.7.3-.2.6-.3 1-.3Zm-.1 5c.5 0 .8-.2 1.1-.5.3-.4.4-.9.4-1.6 0-.6-.1-1.1-.4-1.5-.3-.3-.6-.5-1.1-.5s-.8.2-1.2.5c-.3.3-.5.8-.5 1.5 0 .5.1.9.2 1.2.2.3.4.5.7.7.2.1.5.2.8.2Z"></path><path d="M12.1 15c.6 0 1.1.1 1.5.5.4.4.6.9.6 1.6v3.5h-.8l-.1-.7c-.2.3-.4.5-.7.6-.3.2-.6.2-.9.2-.4 0-.7-.1-1-.2-.3-.1-.5-.3-.7-.6-.2-.2-.2-.5-.2-.9 0-.5.2-1 .6-1.3.4-.3 1-.5 1.7-.5.4 0 .8.1 1.2.2v-.1c0-.5-.1-.9-.3-1.1-.2-.3-.5-.4-.9-.4-.3 0-.6.1-.8.2-.2.1-.4.3-.5.6l-.7-.4c.2-.4.4-.7.8-.9.4-.2.8-.3 1.2-.3Zm1.2 3.2c-.4-.1-.8-.2-1.2-.2s-.8.1-1 .3c-.3.1-.4.4-.4.7 0 .3.1.5.3.7.2.1.5.2.8.2.4 0 .8-.1 1.1-.4.2-.2.4-.6.4-1v-.3Z"></path><rect x="6" y="12.7" width="12" height=".8"></rect></svg>',
-  case:
-    '<svg viewBox="0 0 24 24"><path d="M4 18h2.1l1-2.8h4.2l1 2.8h2.2L10.5 6H8L4 18Zm3.8-4.6 1.4-4.1 1.4 4.1H7.8Zm8 4.6h1.8v-1.5c.5 1.1 1.4 1.7 2.6 1.7 1.7 0 2.8-1.1 2.8-2.7 0-1.7-1.2-2.6-3.2-2.6h-2v-.3c0-1 .6-1.5 1.6-1.5.8 0 1.4.3 1.8 1l1.4-.9c-.6-1.1-1.7-1.7-3.2-1.7-2.1 0-3.4 1.2-3.4 3.1V18Zm3.9-1.4c-1.1 0-1.8-.5-1.8-1.2 0-.7.6-1.1 1.8-1.1h1.5v.5c0 1.1-.6 1.8-1.5 1.8Z"></path></svg>',
+  case: '<svg viewBox="0 0 24 24"><path d="M4 18h2.1l1-2.8h4.2l1 2.8h2.2L10.5 6H8L4 18Zm3.8-4.6 1.4-4.1 1.4 4.1H7.8Zm8 4.6h1.8v-1.5c.5 1.1 1.4 1.7 2.6 1.7 1.7 0 2.8-1.1 2.8-2.7 0-1.7-1.2-2.6-3.2-2.6h-2v-.3c0-1 .6-1.5 1.6-1.5.8 0 1.4.3 1.8 1l1.4-.9c-.6-1.1-1.7-1.7-3.2-1.7-2.1 0-3.4 1.2-3.4 3.1V18Zm3.9-1.4c-1.1 0-1.8-.5-1.8-1.2 0-.7.6-1.1 1.8-1.1h1.5v.5c0 1.1-.6 1.8-1.5 1.8Z"></path></svg>',
   align:
     '<svg viewBox="0 0 24 24"><path d="M4 4h16v2H4V4Zm0 4h12v2H4V8Zm0 4h16v2H4v-2Zm0 4h12v2H4v-2Zm0 4h16v2H4v-2Z"></path></svg>',
   bullets:
@@ -120,8 +209,7 @@ const toolbarIcons = {
     '<svg viewBox="0 0 24 24"><path d="M12 2a7 7 0 0 1 7 7c0 2.1-.9 4-2.3 5.3l-1.4-1.4A5 5 0 1 0 7 9c0 1.9 1 3.5 2.5 4.4V11h2v7h-2v-2.4A7 7 0 0 1 12 2Zm5 15h2v5h-2v-5Zm-4-2h2v7h-2v-7Z"></path></svg>',
   paragraphDefault:
     '<svg viewBox="0 0 24 24"><path d="M5 5h14v2H5V5Zm0 4h10v2H5V9Zm0 4h14v2H5v-2Zm0 4h10v2H5v-2Z"></path></svg>',
-  left:
-    '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm0 4h11v2H4V9Zm0 4h16v2H4v-2Zm0 4h11v2H4v-2Z"></path></svg>',
+  left: '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm0 4h11v2H4V9Zm0 4h16v2H4v-2Zm0 4h11v2H4v-2Z"></path></svg>',
   center:
     '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm3 4h10v2H7V9Zm-3 4h16v2H4v-2Zm3 4h10v2H7v-2Z"></path></svg>',
   right:
@@ -132,6 +220,15 @@ const toolbarIcons = {
     '<svg viewBox="0 0 24 24"><path d="M4 5h16v2H4V5Zm0 4h16v2H4V9Zm0 4h16v2H4v-2Zm0 4h16v2H4v-2Zm-2-1 2 2-2 2v-4Zm20 0v4l-2-2 2-2Z"></path></svg>'
 } as const
 
+/**
+ * Wraps a raw SVG string in a Vue component suitable for ribbon item icons.
+ *
+ * The SVG is normalized to inherit the current text color and to size itself as
+ * `1em`, which lets the shared ribbon CSS control icon sizing consistently.
+ *
+ * @param svg Raw SVG markup for an MText ribbon icon.
+ * @returns Vue component rendering the normalized icon.
+ */
 function svgIcon(svg: string): Component {
   const normalized = svg.replace(
     '<svg ',
@@ -154,11 +251,24 @@ const icons = Object.fromEntries(
   Object.entries(toolbarIcons).map(([key, svg]) => [key, svgIcon(svg)])
 ) as Record<keyof typeof toolbarIcons, Component>
 
+/**
+ * Converts unknown numeric input into a finite number.
+ *
+ * @param value Raw value from a text style record or ribbon item id.
+ * @returns Parsed finite number, or `undefined` for invalid input.
+ */
 function normalizeNumber(value: unknown) {
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
+/**
+ * Trims, filters, and de-duplicates string values while preserving first-seen
+ * order.
+ *
+ * @param values Candidate strings collected from editor state, styles, and fonts.
+ * @returns Unique non-empty strings in display order.
+ */
 function uniqueStrings(values: string[]) {
   const seen = new Set<string>()
   const unique: string[] = []
@@ -171,10 +281,24 @@ function uniqueStrings(values: string[]) {
   return unique
 }
 
+/**
+ * Returns the current drawing database from the document manager.
+ *
+ * @returns Active CAD database, or `undefined` when no document is open.
+ */
 function getCurrentDatabase() {
   return AcApDocManager.instance?.curDocument?.database
 }
 
+/**
+ * Converts the ribbon format color fields into an `AcCmColor` instance.
+ *
+ * ACI values are preferred when present because they preserve ByLayer, ByBlock,
+ * and indexed color semantics. RGB is used only when no ACI value is stored.
+ *
+ * @param format Current ribbon character format snapshot.
+ * @returns CAD color model equivalent to the format color fields.
+ */
 function toAcCmColorFromFormat(format: MTextRibbonFormat) {
   const color = new AcCmColor()
   if (format.aci === 256) {
@@ -197,6 +321,15 @@ function toAcCmColorFromFormat(format: MTextRibbonFormat) {
   return color
 }
 
+/**
+ * Resolves the color swatch displayed in the MText ribbon color control.
+ *
+ * ByLayer colors are rendered using the active layer's color when possible;
+ * ByBlock and missing colors fall back to stable neutral swatches.
+ *
+ * @param color Color currently applied to the MText format.
+ * @returns CSS color string used by the ribbon dropdown display.
+ */
 function resolveColorDisplay(color: AcCmColor | undefined) {
   if (!color) return '#7b8794'
   if (color.isByLayer) {
@@ -210,6 +343,12 @@ function resolveColorDisplay(color: AcCmColor | undefined) {
   return color.cssColor || '#7b8794'
 }
 
+/**
+ * Converts a CAD color selected in the ribbon into editor format fields.
+ *
+ * @param color Color chosen by the user.
+ * @returns Partial format containing either `aci` or `rgb` color data.
+ */
 function toFormatColor(color: AcCmColor) {
   if (color.isByLayer) return { aci: 256, rgb: null }
   if (color.isByBlock) return { aci: 0, rgb: null }
@@ -219,16 +358,35 @@ function toFormatColor(color: AcCmColor) {
   return { aci: null, rgb: color.RGB ?? null }
 }
 
+/**
+ * Reads the MText editor static bridge through the ribbon-facing adapter type.
+ *
+ * @returns Editor bridge used to discover and observe the active input box.
+ */
 function getMTextEditorBridge(): MTextEditorBridge {
   return AcEdMTextEditor as unknown as MTextEditorBridge
 }
 
+/**
+ * Collects text style table records from the active drawing.
+ *
+ * @returns Text style records in database iteration order, or an empty array.
+ */
 function getTextStyleRecords() {
   const db = getCurrentDatabase()
   if (!db) return []
   return Array.from(db.tables.textStyleTable.newIterator())
 }
 
+/**
+ * Builds the text style gallery categories for the MText contextual ribbon.
+ *
+ * Each text style item carries a preview label and a font-family style so the
+ * gallery can display the style using its configured font where possible.
+ *
+ * @param title Display title for the gallery category.
+ * @returns Ribbon gallery categories representing drawing text styles.
+ */
 function buildTextStyleGalleryCategories(
   title: string
 ): RibbonGalleryCategoryModel[] {
@@ -255,14 +413,27 @@ function buildTextStyleGalleryCategories(
   ]
 }
 
+/**
+ * Creates the contextual ribbon controller for inline MTEXT editing.
+ *
+ * The controller observes the active MText input box, mirrors its current
+ * character/paragraph state into ribbon controls, translates ribbon item ids
+ * back into editor operations, and builds the contextual tab model used by the
+ * ribbon renderer.
+ *
+ * @param options Shared ribbon tab state.
+ * @returns Handlers and state consumed by the ribbon command host.
+ */
 export function useMTextContextualRibbon({
   activeTabId
 }: UseMTextContextualRibbonOptions) {
   const {
     isVisible,
     isCommandActive,
+    hideContextTab,
+    showContextTab,
     handleCommandWillStart,
-    handleCommandEnded
+    isContextCommand
   } = useRibbonContextualTab({
     activeTabId,
     tabId: MTEXT_CONTEXTUAL_TAB_ID,
@@ -277,29 +448,70 @@ export function useMTextContextualRibbon({
 
   let observedEditor: MTextRibbonEditor | null = null
 
-  const getActiveEditor = () =>
-    getMTextEditorBridge().getActiveInputBox?.() ?? activeEditor.value
+  /**
+   * Resolves the active MText editor from the bridge with a local ref fallback.
+   *
+   * @returns Active editor adapter, or `null` when no inline editor is open.
+   */
+  const getActiveEditor = () => {
+    const bridge = getMTextEditorBridge()
+    return bridge.getActiveInputBox
+      ? bridge.getActiveInputBox()
+      : activeEditor.value
+  }
 
+  /**
+   * Shows the contextual tab while MTEXT is running or an inline editor exists.
+   */
+  const refreshContextTabVisibility = () => {
+    if (isCommandActive.value || activeEditor.value) {
+      showContextTab()
+      return
+    }
+    hideContextTab()
+  }
+
+  /**
+   * Synchronizes the ribbon color refs from a character format snapshot.
+   *
+   * @param format Current editor format used as the color source.
+   */
   const syncColorStateFromFormat = (format: MTextRibbonFormat) => {
     const color = toAcCmColorFromFormat(format)
     currentColor.value = color
     currentColorDisplay.value = resolveColorDisplay(color)
   }
 
+  /**
+   * Pulls the latest format from the active editor into reactive ribbon state.
+   *
+   * When editing has ended, the ribbon resets to defaults and lets the
+   * contextual tab visibility logic hide the tab if no MTEXT command is active.
+   */
   const syncFormatFromEditor = () => {
     const editor = getActiveEditor()
     if (!editor) {
       activeEditor.value = null
       currentFormat.value = { ...DEFAULT_MTEXT_FORMAT }
       syncColorStateFromFormat(currentFormat.value)
+      refreshContextTabVisibility()
       return
     }
 
     activeEditor.value = editor
-    currentFormat.value = { ...DEFAULT_MTEXT_FORMAT, ...editor.getCurrentFormat() }
+    currentFormat.value = {
+      ...DEFAULT_MTEXT_FORMAT,
+      ...editor.getCurrentFormat()
+    }
     syncColorStateFromFormat(currentFormat.value)
+    refreshContextTabVisibility()
   }
 
+  /**
+   * Rebinds format synchronization listeners when the active editor changes.
+   *
+   * @param editor Editor adapter to observe, or `null` to remove listeners.
+   */
   const bindEditorEvents = (editor: MTextRibbonEditor | null) => {
     if (observedEditor === editor) return
     if (observedEditor?.off) {
@@ -318,8 +530,25 @@ export function useMTextContextualRibbon({
     syncFormatFromEditor()
   }
 
-  const handleActiveInputBoxChanged: ActiveInputBoxChangeListener = inputBox => {
-    bindEditorEvents(inputBox as MTextRibbonEditor | null)
+  /**
+   * Responds to active input box changes reported by the editor bridge.
+   *
+   * @param inputBox Editor-like object from the bridge, or `null` on close.
+   */
+  const handleActiveInputBoxChanged: ActiveInputBoxChangeListener =
+    inputBox => {
+      bindEditorEvents(inputBox as MTextRibbonEditor | null)
+    }
+
+  /**
+   * Handles CAD command completion events for the MTEXT contextual tab.
+   *
+   * @param args Command event payload raised by the CAD command manager.
+   */
+  const handleCommandEnded = (args: AcEdCommandEventArgs) => {
+    if (!isContextCommand(args)) return
+    isCommandActive.value = false
+    refreshContextTabVisibility()
   }
 
   onMounted(() => {
@@ -334,6 +563,11 @@ export function useMTextContextualRibbon({
     bindEditorEvents(null)
   })
 
+  /**
+   * Applies a partial character format to the active MText editor.
+   *
+   * @param format Format fields that should change on the current selection.
+   */
   const applyCurrentFormat = (format: Partial<MTextRibbonFormat>) => {
     const editor = getActiveEditor()
     if (!editor) return
@@ -341,6 +575,12 @@ export function useMTextContextualRibbon({
     syncFormatFromEditor()
   }
 
+  /**
+   * Handles boolean character format toggles from ribbon toggle buttons.
+   *
+   * @param field Character format field controlled by the clicked toggle.
+   * @param value Whether the formatting option should be enabled.
+   */
   const handleFormatToggle = (
     field: 'bold' | 'italic' | 'underline' | 'overline' | 'strike',
     value: boolean
@@ -348,6 +588,16 @@ export function useMTextContextualRibbon({
     applyCurrentFormat({ [field]: value })
   }
 
+  /**
+   * Handles superscript and subscript toggle buttons.
+   *
+   * If the user turns the currently active script option off, the editor returns
+   * to normal baseline text. Otherwise the editor-specific selection toggle is
+   * preferred so selected text can be transformed in place.
+   *
+   * @param script Script mode selected by the ribbon item.
+   * @param active Whether the toggle is being switched on.
+   */
   const handleScriptToggle = (
     script: Exclude<MTextRibbonScript, 'normal'>,
     active: boolean
@@ -366,22 +616,44 @@ export function useMTextContextualRibbon({
     syncFormatFromEditor()
   }
 
+  /**
+   * Toggles stacked-fraction formatting for the current editor selection.
+   */
   const handleStack = () => {
     const editor = getActiveEditor()
     editor?.toggleStackSelection?.()
     syncFormatFromEditor()
   }
 
+  /**
+   * Applies a color chosen from the shared ribbon color dropdown.
+   *
+   * @param color CAD color selected by the user.
+   */
   const handleMTextColorChange = (color?: AcCmColor) => {
     if (!color) return
     applyCurrentFormat(toFormatColor(color))
   }
 
+  /**
+   * Applies a text height chosen from the MText height control.
+   *
+   * @param value Text height in drawing units.
+   */
   const handleFontHeightChange = (value: number) => {
     if (!Number.isFinite(value) || value <= 0) return
     applyCurrentFormat({ fontSize: value })
   }
 
+  /**
+   * Applies a drawing text style to the active editor and database default.
+   *
+   * The style's configured font and usable height are mirrored into the current
+   * character format so the active editor immediately reflects the gallery
+   * selection.
+   *
+   * @param styleName Name of the text style selected in the gallery.
+   */
   const applyTextStyle = (styleName: string) => {
     const db = getCurrentDatabase()
     if (!db || !styleName) return
@@ -398,10 +670,18 @@ export function useMTextContextualRibbon({
     applyCurrentFormat(nextFormat)
   }
 
+  /**
+   * Builds the font dropdown options for the current editor context.
+   *
+   * @returns Unique font family names from current format, text styles,
+   * available system fonts, and the default fallback.
+   */
   const getFontOptions = () => {
     const availableFonts = AcApDocManager.instance?.avaiableFonts ?? []
     const fontNames = availableFonts.flatMap(fontInfo => fontInfo.name)
-    const styleFonts = getTextStyleRecords().map(record => record.textStyle.font)
+    const styleFonts = getTextStyleRecords().map(
+      record => record.textStyle.font
+    )
     return uniqueStrings([
       currentFormat.value.fontFamily,
       ...styleFonts,
@@ -410,6 +690,12 @@ export function useMTextContextualRibbon({
     ])
   }
 
+  /**
+   * Builds the text height options for the MText height picker.
+   *
+   * @returns Unique positive heights from the current format, text styles, and
+   * common drafting defaults.
+   */
   const getHeightOptions = () => {
     const styleHeights = getTextStyleRecords()
       .flatMap(record => [
@@ -419,10 +705,26 @@ export function useMTextContextualRibbon({
       .map(normalizeNumber)
       .filter((value): value is number => value != null && value > 0)
     return Array.from(
-      new Set([currentFormat.value.fontSize, ...styleHeights, 1, 2.5, 3.5, 5, 7, 10, 12, 24])
+      new Set([
+        currentFormat.value.fontSize,
+        ...styleHeights,
+        1,
+        2.5,
+        3.5,
+        5,
+        7,
+        10,
+        12,
+        24
+      ])
     )
   }
 
+  /**
+   * Inserts raw MText content at the active editor cursor.
+   *
+   * @param text MText control code or literal text to insert.
+   */
   const insertText = (text: string) => {
     const editor = getActiveEditor()
     if (!editor) return
@@ -430,11 +732,25 @@ export function useMTextContextualRibbon({
     syncFormatFromEditor()
   }
 
+  /**
+   * Applies paragraph alignment through the active editor.
+   *
+   * @param alignment Alignment id emitted by the ribbon button group.
+   */
   const handleParagraphAlignment = (alignment: string) => {
     getActiveEditor()?.setParagraphAlignment?.(alignment)
     syncFormatFromEditor()
   }
 
+  /**
+   * Routes MText contextual ribbon item clicks to editor operations.
+   *
+   * The dispatcher owns the `mtext-` item id contract for text styles, fonts,
+   * character formatting, paragraph tools, symbol insertion, and editor close.
+   *
+   * @param itemId Ribbon item id emitted by the MText contextual tab.
+   * @returns `true` when the id belongs to the MText contextual ribbon.
+   */
   const handleItem = (itemId: string) => {
     if (!itemId.startsWith(MTEXT_ITEM_PREFIX)) return false
 
@@ -513,6 +829,16 @@ export function useMTextContextualRibbon({
     return true
   }
 
+  /**
+   * Creates a compact ribbon toggle item for MText character formatting.
+   *
+   * @param id Stable ribbon item id and item id prefix.
+   * @param label Localized command label.
+   * @param tooltip Localized tooltip text.
+   * @param icon Icon component shown by the toggle.
+   * @param modelValue Current active state for the toggle.
+   * @returns Ribbon item model configured as a small toggle button.
+   */
   const createToggleItem = (
     id: string,
     label: string,
@@ -538,6 +864,15 @@ export function useMTextContextualRibbon({
     }
   })
 
+  /**
+   * Creates a compact ribbon push button for MText editor commands.
+   *
+   * @param id Stable ribbon item id.
+   * @param label Localized command label.
+   * @param tooltip Localized tooltip text.
+   * @param icon Icon component shown by the button.
+   * @returns Ribbon item model configured as a small icon button.
+   */
   const createButtonItem = (
     id: string,
     label: string,
@@ -554,6 +889,16 @@ export function useMTextContextualRibbon({
     props: { icon }
   })
 
+  /**
+   * Builds the current MTEXT contextual ribbon tab model.
+   *
+   * The editor format is refreshed before construction so gallery, dropdown,
+   * toggle, color, height, and paragraph controls reflect the current cursor or
+   * selection state at render time.
+   *
+   * @param t Translation callback used for all user-facing labels.
+   * @returns Ribbon tab model consumed by the ribbon renderer.
+   */
   const buildContextualTab = (t: Translate): RibbonTabModel => {
     syncFormatFromEditor()
 
@@ -797,14 +1142,38 @@ export function useMTextContextualRibbon({
                   props: {
                     icon: icons.bullets,
                     options: [
-                      { value: 'mtext-list:off', label: t('main.ribbon.mtext.list.off') },
-                      { value: 'mtext-list:number', label: t('main.ribbon.mtext.list.number') },
-                      { value: 'mtext-list:letter', label: t('main.ribbon.mtext.list.letter') },
-                      { value: 'mtext-list:bullet', label: t('main.ribbon.mtext.list.bullet') },
-                      { value: 'mtext-list:start', label: t('main.ribbon.mtext.list.start') },
-                      { value: 'mtext-list:continue', label: t('main.ribbon.mtext.list.continue') },
-                      { value: 'mtext-list:auto', label: t('main.ribbon.mtext.list.auto') },
-                      { value: 'mtext-list:allow-list', label: t('main.ribbon.mtext.list.allowList') }
+                      {
+                        value: 'mtext-list:off',
+                        label: t('main.ribbon.mtext.list.off')
+                      },
+                      {
+                        value: 'mtext-list:number',
+                        label: t('main.ribbon.mtext.list.number')
+                      },
+                      {
+                        value: 'mtext-list:letter',
+                        label: t('main.ribbon.mtext.list.letter')
+                      },
+                      {
+                        value: 'mtext-list:bullet',
+                        label: t('main.ribbon.mtext.list.bullet')
+                      },
+                      {
+                        value: 'mtext-list:start',
+                        label: t('main.ribbon.mtext.list.start')
+                      },
+                      {
+                        value: 'mtext-list:continue',
+                        label: t('main.ribbon.mtext.list.continue')
+                      },
+                      {
+                        value: 'mtext-list:auto',
+                        label: t('main.ribbon.mtext.list.auto')
+                      },
+                      {
+                        value: 'mtext-list:allow-list',
+                        label: t('main.ribbon.mtext.list.allowList')
+                      }
                     ]
                   }
                 },
@@ -881,7 +1250,9 @@ export function useMTextContextualRibbon({
                         value: 'mtext-paragraph-align:distributed',
                         label: '',
                         icon: icons.distributed,
-                        tooltip: t('main.ribbon.mtext.paragraphAlign.distributed')
+                        tooltip: t(
+                          'main.ribbon.mtext.paragraphAlign.distributed'
+                        )
                       }
                     ]
                   }
@@ -909,31 +1280,109 @@ export function useMTextContextualRibbon({
                   props: {
                     icon: icons.symbol,
                     options: [
-                      { value: 'mtext-symbol:%%d', label: t('main.ribbon.mtext.symbol.degree') },
-                      { value: 'mtext-symbol:%%p', label: t('main.ribbon.mtext.symbol.plusMinus') },
-                      { value: 'mtext-symbol:%%c', label: t('main.ribbon.mtext.symbol.diameter') },
-                      { value: 'mtext-symbol:\\U+2248', label: t('main.ribbon.mtext.symbol.almostEqual') },
-                      { value: 'mtext-symbol:\\U+2220', label: t('main.ribbon.mtext.symbol.angle') },
-                      { value: 'mtext-symbol:\\U+E100', label: t('main.ribbon.mtext.symbol.boundary') },
-                      { value: 'mtext-symbol:\\U+2104', label: t('main.ribbon.mtext.symbol.centerLine') },
-                      { value: 'mtext-symbol:\\U+0394', label: t('main.ribbon.mtext.symbol.delta') },
-                      { value: 'mtext-symbol:\\U+0278', label: t('main.ribbon.mtext.symbol.electricalPhase') },
-                      { value: 'mtext-symbol:\\U+E101', label: t('main.ribbon.mtext.symbol.flowLine') },
-                      { value: 'mtext-symbol:\\U+2261', label: t('main.ribbon.mtext.symbol.identical') },
-                      { value: 'mtext-symbol:\\U+2260', label: t('main.ribbon.mtext.symbol.notEqual') },
-                      { value: 'mtext-symbol:\\U+2126', label: t('main.ribbon.mtext.symbol.ohm') },
-                      { value: 'mtext-symbol:\\U+03A9', label: t('main.ribbon.mtext.symbol.omega') },
-                      { value: 'mtext-symbol:\\U+214A', label: t('main.ribbon.mtext.symbol.propertyLine') },
-                      { value: 'mtext-symbol:\\U+2082', label: t('main.ribbon.mtext.symbol.subscriptTwo') },
-                      { value: 'mtext-symbol:\\U+00B2', label: t('main.ribbon.mtext.symbol.squared') },
-                      { value: 'mtext-symbol:\\U+00B3', label: t('main.ribbon.mtext.symbol.cubed') },
+                      {
+                        value: 'mtext-symbol:%%d',
+                        label: t('main.ribbon.mtext.symbol.degree')
+                      },
+                      {
+                        value: 'mtext-symbol:%%p',
+                        label: t('main.ribbon.mtext.symbol.plusMinus')
+                      },
+                      {
+                        value: 'mtext-symbol:%%c',
+                        label: t('main.ribbon.mtext.symbol.diameter')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+2248',
+                        label: t('main.ribbon.mtext.symbol.almostEqual')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+2220',
+                        label: t('main.ribbon.mtext.symbol.angle')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+E100',
+                        label: t('main.ribbon.mtext.symbol.boundary')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+2104',
+                        label: t('main.ribbon.mtext.symbol.centerLine')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+0394',
+                        label: t('main.ribbon.mtext.symbol.delta')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+0278',
+                        label: t('main.ribbon.mtext.symbol.electricalPhase')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+E101',
+                        label: t('main.ribbon.mtext.symbol.flowLine')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+2261',
+                        label: t('main.ribbon.mtext.symbol.identical')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+2260',
+                        label: t('main.ribbon.mtext.symbol.notEqual')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+2126',
+                        label: t('main.ribbon.mtext.symbol.ohm')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+03A9',
+                        label: t('main.ribbon.mtext.symbol.omega')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+214A',
+                        label: t('main.ribbon.mtext.symbol.propertyLine')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+2082',
+                        label: t('main.ribbon.mtext.symbol.subscriptTwo')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+00B2',
+                        label: t('main.ribbon.mtext.symbol.squared')
+                      },
+                      {
+                        value: 'mtext-symbol:\\U+00B3',
+                        label: t('main.ribbon.mtext.symbol.cubed')
+                      },
                       {
                         value: 'mtext-symbol:\\~',
                         label: t('main.ribbon.mtext.symbol.nbsp')
                       },
-                      { value: 'mtext-symbol:other', label: t('main.ribbon.mtext.symbol.other') }
+                      {
+                        value: 'mtext-symbol:other',
+                        label: t('main.ribbon.mtext.symbol.other')
+                      }
                     ]
                   }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'mtext-close-group',
+          title: t('main.ribbon.mtext.group.close'),
+          orientation: 'row',
+          collections: [
+            {
+              id: 'mtext-close-main',
+              layout: 'row',
+              items: [
+                {
+                  id: 'mtext-close',
+                  type: 'button',
+                  label: t('main.ribbon.mtext.command.close'),
+                  tooltip: t('main.ribbon.mtext.tooltip.close'),
+                  size: 'large',
+                  props: { icon: CircleClose }
                 }
               ]
             }
@@ -943,16 +1392,27 @@ export function useMTextContextualRibbon({
     }
   }
 
+  /**
+   * Handles command completion events exposed to the ribbon host.
+   *
+   * In addition to updating contextual command state, this releases editor
+   * listeners when the MTEXT command itself finishes so stale input boxes do not
+   * keep driving ribbon updates.
+   *
+   * @param args Command event payload raised by the CAD command manager.
+   */
+  const handleRibbonCommandEnded = (args: AcEdCommandEventArgs) => {
+    handleCommandEnded(args)
+    if (args.command?.globalName === MTEXT_COMMAND_GLOBAL_NAME) {
+      bindEditorEvents(null)
+    }
+  }
+
   return {
     isVisible,
     isCommandActive,
     handleCommandWillStart,
-    handleCommandEnded: (args: AcEdCommandEventArgs) => {
-      handleCommandEnded(args)
-      if (args.command?.globalName === MTEXT_COMMAND_GLOBAL_NAME) {
-        bindEditorEvents(null)
-      }
-    },
+    handleCommandEnded: handleRibbonCommandEnded,
     handleItem,
     buildContextualTab
   }

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -9,7 +9,8 @@ export default {
     tab: {
       home: 'Home',
       tools: 'Tools',
-      hatchContext: 'Hatch'
+      hatchContext: 'Hatch',
+      mtextEditorContext: 'Text Editor'
     },
     hatch: {
       contextTitle: 'Hatch Creation',
@@ -71,6 +72,112 @@ export default {
         opacity: 'Set the hatch transparency (0-90).',
         imageScale: 'Set the fill image scale.',
         close: 'Exit Hatch creation and close this contextual tab.'
+      }
+    },
+    mtext: {
+      contextTitle: 'Text Editor',
+      group: {
+        textStyle: 'Text Style',
+        format: 'Format',
+        paragraph: 'Paragraph',
+        insert: 'Insert'
+      },
+      field: {
+        textStyle: 'Text Style',
+        font: 'Font',
+        color: 'Color',
+        height: 'Height'
+      },
+      command: {
+        bold: 'Bold',
+        underline: 'Underline',
+        superscript: 'Superscript',
+        italic: 'Italic',
+        overline: 'Overline',
+        subscript: 'Subscript',
+        strikethrough: 'Strikethrough',
+        stack: 'Stack',
+        toggleCase: 'Upper/Lower Case',
+        attachment: 'Justify',
+        list: 'Bullets and Numbering',
+        lineSpacing: 'Line Spacing',
+        paragraphAlignment: 'Paragraph Alignment',
+        symbol: 'Symbol'
+      },
+      tooltip: {
+        textStyle: 'Choose a text style from the current drawing.',
+        bold: 'Toggle bold formatting.',
+        underline: 'Toggle underline formatting.',
+        superscript: 'Toggle superscript formatting.',
+        italic: 'Toggle italic formatting.',
+        overline: 'Toggle overline formatting.',
+        subscript: 'Toggle subscript formatting.',
+        strikethrough: 'Toggle strikethrough formatting.',
+        stack: 'Stack or unstack selected fraction text.',
+        toggleCase: 'Toggle the selected text between upper and lower case.',
+        font: 'Set the current text font.',
+        color: 'Set the current text color.',
+        height: 'Set the current text height. Custom values are allowed.',
+        attachment: 'Set the multiline text attachment point.',
+        list: 'Insert or configure bullets and numbering.',
+        lineSpacing: 'Set line spacing.',
+        paragraphAlignment: 'Set paragraph horizontal alignment.',
+        symbol: 'Insert a common drafting symbol.'
+      },
+      attachment: {
+        TL: 'Top Left TL',
+        TC: 'Top Center TC',
+        TR: 'Top Right TR',
+        ML: 'Middle Left ML',
+        MC: 'Middle Center MC',
+        MR: 'Middle Right MR',
+        BL: 'Bottom Left BL',
+        BC: 'Bottom Center BC',
+        BR: 'Bottom Right BR'
+      },
+      list: {
+        off: 'Off',
+        number: 'Numbered',
+        letter: 'Lettered',
+        bullet: 'Bulleted',
+        start: 'Start',
+        continue: 'Continue',
+        auto: 'Allow Auto Bullets and Numbering',
+        allowList: 'Allow Bullets and Lists'
+      },
+      lineSpacing: {
+        more: 'More...',
+        clear: 'Clear Paragraph Spacing'
+      },
+      paragraphAlign: {
+        default: 'Default',
+        left: 'Left',
+        center: 'Center',
+        right: 'Right',
+        justified: 'Justified',
+        distributed: 'Distributed'
+      },
+      symbol: {
+        degree: 'Degrees  %%d',
+        plusMinus: 'Plus/Minus  %%p',
+        diameter: 'Diameter  %%c',
+        almostEqual: 'Almost Equal  \\U+2248',
+        angle: 'Angle  \\U+2220',
+        boundary: 'Boundary Line  \\U+E100',
+        centerLine: 'Center Line  \\U+2104',
+        delta: 'Delta  \\U+0394',
+        electricalPhase: 'Electrical Phase  \\U+0278',
+        flowLine: 'Flow Line  \\U+E101',
+        identical: 'Identical To  \\U+2261',
+        notEqual: 'Not Equal  \\U+2260',
+        ohm: 'Ohm  \\U+2126',
+        omega: 'Omega  \\U+03A9',
+        propertyLine: 'Property Line  \\U+214A',
+        subscriptTwo: 'Subscript 2  \\U+2082',
+        squared: 'Squared  \\U+00B2',
+        cubed: 'Cubed  \\U+00B3',
+        nbsp: 'Nonbreaking Space Ctrl+Shift+Space',
+        other: 'Other...'
       }
     },
     group: {

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -80,7 +80,8 @@ export default {
         textStyle: 'Text Style',
         format: 'Format',
         paragraph: 'Paragraph',
-        insert: 'Insert'
+        insert: 'Insert',
+        close: 'Close'
       },
       field: {
         textStyle: 'Text Style',
@@ -102,7 +103,8 @@ export default {
         list: 'Bullets and Numbering',
         lineSpacing: 'Line Spacing',
         paragraphAlignment: 'Paragraph Alignment',
-        symbol: 'Symbol'
+        symbol: 'Symbol',
+        close: 'Close'
       },
       tooltip: {
         textStyle: 'Choose a text style from the current drawing.',
@@ -122,7 +124,8 @@ export default {
         list: 'Insert or configure bullets and numbering.',
         lineSpacing: 'Set line spacing.',
         paragraphAlignment: 'Set paragraph horizontal alignment.',
-        symbol: 'Insert a common drafting symbol.'
+        symbol: 'Insert a common drafting symbol.',
+        close: 'Close the text editor and this contextual tab.'
       },
       attachment: {
         TL: 'Top Left TL',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -80,7 +80,8 @@ export default {
         textStyle: '文字样式',
         format: '格式',
         paragraph: '段落',
-        insert: '插入'
+        insert: '插入',
+        close: '关闭'
       },
       field: {
         textStyle: '文字样式',
@@ -102,7 +103,8 @@ export default {
         list: '项目符号和编号',
         lineSpacing: '行距',
         paragraphAlignment: '段落对齐',
-        symbol: '符号'
+        symbol: '符号',
+        close: '关闭'
       },
       tooltip: {
         textStyle: '选择当前图纸中的文字样式。',
@@ -122,7 +124,8 @@ export default {
         list: '插入或设置项目符号和编号。',
         lineSpacing: '设置行距。',
         paragraphAlignment: '设置段落水平对齐方式。',
-        symbol: '插入常用工程符号。'
+        symbol: '插入常用工程符号。',
+        close: '关闭文字编辑器并关闭该上下文标签。'
       },
       attachment: {
         TL: '左上 TL',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -9,7 +9,8 @@ export default {
     tab: {
       home: '常用',
       tools: '工具',
-      hatchContext: '填充'
+      hatchContext: '填充',
+      mtextEditorContext: '文字编辑器'
     },
     hatch: {
       contextTitle: '填充创建',
@@ -71,6 +72,112 @@ export default {
         opacity: '设置填充透明度（0-90）。',
         imageScale: '设置填充图片比例。',
         close: '退出填充创建并关闭该上下文标签。'
+      }
+    },
+    mtext: {
+      contextTitle: '文字编辑器',
+      group: {
+        textStyle: '文字样式',
+        format: '格式',
+        paragraph: '段落',
+        insert: '插入'
+      },
+      field: {
+        textStyle: '文字样式',
+        font: '字体',
+        color: '颜色',
+        height: '高度'
+      },
+      command: {
+        bold: '粗体',
+        underline: '下划线',
+        superscript: '上标',
+        italic: '斜体',
+        overline: '上划线',
+        subscript: '下标',
+        strikethrough: '删除线',
+        stack: '堆叠',
+        toggleCase: '大小写',
+        attachment: '对正',
+        list: '项目符号和编号',
+        lineSpacing: '行距',
+        paragraphAlignment: '段落对齐',
+        symbol: '符号'
+      },
+      tooltip: {
+        textStyle: '选择当前图纸中的文字样式。',
+        bold: '切换粗体格式。',
+        underline: '切换下划线格式。',
+        superscript: '切换上标格式。',
+        italic: '切换斜体格式。',
+        overline: '切换上划线格式。',
+        subscript: '切换下标格式。',
+        strikethrough: '切换删除线格式。',
+        stack: '将选中的分数字符堆叠或还原。',
+        toggleCase: '切换选中文字的大小写。',
+        font: '设置当前文字字体。',
+        color: '设置当前文字颜色。',
+        height: '设置当前文字高度，可输入自定义值。',
+        attachment: '设置多行文字的附着点。',
+        list: '插入或设置项目符号和编号。',
+        lineSpacing: '设置行距。',
+        paragraphAlignment: '设置段落水平对齐方式。',
+        symbol: '插入常用工程符号。'
+      },
+      attachment: {
+        TL: '左上 TL',
+        TC: '中上 TC',
+        TR: '右上 TR',
+        ML: '左中 ML',
+        MC: '正中 MC',
+        MR: '右中 MR',
+        BL: '左下 BL',
+        BC: '中下 BC',
+        BR: '右下 BR'
+      },
+      list: {
+        off: '关闭',
+        number: '以数字标记',
+        letter: '以字母标记',
+        bullet: '以项目符号标记',
+        start: '起点',
+        continue: '连续',
+        auto: '允许自动项目符号和编号',
+        allowList: '允许项目符号和列表'
+      },
+      lineSpacing: {
+        more: '更多...',
+        clear: '清除行间距'
+      },
+      paragraphAlign: {
+        default: '默认',
+        left: '左对齐',
+        center: '居中',
+        right: '右对齐',
+        justified: '对正',
+        distributed: '分散对齐'
+      },
+      symbol: {
+        degree: '度数  %%d',
+        plusMinus: '正/负  %%p',
+        diameter: '直径  %%c',
+        almostEqual: '几乎相等  \\U+2248',
+        angle: '角度  \\U+2220',
+        boundary: '边界线  \\U+E100',
+        centerLine: '中心线  \\U+2104',
+        delta: '差值  \\U+0394',
+        electricalPhase: '电相角  \\U+0278',
+        flowLine: '流线  \\U+E101',
+        identical: '恒等于  \\U+2261',
+        notEqual: '不相等  \\U+2260',
+        ohm: '欧姆  \\U+2126',
+        omega: '欧米加  \\U+03A9',
+        propertyLine: '地界线  \\U+214A',
+        subscriptTwo: '下标 2  \\U+2082',
+        squared: '平方  \\U+00B2',
+        cubed: '立方  \\U+00B3',
+        nbsp: '不断空格 Ctrl+Shift+Space',
+        other: '其他...'
       }
     },
     group: {

--- a/packages/svg-renderer/package.json
+++ b/packages/svg-renderer/package.json
@@ -31,6 +31,6 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "peerDependencies": {
-    "@mlightcad/data-model": "workspace:*"
+    "@mlightcad/data-model": "^1.7.33"
   }
 }

--- a/packages/three-renderer/__tests__/AcTrMText.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMText.spec.ts
@@ -10,9 +10,15 @@ jest.mock('../src/renderer', () => ({
 import { AcTrMText } from '../src/object/AcTrMText'
 
 type GeometryHost = THREE.Object3D & {
+  _text?: {
+    position?: THREE.Vector3Like
+    attachmentPoint?: number
+    height?: number
+  }
   box: THREE.Box3
   computeGeometryBox: () => THREE.Box3
   hasGeometry: (object: THREE.Object3D) => boolean
+  normalizeTopAlignedMText: (mtext: MTextObject) => void
 }
 
 type RaycastHost = THREE.Object3D & {
@@ -24,6 +30,7 @@ const privateMethods = AcTrMText.prototype as unknown as {
   computeGeometryBox(this: GeometryHost): THREE.Box3
   updateSelectionBox(this: GeometryHost, mtext: MTextObject): void
   hasGeometry(object: THREE.Object3D): boolean
+  normalizeTopAlignedMText(this: GeometryHost, mtext: MTextObject): void
   raycast(
     this: RaycastHost,
     raycaster: THREE.Raycaster,
@@ -42,7 +49,70 @@ describe('AcTrMText selection geometry', () => {
     expect(box.max.toArray()).toEqual([14, 22, 0])
   })
 
-  it('prefers rendered geometry over an offset renderer-provided mtext box', () => {
+  it('keeps renderer logical space when it overlaps rendered geometry', () => {
+    const host = createGeometryHost()
+    host.add(createBoxMesh({ x: 10, y: 20, z: 0 }))
+    const logicalMTextBox = new THREE.Box3(
+      new THREE.Vector3(10, 18, 0),
+      new THREE.Vector3(14, 24, 0)
+    )
+
+    privateMethods.updateSelectionBox.call(
+      host,
+      createMTextObject(logicalMTextBox)
+    )
+
+    expect(host.box.min.toArray()).toEqual([10, 18, 0])
+    expect(host.box.max.toArray()).toEqual([14, 24, 0])
+  })
+
+  it('normalizes top-attached mtext to the insertion top edge', () => {
+    const host = createGeometryHost()
+    host._text = {
+      position: new THREE.Vector3(10, 20, 0),
+      attachmentPoint: 1,
+      height: 2
+    }
+    const mtext = createMTextObject(
+      new THREE.Box3(
+        new THREE.Vector3(10, 11, 0),
+        new THREE.Vector3(18, 17, 0)
+      ),
+      [{ y: 14, height: 6 }]
+    )
+
+    privateMethods.normalizeTopAlignedMText.call(host, mtext)
+
+    expect(mtext.position.y).toBeCloseTo(3)
+    expect(mtext.box.min.y).toBeCloseTo(14)
+    expect(mtext.box.max.y).toBeCloseTo(20)
+    expect(mtext.createLayoutData().lines[0].y).toBeCloseTo(17)
+  })
+
+  it('uses the input box minimum line advance when normalizing top-attached mtext', () => {
+    const host = createGeometryHost()
+    host._text = {
+      position: new THREE.Vector3(10, 20, 0),
+      attachmentPoint: 1,
+      height: 6
+    }
+    const mtext = createMTextObject(
+      new THREE.Box3(
+        new THREE.Vector3(10, 11, 0),
+        new THREE.Vector3(18, 17, 0)
+      ),
+      [{ y: 14, height: 6 }]
+    )
+
+    privateMethods.normalizeTopAlignedMText.call(host, mtext)
+
+    expect(mtext.position.y).toBeCloseTo(0)
+    expect(mtext.box.min.y).toBeCloseTo(11)
+    expect(mtext.box.max.y).toBeCloseTo(17)
+    expect(mtext.createLayoutData().lines[0].y).toBeCloseTo(14)
+  })
+
+  it('ignores a disjoint renderer-provided mtext box', () => {
     const host = createGeometryHost()
     host.add(createBoxMesh({ x: 10, y: 20, z: 0 }))
     const offsetMTextBox = new THREE.Box3(
@@ -129,6 +199,7 @@ function createGeometryHost(): GeometryHost {
   host.box = new THREE.Box3()
   host.computeGeometryBox = privateMethods.computeGeometryBox
   host.hasGeometry = privateMethods.hasGeometry
+  host.normalizeTopAlignedMText = privateMethods.normalizeTopAlignedMText
   return host
 }
 
@@ -145,10 +216,13 @@ function createRaycastHost(options: {
   return host
 }
 
-function createMTextObject(box: THREE.Box3): MTextObject {
+function createMTextObject(
+  box: THREE.Box3,
+  lines: Array<{ y: number; height: number }> = []
+): MTextObject {
   const mtext = new THREE.Object3D() as MTextObject
   mtext.box = box
-  mtext.createLayoutData = () => ({ lines: [], chars: [] })
+  mtext.createLayoutData = () => ({ lines, chars: [] })
   return mtext
 }
 
@@ -156,10 +230,7 @@ function createBoxMesh(position: THREE.Vector3Like) {
   const geometry = new THREE.BufferGeometry()
   geometry.setAttribute(
     'position',
-    new THREE.Float32BufferAttribute(
-      [0, 0, 0, 4, 0, 0, 4, 2, 0, 0, 2, 0],
-      3
-    )
+    new THREE.Float32BufferAttribute([0, 0, 0, 4, 0, 0, 4, 2, 0, 0, 2, 0], 3)
   )
   geometry.setIndex([0, 1, 2, 0, 2, 3])
 

--- a/packages/three-renderer/package.json
+++ b/packages/three-renderer/package.json
@@ -44,9 +44,9 @@
     "@types/three": "^0.172.0"
   },
   "peerDependencies": {
-    "@mlightcad/data-model": "workspace:*",
-    "@mlightcad/mtext-renderer": "workspace:*",
+    "@mlightcad/data-model": "^1.7.33",
+    "@mlightcad/mtext-renderer": "^0.10.9",
     "@velipso/polybool": "^1.1.1",
-    "three": "workspace:*"
+    "three": "^0.172.0"
   }
 }

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -5,6 +5,7 @@ import {
   log
 } from '@mlightcad/data-model'
 import {
+  type CharBox,
   ColorSettings,
   MTextData,
   MTextObject
@@ -21,6 +22,10 @@ import { AcTrEntity } from './AcTrEntity'
 // path avoids needless garbage collection pressure.
 const _raycastBox = /*@__PURE__*/ new THREE.Box3()
 const _raycastPoint = /*@__PURE__*/ new THREE.Vector3()
+const _topAlignmentTranslation = /*@__PURE__*/ new THREE.Vector3()
+const MTEXT_INPUT_BOX_LINE_ADVANCE_RATIO = 1.5
+
+const TOP_ATTACHMENT_POINTS = new Set([undefined, 1, 2, 3])
 
 export class AcTrMText extends AcTrEntity {
   private _mtext?: MTextObject
@@ -150,6 +155,7 @@ export class AcTrMText extends AcTrEntity {
    * @param mtext Rendered MTEXT object returned by the shared MTEXT renderer.
    */
   private attachMText(mtext: MTextObject) {
+    this.normalizeTopAlignedMText(mtext)
     this.add(mtext)
     this.flatten()
     this.traverse(object => {
@@ -162,23 +168,89 @@ export class AcTrMText extends AcTrEntity {
   }
 
   /**
+   * Matches the MTEXT input box's top-edge anchoring for top-attached text.
+   *
+   * The shared MTEXT renderer places glyph geometry from typographic metrics,
+   * while the editor normalizes the rendered layout so the logical top of the
+   * first line sits at the insertion point. Without applying the same
+   * normalization here, text created through the input box jumps upward when the
+   * editor closes and the persisted MTEXT entity is rendered normally.
+   *
+   * @param mtext Rendered MTEXT object to normalize before flattening.
+   */
+  private normalizeTopAlignedMText(mtext: MTextObject) {
+    const mtextData = this._text as MTextData
+    if (!TOP_ATTACHMENT_POINTS.has(mtextData.attachmentPoint)) return
+
+    const position = mtextData.position
+    if (!position) return
+
+    const layout = mtext.createLayoutData()
+    let bottomY = mtext.box.min.y
+    let topY = mtext.box.max.y
+
+    layout.lines.forEach(line => {
+      if (!Number.isFinite(line.y) || !Number.isFinite(line.height)) return
+      bottomY = Math.min(bottomY, line.y - line.height / 2)
+      topY = Math.max(topY, line.y + line.height / 2)
+    })
+
+    const textHeight = Number.isFinite(mtextData.height) ? mtextData.height : 0
+    const fallbackLineAdvance = Math.max(
+      1,
+      textHeight * MTEXT_INPUT_BOX_LINE_ADVANCE_RATIO
+    )
+    topY = bottomY + Math.max(topY - bottomY, fallbackLineAdvance)
+
+    const dy = position.y - topY
+    if (!Number.isFinite(dy) || Math.abs(dy) < 1e-8) return
+
+    _topAlignmentTranslation.set(0, dy, 0)
+    mtext.position.y += dy
+    mtext.box.translate(_topAlignmentTranslation)
+    layout.lines.forEach(line => {
+      line.y += dy
+    })
+    layout.chars.forEach(char => {
+      this.translateCharBox(char, _topAlignmentTranslation)
+    })
+    mtext.updateMatrixWorld(true)
+  }
+
+  private translateCharBox(char: CharBox, translation: THREE.Vector3) {
+    char.box?.translate(translation)
+    char.children?.forEach(child => {
+      this.translateCharBox(child, translation)
+    })
+  }
+
+  /**
    * Rebuilds the entity selection box used by the scene spatial index.
    *
-   * The box exposed by the mtext renderer describes its logical MTEXT layout.
-   * For some aligned text, especially middle/center attachment points, that box
-   * can be offset from the glyph geometry that actually appears on screen.  The
-   * scene performs a small spatial-index query before it ever calls raycast, so
-   * an offset box can prevent point selection from even considering the entity.
+   * The box exposed by the mtext renderer describes its logical MTEXT layout,
+   * including per-line vertical space above baseline-drawn glyphs.  The box
+   * computed from rendered children tracks visible geometry more closely, but
+   * by itself it can trim off that leading space and make edit overlays drift
+   * when they round-trip through the MTEXT input box.
    *
-   * To keep the spatial index aligned with what the user sees, prefer a box
-   * computed from the rendered children.  If rendering produced no geometry,
-   * keep the renderer-provided box as a conservative fallback.
+   * Use child geometry as the anchor for selection, then merge the renderer box
+   * only when it overlaps the geometry.  This keeps legitimate line spacing while
+   * still ignoring the known bad case where an aligned renderer box is displaced
+   * away from the glyphs.
    *
    * @param mtext Rendered MTEXT object whose logical box is used as fallback.
    */
   private updateSelectionBox(mtext: MTextObject) {
     const geometryBox = this.computeGeometryBox()
-    this.box = geometryBox.isEmpty() ? mtext.box : geometryBox
+    if (geometryBox.isEmpty()) {
+      this.box = mtext.box
+      return
+    }
+    if (!mtext.box.isEmpty() && mtext.box.intersectsBox(geometryBox)) {
+      this.box = geometryBox.clone().union(mtext.box)
+      return
+    }
+    this.box = geometryBox
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         version: 0.172.0
     devDependencies:
       '@mlightcad/mtext-input-box':
-        specifier: ^0.2.4
-        version: 0.2.4(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)
+        specifier: ../../../mtext-input-box/packages/mtext-input-box
+        version: link:../../../mtext-input-box/packages/mtext-input-box
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.9
         version: 0.10.9(three@0.172.0)
@@ -1393,12 +1393,6 @@ packages:
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
-  '@mlightcad/mtext-input-box@0.2.4':
-    resolution: {integrity: sha512-4A5LJstZzFV3O05GtOfhYLeO9XKLX6ZGFvQnCo5yToQjPM+bLglmK/OUT0mwfKBZlgdQ438eMWY6xDU/8vRABA==}
-    peerDependencies:
-      '@mlightcad/mtext-renderer': ^0.10.9
-      three: ^0.172.0
-
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
@@ -1416,11 +1410,6 @@ packages:
 
   '@mlightcad/shx-parser@1.3.2':
     resolution: {integrity: sha512-j84hqbWOVMDuepLEjVsYvxeiCXOVxHyJhl4gM4HtgXZ6ChgTLsuSnqs2bNOt2SwriTvFOsv3QLsOu2iJh857JA==}
-
-  '@mlightcad/text-box-cursor@0.1.1':
-    resolution: {integrity: sha512-Q3uLz+FXG6mLInq/Q1jUNdyjGFdMWZduWA2WO6d+jUqFbWeh4xsn5M/HY+vy1Rs0bvLWZvdRgJeEFVe6nhIihQ==}
-    peerDependencies:
-      three: ^0.172.0
 
   '@mlightcad/three-viewcube@0.0.9':
     resolution: {integrity: sha512-oGWC+NrfgfHyCGtO/3NGC3M91qrj9Y1cOVaRKGALEicqCJYg7M4fKUbuag2rCNZLml1BdhpS9JMTZyfbYeAO7Q==}
@@ -6185,12 +6174,6 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.1': {}
 
-  '@mlightcad/mtext-input-box@0.2.4(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)':
-    dependencies:
-      '@mlightcad/mtext-renderer': 0.10.9(three@0.172.0)
-      '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
-      three: 0.172.0
-
   '@mlightcad/mtext-parser@1.4.1': {}
 
   '@mlightcad/mtext-renderer@0.10.9(three@0.172.0)':
@@ -6209,10 +6192,6 @@ snapshots:
       vue: 3.5.31(typescript@5.9.3)
 
   '@mlightcad/shx-parser@1.3.2': {}
-
-  '@mlightcad/text-box-cursor@0.1.1(three@0.172.0)':
-    dependencies:
-      three: 0.172.0
 
   '@mlightcad/three-viewcube@0.0.9(three@0.172.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         version: 0.172.0
     devDependencies:
       '@mlightcad/mtext-input-box':
-        specifier: ../../../mtext-input-box/packages/mtext-input-box
-        version: link:../../../mtext-input-box/packages/mtext-input-box
+        specifier: ^0.2.5
+        version: 0.2.5(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.9
         version: 0.10.9(three@0.172.0)
@@ -1393,6 +1393,12 @@ packages:
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
+  '@mlightcad/mtext-input-box@0.2.5':
+    resolution: {integrity: sha512-eA17KwHcNQgRaDYDHImVPYVEpM4J1E7KQMW/HQwsiBbnE7CchdWgWROWNcffLqY9orsteCU+qfsxddPwEeN9/g==}
+    peerDependencies:
+      '@mlightcad/mtext-renderer': ^0.10.9
+      three: ^0.172.0
+
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
@@ -1410,6 +1416,11 @@ packages:
 
   '@mlightcad/shx-parser@1.3.2':
     resolution: {integrity: sha512-j84hqbWOVMDuepLEjVsYvxeiCXOVxHyJhl4gM4HtgXZ6ChgTLsuSnqs2bNOt2SwriTvFOsv3QLsOu2iJh857JA==}
+
+  '@mlightcad/text-box-cursor@0.1.1':
+    resolution: {integrity: sha512-Q3uLz+FXG6mLInq/Q1jUNdyjGFdMWZduWA2WO6d+jUqFbWeh4xsn5M/HY+vy1Rs0bvLWZvdRgJeEFVe6nhIihQ==}
+    peerDependencies:
+      three: ^0.172.0
 
   '@mlightcad/three-viewcube@0.0.9':
     resolution: {integrity: sha512-oGWC+NrfgfHyCGtO/3NGC3M91qrj9Y1cOVaRKGALEicqCJYg7M4fKUbuag2rCNZLml1BdhpS9JMTZyfbYeAO7Q==}
@@ -1489,28 +1500,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.3.1':
     resolution: {integrity: sha512-JMuBbg2Zqdz4N7i+hiJGr2QdsDarDZ8vyzzeoevFq3b8nhZfqKh/lno7+Y0WkXNpH7aT05GHaUA1r1NXf/5BeQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.3.1':
     resolution: {integrity: sha512-cVmDMtolaqK7PziWxvjus1nCyj2wMNM+N0/4+rBEjG4v47gTtBxlZJoxK02jApdV+XELehsTjd0Z/xVfO4Rl1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.3.1':
     resolution: {integrity: sha512-UGujK/TLMz9TNJ6+6HLhoOV7pdlgPVosSyeNZcoXCHOg/Mg9NGM7Hgk9jDodtcAY+TP6QMDJIMVGuXBsCE7NLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.3.1':
     resolution: {integrity: sha512-q+2aaRXarh/+HOOW/JXRwEnEEwPdGipsfzXBPDuDDJ7aOYKuyG7g1DlSERKdzI/aEBP+joneZbcbZHaDcEv2xw==}
@@ -1556,42 +1563,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1675,79 +1676,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -6174,6 +6162,12 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.1': {}
 
+  '@mlightcad/mtext-input-box@0.2.5(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)':
+    dependencies:
+      '@mlightcad/mtext-renderer': 0.10.9(three@0.172.0)
+      '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
+      three: 0.172.0
+
   '@mlightcad/mtext-parser@1.4.1': {}
 
   '@mlightcad/mtext-renderer@0.10.9(three@0.172.0)':
@@ -6192,6 +6186,10 @@ snapshots:
       vue: 3.5.31(typescript@5.9.3)
 
   '@mlightcad/shx-parser@1.3.2': {}
+
+  '@mlightcad/text-box-cursor@0.1.1(three@0.172.0)':
+    dependencies:
+      three: 0.172.0
 
   '@mlightcad/three-viewcube@0.0.9(three@0.172.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
   - 'packages/*'
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  nx: true
+  vue-demi: true

--- a/tools/sync-workspace-versions.mjs
+++ b/tools/sync-workspace-versions.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const toolsDir = path.dirname(new URL(import.meta.url).pathname);
+const rootDir = path.resolve(toolsDir, '..');
+const packagesDir = path.join(rootDir, 'packages');
+const rootPackageJsonPath = path.join(rootDir, 'package.json');
+
+function isWorkspaceVersion(value) {
+  return typeof value === 'string' && value.startsWith('workspace:');
+}
+
+function buildRootVersionMap(rootPkg) {
+  return {
+    ...(rootPkg.dependencies ?? {}),
+    ...(rootPkg.devDependencies ?? {}),
+    ...(rootPkg.peerDependencies ?? {}),
+    ...(rootPkg.pnpm?.overrides ?? {}),
+  };
+}
+
+async function readJson(filePath) {
+  const content = await readFile(filePath, { encoding: 'utf8' });
+  return JSON.parse(content);
+}
+
+async function writeJson(filePath, data) {
+  const content = `${JSON.stringify(data, null, 2)}\n`;
+  await writeFile(filePath, content, { encoding: 'utf8' });
+}
+
+async function findWorkspacePackageNames(rootPkg) {
+  const packageNames = new Set();
+  const entries = await readdir(packagesDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const pkgPath = path.join(packagesDir, entry.name, 'package.json');
+    try {
+      const pkg = await readJson(pkgPath);
+      if (pkg.name) {
+        packageNames.add(pkg.name);
+      }
+    } catch {
+      // ignore packages without package.json
+    }
+  }
+
+  for (const item of rootPkg.workspaces ?? []) {
+    if (item.endsWith('/*')) continue;
+    if (item.endsWith('.json')) continue;
+  }
+
+  return packageNames;
+}
+
+async function syncPackage(packageFilePath, rootVersionMap, workspacePackageNames) {
+  const pkg = await readJson(packageFilePath);
+  const dependencyKeys = [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ];
+  let changed = false;
+
+  for (const depKey of dependencyKeys) {
+    const deps = pkg[depKey];
+    if (!deps || typeof deps !== 'object') continue;
+
+    for (const [name, value] of Object.entries(deps)) {
+      if (!isWorkspaceVersion(value)) continue;
+      if (workspacePackageNames.has(name)) continue;
+
+      const rootVersion = rootVersionMap[name];
+      if (!rootVersion) {
+        console.warn(`⚠️  ${pkg.name || packageFilePath}: no root version found for ${name} in ${depKey}`);
+        continue;
+      }
+
+      if (deps[name] !== rootVersion) {
+        deps[name] = rootVersion;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) {
+    await writeJson(packageFilePath, pkg);
+  }
+
+  return changed;
+}
+
+(async () => {
+  try {
+    const rootPkg = await readJson(rootPackageJsonPath);
+    const rootVersionMap = buildRootVersionMap(rootPkg);
+    const workspacePackageNames = await findWorkspacePackageNames(rootPkg);
+
+    const packageDirs = await readdir(packagesDir, { withFileTypes: true });
+    const changedFiles = [];
+
+    for (const entry of packageDirs) {
+      if (!entry.isDirectory()) continue;
+      const packageFilePath = path.join(packagesDir, entry.name, 'package.json');
+      try {
+        const changed = await syncPackage(packageFilePath, rootVersionMap, workspacePackageNames);
+        if (changed) changedFiles.push(packageFilePath);
+      } catch (error) {
+        console.error(`❌ Failed to process ${packageFilePath}:`, error.message);
+      }
+    }
+
+    if (changedFiles.length === 0) {
+      console.log('✅ No workspace:* versions needed syncing.');
+    } else {
+      console.log('✅ Synced versions in the following package.json files:');
+      for (const file of changedFiles) {
+        console.log(`  - ${path.relative(rootDir, file)}`);
+      }
+    }
+  } catch (error) {
+    console.error('❌ sync-workspace-versions failed:', error.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary

This PR introduces comprehensive MTEXT (multi-line text) editing capabilities to the CAD viewer, including an inline text editor, contextual ribbon interface, and double-click editing support.

## Key Changes

### Core MTEXT Editor (`AcEdMTextEditor`)

-   Added new `AcEdMTextEditor` class with static methods for managing active input boxes
-   Implemented toolbar visibility controls with `setDefaultToolbarEnabled()`
-   Added event system for tracking active editors and format changes
-   Integrated with MText input box for rich text editing

### View Integration (`AcTrView2d`)

-   Added double-click handler for MTEXT entities
-   Implemented `openPickedMTextEditor()` and `editMTextEntity()` methods
-   Added helper methods for resolving editor width, height, and font families

### Contextual Ribbon (`useMTextContextualRibbon`)

-   Created comprehensive MTEXT formatting ribbon with:

    -   Text style gallery
    -   Character formatting toggles (bold, italic, underline, etc.)
    -   Font and color selection
    -   Height controls
    -   Paragraph alignment and line spacing
    -   Symbol insertion

-   Added `MlRibbonMTextHeightSelect` component for text height input

### Rendering Improvements (`AcTrMText`)

-   Added `normalizeTopAlignedMText()` to fix top-attached text positioning
-   Improved selection box calculation to handle logical vs. rendered geometry
-   Enhanced MTEXT rendering consistency with input box behavior

### Dependencies and Build

-   Updated package versions to pin external dependencies (e.g., `@mlightcad/data-model@^1.7.33`, `three@^0.172.0`)
-   Added `sync-workspace-versions.mjs` tool for dependency management
-   Updated pnpm configuration and lockfile
-   Added new test file `AcEdMTextEditor.spec.ts`

### Internationalization

-   Added English and Chinese translations for MTEXT ribbon interface
-   Comprehensive locale support for all new UI elements

## Features

-   **Inline Editing**: Double-click MTEXT entities to edit directly in the canvas
-   **Rich Formatting**: Full character and paragraph formatting through contextual ribbon
-   **Toolbar Control**: Configurable toolbar visibility for different editing modes
-   **Symbol Insertion**: Built-in support for common drafting symbols
-   **Attachment Points**: Support for all MTEXT attachment point configurations
-   **Line Spacing**: Configurable paragraph line spacing factors

## Testing

-   Added unit tests for MTEXT editor functionality
-   Updated existing tests for rendering changes
-   Verified ribbon integration and event handling