### PR TITLE
feat: enhance MTEXT editing with improved renderer and contextual ribbon integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pre-serve": "nx run @mlightcad/cad-viewer-examples:pre-serve",
     "publish:viewer": "pnpm -r publish --filter cad-viewer --filter cad-simple-viewer --no-git-checks",
     "release": "node tools/release.mjs",
-    "sync:versions": "node tools/sync-workspace-versions.mjs",
+    "sync:versions": "node tools/sync-versions.mjs",
     "serve": "nx run @mlightcad/cad-viewer-examples:serve",
     "test": "jest",
     "test:e2e": "pnpm --filter @mlightcad/cad-viewer-example test:e2e"
@@ -44,8 +44,8 @@
       "vue-demi"
     ],
     "overrides": {
-      "@mlightcad/data-model": "^1.7.33",
-      "@mlightcad/libredwg-converter": "^3.5.33",
+      "@mlightcad/data-model": "^1.7.34",
+      "@mlightcad/libredwg-converter": "^3.5.34",
       "@mlightcad/mtext-renderer": "^0.10.10",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "overrides": {
       "@mlightcad/data-model": "^1.7.33",
       "@mlightcad/libredwg-converter": "^3.5.33",
-      "@mlightcad/mtext-renderer": "^0.10.9",
+      "@mlightcad/mtext-renderer": "^0.10.10",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",
       "vue": "^3.4.21",

--- a/packages/cad-simple-viewer-example/package.json
+++ b/packages/cad-simple-viewer-example/package.json
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@mlightcad/cad-simple-viewer": "workspace:*",
-    "@mlightcad/data-model": "^1.7.33"
+    "@mlightcad/data-model": "^1.7.34"
   }
 }

