### PR TITLE
fix: remove duplicate top-anchor shift for MTEXT

### DIFF
--- a/packages/three-renderer/__tests__/AcTrMText.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMText.spec.ts
@@ -10,15 +10,9 @@ jest.mock('../src/renderer', () => ({
 import { AcTrMText } from '../src/object/AcTrMText'
 
 type GeometryHost = THREE.Object3D & {
-  _text?: {
-    position?: THREE.Vector3Like
-    attachmentPoint?: number
-    height?: number
-  }
   box: THREE.Box3
   computeGeometryBox: () => THREE.Box3
   hasGeometry: (object: THREE.Object3D) => boolean
-  normalizeTopAlignedMText: (mtext: MTextObject) => void
 }
 
 type RaycastHost = THREE.Object3D & {
@@ -30,7 +24,6 @@ const privateMethods = AcTrMText.prototype as unknown as {
   computeGeometryBox(this: GeometryHost): THREE.Box3
   updateSelectionBox(this: GeometryHost, mtext: MTextObject): void
   hasGeometry(object: THREE.Object3D): boolean
-  normalizeTopAlignedMText(this: GeometryHost, mtext: MTextObject): void
   raycast(
     this: RaycastHost,
     raycaster: THREE.Raycaster,
@@ -64,52 +57,6 @@ describe('AcTrMText selection geometry', () => {
 
     expect(host.box.min.toArray()).toEqual([10, 18, 0])
     expect(host.box.max.toArray()).toEqual([14, 24, 0])
-  })
-
-  it('normalizes top-attached mtext to the insertion top edge', () => {
-    const host = createGeometryHost()
-    host._text = {
-      position: new THREE.Vector3(10, 20, 0),
-      attachmentPoint: 1,
-      height: 2
-    }
-    const mtext = createMTextObject(
-      new THREE.Box3(
-        new THREE.Vector3(10, 11, 0),
-        new THREE.Vector3(18, 17, 0)
-      ),
-      [{ y: 14, height: 6 }]
-    )
-
-    privateMethods.normalizeTopAlignedMText.call(host, mtext)
-
-    expect(mtext.position.y).toBeCloseTo(3)
-    expect(mtext.box.min.y).toBeCloseTo(14)
-    expect(mtext.box.max.y).toBeCloseTo(20)
-    expect(mtext.createLayoutData().lines[0].y).toBeCloseTo(17)
-  })
-
-  it('uses the input box minimum line advance when normalizing top-attached mtext', () => {
-    const host = createGeometryHost()
-    host._text = {
-      position: new THREE.Vector3(10, 20, 0),
-      attachmentPoint: 1,
-      height: 6
-    }
-    const mtext = createMTextObject(
-      new THREE.Box3(
-        new THREE.Vector3(10, 11, 0),
-        new THREE.Vector3(18, 17, 0)
-      ),
-      [{ y: 14, height: 6 }]
-    )
-
-    privateMethods.normalizeTopAlignedMText.call(host, mtext)
-
-    expect(mtext.position.y).toBeCloseTo(0)
-    expect(mtext.box.min.y).toBeCloseTo(11)
-    expect(mtext.box.max.y).toBeCloseTo(17)
-    expect(mtext.createLayoutData().lines[0].y).toBeCloseTo(14)
   })
 
   it('ignores a disjoint renderer-provided mtext box', () => {
@@ -199,7 +146,6 @@ function createGeometryHost(): GeometryHost {
   host.box = new THREE.Box3()
   host.computeGeometryBox = privateMethods.computeGeometryBox
   host.hasGeometry = privateMethods.hasGeometry
-  host.normalizeTopAlignedMText = privateMethods.normalizeTopAlignedMText
   return host
 }
 

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -5,7 +5,6 @@ import {
   log
 } from '@mlightcad/data-model'
 import {
-  type CharBox,
   ColorSettings,
   MTextData,
   MTextObject
@@ -22,10 +21,6 @@ import { AcTrEntity } from './AcTrEntity'
 // path avoids needless garbage collection pressure.
 const _raycastBox = /*@__PURE__*/ new THREE.Box3()
 const _raycastPoint = /*@__PURE__*/ new THREE.Vector3()
-const _topAlignmentTranslation = /*@__PURE__*/ new THREE.Vector3()
-const MTEXT_INPUT_BOX_LINE_ADVANCE_RATIO = 1.5
-
-const TOP_ATTACHMENT_POINTS = new Set([undefined, 1, 2, 3])
 
 export class AcTrMText extends AcTrEntity {
   private _mtext?: MTextObject
@@ -155,7 +150,6 @@ export class AcTrMText extends AcTrEntity {
    * @param mtext Rendered MTEXT object returned by the shared MTEXT renderer.
    */
   private attachMText(mtext: MTextObject) {
-    this.normalizeTopAlignedMText(mtext)
     this.add(mtext)
     this.flatten()
     this.traverse(object => {
@@ -165,63 +159,6 @@ export class AcTrMText extends AcTrEntity {
       object.userData.bboxIntersectionCheck = true
     })
     this.updateSelectionBox(mtext)
-  }
-
-  /**
-   * Matches the MTEXT input box's top-edge anchoring for top-attached text.
-   *
-   * The shared MTEXT renderer places glyph geometry from typographic metrics,
-   * while the editor normalizes the rendered layout so the logical top of the
-   * first line sits at the insertion point. Without applying the same
-   * normalization here, text created through the input box jumps upward when the
-   * editor closes and the persisted MTEXT entity is rendered normally.
-   *
-   * @param mtext Rendered MTEXT object to normalize before flattening.
-   */
-  private normalizeTopAlignedMText(mtext: MTextObject) {
-    const mtextData = this._text as MTextData
-    if (!TOP_ATTACHMENT_POINTS.has(mtextData.attachmentPoint)) return
-
-    const position = mtextData.position
-    if (!position) return
-
-    const layout = mtext.createLayoutData()
-    let bottomY = mtext.box.min.y
-    let topY = mtext.box.max.y
-
-    layout.lines.forEach(line => {
-      if (!Number.isFinite(line.y) || !Number.isFinite(line.height)) return
-      bottomY = Math.min(bottomY, line.y - line.height / 2)
-      topY = Math.max(topY, line.y + line.height / 2)
-    })
-
-    const textHeight = Number.isFinite(mtextData.height) ? mtextData.height : 0
-    const fallbackLineAdvance = Math.max(
-      1,
-      textHeight * MTEXT_INPUT_BOX_LINE_ADVANCE_RATIO
-    )
-    topY = bottomY + Math.max(topY - bottomY, fallbackLineAdvance)
-
-    const dy = position.y - topY
-    if (!Number.isFinite(dy) || Math.abs(dy) < 1e-8) return
-
-    _topAlignmentTranslation.set(0, dy, 0)
-    mtext.position.y += dy
-    mtext.box.translate(_topAlignmentTranslation)
-    layout.lines.forEach(line => {
-      line.y += dy
-    })
-    layout.chars.forEach(char => {
-      this.translateCharBox(char, _topAlignmentTranslation)
-    })
-    mtext.updateMatrixWorld(true)
-  }
-
-  private translateCharBox(char: CharBox, translation: THREE.Vector3) {
-    char.box?.translate(translation)
-    char.children?.forEach(child => {
-      this.translateCharBox(child, translation)
-    })
   }
 
   /**


### PR DESCRIPTION
## Summary

- Removes the extra `normalizeTopAlignedMText()` step from `AcTrMText` so MTEXT is positioned only by `@mlightcad/mtext-renderer` attachment logic.
- Drops the two unit tests that asserted that normalization behavior; keeps selection-box and raycast coverage unchanged.

## Problem

After MTEXT editing work landed, some MTEXT in existing DXF/DWG drawings (especially top-aligned values like title-block fields) rendered **too low**, overlapping labels. That came from applying a second vertical adjustment on top of the renderer’s existing anchor handling (`TopLeft` / `TopCenter` / `TopRight` and `undefined` attachment).

## Root cause

`normalizeTopAlignedMText()` was meant to match the MTEXT input box’s top-edge anchoring for editor-created text, but it ran for **all** top-attached MTEXT. The renderer already aligns the logical frame to the insertion point via `calculateAnchorPoint()`. The extra shift used a minimum line advance (`height * 1.5`), which could force `topY` lower than the real layout and push glyphs downward.

## Fix

Remove the global normalization from `attachMText()` and delete the dead code path so DXF MTEXT matches the renderer again.