### PR TITLE
feat: persist attachment point and switch to on-demand Element Plus imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "overrides": {
       "@mlightcad/data-model": "^1.7.34",
       "@mlightcad/libredwg-converter": "^3.5.34",
-      "@mlightcad/mtext-renderer": "^0.10.13",
+      "@mlightcad/mtext-input-box": "^0.2.10",
+      "@mlightcad/mtext-renderer": "^0.10.14",
+      "@mlightcad/ribbon": "^0.1.8",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",
       "vue": "^3.4.21",

--- a/packages/cad-simple-viewer/__tests__/AcApMTextCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMTextCmd.spec.ts
@@ -93,7 +93,9 @@ describe('AcApMTextCmd', () => {
       contents: 'Hello',
       location: { x: 10, y: 70, z: 0 },
       width: 100,
-      height: 24
+      height: 24,
+      lineSpacingFactor: 0.25,
+      attachmentPoint: 1
     })
 
     await new AcApMTextCmd().execute(context as never)

--- a/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
@@ -14,6 +14,8 @@ class MockMTextInputBox {
   readonly setToolbarTheme = jest.fn()
   readonly getText = jest.fn(() => 'typed text')
   readonly getMTextInsertionPoint = jest.fn(() => ({ x: 1, y: 2, z: 3 }))
+  readonly getMTextAttachmentPoint = jest.fn(() => 1)
+  readonly getLineSpacingFactor = jest.fn(() => 0.3)
   readonly setCurrentFormat = jest.fn()
   readonly refreshCurrentFormatFromDocument = jest.fn()
   readonly toggleCase = jest.fn()
@@ -72,12 +74,16 @@ jest.mock(
 )
 
 jest.mock('@mlightcad/mtext-renderer', () => ({
-  MTextColor: class MTextColor {}
+  MTextColor: class MTextColor {},
+  MTextAttachmentPoint: { TopLeft: 1 }
 }))
 
 jest.mock('@mlightcad/data-model', () => ({
   AcDbSystemVariables: {
     COLORTHEME: 'COLORTHEME'
+  },
+  AcGiMTextAttachmentPoint: {
+    TopLeft: 1
   },
   AcDbSysVarManager: {
     instance: jest.fn(() => ({
@@ -200,7 +206,8 @@ describe('AcEdMTextEditor', () => {
       location: { x: 1, y: 2, z: 3 },
       width: 10,
       height: 2,
-      lineSpacingFactor: 0.3
+      lineSpacingFactor: 0.3,
+      attachmentPoint: 1
     })
     expect(inputBox.dispose).toHaveBeenCalled()
     expect(toolbar.container.remove).toHaveBeenCalled()

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -41,8 +41,8 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
-    "@mlightcad/mtext-input-box": "^0.2.8",
-    "@mlightcad/mtext-renderer": "^0.10.13",
+    "@mlightcad/mtext-input-box": "^0.2.10",
+    "@mlightcad/mtext-renderer": "^0.10.14",
     "@mlightcad/svg-renderer": "workspace:*",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "@mlightcad/data-model": "^1.7.34",
-    "@mlightcad/mtext-renderer": "^0.10.13",
+    "@mlightcad/mtext-renderer": "^0.10.14",
     "three": "^0.172.0",
     "lodash-es": "4.17.21"
   }

--- a/packages/cad-simple-viewer/src/command/draw/AcApMTextCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApMTextCmd.ts
@@ -63,6 +63,7 @@ export class AcApMTextCmd extends AcEdCommand {
     mtext.width = result.width
     mtext.height = result.height
     mtext.lineSpacingFactor = result.lineSpacingFactor
+    mtext.attachmentPoint = result.attachmentPoint
 
     context.doc.database.tables.blockTable.modelSpace.appendEntity(mtext)
   }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
@@ -1,18 +1,34 @@
 import {
   AcDbSystemVariables,
   AcDbSysVarManager,
-  AcGePoint3dLike
+  AcGePoint3dLike,
+  AcGiMTextAttachmentPoint
 } from '@mlightcad/data-model'
 import {
   MTextInputBox,
   type MTextToolbarColorPickerFactory,
   type MTextToolbarTheme
 } from '@mlightcad/mtext-input-box'
-import { MTextColor } from '@mlightcad/mtext-renderer'
+import { MTextAttachmentPoint, MTextColor } from '@mlightcad/mtext-renderer'
 import * as THREE from 'three'
 
 import { AcApDocManager } from '../../../app'
 import { AcTrView2d } from '../../../view'
+
+function acGiAttachmentToMText(
+  ap: AcGiMTextAttachmentPoint | undefined
+): MTextAttachmentPoint | undefined {
+  if (ap === undefined) return undefined
+  const v = ap as number
+  if (v >= 1 && v <= 12) return v as MTextAttachmentPoint
+  return MTextAttachmentPoint.TopLeft
+}
+
+function mTextAttachmentToAcGi(
+  ap: MTextAttachmentPoint
+): AcGiMTextAttachmentPoint {
+  return ap as unknown as AcGiMTextAttachmentPoint
+}
 
 export type AcEdMTextEditorCurrentFormatChangeListener = () => void
 export interface AcEdMTextEditorCurrentFormatObservable {
@@ -85,6 +101,8 @@ export interface AcEdMTextEditorResult {
   height: number
   /** Line spacing factor used by the MTEXT input box renderer. */
   lineSpacingFactor: number
+  /** MTEXT attachment (DXF group 71) matching the editor justify control. */
+  attachmentPoint: AcGiMTextAttachmentPoint
 }
 
 /**
@@ -95,6 +113,11 @@ export interface AcEdMTextEditorOptions {
   view: AcTrView2d
   /** Insertion location (top-left anchor) in world coordinates. */
   location: AcGePoint3dLike
+  /**
+   * Initial MTEXT attachment (DXF 71). When omitted, the editor uses top-left
+   * until the user changes justify in the ribbon.
+   */
+  initialAttachmentPoint?: AcGiMTextAttachmentPoint
   /** Initial MTEXT box width in world units. */
   width: number
   /** Default text height in world units. */
@@ -370,7 +393,8 @@ export class AcEdMTextEditor {
       initialText = '',
       toolbarFontFamilies = [],
       toolbarColorPicker,
-      toolbarEnabled = AcEdMTextEditor.defaultToolbarEnabled
+      toolbarEnabled = AcEdMTextEditor.defaultToolbarEnabled,
+      initialAttachmentPoint
     } = options
     const origin = new THREE.Vector3(location.x, location.y, location.z ?? 0)
     const isLightBackground = view.backgroundColor === 0xffffff
@@ -421,12 +445,17 @@ export class AcEdMTextEditor {
       ? null
       : AcEdMTextEditor.createHiddenToolbarContainer(view.container)
 
+    const mtextAttachment = acGiAttachmentToMText(initialAttachmentPoint)
+
     const mtextInputBox = new MTextInputBox({
       scene: view.internalScene,
       camera: view.internalCamera,
       width,
       position: origin.clone(),
       initialText,
+      ...(mtextAttachment !== undefined
+        ? { initialAttachmentPoint: mtextAttachment }
+        : {}),
       textStyle: defaultTextStyle,
       cursorStyle: {
         color: cursorColor,
@@ -510,7 +539,10 @@ export class AcEdMTextEditor {
           height: normalizedTextHeight,
           lineSpacingFactor:
             mtextInputBox.getLineSpacingFactor?.() ??
-            AcEdMTextEditor.defaultLineSpacingFactor
+            AcEdMTextEditor.defaultLineSpacingFactor,
+          attachmentPoint: mTextAttachmentToAcGi(
+            mtextInputBox.getMTextAttachmentPoint()
+          )
         })
       }
 

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -680,6 +680,7 @@ export class AcTrView2d extends AcEdBaseView {
       width: this.resolveMTextEditorWidth(mtext),
       textHeight: this.resolveMTextEditorTextHeight(mtext),
       initialText: mtext.contents,
+      initialAttachmentPoint: mtext.attachmentPoint,
       toolbarFontFamilies: this.getMTextToolbarFontFamilies()
     })
     if (!result) return
@@ -689,6 +690,7 @@ export class AcTrView2d extends AcEdBaseView {
     mtext.width = result.width
     mtext.height = result.height
     mtext.lineSpacingFactor = result.lineSpacingFactor
+    mtext.attachmentPoint = result.attachmentPoint
     mtext.triggerModifiedEvent()
   }
 

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -47,6 +47,7 @@ import { UploadFilled } from '@element-plus/icons-vue'
 import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
 import { log } from '@mlightcad/data-model'
 import type { UploadFile, UploadProps } from 'element-plus'
+import { ElIcon, ElRadio, ElRadioGroup, ElUpload } from 'element-plus'
 import { ref } from 'vue'
 
 interface Props {

--- a/packages/cad-viewer-example/src/main.ts
+++ b/packages/cad-viewer-example/src/main.ts
@@ -1,8 +1,6 @@
 import 'element-plus/dist/index.css'
-import 'element-plus/dist/index.css'
 
 import { i18n } from '@mlightcad/cad-viewer'
-import ElementPlus from 'element-plus'
 import { createApp } from 'vue'
 
 import App from './App.vue'
@@ -10,9 +8,7 @@ import App from './App.vue'
 const initApp = () => {
   const app = createApp(App)
   app.use(i18n)
-  app.use(ElementPlus)
   app.mount('#app')
-
   // Hide the loading spinner
   const loader = document.getElementById('loader')
   if (loader) {

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -43,7 +43,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
-    "@mlightcad/ribbon": "0.1.7",
+    "@mlightcad/ribbon": "^0.1.8",
     "@mlightcad/svg-renderer": "workspace:*",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -89,7 +89,7 @@ import {
   eventBus
 } from '@mlightcad/cad-simple-viewer'
 import { log } from '@mlightcad/data-model'
-import { ElMessage } from 'element-plus'
+import { ElConfigProvider, ElMessage } from 'element-plus'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/common/MlBaseDialog.vue
+++ b/packages/cad-viewer/src/component/common/MlBaseDialog.vue
@@ -45,6 +45,7 @@
 
 <script setup lang="ts">
 import { Close } from '@element-plus/icons-vue'
+import { ElButton, ElConfigProvider, ElIcon } from 'element-plus'
 import { type Component, computed, nextTick, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/common/MlColorDropdown.vue
+++ b/packages/cad-viewer/src/component/common/MlColorDropdown.vue
@@ -73,6 +73,7 @@
 
 <script setup lang="ts">
 import { AcCmColor, AcCmColorMethod } from '@mlightcad/data-model'
+import { ElOption, ElSelect } from 'element-plus'
 import { type Component, computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/common/MlLayerSelect.vue
+++ b/packages/cad-viewer/src/component/common/MlLayerSelect.vue
@@ -189,7 +189,7 @@
 
 <script setup lang="ts">
 import { Search } from '@element-plus/icons-vue'
-import { ElInput } from 'element-plus'
+import { ElIcon, ElInput, ElOption, ElSelect } from 'element-plus'
 import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/common/MlLineTypeSelect.vue
+++ b/packages/cad-viewer/src/component/common/MlLineTypeSelect.vue
@@ -62,6 +62,7 @@
 
 <script setup lang="ts">
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { ElOption, ElSelect } from 'element-plus'
 import {
   type Component,
   computed,

--- a/packages/cad-viewer/src/component/common/MlLineWeightSelect.vue
+++ b/packages/cad-viewer/src/component/common/MlLineWeightSelect.vue
@@ -50,6 +50,12 @@
 <script setup lang="ts">
 import { ArrowDown } from '@element-plus/icons-vue'
 import { AcGiLineWeight } from '@mlightcad/data-model'
+import {
+  ElDropdown,
+  ElDropdownItem,
+  ElDropdownMenu,
+  ElIcon
+} from 'element-plus'
 import { computed } from 'vue'
 
 /**

--- a/packages/cad-viewer/src/component/common/MlToggleButton.vue
+++ b/packages/cad-viewer/src/component/common/MlToggleButton.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script lang="ts" setup>
+import { ElButton, ElTooltip } from 'element-plus'
 import { Component, computed, DefineComponent } from 'vue'
 
 export type MlIconType = (() => DefineComponent) | Component

--- a/packages/cad-viewer/src/component/dialog/MlCharacterMapDialog.vue
+++ b/packages/cad-viewer/src/component/dialog/MlCharacterMapDialog.vue
@@ -112,7 +112,7 @@
  */
 import { AcApFontUtil, type ShxParserFont } from '@mlightcad/cad-simple-viewer'
 import { useEventListener } from '@vueuse/core'
-import { ElMessage } from 'element-plus'
+import { ElButton, ElInput, ElMessage } from 'element-plus'
 import { computed, nextTick, onUnmounted, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/dialog/MlPointStyleDlg.vue
+++ b/packages/cad-viewer/src/component/dialog/MlPointStyleDlg.vue
@@ -28,6 +28,7 @@
 
 <script lang="ts" setup>
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { ElButton, ElCol, ElRow } from 'element-plus'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -98,10 +99,9 @@ reset()
 
 const buttonType = (rowIndex: number, colIndex: number) => {
   if (icons[rowIndex][colIndex].id == currentPointStyleIndex.value) {
-    return 'primary'
-  } else {
-    return null
+    return 'primary' as const
   }
+  return undefined
 }
 
 const handleSelectPointStyle = (rowIndex: number, colIndex: number) => {

--- a/packages/cad-viewer/src/component/dialog/MlQuickSelectDlg.vue
+++ b/packages/cad-viewer/src/component/dialog/MlQuickSelectDlg.vue
@@ -98,7 +98,7 @@
 
 <script setup lang="ts">
 import { AcDbEntity } from '@mlightcad/data-model'
-import { ElMessage } from 'element-plus'
+import { ElForm, ElFormItem, ElMessage, ElOption, ElSelect } from 'element-plus'
 import { computed, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/dialog/MlReplacementDlg.vue
+++ b/packages/cad-viewer/src/component/dialog/MlReplacementDlg.vue
@@ -101,6 +101,17 @@ import {
   AcApSettingManager
 } from '@mlightcad/cad-simple-viewer'
 import { AcDbRasterImage } from '@mlightcad/data-model'
+import {
+  ElButton,
+  ElCol,
+  ElOption,
+  ElRow,
+  ElSelect,
+  ElTable,
+  ElTableColumn,
+  ElTabPane,
+  ElTabs
+} from 'element-plus'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/layout/MlEntityInfo.vue
+++ b/packages/cad-viewer/src/component/layout/MlEntityInfo.vue
@@ -37,6 +37,7 @@
 <script setup lang="ts">
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { AcDbEntity } from '@mlightcad/data-model'
+import { ElCard, ElCol, ElRow, ElText } from 'element-plus'
 import { ComponentPublicInstance, computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/layout/MlMainMenu.vue
+++ b/packages/cad-viewer/src/component/layout/MlMainMenu.vue
@@ -32,6 +32,12 @@ import {
   AcApOpenCmd,
   AcApQNewCmd
 } from '@mlightcad/cad-simple-viewer'
+import {
+  ElDropdown,
+  ElDropdownItem,
+  ElDropdownMenu,
+  ElIcon
+} from 'element-plus'
 import { useI18n } from 'vue-i18n'
 
 import { useSettings } from '../../composable'

--- a/packages/cad-viewer/src/component/notification/MlNotificationCenter.vue
+++ b/packages/cad-viewer/src/component/notification/MlNotificationCenter.vue
@@ -61,19 +61,20 @@
 
 <script setup lang="ts">
 import { Bell, Close, Delete } from '@element-plus/icons-vue'
+import { ElButton, ElIcon, ElTooltip } from 'element-plus'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-
-interface Props {
-  /** Optional custom title for the notification center header */
-  title?: string
-}
 
 import {
   type NotificationAction,
   useNotificationCenter
 } from '../../composable/useNotificationCenter'
 import MlNotificationItem from './MlNotificationItem.vue'
+
+interface Props {
+  /** Optional custom title for the notification center header */
+  title?: string
+}
 
 const { t } = useI18n()
 const props = defineProps<Props>()

--- a/packages/cad-viewer/src/component/notification/MlNotificationItem.vue
+++ b/packages/cad-viewer/src/component/notification/MlNotificationItem.vue
@@ -55,6 +55,7 @@ import {
   SuccessFilled,
   WarningFilled
 } from '@element-plus/icons-vue'
+import { ElButton, ElIcon } from 'element-plus'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/palette/MlEntityProperties.vue
+++ b/packages/cad-viewer/src/component/palette/MlEntityProperties.vue
@@ -172,7 +172,16 @@ import {
   AcGiLineWeight,
   log
 } from '@mlightcad/data-model'
-import { ElMessage } from 'element-plus'
+import {
+  ElInput,
+  ElInputNumber,
+  ElMessage,
+  ElOption,
+  ElSelect,
+  ElSwitch,
+  ElTable,
+  ElTableColumn
+} from 'element-plus'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/palette/MlLayerList.vue
+++ b/packages/cad-viewer/src/component/palette/MlLayerList.vue
@@ -65,7 +65,13 @@
 <script setup lang="ts">
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { AcCmColor } from '@mlightcad/data-model'
-import { ElMessage, ElTable } from 'element-plus'
+import {
+  ElCheckbox,
+  ElMessage,
+  ElTable,
+  ElTableColumn,
+  ElTag
+} from 'element-plus'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/palette/MlPaletteManager.vue
+++ b/packages/cad-viewer/src/component/palette/MlPaletteManager.vue
@@ -27,6 +27,7 @@
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { AcDbEntityProperties } from '@mlightcad/data-model'
 import { MlToolPalette, MlToolPaletteTab } from '@mlightcad/ui-components'
+import { ElConfigProvider } from 'element-plus'
 import { computed, nextTick, watch } from 'vue'
 
 import { store } from '../../app'

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonFontSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonFontSelect.vue
@@ -42,6 +42,7 @@
 </template>
 
 <script setup lang="ts">
+import { ElOption, ElSelect } from 'element-plus'
 import { h } from 'vue'
 
 import MlRibbonPropertyField from './MlRibbonPropertyField.vue'

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonMTextHeightSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonMTextHeightSelect.vue
@@ -25,6 +25,7 @@
 </template>
 
 <script setup lang="ts">
+import { ElOption, ElSelect } from 'element-plus'
 import { computed } from 'vue'
 
 import { mtext as mtextIcon } from '../../svg'

--- a/packages/cad-viewer/src/component/statusBar/MlNotificationButton.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlNotificationButton.vue
@@ -20,6 +20,7 @@
 
 <script setup lang="ts">
 import { Bell } from '@element-plus/icons-vue'
+import { ElBadge, ElButton, ElTooltip } from 'element-plus'
 import { useI18n } from 'vue-i18n'
 
 import { useNotificationCenter } from '../../composable/useNotificationCenter'

--- a/packages/cad-viewer/src/component/statusBar/MlOsnapButton.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlOsnapButton.vue
@@ -30,6 +30,13 @@ import {
   AcDbOsnapMode,
   acdbToggleOsnapMode
 } from '@mlightcad/data-model'
+import {
+  ElButton,
+  ElDropdown,
+  ElDropdownItem,
+  ElDropdownMenu,
+  ElTooltip
+} from 'element-plus'
 import { useI18n } from 'vue-i18n'
 
 import { useSettings } from '../../composable'

--- a/packages/cad-viewer/src/component/statusBar/MlPointStyleButton.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlPointStyleButton.vue
@@ -11,6 +11,7 @@
 <script lang="ts" setup>
 import { Operation } from '@element-plus/icons-vue'
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { ElButton, ElTooltip } from 'element-plus'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()

--- a/packages/cad-viewer/src/component/statusBar/MlSettingButton.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlSettingButton.vue
@@ -61,6 +61,13 @@
 <script lang="ts" setup>
 import { Check, Setting } from '@element-plus/icons-vue'
 import { AcApSettingManager, AcApSettings } from '@mlightcad/cad-simple-viewer'
+import {
+  ElButton,
+  ElDropdown,
+  ElDropdownItem,
+  ElDropdownMenu,
+  ElTooltip
+} from 'element-plus'
 import { useI18n } from 'vue-i18n'
 
 import { useSettings } from '../../composable'

--- a/packages/cad-viewer/src/component/statusBar/MlStatusBar.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlStatusBar.vue
@@ -69,6 +69,7 @@ import {
   AcDbSystemVariables
 } from '@mlightcad/data-model'
 import { MlStatusBar } from '@mlightcad/ui-components'
+import { ElButton, ElButtonGroup } from 'element-plus'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/packages/cad-viewer/src/component/statusBar/MlWarningButton.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlWarningButton.vue
@@ -11,6 +11,7 @@
 <script lang="ts" setup>
 import { Warning } from '@element-plus/icons-vue'
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { ElButton } from 'element-plus'
 import { computed } from 'vue'
 
 import { useMissedData } from '../../composable'

--- a/packages/three-renderer/package.json
+++ b/packages/three-renderer/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@mlightcad/data-model": "^1.7.34",
-    "@mlightcad/mtext-renderer": "^0.10.13",
+    "@mlightcad/mtext-renderer": "^0.10.14",
     "@velipso/polybool": "^1.1.1",
     "three": "^0.172.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,9 @@ settings:
 overrides:
   '@mlightcad/data-model': ^1.7.34
   '@mlightcad/libredwg-converter': ^3.5.34
-  '@mlightcad/mtext-renderer': ^0.10.13
+  '@mlightcad/mtext-input-box': ^0.2.10
+  '@mlightcad/mtext-renderer': ^0.10.14
+  '@mlightcad/ribbon': ^0.1.8
   element-plus: ^2.12.0
   three: ^0.172.0
   vue: ^3.4.21
@@ -124,11 +126,11 @@ importers:
         version: 0.172.0
     devDependencies:
       '@mlightcad/mtext-input-box':
-        specifier: ^0.2.8
-        version: 0.2.8(@mlightcad/mtext-renderer@0.10.13(three@0.172.0))(three@0.172.0)
+        specifier: ^0.2.10
+        version: 0.2.10(@mlightcad/mtext-renderer@0.10.14(three@0.172.0))(three@0.172.0)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.10.13
-        version: 0.10.13(three@0.172.0)
+        specifier: ^0.10.14
+        version: 0.10.14(three@0.172.0)
       '@mlightcad/svg-renderer':
         specifier: workspace:*
         version: link:../svg-renderer
@@ -188,8 +190,8 @@ importers:
         version: 10.0.8(vue@3.5.31(typescript@5.9.3))
     devDependencies:
       '@mlightcad/ribbon':
-        specifier: 0.1.7
-        version: 0.1.7(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+        specifier: ^0.1.8
+        version: 0.1.8(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
       '@mlightcad/svg-renderer':
         specifier: workspace:*
         version: link:../svg-renderer
@@ -303,8 +305,8 @@ importers:
         specifier: ^1.7.34
         version: 1.7.34
       '@mlightcad/mtext-renderer':
-        specifier: ^0.10.13
-        version: 0.10.13(three@0.172.0)
+        specifier: ^0.10.14
+        version: 0.10.14(three@0.172.0)
       '@velipso/polybool':
         specifier: ^1.1.1
         version: 1.1.1
@@ -1402,22 +1404,22 @@ packages:
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
-  '@mlightcad/mtext-input-box@0.2.8':
-    resolution: {integrity: sha512-bbQQWok0YzO6GwdP9HdJuFk4DzohlCx24tAVzAwU8zX6WH9p1FzPQyYw/6MrseR6kF0TZvSCZZWEaLkOmkPtQA==}
+  '@mlightcad/mtext-input-box@0.2.10':
+    resolution: {integrity: sha512-caBM2Pzt5BNuIC/AYRK+Lg+Z0rIVIQsth1dqc7hU3M5ZsjNpYKpWOJq9M/2HC0peJH+q46kWxqv654g3JdQBoA==}
     peerDependencies:
-      '@mlightcad/mtext-renderer': ^0.10.13
+      '@mlightcad/mtext-renderer': ^0.10.14
       three: ^0.172.0
 
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
-  '@mlightcad/mtext-renderer@0.10.13':
-    resolution: {integrity: sha512-zNT3Bivh0IdFisayBze9z9+4xi3FmPx31V1JTf0uTMjS0deb1rBZ6H7Sz7E9gOcGDpcZFnKtD/C9/o8sLKq0wg==}
+  '@mlightcad/mtext-renderer@0.10.14':
+    resolution: {integrity: sha512-Zeo0R6s5mczMf1aWZaw+11gunAkn0EwzylWW/KYmOBmzT8sraDcF757uhObeNiFKP6NIGrT8iYKrxuHIwu1RPA==}
     peerDependencies:
       three: ^0.172.0
 
-  '@mlightcad/ribbon@0.1.7':
-    resolution: {integrity: sha512-hYbuRIMDliWuMYzg/jqKI/63uHfVlSFypGUgJTQJgX3T6f8vX4TLamx0eiruR+LooHlkPEF0mXKa3p8yDrQKtg==}
+  '@mlightcad/ribbon@0.1.8':
+    resolution: {integrity: sha512-IeeVangvmLqzMS2PFjUohf6Xfpz3lG5Q6d/6KijnXCn+UMVmepth6irQ7QObx0WwmzILf/jdmjnW8sG2fwCBAw==}
     peerDependencies:
       '@element-plus/icons-vue': ^2.3.2
       element-plus: ^2.12.0
@@ -6189,15 +6191,15 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.1': {}
 
-  '@mlightcad/mtext-input-box@0.2.8(@mlightcad/mtext-renderer@0.10.13(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/mtext-input-box@0.2.10(@mlightcad/mtext-renderer@0.10.14(three@0.172.0))(three@0.172.0)':
     dependencies:
-      '@mlightcad/mtext-renderer': 0.10.13(three@0.172.0)
+      '@mlightcad/mtext-renderer': 0.10.14(three@0.172.0)
       '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
       three: 0.172.0
 
   '@mlightcad/mtext-parser@1.4.1': {}
 
-  '@mlightcad/mtext-renderer@0.10.13(three@0.172.0)':
+  '@mlightcad/mtext-renderer@0.10.14(three@0.172.0)':
     dependencies:
       '@mlightcad/mtext-parser': 1.4.1
       '@mlightcad/shx-parser': 1.3.2
@@ -6206,7 +6208,7 @@ snapshots:
       opentype.js: 1.3.4
       three: 0.172.0
 
-  '@mlightcad/ribbon@0.1.7(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
+  '@mlightcad/ribbon@0.1.8(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@element-plus/icons-vue': 2.3.2(vue@3.5.31(typescript@5.9.3))
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))


### PR DESCRIPTION
## Summary

This PR improves MTEXT editing by persisting the attachment point (DXF group 71) through the full create/edit lifecycle, and modernizes Element Plus usage across the viewer UI for better tree-shaking and smaller bundles.

- **MTEXT attachment point support**
  - Wire `attachmentPoint` through `AcEdMTextEditor`, `AcApMTextCmd`, and `AcTrView2d` so justify/alignment chosen in the ribbon is saved on the entity and restored when editing existing MTEXT.
  - Add conversion helpers between `AcGiMTextAttachmentPoint` (data model) and `MTextAttachmentPoint` (mtext-renderer).
  - Pass `initialAttachmentPoint` into `MTextInputBox` when opening the editor for existing text.
  - Update unit tests to cover the new fields and APIs.

- **Element Plus on-demand imports**
  - Remove global `app.use(ElementPlus)` from `cad-viewer-example` (and a duplicate CSS import).
  - Add explicit `element-plus` component imports across `cad-viewer` Vue components (dialogs, palettes, ribbon, status bar, notifications, etc.) so only used components are bundled.
  - Import `ElConfigProvider` where locale/config context is required.

- **Dependency updates**
  - Bump `@mlightcad/mtext-input-box` to `^0.2.10`
  - Bump `@mlightcad/mtext-renderer` to `^0.10.14`
  - Bump `@mlightcad/ribbon` to `^0.1.8`
  - Align root `pnpm` overrides and lockfile.

## Motivation

Previously, MTEXT justify/attachment settings from the editor were not written back to the entity, so alignment could be lost after creation or double-click edit. Separately, registering all of Element Plus globally prevented effective tree-shaking; per-component imports let consumers rely on the library without pulling in the full Element Plus bundle.