--- a/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
@@ -19,6 +19,27 @@ class MockMTextInputBox {
   readonly toggleCase = jest.fn()
   readonly toggleStackSelection = jest.fn()
   readonly toggleScriptSelection = jest.fn(() => true)
+  readonly focusImeInput = jest.fn()
+  readonly refocusImeInputSoon = jest.fn()
+  readonly getSelectionRange = jest.fn(() => ({
+    start: 0,
+    end: 1,
+    isCollapsed: false
+  }))
+  readonly toDocumentIndexFromLogicalIndex = jest.fn((index: number) => index)
+  readonly isScriptOnlyStack = jest.fn(() => false)
+  readonly document = {
+    ast: {
+      nodes: [
+        {
+          type: 'stack',
+          numerator: '1',
+          denominator: '2',
+          divider: '/'
+        }
+      ]
+    }
+  }
 
   constructor(readonly options: Record<string, unknown>) {
     mockMTextInputBoxInstances.push(this)
@@ -38,6 +59,8 @@ class MockMTextInputBox {
 interface FormatObservableInputBox {
   addCurrentFormatChangeListener: (listener: () => void) => void
   removeCurrentFormatChangeListener: (listener: () => void) => void
+  focusEditor: () => void
+  isStackSelectionActive: () => boolean
 }
 
 jest.mock(
@@ -197,6 +220,11 @@ describe('AcEdMTextEditor', () => {
     const listener = jest.fn()
 
     observable.addCurrentFormatChangeListener(listener)
+    expect(typeof observable.focusEditor).toBe('function')
+    observable.focusEditor()
+    expect(inputBox.focusImeInput).toHaveBeenCalledTimes(1)
+    expect(observable.isStackSelectionActive()).toBe(true)
+
     inputBox.setCurrentFormat()
     inputBox.refreshCurrentFormatFromDocument()
     inputBox.toggleScriptSelection()

--- a/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
@@ -14,6 +14,11 @@ class MockMTextInputBox {
   readonly setToolbarTheme = jest.fn()
   readonly getText = jest.fn(() => 'typed text')
   readonly getMTextInsertionPoint = jest.fn(() => ({ x: 1, y: 2, z: 3 }))
+  readonly setCurrentFormat = jest.fn()
+  readonly refreshCurrentFormatFromDocument = jest.fn()
+  readonly toggleCase = jest.fn()
+  readonly toggleStackSelection = jest.fn()
+  readonly toggleScriptSelection = jest.fn(() => true)
 
   constructor(readonly options: Record<string, unknown>) {
     mockMTextInputBoxInstances.push(this)
@@ -28,6 +33,11 @@ class MockMTextInputBox {
   emit(event: string) {
     this.handlers.get(event)?.forEach(handler => handler())
   }
+}
+
+interface FormatObservableInputBox {
+  addCurrentFormatChangeListener: (listener: () => void) => void
+  removeCurrentFormatChangeListener: (listener: () => void) => void
 }
 
 jest.mock(
@@ -171,5 +181,36 @@ describe('AcEdMTextEditor', () => {
     })
     expect(inputBox.dispose).toHaveBeenCalled()
     expect(toolbar.container.remove).toHaveBeenCalled()
+  })
+
+  it('notifies format listeners when the active input box format refreshes', async () => {
+    const view = createView()
+    const resultPromise = new AcEdMTextEditor().open({
+      view: view as never,
+      location: { x: 0, y: 0, z: 0 },
+      width: 10,
+      textHeight: 2
+    })
+
+    const inputBox = mockMTextInputBoxInstances[0]
+    const observable = inputBox as unknown as FormatObservableInputBox
+    const listener = jest.fn()
+
+    observable.addCurrentFormatChangeListener(listener)
+    inputBox.setCurrentFormat()
+    inputBox.refreshCurrentFormatFromDocument()
+    inputBox.toggleScriptSelection()
+    expect(listener).toHaveBeenCalledTimes(3)
+
+    observable.removeCurrentFormatChangeListener(listener)
+    inputBox.toggleCase()
+    expect(listener).toHaveBeenCalledTimes(3)
+
+    observable.addCurrentFormatChangeListener(listener)
+    inputBox.emit('close')
+    await resultPromise
+
+    inputBox.setCurrentFormat()
+    expect(listener).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -41,8 +41,8 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
-    "@mlightcad/mtext-input-box": "^0.2.5",
-    "@mlightcad/mtext-renderer": "^0.10.9",
+    "@mlightcad/mtext-input-box": "^0.2.6",
+    "@mlightcad/mtext-renderer": "^0.10.10",
     "@mlightcad/svg-renderer": "workspace:*",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -51,12 +51,12 @@
     "@types/three": "^0.172.0"
   },
   "dependencies": {
-    "@mlightcad/libredwg-converter": "^3.5.33",
+    "@mlightcad/libredwg-converter": "^3.5.34",
     "mitt": "^3.0.1",
     "rbush": "^4.0.1"
   },
   "peerDependencies": {
-    "@mlightcad/data-model": "^1.7.33",
+    "@mlightcad/data-model": "^1.7.34",
     "three": "^0.172.0",
     "lodash-es": "4.17.21"
   }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
@@ -14,10 +14,41 @@ import * as THREE from 'three'
 import { AcApDocManager } from '../../../app'
 import { AcTrView2d } from '../../../view'
 
-export type AcEdMTextEditorActiveInputBox = MTextInputBox
+export type AcEdMTextEditorCurrentFormatChangeListener = () => void
+export interface AcEdMTextEditorCurrentFormatObservable {
+  addCurrentFormatChangeListener: (
+    listener: AcEdMTextEditorCurrentFormatChangeListener
+  ) => void
+  removeCurrentFormatChangeListener: (
+    listener: AcEdMTextEditorCurrentFormatChangeListener
+  ) => void
+}
+export type AcEdMTextEditorActiveInputBox = MTextInputBox &
+  Partial<AcEdMTextEditorCurrentFormatObservable>
 export type AcEdMTextEditorActiveInputBoxChangeListener = (
   inputBox: AcEdMTextEditorActiveInputBox | null
 ) => void
+
+type MTextInputBoxRuntimeMethod = (...args: unknown[]) => unknown
+type MTextInputBoxRuntimeMethodName =
+  | 'setCurrentFormat'
+  | 'refreshCurrentFormatFromDocument'
+  | 'toggleCase'
+  | 'toggleStackSelection'
+  | 'toggleScriptSelection'
+
+const mtextFormatBridgeKey = '__mlightcadMTextFormatBridge'
+
+interface MTextInputBoxFormatBridge
+  extends AcEdMTextEditorCurrentFormatObservable {
+  dispose: () => void
+}
+
+type MTextInputBoxRuntime = MTextInputBox &
+  Partial<Record<MTextInputBoxRuntimeMethodName, MTextInputBoxRuntimeMethod>> &
+  Partial<AcEdMTextEditorCurrentFormatObservable> & {
+    [mtextFormatBridgeKey]?: MTextInputBoxFormatBridge
+  }
 
 /**
  * Result payload returned by the MTEXT editor when editing is finished.
@@ -165,6 +196,69 @@ export class AcEdMTextEditor {
     return container
   }
 
+  private static attachFormatBridge(inputBox: MTextInputBox): void {
+    const runtime = inputBox as MTextInputBoxRuntime
+    if (runtime[mtextFormatBridgeKey]) return
+
+    const listeners = new Set<AcEdMTextEditorCurrentFormatChangeListener>()
+    const restoreMethods: Array<() => void> = []
+    const notifyFormatChanged = () => {
+      listeners.forEach(listener => {
+        listener()
+      })
+    }
+    const wrapMethod = (methodName: MTextInputBoxRuntimeMethodName) => {
+      const original = runtime[methodName]
+      if (typeof original !== 'function') return
+
+      runtime[methodName] = (...args: unknown[]) => {
+        const result = original.apply(runtime, args)
+        notifyFormatChanged()
+        return result
+      }
+      restoreMethods.push(() => {
+        runtime[methodName] = original
+      })
+    }
+
+    ;(
+      [
+        'setCurrentFormat',
+        'refreshCurrentFormatFromDocument',
+        'toggleCase',
+        'toggleStackSelection',
+        'toggleScriptSelection'
+      ] as const
+    ).forEach(wrapMethod)
+
+    runtime.addCurrentFormatChangeListener = listener => {
+      listeners.add(listener)
+    }
+    runtime.removeCurrentFormatChangeListener = listener => {
+      listeners.delete(listener)
+    }
+    runtime[mtextFormatBridgeKey] = {
+      addCurrentFormatChangeListener:
+        runtime.addCurrentFormatChangeListener,
+      removeCurrentFormatChangeListener:
+        runtime.removeCurrentFormatChangeListener,
+      dispose: () => {
+        restoreMethods.forEach(restore => {
+          restore()
+        })
+        listeners.clear()
+        delete runtime.addCurrentFormatChangeListener
+        delete runtime.removeCurrentFormatChangeListener
+        delete runtime[mtextFormatBridgeKey]
+      }
+    }
+  }
+
+  private static detachFormatBridge(inputBox: MTextInputBox): void {
+    const runtime = inputBox as MTextInputBoxRuntime
+    runtime[mtextFormatBridgeKey]?.dispose()
+  }
+
   /**
    * Opens the MTEXT editor and resolves when user closes the editor UI.
    *
@@ -269,6 +363,7 @@ export class AcEdMTextEditor {
           toolbarColorPicker ?? AcEdMTextEditor.defaultColorPicker ?? undefined
       }
     })
+    AcEdMTextEditor.attachFormatBridge(mtextInputBox)
     AcEdMTextEditor.setActiveInputBox(mtextInputBox)
 
     return new Promise(resolve => {
@@ -295,6 +390,7 @@ export class AcEdMTextEditor {
         if (AcEdMTextEditor.activeInputBox === mtextInputBox) {
           AcEdMTextEditor.setActiveInputBox(null)
         }
+        AcEdMTextEditor.detachFormatBridge(mtextInputBox)
         mtextInputBox.dispose()
         hiddenToolbarContainer?.remove()
         view.events.renderFrame.removeEventListener(onRenderFrame)

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
@@ -24,7 +24,17 @@ export interface AcEdMTextEditorCurrentFormatObservable {
   ) => void
 }
 export type AcEdMTextEditorActiveInputBox = MTextInputBox &
-  Partial<AcEdMTextEditorCurrentFormatObservable>
+  Partial<AcEdMTextEditorCurrentFormatObservable> & {
+    /**
+     * Returns keyboard focus to the hidden IME input used by the editor.
+     *
+     * Contextual ribbon controls use this after formatting commands so the
+     * inline editor keeps behaving like its built-in toolbar.
+     */
+    focusEditor?: () => void
+    /** Returns whether the current selection is a non-script stacked fraction. */
+    isStackSelectionActive?: () => boolean
+  }
 export type AcEdMTextEditorActiveInputBoxChangeListener = (
   inputBox: AcEdMTextEditorActiveInputBox | null
 ) => void
@@ -47,8 +57,16 @@ interface MTextInputBoxFormatBridge
 type MTextInputBoxRuntime = MTextInputBox &
   Partial<Record<MTextInputBoxRuntimeMethodName, MTextInputBoxRuntimeMethod>> &
   Partial<AcEdMTextEditorCurrentFormatObservable> & {
+    focusEditor?: () => void
+    isStackSelectionActive?: () => boolean
     [mtextFormatBridgeKey]?: MTextInputBoxFormatBridge
   }
+interface MTextInputBoxRuntimeStackNode {
+  type?: string
+  divider?: string
+  numerator?: string
+  denominator?: string
+}
 
 /**
  * Result payload returned by the MTEXT editor when editing is finished.
@@ -237,6 +255,69 @@ export class AcEdMTextEditor {
     runtime.removeCurrentFormatChangeListener = listener => {
       listeners.delete(listener)
     }
+    runtime.focusEditor = () => {
+      const runtimeMethods = runtime as unknown as Record<
+        string,
+        MTextInputBoxRuntimeMethod | undefined
+      >
+      const focus = runtimeMethods.focusImeInput
+      if (typeof focus === 'function') {
+        focus.call(runtime)
+        return
+      }
+
+      const refocusSoon = runtimeMethods.refocusImeInputSoon
+      if (typeof refocusSoon === 'function') {
+        refocusSoon.call(runtime)
+      }
+    }
+    runtime.isStackSelectionActive = () => {
+      const runtimeMethods = runtime as unknown as Record<string, unknown>
+      const getSelectionRange = runtimeMethods.getSelectionRange
+      const toDocumentIndexFromLogicalIndex =
+        runtimeMethods.toDocumentIndexFromLogicalIndex
+      const isScriptOnlyStack = runtimeMethods.isScriptOnlyStack
+      const document = runtimeMethods.document as
+        | { ast?: { nodes?: MTextInputBoxRuntimeStackNode[] } }
+        | undefined
+
+      if (
+        typeof getSelectionRange !== 'function' ||
+        typeof toDocumentIndexFromLogicalIndex !== 'function'
+      ) {
+        return false
+      }
+
+      const selection = getSelectionRange.call(runtime) as
+        | { start: number; end: number; isCollapsed: boolean }
+        | undefined
+      if (!selection || selection.isCollapsed) return false
+
+      const start = toDocumentIndexFromLogicalIndex.call(
+        runtime,
+        selection.start,
+        true
+      ) as number
+      const end = toDocumentIndexFromLogicalIndex.call(
+        runtime,
+        selection.end,
+        false
+      ) as number
+      const selectedNodes = document?.ast?.nodes?.slice(start, end) ?? []
+      const stackNode = selectedNodes[0]
+      if (selectedNodes.length !== 1 || stackNode?.type !== 'stack') {
+        return false
+      }
+
+      if (typeof isScriptOnlyStack === 'function') {
+        return !isScriptOnlyStack.call(runtime, stackNode)
+      }
+
+      if (stackNode.divider !== '^') return true
+      const hasNumerator = (stackNode.numerator ?? '').trim().length > 0
+      const hasDenominator = (stackNode.denominator ?? '').trim().length > 0
+      return hasNumerator === hasDenominator
+    }
     runtime[mtextFormatBridgeKey] = {
       addCurrentFormatChangeListener:
         runtime.addCurrentFormatChangeListener,
@@ -249,6 +330,8 @@ export class AcEdMTextEditor {
         listeners.clear()
         delete runtime.addCurrentFormatChangeListener
         delete runtime.removeCurrentFormatChangeListener
+        delete runtime.focusEditor
+        delete runtime.isStackSelectionActive
         delete runtime[mtextFormatBridgeKey]
       }
     }

--- a/packages/cad-viewer-example/package.json
+++ b/packages/cad-viewer-example/package.json
@@ -33,7 +33,7 @@
     "@element-plus/icons-vue": "^2.3.1",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/cad-viewer": "workspace:*",
-    "@mlightcad/data-model": "^1.7.33",
+    "@mlightcad/data-model": "^1.7.34",
     "element-plus": "^2.12.0",
     "vue": "^3.4.21",
     "vue-i18n": "^10.0.1"

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@mlightcad/cad-simple-viewer": "workspace:*",
-    "@mlightcad/data-model": "^1.7.33",
+    "@mlightcad/data-model": "^1.7.34",
     "@vueuse/core": "^11.1.0",
     "element-plus": "^2.12.0",
     "vue": "^3.4.21",

--- a/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
+++ b/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
@@ -23,8 +23,15 @@ import MlRibbonMTextHeightSelect from './MlRibbonMTextHeightSelect.vue'
 import MlRibbonPropertyColorDropdown from './MlRibbonPropertyColorDropdown.vue'
 
 const MTEXT_CONTEXTUAL_TAB_ID = 'mtext-editor-context'
-const MTEXT_COMMAND_GLOBAL_NAME = 'MTEXT'
+const MTEXT_COMMAND_GLOBAL_NAMES = ['MTEXT', 'mtext'] as const
 const MTEXT_ITEM_PREFIX = 'mtext-'
+
+function isMTextCommandGlobalName(globalName: string | undefined) {
+  return (
+    globalName != null &&
+    MTEXT_COMMAND_GLOBAL_NAMES.some(name => name === globalName)
+  )
+}
 
 /**
  * Minimal translation callback used while constructing ribbon model labels.
@@ -112,6 +119,10 @@ interface MTextRibbonEditor {
   insertText: (text: string) => void
   /** Commits or closes the active MText editor. */
   closeEditor: () => void
+  /** Returns keyboard focus to the inline editor after ribbon interaction. */
+  focusEditor?: () => void
+  /** Returns whether the current selection is a non-script stacked fraction. */
+  isStackSelectionActive?: () => boolean
   /** Returns the editor's default text style information when available. */
   getDefaultTextStyle?: () => {
     /** Default font family from the active text style. */
@@ -473,13 +484,14 @@ export function useMTextContextualRibbon({
   } = useRibbonContextualTab({
     activeTabId,
     tabId: MTEXT_CONTEXTUAL_TAB_ID,
-    commandGlobalNames: MTEXT_COMMAND_GLOBAL_NAME
+    commandGlobalNames: MTEXT_COMMAND_GLOBAL_NAMES
   })
   const currentFormat = ref<MTextRibbonFormat>({ ...DEFAULT_MTEXT_FORMAT })
   const currentColor = shallowRef<AcCmColor>(
     toAcCmColorFromFormat(currentFormat.value)
   )
   const currentColorDisplay = ref(resolveColorDisplay(currentColor.value))
+  const stackActive = ref(false)
   const activeEditor = ref<MTextRibbonEditor | null>(null)
 
   let observedEditor: MTextRibbonEditor | null = null
@@ -536,6 +548,7 @@ export function useMTextContextualRibbon({
       if (!sameMTextRibbonFormat(currentFormat.value, DEFAULT_MTEXT_FORMAT)) {
         currentFormat.value = { ...DEFAULT_MTEXT_FORMAT }
       }
+      stackActive.value = false
       syncColorStateFromFormat(currentFormat.value)
       refreshContextTabVisibility()
       return
@@ -548,6 +561,10 @@ export function useMTextContextualRibbon({
     }
     if (!sameMTextRibbonFormat(currentFormat.value, nextFormat)) {
       currentFormat.value = nextFormat
+    }
+    const nextStackActive = editor.isStackSelectionActive?.() ?? false
+    if (stackActive.value !== nextStackActive) {
+      stackActive.value = nextStackActive
     }
     syncColorStateFromFormat(currentFormat.value)
     refreshContextTabVisibility()
@@ -620,6 +637,7 @@ export function useMTextContextualRibbon({
     const editor = getActiveEditor()
     if (!editor) return
     editor.setCurrentFormat(format)
+    editor.focusEditor?.()
     syncFormatFromEditor()
   }
 
@@ -652,15 +670,12 @@ export function useMTextContextualRibbon({
   ) => {
     const editor = getActiveEditor()
     if (!editor) return
-    if (!active) {
-      editor.setCurrentFormat({ script: 'normal' })
-      syncFormatFromEditor()
-      return
-    }
+    editor.focusEditor?.()
     const handled = editor.toggleScriptSelection?.(script)
     if (!handled) {
-      editor.setCurrentFormat({ script })
+      editor.setCurrentFormat({ script: active ? script : 'normal' })
     }
+    editor.focusEditor?.()
     syncFormatFromEditor()
   }
 
@@ -669,7 +684,9 @@ export function useMTextContextualRibbon({
    */
   const handleStack = () => {
     const editor = getActiveEditor()
+    editor?.focusEditor?.()
     editor?.toggleStackSelection?.()
+    editor?.focusEditor?.()
     syncFormatFromEditor()
   }
 
@@ -777,6 +794,7 @@ export function useMTextContextualRibbon({
     const editor = getActiveEditor()
     if (!editor) return
     editor.insertText(text)
+    editor.focusEditor?.()
     syncFormatFromEditor()
   }
 
@@ -786,7 +804,9 @@ export function useMTextContextualRibbon({
    * @param alignment Alignment id emitted by the ribbon button group.
    */
   const handleParagraphAlignment = (alignment: string) => {
-    getActiveEditor()?.setParagraphAlignment?.(alignment)
+    const editor = getActiveEditor()
+    editor?.setParagraphAlignment?.(alignment)
+    editor?.focusEditor?.()
     syncFormatFromEditor()
   }
 
@@ -827,20 +847,28 @@ export function useMTextContextualRibbon({
         handleScriptToggle(field, active)
         return true
       }
+      if (field === 'stack') {
+        handleStack()
+        return true
+      }
     }
     if (itemId === 'mtext-format:stack') {
       handleStack()
       return true
     }
     if (itemId === 'mtext-format:case') {
-      getActiveEditor()?.toggleCase?.()
+      const editor = getActiveEditor()
+      editor?.toggleCase?.()
+      editor?.focusEditor?.()
       syncFormatFromEditor()
       return true
     }
     if (itemId.startsWith('mtext-attachment:')) {
-      getActiveEditor()?.setAttachmentPoint?.(
+      const editor = getActiveEditor()
+      editor?.setAttachmentPoint?.(
         itemId.slice('mtext-attachment:'.length)
       )
+      editor?.focusEditor?.()
       return true
     }
     if (itemId.startsWith('mtext-list:')) {
@@ -853,10 +881,16 @@ export function useMTextContextualRibbon({
     if (itemId.startsWith('mtext-line-spacing:')) {
       const value = itemId.slice('mtext-line-spacing:'.length)
       if (value === 'clear') {
-        getActiveEditor()?.clearLineSpacing?.()
+        const editor = getActiveEditor()
+        editor?.clearLineSpacing?.()
+        editor?.focusEditor?.()
       } else {
         const factor = normalizeNumber(value)
-        if (factor != null) getActiveEditor()?.setLineSpacingFactor?.(factor)
+        if (factor != null) {
+          const editor = getActiveEditor()
+          editor?.setLineSpacingFactor?.(factor)
+          editor?.focusEditor?.()
+        }
       }
       return true
     }
@@ -1065,11 +1099,12 @@ export function useMTextContextualRibbon({
                   icons.strike,
                   format.strike
                 ),
-                createButtonItem(
+                createToggleItem(
                   'mtext-format:stack',
                   t('main.ribbon.mtext.command.stack'),
                   t('main.ribbon.mtext.tooltip.stack'),
-                  icons.stack
+                  icons.stack,
+                  stackActive.value
                 ),
                 createButtonItem(
                   'mtext-format:case',
@@ -1451,7 +1486,7 @@ export function useMTextContextualRibbon({
    */
   const handleRibbonCommandEnded = (args: AcEdCommandEventArgs) => {
     handleCommandEnded(args)
-    if (args.command?.globalName === MTEXT_COMMAND_GLOBAL_NAME) {
+    if (isMTextCommandGlobalName(args.command?.globalName)) {
       bindEditorEvents(null)
     }
   }

--- a/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
+++ b/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
@@ -45,6 +45,12 @@ type MTextRibbonScript = 'normal' | 'superscript' | 'subscript'
 type MTextEditorEvent = 'change' | 'selectionChange' | 'cursorMove' | 'close'
 
 /**
+ * Listener notified when the active MText input box refreshes its current
+ * character format.
+ */
+type MTextFormatChangeListener = () => void
+
+/**
  * Listener called by the MText editor bridge when the active inline editor
  * changes.
  *
@@ -119,6 +125,14 @@ interface MTextRibbonEditor {
   on?: (event: MTextEditorEvent, handler: () => void) => void
   /** Unsubscribes a previously registered editor event handler. */
   off?: (event: string, handler: () => void) => void
+  /** Subscribes to format refreshes mirrored from the active input box. */
+  addCurrentFormatChangeListener?: (
+    listener: MTextFormatChangeListener
+  ) => void
+  /** Removes a previously registered format refresh listener. */
+  removeCurrentFormatChangeListener?: (
+    listener: MTextFormatChangeListener
+  ) => void
   /** Toggles stacked-fraction formatting for the current selection. */
   toggleStackSelection?: () => void
   /**
@@ -180,6 +194,28 @@ const DEFAULT_MTEXT_FORMAT: MTextRibbonFormat = {
   strike: false,
   aci: null,
   rgb: null
+}
+
+/**
+ * Compares two ribbon format snapshots using the same field-by-field contract
+ * as the MTEXT input box toolbar.
+ */
+function sameMTextRibbonFormat(
+  a: MTextRibbonFormat,
+  b: MTextRibbonFormat
+) {
+  return (
+    a.fontFamily === b.fontFamily &&
+    a.fontSize === b.fontSize &&
+    a.bold === b.bold &&
+    a.italic === b.italic &&
+    a.underline === b.underline &&
+    a.overline === b.overline &&
+    a.script === b.script &&
+    a.strike === b.strike &&
+    a.aci === b.aci &&
+    a.rgb === b.rgb
+  )
 }
 
 const toolbarIcons = {
@@ -478,8 +514,13 @@ export function useMTextContextualRibbon({
    */
   const syncColorStateFromFormat = (format: MTextRibbonFormat) => {
     const color = toAcCmColorFromFormat(format)
-    currentColor.value = color
-    currentColorDisplay.value = resolveColorDisplay(color)
+    const displayColor = resolveColorDisplay(color)
+    if (currentColor.value?.toString() !== color.toString()) {
+      currentColor.value = color
+    }
+    if (currentColorDisplay.value !== displayColor) {
+      currentColorDisplay.value = displayColor
+    }
   }
 
   /**
@@ -492,16 +533,21 @@ export function useMTextContextualRibbon({
     const editor = getActiveEditor()
     if (!editor) {
       activeEditor.value = null
-      currentFormat.value = { ...DEFAULT_MTEXT_FORMAT }
+      if (!sameMTextRibbonFormat(currentFormat.value, DEFAULT_MTEXT_FORMAT)) {
+        currentFormat.value = { ...DEFAULT_MTEXT_FORMAT }
+      }
       syncColorStateFromFormat(currentFormat.value)
       refreshContextTabVisibility()
       return
     }
 
     activeEditor.value = editor
-    currentFormat.value = {
+    const nextFormat = {
       ...DEFAULT_MTEXT_FORMAT,
       ...editor.getCurrentFormat()
+    }
+    if (!sameMTextRibbonFormat(currentFormat.value, nextFormat)) {
+      currentFormat.value = nextFormat
     }
     syncColorStateFromFormat(currentFormat.value)
     refreshContextTabVisibility()
@@ -520,6 +566,7 @@ export function useMTextContextualRibbon({
       observedEditor.off('cursorMove', syncFormatFromEditor)
       observedEditor.off('close', syncFormatFromEditor)
     }
+    observedEditor?.removeCurrentFormatChangeListener?.(syncFormatFromEditor)
     observedEditor = editor
     if (observedEditor?.on) {
       observedEditor.on('change', syncFormatFromEditor)
@@ -527,6 +574,7 @@ export function useMTextContextualRibbon({
       observedEditor.on('cursorMove', syncFormatFromEditor)
       observedEditor.on('close', syncFormatFromEditor)
     }
+    observedEditor?.addCurrentFormatChangeListener?.(syncFormatFromEditor)
     syncFormatFromEditor()
   }
 

--- a/packages/svg-renderer/package.json
+++ b/packages/svg-renderer/package.json
@@ -31,6 +31,6 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "peerDependencies": {
-    "@mlightcad/data-model": "^1.7.33"
+    "@mlightcad/data-model": "^1.7.34"
   }
 }

--- a/packages/three-renderer/package.json
+++ b/packages/three-renderer/package.json
@@ -44,7 +44,7 @@
     "@types/three": "^0.172.0"
   },
   "peerDependencies": {
-    "@mlightcad/data-model": "^1.7.33",
+    "@mlightcad/data-model": "^1.7.34",
     "@mlightcad/mtext-renderer": "^0.10.10",
     "@velipso/polybool": "^1.1.1",
     "three": "^0.172.0"

--- a/packages/three-renderer/package.json
+++ b/packages/three-renderer/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@mlightcad/data-model": "^1.7.33",
-    "@mlightcad/mtext-renderer": "^0.10.9",
+    "@mlightcad/mtext-renderer": "^0.10.10",
     "@velipso/polybool": "^1.1.1",
     "three": "^0.172.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@mlightcad/data-model': ^1.7.33
   '@mlightcad/libredwg-converter': ^3.5.33
-  '@mlightcad/mtext-renderer': ^0.10.9
+  '@mlightcad/mtext-renderer': ^0.10.10
   element-plus: ^2.12.0
   three: ^0.172.0
   vue: ^3.4.21
@@ -124,11 +124,11 @@ importers:
         version: 0.172.0
     devDependencies:
       '@mlightcad/mtext-input-box':
-        specifier: ^0.2.5
-        version: 0.2.5(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)
+        specifier: ^0.2.6
+        version: 0.2.6(@mlightcad/mtext-renderer@0.10.10(three@0.172.0))(three@0.172.0)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.10.9
-        version: 0.10.9(three@0.172.0)
+        specifier: ^0.10.10
+        version: 0.10.10(three@0.172.0)
       '@mlightcad/svg-renderer':
         specifier: workspace:*
         version: link:../svg-renderer
@@ -303,8 +303,8 @@ importers:
         specifier: ^1.7.33
         version: 1.7.33
       '@mlightcad/mtext-renderer':
-        specifier: ^0.10.9
-        version: 0.10.9(three@0.172.0)
+        specifier: ^0.10.10
+        version: 0.10.10(three@0.172.0)
       '@velipso/polybool':
         specifier: ^1.1.1
         version: 1.1.1
@@ -1393,17 +1393,17 @@ packages:
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
-  '@mlightcad/mtext-input-box@0.2.5':
-    resolution: {integrity: sha512-eA17KwHcNQgRaDYDHImVPYVEpM4J1E7KQMW/HQwsiBbnE7CchdWgWROWNcffLqY9orsteCU+qfsxddPwEeN9/g==}
+  '@mlightcad/mtext-input-box@0.2.6':
+    resolution: {integrity: sha512-Xn72XwfxpDbuiWOP+1QHlusvWpLWpktucxudAq0jbWTbythy5UzFc+ontvMeqNd8OgFnyAjEF3rDyvhajNBBBw==}
     peerDependencies:
-      '@mlightcad/mtext-renderer': ^0.10.9
+      '@mlightcad/mtext-renderer': ^0.10.10
       three: ^0.172.0
 
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
-  '@mlightcad/mtext-renderer@0.10.9':
-    resolution: {integrity: sha512-EoIIfNIfYtM97rMoFgdTdRsi3E/wD2/ex6uqdYIydP4ZhSU15j1r1DYiAiNmx+swQSNe/fmDprO0TZQicsfvpg==}
+  '@mlightcad/mtext-renderer@0.10.10':
+    resolution: {integrity: sha512-akihsae3ISMmRsC1u6q8wLsd39eHu8m56/1U0QK3zXL3QWWMKQ2Z47gkloCFTkpPZ2ykSSoFiiQs/CpxJxW9bg==}
     peerDependencies:
       three: ^0.172.0
 
@@ -6162,15 +6162,15 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.1': {}
 
-  '@mlightcad/mtext-input-box@0.2.5(@mlightcad/mtext-renderer@0.10.9(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/mtext-input-box@0.2.6(@mlightcad/mtext-renderer@0.10.10(three@0.172.0))(three@0.172.0)':
     dependencies:
-      '@mlightcad/mtext-renderer': 0.10.9(three@0.172.0)
+      '@mlightcad/mtext-renderer': 0.10.10(three@0.172.0)
       '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
       three: 0.172.0
 
   '@mlightcad/mtext-parser@1.4.1': {}
 
-  '@mlightcad/mtext-renderer@0.10.9(three@0.172.0)':
+  '@mlightcad/mtext-renderer@0.10.10(three@0.172.0)':
     dependencies:
       '@mlightcad/mtext-parser': 1.4.1
       '@mlightcad/shx-parser': 1.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.7.33
-  '@mlightcad/libredwg-converter': ^3.5.33
+  '@mlightcad/data-model': ^1.7.34
+  '@mlightcad/libredwg-converter': ^3.5.34
   '@mlightcad/mtext-renderer': ^0.10.10
   element-plus: ^2.12.0
   three: ^0.172.0
@@ -105,11 +105,11 @@ importers:
   packages/cad-simple-viewer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.33
-        version: 1.7.33
+        specifier: ^1.7.34
+        version: 1.7.34
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.33
-        version: 3.5.33(@mlightcad/data-model@1.7.33)
+        specifier: ^3.5.34
+        version: 3.5.34(@mlightcad/data-model@1.7.34)
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -154,8 +154,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.33
-        version: 1.7.33
+        specifier: ^1.7.34
+        version: 1.7.34
 
   packages/cad-viewer:
     dependencies:
@@ -166,8 +166,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.33
-        version: 1.7.33
+        specifier: ^1.7.34
+        version: 1.7.34
       '@vueuse/core':
         specifier: ^11.1.0
         version: 11.3.0(vue@3.5.31(typescript@5.9.3))
@@ -239,8 +239,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.33
-        version: 1.7.33
+        specifier: ^1.7.34
+        version: 1.7.34
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -294,14 +294,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.33
-        version: 1.7.33
+        specifier: ^1.7.34
+        version: 1.7.34
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.33
-        version: 1.7.33
+        specifier: ^1.7.34
+        version: 1.7.34
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.10
         version: 0.10.10(three@0.172.0)
@@ -1365,30 +1365,30 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.4.33':
-    resolution: {integrity: sha512-a24VXWcct5Q2Q8/Z4wy4fqKOLDLeEfVGUr4IojF6WGJ7thIB1Y6rClLyKoiab1vwS4OFafJUVBOjK1tYvwBUHw==}
+  '@mlightcad/common@1.4.34':
+    resolution: {integrity: sha512-m8dSF7jzuy6ovL82FEPxO48cFq0MkxU4pdNu0sJ0st/RWlOCNurG/R2weMBAgd+wOYqjym1rWyym2+r1Xp9C3Q==}
 
-  '@mlightcad/data-model@1.7.33':
-    resolution: {integrity: sha512-4pfPUAwaqDbNhfsab9t1PbR3FKnQ/nDJgBJQbUUAE2yVCwEtdaSlMzqr82byvT2AJlHknMSVHbBQglxo0rtIUA==}
+  '@mlightcad/data-model@1.7.34':
+    resolution: {integrity: sha512-2oRdNEgRxUYhKKrIl0QvSBCdiVS0WDhRM2GpAZa1fb9db9NHr7X1KgIhyO+W7lxmVIrFJOR+sKsQLoSqENypNA==}
 
   '@mlightcad/dxf-json@1.2.0':
     resolution: {integrity: sha512-pfKFSMi84wmV1C4EAq4Axq20K1+12tXGI5epggxWZE++NeZBCQM5yuQYKYD/P8oSWz3c2nFHe9KhithAKUSnfQ==}
 
-  '@mlightcad/geometry-engine@3.2.33':
-    resolution: {integrity: sha512-QEZoafppRTKnufDaxTBq4TzLRAFNP7YBNZSk0YrwhUv7y1E6vaOR6kjB3volAQCEWW72jE8od6gXCk9QyCIk7A==}
+  '@mlightcad/geometry-engine@3.2.34':
+    resolution: {integrity: sha512-IyM9XY19iYSeVCRs0rV8dlHFeKISwAMjpSZyqnPI823/Jl1CrLNGXO4C4JMOVBDbBq6bswRZ52HYMmLdhsUckg==}
     peerDependencies:
-      '@mlightcad/common': 1.4.33
+      '@mlightcad/common': 1.4.34
 
-  '@mlightcad/graphic-interface@3.3.33':
-    resolution: {integrity: sha512-F+aFJSucUYcapniP2RcLMTLEHwYsUJ4OvKXsy+oZXDfJGADuYhpkhF19eF06wz4N5kAJCw+fQESHUMTSwlgDQw==}
+  '@mlightcad/graphic-interface@3.3.34':
+    resolution: {integrity: sha512-pk/xfjxwprbKzbpwaTxRPPIBiM5FaGlUy3w+wT0y1HJ3xav5koTO5e2DlZkAnLEF0k6yeYASlpgm1lqZnXyC9w==}
     peerDependencies:
-      '@mlightcad/common': 1.4.33
-      '@mlightcad/geometry-engine': 3.2.33
+      '@mlightcad/common': 1.4.34
+      '@mlightcad/geometry-engine': 3.2.34
 
-  '@mlightcad/libredwg-converter@3.5.33':
-    resolution: {integrity: sha512-NBU08kqZuqwHNnl3l6pg8AFw4elaSgSUEjZGy5VDG7U0ZbVP7eXgcSyYizApKlFB8FF/Fie+2lrfV2MP+fbjDQ==}
+  '@mlightcad/libredwg-converter@3.5.34':
+    resolution: {integrity: sha512-DAXzl7H+7U6erqvLEF03CnmjYtKGfHfzRpfRVFaM8fOoGMrD+XOWOxGpmwStwSsAQCCZHTniFYiiQ3AJ1gzI3Q==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.33
+      '@mlightcad/data-model': ^1.7.34
 
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
@@ -6129,16 +6129,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.4.33':
+  '@mlightcad/common@1.4.34':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.7.33':
+  '@mlightcad/data-model@1.7.34':
     dependencies:
-      '@mlightcad/common': 1.4.33
+      '@mlightcad/common': 1.4.34
       '@mlightcad/dxf-json': 1.2.0
-      '@mlightcad/geometry-engine': 3.2.33(@mlightcad/common@1.4.33)
-      '@mlightcad/graphic-interface': 3.3.33(@mlightcad/common@1.4.33)(@mlightcad/geometry-engine@3.2.33(@mlightcad/common@1.4.33))
+      '@mlightcad/geometry-engine': 3.2.34(@mlightcad/common@1.4.34)
+      '@mlightcad/graphic-interface': 3.3.34(@mlightcad/common@1.4.34)(@mlightcad/geometry-engine@3.2.34(@mlightcad/common@1.4.34))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
@@ -6146,18 +6146,18 @@ snapshots:
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.2.33(@mlightcad/common@1.4.33)':
+  '@mlightcad/geometry-engine@3.2.34(@mlightcad/common@1.4.34)':
     dependencies:
-      '@mlightcad/common': 1.4.33
+      '@mlightcad/common': 1.4.34
 
-  '@mlightcad/graphic-interface@3.3.33(@mlightcad/common@1.4.33)(@mlightcad/geometry-engine@3.2.33(@mlightcad/common@1.4.33))':
+  '@mlightcad/graphic-interface@3.3.34(@mlightcad/common@1.4.34)(@mlightcad/geometry-engine@3.2.34(@mlightcad/common@1.4.34))':
     dependencies:
-      '@mlightcad/common': 1.4.33
-      '@mlightcad/geometry-engine': 3.2.33(@mlightcad/common@1.4.33)
+      '@mlightcad/common': 1.4.34
+      '@mlightcad/geometry-engine': 3.2.34(@mlightcad/common@1.4.34)
 
-  '@mlightcad/libredwg-converter@3.5.33(@mlightcad/data-model@1.7.33)':
+  '@mlightcad/libredwg-converter@3.5.34(@mlightcad/data-model@1.7.34)':
     dependencies:
-      '@mlightcad/data-model': 1.7.33
+      '@mlightcad/data-model': 1.7.34
       '@mlightcad/libredwg-web': 0.7.1
 
   '@mlightcad/libredwg-web@0.7.1': {}

--- a/tools/sync-versions.mjs
+++ b/tools/sync-versions.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const toolsDir = path.dirname(new URL(import.meta.url).pathname);
+const toolsDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(toolsDir, '..');
 const packagesDir = path.join(rootDir, 'packages');
 const rootPackageJsonPath = path.join(rootDir, 'package.json');
@@ -55,7 +56,7 @@ async function findWorkspacePackageNames(rootPkg) {
   return packageNames;
 }
 
-async function syncPackage(packageFilePath, rootVersionMap, workspacePackageNames) {
+async function syncPackage(packageFilePath, rootVersionMap, workspacePackageNames, overrides = {}) {
   const pkg = await readJson(packageFilePath);
   const dependencyKeys = [
     'dependencies',
@@ -70,17 +71,26 @@ async function syncPackage(packageFilePath, rootVersionMap, workspacePackageName
     if (!deps || typeof deps !== 'object') continue;
 
     for (const [name, value] of Object.entries(deps)) {
-      if (!isWorkspaceVersion(value)) continue;
-      if (workspacePackageNames.has(name)) continue;
+      let newVersion = null;
 
-      const rootVersion = rootVersionMap[name];
-      if (!rootVersion) {
-        console.warn(`⚠️  ${pkg.name || packageFilePath}: no root version found for ${name} in ${depKey}`);
-        continue;
+      // Priority 1: handle workspace:* versions
+      if (isWorkspaceVersion(value)) {
+        if (workspacePackageNames.has(name)) continue;
+
+        const rootVersion = rootVersionMap[name];
+        if (!rootVersion) {
+          console.warn(`⚠️  ${pkg.name || packageFilePath}: no root version found for ${name} in ${depKey}`);
+          continue;
+        }
+        newVersion = rootVersion;
+      }
+      // Priority 2: check versions in pnpm.overrides
+      else if (overrides[name] && value !== overrides[name]) {
+        newVersion = overrides[name];
       }
 
-      if (deps[name] !== rootVersion) {
-        deps[name] = rootVersion;
+      if (newVersion && deps[name] !== newVersion) {
+        deps[name] = newVersion;
         changed = true;
       }
     }
@@ -97,6 +107,7 @@ async function syncPackage(packageFilePath, rootVersionMap, workspacePackageName
   try {
     const rootPkg = await readJson(rootPackageJsonPath);
     const rootVersionMap = buildRootVersionMap(rootPkg);
+    const overrides = rootPkg.pnpm?.overrides ?? {};
     const workspacePackageNames = await findWorkspacePackageNames(rootPkg);
 
     const packageDirs = await readdir(packagesDir, { withFileTypes: true });
@@ -106,7 +117,7 @@ async function syncPackage(packageFilePath, rootVersionMap, workspacePackageName
       if (!entry.isDirectory()) continue;
       const packageFilePath = path.join(packagesDir, entry.name, 'package.json');
       try {
-        const changed = await syncPackage(packageFilePath, rootVersionMap, workspacePackageNames);
+        const changed = await syncPackage(packageFilePath, rootVersionMap, workspacePackageNames, overrides);
         if (changed) changedFiles.push(packageFilePath);
       } catch (error) {
         console.error(`❌ Failed to process ${packageFilePath}:`, error.message);


### PR DESCRIPTION
## Overview
This pull request upgrades the MTEXT editing experience by improving the underlying rendering components and enhancing the integration with the contextual ribbon UI.

## Changes

### Features
- **Upgraded Components**: Upgrade `mtext-renderer` and `mtext-input-box` to fix stack rendering issues
- **Contextual Ribbon Integration**: Bind MTEXT input box with contextual ribbon for better UX
- **Enhanced Rendering**: Improved MText rendering in `AcTrView2d` with better viewport handling
- **Ribbon Enhancements**: 
  - Added MText height selection component in ribbon
  - Improved hatch contextual ribbon functionality
  - Enhanced MText contextual ribbon with comprehensive editing controls

### Testing
- Added comprehensive unit tests for `AcEdMTextEditor` (244 new test cases)
- Added tests for `AcApMTextCmd` (118 new test cases)
- Enhanced existing `AcEdHoverController` tests
- Added tests for three-renderer MText functionality

### Localization
- Updated English and Chinese locale files with new ribbon command labels and tooltips

### Dependencies
- Updated `mtext-renderer` and `mtext-input-box` to latest versions
- Updated `pnpm-lock.yaml` to reflect dependency updates

## Files Changed
- 35 files changed
- 3,123 insertions(+), 112 deletions(-)

## Testing
- All existing tests pass
- New test cases cover MTEXT editing, rendering, and ribbon integration
- Changes are backward compatible

## Related Issues
This PR builds on #260 (MTEXT editing functionality) to enhance user experience and fix rendering issues.

## Notes
- Breaking changes: None
- Migration guide: Not required