### PR TITLE
feat: character map dialog, ribbon font picker, and shared font utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "overrides": {
       "@mlightcad/data-model": "^1.7.34",
       "@mlightcad/libredwg-converter": "^3.5.34",
-      "@mlightcad/mtext-renderer": "^0.10.10",
+      "@mlightcad/mtext-renderer": "^0.10.11",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",
       "vue": "^3.4.21",

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -41,8 +41,8 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
-    "@mlightcad/mtext-input-box": "^0.2.6",
-    "@mlightcad/mtext-renderer": "^0.10.10",
+    "@mlightcad/mtext-input-box": "^0.2.7",
+    "@mlightcad/mtext-renderer": "^0.10.11",
     "@mlightcad/svg-renderer": "workspace:*",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",
@@ -57,6 +57,7 @@
   },
   "peerDependencies": {
     "@mlightcad/data-model": "^1.7.34",
+    "@mlightcad/mtext-renderer": "^0.10.11",
     "three": "^0.172.0",
     "lodash-es": "4.17.21"
   }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
@@ -49,8 +49,7 @@ type MTextInputBoxRuntimeMethodName =
 
 const mtextFormatBridgeKey = '__mlightcadMTextFormatBridge'
 
-interface MTextInputBoxFormatBridge
-  extends AcEdMTextEditorCurrentFormatObservable {
+interface MTextInputBoxFormatBridge extends AcEdMTextEditorCurrentFormatObservable {
   dispose: () => void
 }
 
@@ -319,8 +318,7 @@ export class AcEdMTextEditor {
       return hasNumerator === hasDenominator
     }
     runtime[mtextFormatBridgeKey] = {
-      addCurrentFormatChangeListener:
-        runtime.addCurrentFormatChangeListener,
+      addCurrentFormatChangeListener: runtime.addCurrentFormatChangeListener,
       removeCurrentFormatChangeListener:
         runtime.removeCurrentFormatChangeListener,
       dispose: () => {

--- a/packages/cad-simple-viewer/src/index.ts
+++ b/packages/cad-simple-viewer/src/index.ts
@@ -1,4 +1,5 @@
 export * from './app'
+export * from './util'
 export * from './command'
 export * from './editor'
 export * from './i18n'

--- a/packages/cad-simple-viewer/src/util/AcApFontUtil.ts
+++ b/packages/cad-simple-viewer/src/util/AcApFontUtil.ts
@@ -1,0 +1,117 @@
+import {
+  type FontInfo,
+  FontManager,
+  type FontType,
+  type ShxFontData,
+  ShxParserFont} from '@mlightcad/mtext-renderer'
+
+import { AcApDocManager } from '../app/AcApDocManager'
+
+export type { FontInfo, FontType, ShxFontData } from '@mlightcad/mtext-renderer'
+export { ShxParserFont } from '@mlightcad/mtext-renderer'
+
+/**
+ * Font helpers for MTEXT and UI (character map, ribbon): wraps the shared
+ * {@link FontManager} cache, SHX parsing ({@link ShxParserFont}), and drawing
+ * font catalog ({@link AcApDocManager}).
+ *
+ * @remarks
+ * Keeps UI packages off direct `@mlightcad/mtext-renderer` imports while using
+ * the same global font pipeline as rendering.
+ */
+export class AcApFontUtil {
+  /**
+   * @inheritdoc FontManager.isFontLoaded
+   */
+  static isFontLoaded(fontName: string): boolean {
+    return FontManager.instance.isFontLoaded(fontName)
+  }
+
+  /**
+   * @inheritdoc FontManager.getFontType
+   */
+  static getFontType(fontName: string): FontType | undefined {
+    return FontManager.instance.getFontType(fontName)
+  }
+
+  /**
+   * Sorted SHX glyph indices present in the loaded font payload.
+   *
+   * @param fontName - Name as registered in the font manager after load.
+   * @returns Code list, or empty when the font is missing or not SHX.
+   */
+  static getShxCodePoints(fontName: string): number[] {
+    const font = FontManager.instance.getFontByName(fontName, false)
+    if (!font || font.type !== 'shx') return []
+    const data = font.data as ShxFontData
+    const keys = Object.keys(data.content?.data ?? {})
+    return keys
+      .map(k => Number(k))
+      .filter(n => Number.isFinite(n))
+      .sort((a, b) => a - b)
+  }
+
+  /**
+   * Raw SHX font data for UI previews (e.g. character map SVG).
+   *
+   * @param fontName - Name as registered in {@link FontManager}.
+   * @returns Parsed SHX payload, or `undefined` if unavailable or not SHX.
+   */
+  static getLoadedShxFontData(fontName: string): ShxFontData | undefined {
+    const font = FontManager.instance.getFontByName(fontName, false)
+    if (!font || font.type !== 'shx') return undefined
+    return font.data as ShxFontData
+  }
+
+  /**
+   * Creates a SHX parser for inline SVG glyph previews.
+   *
+   * @param data - Parsed SHX payload from {@link getLoadedShxFontData}.
+   */
+  static createShxParserFont(data: ShxFontData): ShxParserFont {
+    return new ShxParserFont(data)
+  }
+
+  /**
+   * Looks up {@link FontInfo} for a display name against the drawing’s available-font
+   * catalog ({@link AcApDocManager.instance.avaiableFonts}).
+   *
+   * @remarks
+   * Matching is case-insensitive; the first catalog entry whose `name` array
+   * contains a trimmed, case-insensitive match wins.
+   */
+  static findFontInfoByName(fontName: string): FontInfo | undefined {
+    const list = AcApDocManager.instance?.avaiableFonts ?? []
+    const target = fontName.trim().toLowerCase()
+    if (!target) return undefined
+    return list.find(info =>
+      info.name.some(n => n.trim().toLowerCase() === target)
+    )
+  }
+
+  /**
+   * Declared font engine kind from the CAD font catalog only (before or after load).
+   *
+   * @remarks
+   * Use when {@link AcApFontUtil} has not yet loaded the font: the catalog still
+   * knows `shx` vs `mesh`. After load, {@link getFontType} is authoritative.
+   */
+  static getCatalogFontType(fontName: string): 'shx' | 'mesh' | undefined {
+    return AcApFontUtil.findFontInfoByName(fontName)?.type
+  }
+
+  /**
+   * Loads a font through the same pipeline as MTEXT rendering so binaries are cached
+   * and SHX glyph tables are available.
+   *
+   * @remarks
+   * No-ops when there is no {@link AcApDocManager.instance} or the font is already
+   * loaded. Delegates to {@link AcApDocManager.loadFonts}.
+   */
+  static async ensureDrawingFontLoaded(fontName: string): Promise<void> {
+    const dm = AcApDocManager.instance
+    if (!dm) return
+    if (AcApFontUtil.isFontLoaded(fontName)) return
+    await dm.loadFonts([fontName])
+  }
+}

--- a/packages/cad-simple-viewer/src/util/index.ts
+++ b/packages/cad-simple-viewer/src/util/index.ts
@@ -1,2 +1,3 @@
+export * from './AcApFontUtil'
 export * from './AcApMeasurementElementGenerator'
 export * from './AcTrGeometryUtil'

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -43,7 +43,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
-    "@mlightcad/ribbon": "0.1.4",
+    "@mlightcad/ribbon": "0.1.5",
     "@mlightcad/svg-renderer": "workspace:*",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",

--- a/packages/cad-viewer/src/component/dialog/MlCharacterMapDialog.vue
+++ b/packages/cad-viewer/src/component/dialog/MlCharacterMapDialog.vue
@@ -1,0 +1,699 @@
+<template>
+  <ml-base-dialog
+    v-model="visible"
+    :title="t('main.ribbon.mtext.characterMap.title')"
+    :width="580"
+    @ok="handleBaseOk"
+    @cancel="handleBaseCancel"
+  >
+    <div class="ml-character-map-dialog__toolbar">
+      <span class="ml-character-map-dialog__font-label">{{
+        t('main.ribbon.mtext.characterMap.font')
+      }}</span>
+      <div class="ml-character-map-dialog__font-select">
+        <ml-ribbon-font-select
+          v-model="selectedFont"
+          variant="plain"
+          :options="fontOptions"
+          :disabled="loading"
+          :placeholder="t('main.ribbon.mtext.field.font')"
+          control-width="100%"
+        />
+      </div>
+    </div>
+
+    <div v-loading="loading" class="ml-character-map-dialog__body">
+      <div
+        v-if="!gridCodes.length && !loading"
+        class="ml-character-map-dialog__empty"
+      >
+        {{ t('main.ribbon.mtext.characterMap.noGlyphs') }}
+      </div>
+      <template v-else>
+        <div
+          class="ml-character-map-dialog__scroll"
+          @scroll.passive="onGridScroll"
+        >
+          <div class="ml-character-map-dialog__grid">
+            <button
+              v-for="code in gridCodes"
+              :key="code"
+              type="button"
+              class="ml-character-map-dialog__cell"
+              :class="{ 'is-active': code === activeCode }"
+              @click="onCellClick(code, $event)"
+              @dblclick.prevent="insertAndClose(safeCharFromCode(code))"
+            >
+              <span
+                v-if="fontKind === 'mesh'"
+                class="ml-character-map-dialog__cell-ttf"
+                :style="cellTtfStyle"
+                >{{ safeCharFromCode(code) }}</span
+              >
+              <span
+                v-else
+                class="ml-character-map-dialog__cell-shx"
+                v-html="cellShxSvg(code)"
+              />
+            </button>
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <div class="ml-character-map-dialog__inline-footer">
+      <span class="ml-character-map-dialog__inline-footer-label">{{
+        t('main.ribbon.mtext.characterMap.charsToCopy')
+      }}</span>
+      <el-input
+        v-model="copyBuffer"
+        class="ml-character-map-dialog__inline-footer-input"
+        clearable
+      />
+      <el-button @click="appendActiveToBuffer">{{
+        t('main.ribbon.mtext.characterMap.select')
+      }}</el-button>
+      <el-button @click="copyBufferToClipboard">{{
+        t('main.ribbon.mtext.characterMap.copy')
+      }}</el-button>
+    </div>
+  </ml-base-dialog>
+
+  <Teleport to="body">
+    <div
+      v-show="magnifierDisplayed"
+      class="ml-character-map-magnifier"
+      :style="magnifierBoxStyle"
+      aria-hidden="true"
+    >
+      <div
+        v-if="fontKind === 'shx'"
+        class="ml-character-map-magnifier__shx"
+        v-html="magnifierShxSvg"
+      />
+      <div
+        v-else
+        class="ml-character-map-magnifier__ttf"
+        :style="magnifierTtfStyle"
+      >
+        {{ activeChar }}
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+/**
+ * Modal character map for MTEXT: browse glyphs for the selected drawing font,
+ * copy to a buffer, or insert into the document. SHX fonts preview via stroke
+ * SVG from {@link AcApFontUtil.createShxParserFont}; mesh (TTF/OTF) cells use the browser’s normal
+ * text layout with `font-family` set to the loaded face (see template branches
+ * `fontKind === 'mesh'` vs `'shx'`).
+ */
+import { AcApFontUtil, type ShxParserFont } from '@mlightcad/cad-simple-viewer'
+import { useEventListener } from '@vueuse/core'
+import { ElMessage } from 'element-plus'
+import { computed, nextTick, onUnmounted, ref, shallowRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import MlBaseDialog from '../common/MlBaseDialog.vue'
+import MlRibbonFontSelect from '../ribbon/MlRibbonFontSelect.vue'
+import { expandTtfCharacterMapCodepoints } from './charMapTtfCodepoints'
+
+/**
+ * Public props for {@link MlCharacterMapDialog} (character map modal).
+ *
+ * @remarks
+ * Parents typically bind `v-model` to `modelValue` and pass the same font name
+ * list used by MTEXT so the dropdown stays consistent with the editor.
+ */
+export interface MlCharacterMapDialogProps {
+  /**
+   * Controls dialog visibility; use with `v-model` / `update:modelValue`.
+   */
+  modelValue: boolean
+  /**
+   * Display names for the font selector (drawing-resolved font families).
+   */
+  fontOptions: string[]
+  /**
+   * Font to pre-select when the dialog opens. When empty after trim, the first
+   * entry in {@link MlCharacterMapDialogProps.fontOptions} is used.
+   */
+  initialFont?: string
+}
+
+/**
+ * Payload for the `insert` event: text to place in the document and the font
+ * family that should apply to that insertion.
+ *
+ * @remarks
+ * `text` may contain multiple scalar characters if the user built a string in
+ * the copy buffer; callers should apply `fontFamily` consistently with MTEXT
+ * formatting rules.
+ */
+export interface MlCharacterMapInsertPayload {
+  /**
+   * Trimmed drawing font family name matching the user’s selection in the map.
+   */
+  fontFamily: string
+  /**
+   * UTF-16 string to insert (from grid selection, buffer, or combined picks).
+   */
+  text: string
+}
+
+/**
+ * Emits supported by {@link MlCharacterMapDialog}.
+ *
+ * @remarks
+ * - `update:modelValue` — standard dialog visibility sync.
+ * - `insert` — user confirmed; parent should insert `payload.text` with `payload.fontFamily`.
+ */
+export type MlCharacterMapDialogEmits = {
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'insert', payload: MlCharacterMapInsertPayload): void
+}
+
+/**
+ * Fixed Unicode code-point list for mesh (TTF/OTF) grids; built once from
+ * {@link expandTtfCharacterMapCodepoints}.
+ */
+const TTF_GRID_CODES = expandTtfCharacterMapCodepoints()
+
+const props = withDefaults(defineProps<MlCharacterMapDialogProps>(), {
+  initialFont: ''
+})
+
+const emit = defineEmits<MlCharacterMapDialogEmits>()
+
+const { t } = useI18n()
+
+/** Bridges `v-model` on the base dialog to `modelValue` / `update:modelValue`. */
+const visible = computed({
+  get: () => props.modelValue,
+  set: (v: boolean) => emit('update:modelValue', v)
+})
+
+/** Current font display name from {@link MlRibbonFontSelect}. */
+const selectedFont = ref('')
+/** Characters queued for copy or insert from the footer row. */
+const copyBuffer = ref('')
+/** Selected grid code: SHX index or Unicode scalar depending on {@link fontKind}. */
+const activeCode = ref<number | null>(null)
+/** True while {@link loadGridForCurrentFont} runs (font load + classification). */
+const loading = ref(false)
+/**
+ * Rendering mode for the grid and magnifier: `'shx'` stroke SVG vs `'mesh'` browser text.
+ * Mirrors resolved engine type where non-SHX outline fonts are labeled `mesh`.
+ */
+const fontKind = ref<'shx' | 'mesh'>('mesh')
+/** Glyph indices present in the loaded SHX font; unused (empty) for mesh fonts. */
+const shxCodes = ref<number[]>([])
+
+/** Parsed SHX font used only for SVG previews; released when switching fonts or closing. */
+const shxWorkFont = shallowRef<ShxParserFont | null>(null)
+
+/**
+ * Releases native/parser resources held by {@link shxWorkFont} and clears the ref.
+ */
+function disposeShxWorkFont() {
+  shxWorkFont.value?.release()
+  shxWorkFont.value = null
+}
+
+/**
+ * Code points rendered in the scroll grid: dynamic SHX keys or static TTF list.
+ */
+const gridCodes = computed(() =>
+  fontKind.value === 'shx' ? shxCodes.value : TTF_GRID_CODES
+)
+
+/** UTF-16 string for the currently highlighted cell (empty when none). */
+const activeChar = computed(() =>
+  activeCode.value == null ? '' : safeCharFromCode(activeCode.value)
+)
+
+/**
+ * Converts a scalar Unicode code point to a JavaScript string, guarding invalid
+ * ranges and surrogate halves.
+ *
+ * @param code - Unicode scalar value (not UTF-16 code units).
+ * @returns One code point as a string, or `''` if out of range or unrepresentable.
+ */
+function safeCharFromCode(code: number): string {
+  if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return ''
+  if (code >= 0xd800 && code <= 0xdfff) return ''
+  try {
+    return String.fromCodePoint(code)
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Builds a CSS `font-family` entry with minimal escaping for backslashes and quotes.
+ *
+ * @param name - Font family name as shown in the drawing.
+ * @returns A quoted family token followed by `sans-serif` fallback.
+ */
+function cssFontStack(name: string) {
+  const escaped = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return `"${escaped}", sans-serif`
+}
+
+/** Inline style for mesh cells: forces `font-family` to the drawing’s loaded webfont. */
+const cellTtfStyle = computed(() => ({
+  fontFamily: cssFontStack(selectedFont.value)
+}))
+
+/** Larger `font-family` / size for the mesh magnifier preview. */
+const magnifierTtfStyle = computed(() => ({
+  fontFamily: cssFontStack(selectedFont.value),
+  fontSize: '44px',
+  lineHeight: '1.05'
+}))
+
+/**
+ * Renders one SHX glyph as inline SVG for a grid cell using {@link shxWorkFont}.
+ *
+ * @param code - SHX character index from {@link shxCodes}.
+ * @returns SVG markup string, or empty when the parser or shape is unavailable.
+ */
+function cellShxSvg(code: number): string {
+  const font = shxWorkFont.value
+  if (!font) return ''
+  const shape = font.getCharShape(code, 13)
+  return (
+    shape?.toSVG({
+      strokeWidth: '0.55',
+      strokeColor: 'currentColor',
+      isAutoFit: true
+    }) ?? ''
+  )
+}
+
+/** Enlarged SHX SVG for the teleported magnifier (`v-html` in template). */
+const magnifierShxSvg = computed(() => {
+  const font = shxWorkFont.value
+  const code = activeCode.value
+  if (!font || code == null) return ''
+  const shape = font.getCharShape(code, 40)
+  return (
+    shape?.toSVG({
+      strokeWidth: '0.75',
+      strokeColor: 'currentColor',
+      isAutoFit: true
+    }) ?? ''
+  )
+})
+
+/** Pixel width/height of the magnifier box (fixed positioning). */
+const MAGNIFIER_SIZE = 76
+/** Gap between magnifier and anchored cell when flipping above/below. */
+const MAGNIFIER_GAP = 6
+
+/** Last clicked grid cell element; drives loupe placement on scroll/resize. */
+const magnifierAnchorEl = ref<HTMLElement | null>(null)
+/** Inline `position: fixed` box coordinates for the magnifier overlay. */
+const magnifierBoxStyle = ref<Record<string, string>>({})
+
+/** True when a cell is active, anchored, and styles have been applied at least once. */
+const magnifierDisplayed = computed(
+  () =>
+    activeCode.value != null &&
+    magnifierAnchorEl.value != null &&
+    magnifierBoxStyle.value.position === 'fixed'
+)
+
+/**
+ * Positions the floating magnifier above the active cell when there is room,
+ * otherwise below; clamps horizontally and vertically inside the viewport.
+ *
+ * @param anchor - The focused grid cell element used for anchor coordinates.
+ */
+function updateMagnifierPosition(anchor: HTMLElement) {
+  const r = anchor.getBoundingClientRect()
+  const w = MAGNIFIER_SIZE
+  const h = MAGNIFIER_SIZE
+  let top = r.top - h - MAGNIFIER_GAP
+  if (top < 8) {
+    top = r.bottom + MAGNIFIER_GAP
+  }
+  let left = r.left + r.width / 2 - w / 2
+  left = Math.max(8, Math.min(left, window.innerWidth - w - 8))
+  if (top + h > window.innerHeight - 8) {
+    top = Math.max(8, window.innerHeight - h - 8)
+  }
+  magnifierBoxStyle.value = {
+    position: 'fixed',
+    top: `${top}px`,
+    left: `${left}px`,
+    width: `${w}px`,
+    height: `${h}px`,
+    zIndex: '2200'
+  }
+}
+
+/**
+ * Selects a code point and anchors the magnifier to the clicked cell.
+ *
+ * @param code - Active SHX index or Unicode scalar depending on {@link fontKind}.
+ * @param ev - Click event; `currentTarget` supplies layout box for the loupe.
+ */
+function onCellClick(code: number, ev: MouseEvent) {
+  activeCode.value = code
+  const el = ev.currentTarget as HTMLElement | null
+  magnifierAnchorEl.value = el
+  void nextTick(() => {
+    if (el && document.contains(el)) {
+      updateMagnifierPosition(el)
+    }
+  })
+}
+
+/** Keeps the magnifier aligned with the active cell while the grid scrolls. */
+function onGridScroll() {
+  const el = magnifierAnchorEl.value
+  if (el && document.contains(el)) {
+    updateMagnifierPosition(el)
+  }
+}
+
+/** Hides the magnifier by dropping anchor and inline positioning styles. */
+function clearMagnifier() {
+  magnifierAnchorEl.value = null
+  magnifierBoxStyle.value = {}
+}
+
+/**
+ * Hides the magnified preview when keyboard or programmatic focus moves to any
+ * control other than a character grid cell (font field, copy row, dialog OK/Cancel, etc.).
+ *
+ * @param ev - Focus event whose target is tested against the grid cell selector.
+ */
+function onDocumentFocusIn(ev: Event) {
+  if (!props.modelValue) return
+  if (!magnifierAnchorEl.value) return
+  const t = (ev as FocusEvent).target
+  if (!t || !(t instanceof HTMLElement) || !t.isConnected) return
+  if (t.closest('.ml-character-map-dialog__cell')) return
+  clearMagnifier()
+}
+
+const stopWinScroll = useEventListener(
+  window,
+  'scroll',
+  () => {
+    const el = magnifierAnchorEl.value
+    if (el && document.contains(el)) {
+      updateMagnifierPosition(el)
+    }
+  },
+  { capture: true }
+)
+
+const stopResize = useEventListener(window, 'resize', () => {
+  const el = magnifierAnchorEl.value
+  if (el && document.contains(el)) {
+    updateMagnifierPosition(el)
+  }
+})
+
+const stopDocumentFocusIn = useEventListener(
+  document,
+  'focusin',
+  onDocumentFocusIn,
+  true
+)
+
+onUnmounted(() => {
+  stopWinScroll()
+  stopResize()
+  stopDocumentFocusIn()
+})
+
+watch(
+  () => props.modelValue,
+  open => {
+    if (open) {
+      copyBuffer.value = ''
+      activeCode.value = null
+      clearMagnifier()
+      selectedFont.value =
+        props.initialFont?.trim() || props.fontOptions[0] || ''
+    } else {
+      clearMagnifier()
+      disposeShxWorkFont()
+    }
+  }
+)
+
+/**
+ * Loads the selected font, resolves SHX vs mesh, and prepares grid data.
+ *
+ * @remarks
+ * For SHX: builds a parser from loaded bytes via {@link AcApFontUtil.createShxParserFont} and fills
+ * {@link shxCodes} from the font manager. For mesh: clears SHX codes, waits on
+ * {@link FontFaceSet} (`document.fonts.ready` / `load`) so cells paint with the
+ * correct webfont when available.
+ */
+async function loadGridForCurrentFont() {
+  if (!props.modelValue) return
+  activeCode.value = null
+  clearMagnifier()
+  const trimmed = selectedFont.value.trim()
+  if (!trimmed) {
+    shxCodes.value = []
+    fontKind.value = 'mesh'
+    disposeShxWorkFont()
+    return
+  }
+  loading.value = true
+  disposeShxWorkFont()
+  try {
+    await AcApFontUtil.ensureDrawingFontLoaded(trimmed)
+    await document.fonts.ready.catch(() => undefined)
+    const resolved =
+      AcApFontUtil.getFontType(trimmed) ??
+      AcApFontUtil.getCatalogFontType(trimmed) ??
+      'mesh'
+    fontKind.value = resolved === 'shx' ? 'shx' : 'mesh'
+    if (fontKind.value === 'shx') {
+      const data = AcApFontUtil.getLoadedShxFontData(trimmed)
+      if (data) {
+        shxWorkFont.value = AcApFontUtil.createShxParserFont(data)
+      }
+      shxCodes.value = AcApFontUtil.getShxCodePoints(trimmed)
+    } else {
+      shxCodes.value = []
+      try {
+        await document.fonts.load(`18px ${cssFontStack(trimmed)}`)
+      } catch {
+        /* ignore */
+      }
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => [props.modelValue, selectedFont.value] as const,
+  () => {
+    void loadGridForCurrentFont()
+  }
+)
+
+/** Appends {@link activeChar} to the footer copy buffer when a cell is selected. */
+function appendActiveToBuffer() {
+  const ch = activeChar.value
+  if (!ch) return
+  copyBuffer.value += ch
+}
+
+/** Writes {@link copyBuffer} to the system clipboard; shows a warning toast on failure. */
+async function copyBufferToClipboard() {
+  try {
+    await navigator.clipboard.writeText(copyBuffer.value)
+  } catch {
+    ElMessage({
+      type: 'warning',
+      message: t('main.ribbon.mtext.characterMap.copyFailed')
+    })
+  }
+}
+
+/**
+ * Emits `insert` with the trimmed font name and closes the dialog.
+ *
+ * @param text - UTF-16 string to insert (usually one scalar from the grid).
+ */
+function insertAndClose(text: string) {
+  if (!text || !selectedFont.value.trim()) return
+  clearMagnifier()
+  emit('insert', {
+    fontFamily: selectedFont.value.trim(),
+    text
+  })
+  emit('update:modelValue', false)
+}
+
+/** Inserts {@link copyBuffer} if non-empty, otherwise the active character. */
+function insertFromBuffer() {
+  const text = copyBuffer.value || activeChar.value
+  if (!text) return
+  insertAndClose(text)
+}
+
+/**
+ * Base dialog OK: insert current buffer or active cell (same as former Insert button).
+ *
+ * @remarks Delegates to {@link insertFromBuffer}.
+ */
+function handleBaseOk() {
+  insertFromBuffer()
+}
+
+/** Clears magnifier state and releases SHX parser resources on cancel. */
+function handleBaseCancel() {
+  clearMagnifier()
+  disposeShxWorkFont()
+}
+</script>
+
+<style scoped>
+.ml-character-map-dialog__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.ml-character-map-dialog__font-label {
+  flex: 0 0 auto;
+  font-size: 13px;
+  color: var(--el-text-color-regular);
+}
+
+.ml-character-map-dialog__font-select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ml-character-map-dialog__body {
+  min-height: 120px;
+}
+
+.ml-character-map-dialog__empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+}
+
+.ml-character-map-dialog__scroll {
+  max-height: 280px;
+  overflow: auto;
+}
+
+.ml-character-map-dialog__grid {
+  display: grid;
+  grid-template-columns: repeat(16, 1fr);
+  gap: 2px;
+  padding: 2px;
+}
+
+.ml-character-map-dialog__cell {
+  box-sizing: border-box;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 2px;
+  background: var(--el-fill-color-blank);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ml-character-map-dialog__cell:hover {
+  background: var(--el-fill-color-light);
+}
+
+.ml-character-map-dialog__cell.is-active {
+  outline: 2px solid var(--el-color-primary);
+  outline-offset: -1px;
+  z-index: 1;
+}
+
+.ml-character-map-dialog__cell-ttf {
+  font-size: 15px;
+  line-height: 1;
+}
+
+.ml-character-map-dialog__cell-shx {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--el-text-color-primary);
+}
+
+.ml-character-map-dialog__cell-shx :deep(svg) {
+  max-width: 22px;
+  max-height: 22px;
+}
+
+.ml-character-map-dialog__inline-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.ml-character-map-dialog__inline-footer-label {
+  flex: 0 0 auto;
+  font-size: 13px;
+  color: var(--el-text-color-regular);
+}
+
+.ml-character-map-dialog__inline-footer-input {
+  flex: 1 1 160px;
+  min-width: 120px;
+}
+
+.ml-character-map-magnifier {
+  box-sizing: border-box;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--el-bg-color);
+  border: 1px solid var(--el-border-color-darker);
+  border-radius: 2px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+  color: var(--el-text-color-primary);
+}
+
+.ml-character-map-magnifier__shx {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ml-character-map-magnifier__shx :deep(svg) {
+  max-width: 88%;
+  max-height: 88%;
+}
+
+.ml-character-map-magnifier__ttf {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/packages/cad-viewer/src/component/dialog/charMapTtfCodepoints.ts
+++ b/packages/cad-viewer/src/component/dialog/charMapTtfCodepoints.ts
@@ -1,0 +1,52 @@
+/**
+ * Inclusive Unicode ranges used to build the TTF/mesh character-map grid.
+ *
+ * @remarks
+ * Each tuple is `[startCodePoint, endCodePoint]` (both inclusive). The dialog
+ * does not walk the font’s `cmap` in JS; instead it shows this fixed superset
+ * of useful blocks (Latin-1 supplement, Latin Extended-A/B, Greek, Cyrillic,
+ * General Punctuation, superscripts, currency, letterlike symbols, arrows,
+ * mathematical operators, misc technical, box drawing, geometric shapes,
+ * dingbats, CJK punctuation/symbols). Glyphs missing from the chosen face
+ * typically render as tofu or blank per the browser’s font fallback rules.
+ */
+export const MTEXT_CHARACTER_MAP_TTF_RANGES: readonly [number, number][] = [
+  [0x0020, 0x007e],
+  [0x00a0, 0x00ff],
+  [0x0100, 0x017f],
+  [0x0180, 0x024f],
+  [0x0370, 0x03ff],
+  [0x0400, 0x04ff],
+  [0x2000, 0x206f],
+  [0x2070, 0x209f],
+  [0x20a0, 0x20cf],
+  [0x2100, 0x214f],
+  [0x2190, 0x21ff],
+  [0x2200, 0x22ff],
+  [0x2300, 0x23ff],
+  [0x2500, 0x257f],
+  [0x25a0, 0x25ff],
+  [0x2600, 0x26ff],
+  [0x3000, 0x303f]
+]
+
+/**
+ * Flattens {@link MTEXT_CHARACTER_MAP_TTF_RANGES} into one ascending code-point array.
+ *
+ * @remarks
+ * Surrogate code units U+D800–U+DFFF are skipped so every value is safe for
+ * {@link String.fromCodePoint}. The result is computed once at module load in
+ * the character map dialog for stable keys and iteration order.
+ *
+ * @returns All code points from the configured ranges, in ascending order.
+ */
+export function expandTtfCharacterMapCodepoints(): number[] {
+  const out: number[] = []
+  for (const [from, to] of MTEXT_CHARACTER_MAP_TTF_RANGES) {
+    for (let cp = from; cp <= to; cp++) {
+      if (cp >= 0xd800 && cp <= 0xdfff) continue
+      out.push(cp)
+    }
+  }
+  return out
+}

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -100,6 +100,7 @@ import {
   xline
 } from '../../svg'
 import MlLayerSelect from '../common/MlLayerSelect.vue'
+import MlCharacterMapDialog from '../dialog/MlCharacterMapDialog.vue'
 import MlRibbonLanguageSelector from './MlRibbonLanguageSelector.vue'
 import MlRibbonPropertyColorDropdown from './MlRibbonPropertyColorDropdown.vue'
 import MlRibbonPropertyLineTypeSelect from './MlRibbonPropertyLineTypeSelect.vue'
@@ -151,7 +152,11 @@ const {
   handleCommandWillStart: handleMTextCommandWillStart,
   handleCommandEnded: handleMTextCommandEnded,
   handleItem: handleMTextItem,
-  buildContextualTab: buildMTextContextualTab
+  buildContextualTab: buildMTextContextualTab,
+  characterMapVisible: mtextCharacterMapVisible,
+  characterMapFontOptions: mtextCharacterMapFontOptions,
+  characterMapInitialFont: mtextCharacterMapInitialFont,
+  handleCharacterMapInsert: handleMTextCharacterMapInsert
 } = useMTextContextualRibbon({
   activeTabId: activeRibbonTabId
 })
@@ -1545,6 +1550,12 @@ const handleFileMenuSelect = (command: string) => {
         />
       </template>
     </ml-ribbon>
+    <ml-character-map-dialog
+      v-model="mtextCharacterMapVisible"
+      :font-options="mtextCharacterMapFontOptions"
+      :initial-font="mtextCharacterMapInitialFont"
+      @insert="handleMTextCharacterMapInsert"
+    />
   </div>
 </template>
 

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonFontSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonFontSelect.vue
@@ -1,0 +1,94 @@
+<template>
+  <ml-ribbon-property-field
+    v-if="variant === 'property'"
+    :icon="fontIcon"
+    :disabled="disabled"
+    :control-width="controlWidth"
+  >
+    <el-select
+      :model-value="modelValue"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      filterable
+      size="small"
+      class="ml-ribbon-font-select__control"
+      @update:model-value="emit('update:modelValue', $event as string)"
+    >
+      <el-option
+        v-for="name in options"
+        :key="name"
+        :label="name"
+        :value="name"
+      />
+    </el-select>
+  </ml-ribbon-property-field>
+  <el-select
+    v-else
+    :model-value="modelValue"
+    :disabled="disabled"
+    :placeholder="placeholder"
+    filterable
+    size="default"
+    class="ml-ribbon-font-select--plain"
+    @update:model-value="emit('update:modelValue', $event as string)"
+  >
+    <el-option
+      v-for="name in options"
+      :key="name"
+      :label="name"
+      :value="name"
+    />
+  </el-select>
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue'
+
+import MlRibbonPropertyField from './MlRibbonPropertyField.vue'
+
+const fontIcon = () =>
+  h(
+    'svg',
+    {
+      viewBox: '0 0 24 24',
+      width: '1em',
+      height: '1em',
+      fill: 'currentColor',
+      'aria-hidden': 'true'
+    },
+    [
+      h('path', {
+        d: 'M5 18h2.2l1.1-3.2h5.4l1.1 3.2H17l-4.8-13h-2.4L5 18Zm3.9-5 2-5.8 2 5.8H8.9Z'
+      })
+    ]
+  )
+
+interface RibbonFontSelectProps {
+  modelValue?: string
+  options?: string[]
+  disabled?: boolean
+  placeholder?: string
+  controlWidth?: string
+  /** Ribbon property shell vs standalone control (e.g. character map dialog). */
+  variant?: 'property' | 'plain'
+}
+
+withDefaults(defineProps<RibbonFontSelectProps>(), {
+  modelValue: '',
+  options: () => [],
+  disabled: false,
+  placeholder: '',
+  controlWidth: '154px',
+  variant: 'property'
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+}>()
+</script>
+
+<style scoped>
+.ml-ribbon-font-select--plain {
+  width: 100%;
+}
+</style>

--- a/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
+++ b/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
@@ -1,6 +1,10 @@
 import { CircleClose } from '@element-plus/icons-vue'
 import type { AcEdCommandEventArgs } from '@mlightcad/cad-simple-viewer'
-import { AcApDocManager, AcEdMTextEditor } from '@mlightcad/cad-simple-viewer'
+import {
+  AcApDocManager,
+  AcApFontUtil,
+  AcEdMTextEditor
+} from '@mlightcad/cad-simple-viewer'
 import { AcCmColor } from '@mlightcad/data-model'
 import type {
   RibbonGalleryCategoryModel,
@@ -9,6 +13,7 @@ import type {
 } from '@mlightcad/ribbon'
 import {
   type Component,
+  computed,
   defineComponent,
   h,
   onMounted,
@@ -19,18 +24,44 @@ import {
 } from 'vue'
 
 import { useRibbonContextualTab } from '../../composable'
+import MlRibbonFontSelect from './MlRibbonFontSelect.vue'
 import MlRibbonMTextHeightSelect from './MlRibbonMTextHeightSelect.vue'
 import MlRibbonPropertyColorDropdown from './MlRibbonPropertyColorDropdown.vue'
 
 const MTEXT_CONTEXTUAL_TAB_ID = 'mtext-editor-context'
 const MTEXT_COMMAND_GLOBAL_NAMES = ['MTEXT', 'mtext'] as const
 const MTEXT_ITEM_PREFIX = 'mtext-'
+/** Shared width for font, color, and height fields in the MText format ribbon group. */
+const MTEXT_FORMAT_PROPERTY_CONTROL_WIDTH = '154px'
 
 function isMTextCommandGlobalName(globalName: string | undefined) {
   return (
     globalName != null &&
     MTEXT_COMMAND_GLOBAL_NAMES.some(name => name === globalName)
   )
+}
+
+/** Matches a single AutoCAD-style MTEXT Unicode escape such as `\U+2248`. */
+const MTEXT_UNICODE_ESCAPE = /^\\U\+([0-9A-Fa-f]{1,6})$/i
+
+/**
+ * Turns a ribbon symbol payload into the string passed to the inline editor.
+ *
+ * AutoCAD MTEXT stores symbols as `\U+hhhh` escapes; the Vue input box shows
+ * those literally unless we expand them to real characters. Sequences like
+ * `%%d` or `\~` are left unchanged so the editor can interpret them.
+ *
+ * @param payload Text after the `mtext-symbol:` prefix (or a standalone escape).
+ * @returns The character for a `\U+` escape, or the original string otherwise.
+ */
+function mtextRibbonInsertPayloadToString(payload: string): string {
+  const match = MTEXT_UNICODE_ESCAPE.exec(payload)
+  if (!match) return payload
+  const codePoint = parseInt(match[1], 16)
+  if (!Number.isFinite(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return payload
+  }
+  return String.fromCodePoint(codePoint)
 }
 
 /**
@@ -137,9 +168,7 @@ interface MTextRibbonEditor {
   /** Unsubscribes a previously registered editor event handler. */
   off?: (event: string, handler: () => void) => void
   /** Subscribes to format refreshes mirrored from the active input box. */
-  addCurrentFormatChangeListener?: (
-    listener: MTextFormatChangeListener
-  ) => void
+  addCurrentFormatChangeListener?: (listener: MTextFormatChangeListener) => void
   /** Removes a previously registered format refresh listener. */
   removeCurrentFormatChangeListener?: (
     listener: MTextFormatChangeListener
@@ -211,10 +240,7 @@ const DEFAULT_MTEXT_FORMAT: MTextRibbonFormat = {
  * Compares two ribbon format snapshots using the same field-by-field contract
  * as the MTEXT input box toolbar.
  */
-function sameMTextRibbonFormat(
-  a: MTextRibbonFormat,
-  b: MTextRibbonFormat
-) {
+function sameMTextRibbonFormat(a: MTextRibbonFormat, b: MTextRibbonFormat) {
   return (
     a.fontFamily === b.fontFamily &&
     a.fontSize === b.fontSize &&
@@ -437,25 +463,30 @@ function getTextStyleRecords() {
 function buildTextStyleGalleryCategories(
   title: string
 ): RibbonGalleryCategoryModel[] {
-  const records = getTextStyleRecords()
+  const seen = new Set<string>()
+  const items: RibbonGalleryCategoryModel['items'] = []
+  for (const record of getTextStyleRecords()) {
+    const raw = record.name ?? record.textStyle.name
+    const name = typeof raw === 'string' ? raw.trim() : ''
+    if (!name || seen.has(name)) continue
+    seen.add(name)
+    const font = record.textStyle.font || name
+    items.push({
+      id: `mtext-style:${name}`,
+      label: name,
+      preview: name,
+      componentProps: {
+        style: {
+          fontFamily: font
+        }
+      }
+    })
+  }
   return [
     {
       id: 'mtext-text-styles',
       title,
-      items: records.map(record => {
-        const name = record.name || record.textStyle.name
-        const font = record.textStyle.font || name
-        return {
-          id: `mtext-style:${name}`,
-          label: name,
-          preview: name,
-          componentProps: {
-            style: {
-              fontFamily: font
-            }
-          }
-        }
-      })
+      items
     }
   ]
 }
@@ -493,6 +524,7 @@ export function useMTextContextualRibbon({
   const currentColorDisplay = ref(resolveColorDisplay(currentColor.value))
   const stackActive = ref(false)
   const activeEditor = ref<MTextRibbonEditor | null>(null)
+  const characterMapVisible = ref(false)
 
   let observedEditor: MTextRibbonEditor | null = null
 
@@ -727,7 +759,10 @@ export function useMTextContextualRibbon({
     db.textstyle = styleName
     const textStyle = record.textStyle
     const nextFormat: Partial<MTextRibbonFormat> = {}
-    if (textStyle.font) nextFormat.fontFamily = textStyle.font
+    if (textStyle.font) {
+      void AcApFontUtil.ensureDrawingFontLoaded(textStyle.font)
+      nextFormat.fontFamily = textStyle.font
+    }
     const height =
       normalizeNumber(textStyle.fixedTextHeight) ??
       normalizeNumber(textStyle.lastHeight)
@@ -799,6 +834,33 @@ export function useMTextContextualRibbon({
   }
 
   /**
+   * Inserts text from the character map after applying the picked font to the editor.
+   *
+   * Loads the font through the same {@link AcApDocManager} / FontManager path as
+   * CAD text rendering so glyphs exist before the inline editor paints the run.
+   */
+  const handleCharacterMapInsert = async (payload: {
+    fontFamily: string
+    text: string
+  }) => {
+    if (!payload.text) return
+    const font = payload.fontFamily.trim()
+    if (font) {
+      try {
+        await AcApFontUtil.ensureDrawingFontLoaded(font)
+      } catch {
+        /* still apply format and insert; editor may substitute fonts */
+      }
+    }
+    applyCurrentFormat({ fontFamily: payload.fontFamily })
+    insertText(payload.text)
+  }
+
+  const characterMapFontOptions = computed(() => getFontOptions())
+
+  const characterMapInitialFont = computed(() => currentFormat.value.fontFamily)
+
+  /**
    * Applies paragraph alignment through the active editor.
    *
    * @param alignment Alignment id emitted by the ribbon button group.
@@ -827,7 +889,9 @@ export function useMTextContextualRibbon({
       return true
     }
     if (itemId.startsWith('mtext-font:')) {
-      applyCurrentFormat({ fontFamily: itemId.slice('mtext-font:'.length) })
+      const name = itemId.slice('mtext-font:'.length)
+      void AcApFontUtil.ensureDrawingFontLoaded(name)
+      applyCurrentFormat({ fontFamily: name })
       return true
     }
     if (itemId.startsWith('mtext-format:')) {
@@ -865,9 +929,7 @@ export function useMTextContextualRibbon({
     }
     if (itemId.startsWith('mtext-attachment:')) {
       const editor = getActiveEditor()
-      editor?.setAttachmentPoint?.(
-        itemId.slice('mtext-attachment:'.length)
-      )
+      editor?.setAttachmentPoint?.(itemId.slice('mtext-attachment:'.length))
       editor?.focusEditor?.()
       return true
     }
@@ -875,7 +937,8 @@ export function useMTextContextualRibbon({
       const value = itemId.slice('mtext-list:'.length)
       if (value === 'number') insertText('1. ')
       if (value === 'letter') insertText('a. ')
-      if (value === 'bullet') insertText('\\U+2022 ')
+      if (value === 'bullet')
+        insertText(`${mtextRibbonInsertPayloadToString('\\U+2022')} `)
       return true
     }
     if (itemId.startsWith('mtext-line-spacing:')) {
@@ -900,7 +963,11 @@ export function useMTextContextualRibbon({
     }
     if (itemId.startsWith('mtext-symbol:')) {
       const symbol = itemId.slice('mtext-symbol:'.length)
-      if (symbol !== 'other') insertText(symbol)
+      if (symbol === 'other') {
+        characterMapVisible.value = true
+      } else {
+        insertText(mtextRibbonInsertPayloadToString(symbol))
+      }
       return true
     }
     if (itemId === 'mtext-close') {
@@ -984,10 +1051,6 @@ export function useMTextContextualRibbon({
   const buildContextualTab = (t: Translate): RibbonTabModel => {
     syncFormatFromEditor()
 
-    const fontOptions = getFontOptions().map(fontName => ({
-      label: fontName,
-      value: `mtext-font:${fontName}`
-    }))
     const disabled = !activeEditor.value
     const format = currentFormat.value
 
@@ -1017,6 +1080,7 @@ export function useMTextContextualRibbon({
                   props: {
                     modelValue: `mtext-style:${getCurrentDatabase()?.textstyle ?? ''}`,
                     inlineItemLimit: 3,
+                    inlineItemWidthMode: 'auto',
                     categories: buildTextStyleGalleryCategories(
                       t('main.ribbon.mtext.field.textStyle')
                     )
@@ -1121,16 +1185,22 @@ export function useMTextContextualRibbon({
               items: [
                 {
                   id: 'mtext-font',
-                  type: 'comboBox',
+                  type: 'custom',
                   label: t('main.ribbon.mtext.field.font'),
                   tooltip: t('main.ribbon.mtext.tooltip.font'),
                   size: 'small',
                   disabled,
                   props: {
-                    width: '154px',
-                    modelValue: `mtext-font:${format.fontFamily}`,
-                    emitValueOnChange: true,
-                    options: fontOptions
+                    component: MlRibbonFontSelect,
+                    componentProps: {
+                      modelValue: format.fontFamily,
+                      options: getFontOptions(),
+                      disabled,
+                      placeholder: t('main.ribbon.mtext.field.font'),
+                      controlWidth: MTEXT_FORMAT_PROPERTY_CONTROL_WIDTH,
+                      'onUpdate:modelValue': (name: string) =>
+                        handleItem(`mtext-font:${name}`)
+                    }
                   }
                 },
                 {
@@ -1146,7 +1216,7 @@ export function useMTextContextualRibbon({
                       modelValue: currentColor.value,
                       displayColor: currentColorDisplay.value,
                       placeholder: t('main.ribbon.mtext.field.color'),
-                      controlWidth: '132px',
+                      controlWidth: MTEXT_FORMAT_PROPERTY_CONTROL_WIDTH,
                       'onUpdate:modelValue': handleMTextColorChange
                     }
                   }
@@ -1164,7 +1234,7 @@ export function useMTextContextualRibbon({
                       modelValue: format.fontSize,
                       options: getHeightOptions(),
                       placeholder: t('main.ribbon.mtext.field.height'),
-                      controlWidth: '132px',
+                      controlWidth: MTEXT_FORMAT_PROPERTY_CONTROL_WIDTH,
                       'onUpdate:modelValue': handleFontHeightChange
                     }
                   }
@@ -1441,7 +1511,8 @@ export function useMTextContextualRibbon({
                       },
                       {
                         value: 'mtext-symbol:other',
-                        label: t('main.ribbon.mtext.symbol.other')
+                        label: t('main.ribbon.mtext.symbol.other'),
+                        divided: true
                       }
                     ]
                   }
@@ -1497,6 +1568,10 @@ export function useMTextContextualRibbon({
     handleCommandWillStart,
     handleCommandEnded: handleRibbonCommandEnded,
     handleItem,
-    buildContextualTab
+    buildContextualTab,
+    characterMapVisible,
+    characterMapFontOptions,
+    characterMapInitialFont,
+    handleCharacterMapInsert
   }
 }

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -89,6 +89,15 @@ export default {
         color: 'Color',
         height: 'Height'
       },
+      characterMap: {
+        title: 'Character Map',
+        font: 'Font(F):',
+        charsToCopy: 'Characters to copy(A):',
+        select: 'Select(S)',
+        copy: 'Copy(C)',
+        noGlyphs: 'No characters are available for this font.',
+        copyFailed: 'Unable to copy to the clipboard.'
+      },
       command: {
         bold: 'Bold',
         underline: 'Underline',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -89,6 +89,15 @@ export default {
         color: '颜色',
         height: '高度'
       },
+      characterMap: {
+        title: '字符映射表',
+        font: '字体(F):',
+        charsToCopy: '复制字符(A):',
+        select: '选择(S)',
+        copy: '复制(C)',
+        noGlyphs: '该字体没有可显示的字符。',
+        copyFailed: '无法复制到剪贴板。'
+      },
       command: {
         bold: '粗体',
         underline: '下划线',

--- a/packages/three-renderer/package.json
+++ b/packages/three-renderer/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@mlightcad/data-model": "^1.7.34",
-    "@mlightcad/mtext-renderer": "^0.10.10",
+    "@mlightcad/mtext-renderer": "^0.10.11",
     "@velipso/polybool": "^1.1.1",
     "three": "^0.172.0"
   }

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -91,8 +91,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const drawOrder = traits.drawOrder ?? 0
     if (drawOrder >= 0) return true
     const style = traits.fillType
-    const isPatterned =
-      !style.gradient && !!style.definitionLines?.length
+    const isPatterned = !style.gradient && !!style.definitionLines?.length
     return isPatterned
   }
 
@@ -340,7 +339,9 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const style = traits.fillType
     const sideSuffix = options.side === 'back' ? '_back' : ''
     const drawOrderSuffix = this.buildDrawOrderSuffix(traits)
-    const bgSuffix = this.shouldTrackBackground(traits, options) ? '_bgfill' : ''
+    const bgSuffix = this.shouldTrackBackground(traits, options)
+      ? '_bgfill'
+      : ''
     // Use color + layer + rebaseOffset + pattern info for key
     if (style.gradient) {
       const gradient = style.gradient

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@mlightcad/data-model': ^1.7.34
   '@mlightcad/libredwg-converter': ^3.5.34
-  '@mlightcad/mtext-renderer': ^0.10.10
+  '@mlightcad/mtext-renderer': ^0.10.11
   element-plus: ^2.12.0
   three: ^0.172.0
   vue: ^3.4.21
@@ -124,11 +124,11 @@ importers:
         version: 0.172.0
     devDependencies:
       '@mlightcad/mtext-input-box':
-        specifier: ^0.2.6
-        version: 0.2.6(@mlightcad/mtext-renderer@0.10.10(three@0.172.0))(three@0.172.0)
+        specifier: ^0.2.7
+        version: 0.2.7(@mlightcad/mtext-renderer@0.10.11(three@0.172.0))(three@0.172.0)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.10.10
-        version: 0.10.10(three@0.172.0)
+        specifier: ^0.10.11
+        version: 0.10.11(three@0.172.0)
       '@mlightcad/svg-renderer':
         specifier: workspace:*
         version: link:../svg-renderer
@@ -188,8 +188,8 @@ importers:
         version: 10.0.8(vue@3.5.31(typescript@5.9.3))
     devDependencies:
       '@mlightcad/ribbon':
-        specifier: 0.1.4
-        version: 0.1.4(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+        specifier: 0.1.5
+        version: 0.1.5(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
       '@mlightcad/svg-renderer':
         specifier: workspace:*
         version: link:../svg-renderer
@@ -303,8 +303,8 @@ importers:
         specifier: ^1.7.34
         version: 1.7.34
       '@mlightcad/mtext-renderer':
-        specifier: ^0.10.10
-        version: 0.10.10(three@0.172.0)
+        specifier: ^0.10.11
+        version: 0.10.11(three@0.172.0)
       '@velipso/polybool':
         specifier: ^1.1.1
         version: 1.1.1
@@ -1393,22 +1393,22 @@ packages:
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
-  '@mlightcad/mtext-input-box@0.2.6':
-    resolution: {integrity: sha512-Xn72XwfxpDbuiWOP+1QHlusvWpLWpktucxudAq0jbWTbythy5UzFc+ontvMeqNd8OgFnyAjEF3rDyvhajNBBBw==}
+  '@mlightcad/mtext-input-box@0.2.7':
+    resolution: {integrity: sha512-ueaeV/+ttaErHEtqol8+lvEr97IvJPa/VR9fhsNP1qcC7cvvjB+aafrPT3PnvbnvdkFf8JA0m5CFR13x9+YmWw==}
     peerDependencies:
-      '@mlightcad/mtext-renderer': ^0.10.10
+      '@mlightcad/mtext-renderer': ^0.10.11
       three: ^0.172.0
 
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
-  '@mlightcad/mtext-renderer@0.10.10':
-    resolution: {integrity: sha512-akihsae3ISMmRsC1u6q8wLsd39eHu8m56/1U0QK3zXL3QWWMKQ2Z47gkloCFTkpPZ2ykSSoFiiQs/CpxJxW9bg==}
+  '@mlightcad/mtext-renderer@0.10.11':
+    resolution: {integrity: sha512-1K6SJ8y7yLkh6UhS1uQB5QfZ0rqYKK75DsOQIqWut6AIGkJteuwoP2YD0BLZbObSBq28VR6kWWr0te3nbHWujA==}
     peerDependencies:
       three: ^0.172.0
 
-  '@mlightcad/ribbon@0.1.4':
-    resolution: {integrity: sha512-PMUAzwTtMqwYEh/n+KR3xhQ4SS0ztb0ing9zBAn3Dmn1qkfk4EFNbdRVzfEF76tdAKBGONPJOYXmqxN+aorIEA==}
+  '@mlightcad/ribbon@0.1.5':
+    resolution: {integrity: sha512-5Q+jaBu2rgdviqBlnrLjVVgJd4ZlSjJQcIQ516E/wS+pBAQbvsFPJOEh3JhMHgq3A1ulmrbG+IQBjV5Q0M3KiA==}
     peerDependencies:
       '@element-plus/icons-vue': ^2.3.2
       element-plus: ^2.12.0
@@ -6162,15 +6162,15 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.1': {}
 
-  '@mlightcad/mtext-input-box@0.2.6(@mlightcad/mtext-renderer@0.10.10(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/mtext-input-box@0.2.7(@mlightcad/mtext-renderer@0.10.11(three@0.172.0))(three@0.172.0)':
     dependencies:
-      '@mlightcad/mtext-renderer': 0.10.10(three@0.172.0)
+      '@mlightcad/mtext-renderer': 0.10.11(three@0.172.0)
       '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
       three: 0.172.0
 
   '@mlightcad/mtext-parser@1.4.1': {}
 
-  '@mlightcad/mtext-renderer@0.10.10(three@0.172.0)':
+  '@mlightcad/mtext-renderer@0.10.11(three@0.172.0)':
     dependencies:
       '@mlightcad/mtext-parser': 1.4.1
       '@mlightcad/shx-parser': 1.3.2
@@ -6179,7 +6179,7 @@ snapshots:
       opentype.js: 1.3.4
       three: 0.172.0
 
-  '@mlightcad/ribbon@0.1.4(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
+  '@mlightcad/ribbon@0.1.5(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@element-plus/icons-vue': 2.3.2(vue@3.5.31(typescript@5.9.3))
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))


### PR DESCRIPTION
## Summary

Adds an MTEXT **Character Map** dialog from the contextual ribbon, with correct handling for **SHX** (stroke SVG previews) and **mesh/TTF** (browser text grid). Introduces a shared **`AcApFontUtil`** wrapper so UI code uses the same font pipeline as rendering, and replaces the ribbon font combo with a **filterable custom font control**.

## User-facing changes

- **Character Map** (`MlCharacterMapDialog.vue`): font selector, virtualized-style scroll grid, magnifier (SHX SVG / mesh text), “characters to copy” buffer, select/copy, and insert on confirm.
- **Ribbon → Symbol → “Other”** opens the character map; insert applies the chosen font and text via `handleCharacterMapInsert`.
- **Font picker** on the MTEXT contextual tab is now a **custom ribbon item** (`MlRibbonFontSelect.vue`) with search/filter instead of a plain combo mapping to command IDs.
- **Text style gallery**: de-duplicates style names by trimmed string and sets `inlineItemWidthMode: 'auto'` for the gallery control.
- **i18n**: English and Chinese strings for the character map UI.

## Technical notes

- New **`AcApFontUtil`** in `cad-simple-viewer` wraps `FontManager` / `ShxParserFont` and drawing font catalog (`AcApDocManager`) for load, SHX code points, and catalog font type; **`cad-simple-viewer` now exports `./util`** and declares **`@mlightcad/mtext-renderer`** as a **peerDependency** so consumers align with the renderer version.
- Character map uses **`expandTtfCharacterMapCodepoints`** (`charMapTtfCodepoints.ts`) for a fixed Unicode superset on mesh fonts; SHX grids use glyph indices from loaded SHX data.
- Font changes and text-style application call **`ensureDrawingFontLoaded`** so glyphs exist before the inline editor updates; symbol/bullet insertion paths use **`mtextRibbonInsertPayloadToString`** for consistent encoding.
- **`MlRibbonCommands.vue`** wires the dialog with `v-model`, font options, initial font, and `@insert`.

## Dependencies

- Bump **`@mlightcad/mtext-renderer`** to `^0.10.11` (root override, `cad-simple-viewer`, `three-renderer` peer).
- Bump **`@mlightcad/mtext-input-box`** to `^0.2.7` (`cad-simple-viewer` dev).
- Bump **`@mlightcad/ribbon`** to `0.1.5` (`cad-viewer` dev).
- `pnpm-lock.yaml` updated accordingly.

## Other

- Minor formatting-only edits in `AcEdMTextEditor.ts` and `AcTrFillMaterialManager.ts` (line breaks / readability).

## How to test

1. Start MTEXT edit, open the contextual ribbon **Symbol** menu and choose **Other** — Character Map should open with the current font pre-selected when possible.
2. Pick **SHX** vs **TTF/mesh** fonts: grid should show SHX indices with SVG cells vs Unicode grid with styled text; magnifier and double-click insert behave sensibly.
3. Use **Select** / **Copy** / OK insert with the copy buffer; confirm text and font in the editor match expectations.
4. Change **font** and **text style** from the ribbon; confirm no duplicate entries in the text style gallery and that switching fonts does not leave missing glyphs where fonts are loadable.