### PR TITLE
Fix CJK MTEXT rendering with tiny wrap width

### DIFF
--- a/.changeset/dull-results-sip.md
+++ b/.changeset/dull-results-sip.md
@@ -1,0 +1,5 @@
+---
+'@mlightcad/three-renderer': patch
+---
+
+Fix MTEXT rendering when tiny wrap widths force CJK text to wrap one character per line.

--- a/packages/three-renderer/__tests__/AcTrMText.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMText.spec.ts
@@ -1,4 +1,5 @@
 import type { MTextObject } from '@mlightcad/mtext-renderer'
+import type { AcGiMTextData } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
 jest.mock('../src/renderer', () => ({
@@ -10,14 +11,11 @@ jest.mock('../src/renderer', () => ({
 import { AcTrMText } from '../src/object/AcTrMText'
 
 type GeometryHost = THREE.Object3D & {
-  _text?: {
-    position?: THREE.Vector3Like
-    attachmentPoint?: number
-    height?: number
-  }
+  _text?: Partial<AcGiMTextData>
   box: THREE.Box3
   computeGeometryBox: () => THREE.Box3
   hasGeometry: (object: THREE.Object3D) => boolean
+  normalizeMTextData: () => AcGiMTextData
   normalizeTopAlignedMText: (mtext: MTextObject) => void
 }
 
@@ -30,6 +28,7 @@ const privateMethods = AcTrMText.prototype as unknown as {
   computeGeometryBox(this: GeometryHost): THREE.Box3
   updateSelectionBox(this: GeometryHost, mtext: MTextObject): void
   hasGeometry(object: THREE.Object3D): boolean
+  normalizeMTextData(this: GeometryHost): AcGiMTextData
   normalizeTopAlignedMText(this: GeometryHost, mtext: MTextObject): void
   raycast(
     this: RaycastHost,
@@ -192,6 +191,35 @@ describe('AcTrMText selection geometry', () => {
 
     expect(intersects).toHaveLength(0)
   })
+
+  it('expands an impossible positive mtext wrap width before rendering', () => {
+    const host = createGeometryHost()
+    host._text = {
+      text: '设计依据\\P建筑机电工程抗震设计规范',
+      height: 100,
+      width: 0.5
+    }
+
+    const normalized = privateMethods.normalizeMTextData.call(host)
+
+    expect(normalized).not.toBe(host._text)
+    expect(normalized.width).toBe(960)
+    expect(host._text.width).toBe(0.5)
+  })
+
+  it('keeps a plausible mtext wrap width unchanged', () => {
+    const host = createGeometryHost()
+    host._text = {
+      text: '设计依据',
+      height: 100,
+      width: 300
+    }
+
+    const normalized = privateMethods.normalizeMTextData.call(host)
+
+    expect(normalized).toBe(host._text)
+    expect(normalized.width).toBe(300)
+  })
 })
 
 function createGeometryHost(): GeometryHost {
@@ -199,6 +227,7 @@ function createGeometryHost(): GeometryHost {
   host.box = new THREE.Box3()
   host.computeGeometryBox = privateMethods.computeGeometryBox
   host.hasGeometry = privateMethods.hasGeometry
+  host.normalizeMTextData = privateMethods.normalizeMTextData
   host.normalizeTopAlignedMText = privateMethods.normalizeTopAlignedMText
   return host
 }

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -24,8 +24,22 @@ const _raycastBox = /*@__PURE__*/ new THREE.Box3()
 const _raycastPoint = /*@__PURE__*/ new THREE.Vector3()
 const _topAlignmentTranslation = /*@__PURE__*/ new THREE.Vector3()
 const MTEXT_INPUT_BOX_LINE_ADVANCE_RATIO = 1.5
+const MIN_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO = 1.5
+const CJK_MTEXT_CHAR_WIDTH_HEIGHT_RATIO = 0.8
 
 const TOP_ATTACHMENT_POINTS = new Set([undefined, 1, 2, 3])
+
+function estimateMTextWidth(text: string, height: number) {
+  const maxLineLength = Math.max(
+    1,
+    ...String(text ?? '')
+      .replace(/\\P/g, '\n')
+      .replace(/[{}]/g, '')
+      .split(/\r?\n/)
+      .map(line => line.length)
+  )
+  return maxLineLength * height * CJK_MTEXT_CHAR_WIDTH_HEIGHT_RATIO
+}
 
 export class AcTrMText extends AcTrEntity {
   private _mtext?: MTextObject
@@ -60,7 +74,7 @@ export class AcTrMText extends AcTrEntity {
 
     try {
       const style = this._style
-      const mtextData = this._text as MTextData
+      const mtextData = this.normalizeMTextData()
 
       this._mtext = mtextRenderer.syncRenderMText(
         mtextData,
@@ -82,7 +96,7 @@ export class AcTrMText extends AcTrEntity {
 
     try {
       const style = this._style
-      const mtextData = this._text as MTextData
+      const mtextData = this.normalizeMTextData()
 
       const mtext = await mtextRenderer.asyncRenderMText(
         mtextData,
@@ -96,6 +110,37 @@ export class AcTrMText extends AcTrEntity {
         `Failed to render mtext '${this._text.text}' with the following error:\n`,
         error
       )
+    }
+  }
+
+  /**
+   * Normalizes MTEXT data before handing it to the shared MTEXT renderer.
+   *
+   * Some CAD files contain MTEXT group-code 41 values that are smaller than a
+   * single glyph height, usually because the value came from a text width
+   * factor instead of an actual wrapping box width. Treating that tiny positive
+   * value as the word-wrap width forces CJK text to wrap one character per line.
+   * When the width is clearly impossible as a layout width, estimate a usable
+   * width from the longest explicit MTEXT line and preserve explicit line
+   * breaks such as \P.
+   */
+  private normalizeMTextData(): MTextData {
+    const mtextData = this._text as MTextData
+    const width = mtextData.width
+    const height = mtextData.height
+    if (
+      !Number.isFinite(width) ||
+      !Number.isFinite(height) ||
+      width <= 0 ||
+      height <= 0 ||
+      width >= height * MIN_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO
+    ) {
+      return mtextData
+    }
+
+    return {
+      ...mtextData,
+      width: estimateMTextWidth(mtextData.text, height)
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes MTEXT rendering when a DXF contains a positive wrap width that is smaller than the text height.

In this case, the MTEXT renderer treats the tiny value as the word-wrap width, which forces CJK text to wrap one character per line. This patch detects clearly impossible MTEXT widths and estimates a usable width from the longest explicit MTEXT line while preserving explicit line breaks such as `\P`.

## Test

```bash
corepack pnpm test -- packages/three-renderer/__tests__/AcTrMText.spec.ts
