### PR TITLE
feat: format measurements and UI numbers with drawing units (LUNITS/AUNITS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
       "vue-demi"
     ],
     "overrides": {
-      "@mlightcad/data-model": "^1.7.35",
-      "@mlightcad/libredwg-converter": "^3.5.35",
+      "@mlightcad/data-model": "^1.7.36",
+      "@mlightcad/libredwg-converter": "^3.5.36",
       "@mlightcad/mtext-input-box": "^0.2.11",
       "@mlightcad/mtext-renderer": "^0.10.14",
       "@mlightcad/ribbon": "^0.1.9",

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
@@ -1,5 +1,6 @@
 import {
   AcCmColor,
+  AcDbDatabase,
   AcDbLine,
   AcGePoint3dLike,
   AcGiLineWeight
@@ -188,9 +189,11 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
   private _badge: HTMLDivElement
   private _canvas: HTMLCanvasElement
   private _color: AcCmColor
+  private _db: AcDbDatabase
 
   constructor(
     view: AcEdBaseView,
+    db: AcDbDatabase,
     vertex: AcGePoint3dLike,
     arm1: AcGePoint3dLike,
     canvas: HTMLCanvasElement,
@@ -202,6 +205,7 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._view = view
     this._canvas = canvas
     this._color = color
+    this._db = db
     this._line = new AcDbLine(vertex, vertex)
     this._line.color = color
     this._line.lineWeight = AcGiLineWeight.LineWeight070
@@ -226,7 +230,14 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
     )
 
     const deg = calcAngleDeg(this._vertex, this._arm1, p)
-    this._badge.textContent = `~ ${deg.toFixed(2)}\u00B0`
+    this._badge.textContent = this._db.formatter.formatAngle(
+      (deg * Math.PI) / 180,
+      {
+        showUnits: true,
+        showApproximate: true,
+        applyAngbaseAngdir: false
+      }
+    )
     this._badge.style.display = 'block'
 
     const rect = this._view.canvas.getBoundingClientRect()
@@ -257,7 +268,8 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
 
   async execute(context: AcApContext) {
     const editor = context.view.editor
-    const color = measurementColor(context.doc.database)
+    const db = context.doc.database
+    const color = measurementColor(db)
 
     await context.view.withMode(AcEdViewMode.SELECTION, () =>
       editor.withCursor(AcEdCorsorType.Crosshair, async () => {
@@ -293,6 +305,7 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
         )
         arm2Prompt.jig = new AcApMeasureAngleJig(
           context.view,
+          db,
           vertex,
           arm1,
           armCanvas,
@@ -401,7 +414,13 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
         }
         htManager.add(
           `${id}-badge`,
-          makeBadge(color, `${degrees.toFixed(2)}\u00B0`),
+          makeBadge(
+            color,
+            db.formatter.formatAngle((degrees * Math.PI) / 180, {
+              showUnits: true,
+              applyAngbaseAngdir: false
+            })
+          ),
           badgeWorld,
           'measurement'
         )

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
@@ -306,7 +306,8 @@ export class AcApMeasureArcCmd extends AcEdCommand {
 
   async execute(context: AcApContext) {
     const editor = context.view.editor
-    const color = measurementColor(context.doc.database)
+    const db = context.doc.database
+    const color = measurementColor(db)
 
     // Construction-phase canvas — removed before this method returns
     const arcCanvas = makeOverlayCanvas(context.view.container)
@@ -371,7 +372,10 @@ export class AcApMeasureArcCmd extends AcEdCommand {
           drawArcOnCanvas(arcCanvas, context.view, geom, start, snapped, color)
 
           const len = shortArcLength(start, snapped, geom)
-          liveBadge.textContent = `~ ${len.toFixed(4)} m`
+          liveBadge.textContent = db.formatter.formatLength(len, {
+            showUnits: true,
+            showApproximate: true
+          })
           liveBadge.style.display = ''
 
           const mid = shortArcMid(start, snapped, geom)
@@ -439,7 +443,13 @@ export class AcApMeasureArcCmd extends AcEdCommand {
         htManager.add(`${id}-dot2`, makeDot(color), end, 'measurement')
         htManager.add(
           `${id}-badge`,
-          makeBadge(color, `~ ${arcLen.toFixed(4)} m`),
+          makeBadge(
+            color,
+            db.formatter.formatLength(arcLen, {
+              showUnits: true,
+              showApproximate: true
+            })
+          ),
           mid,
           'measurement'
         )

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
@@ -169,7 +169,8 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
 
   async execute(context: AcApContext) {
     const editor = context.view.editor
-    const color = measurementColor(context.doc.database)
+    const db = context.doc.database
+    const color = measurementColor(db)
 
     const points: AcGePoint3dLike[] = []
 
@@ -260,7 +261,10 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
               if (points.length < 2) return
               const tempPts = [...points, cursor]
               const area = shoelaceArea(tempPts)
-              liveBadge.textContent = `~ ${area.toFixed(3)} m²`
+              liveBadge.textContent = `${db.formatter.formatLength(area, {
+                showUnits: true,
+                showApproximate: true
+              })}²`
               liveBadge.style.display = ''
               const mid = centroid(tempPts)
               const rect = context.view.canvas.getBoundingClientRect()
@@ -336,7 +340,13 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
 
         htManager.add(
           `${id}-badge`,
-          makeBadge(color, `~ ${area.toFixed(3)} m²`),
+          makeBadge(
+            color,
+            `${db.formatter.formatLength(area, {
+              showUnits: true,
+              showApproximate: true
+            })}²`
+          ),
           mid,
           'measurement'
         )

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
@@ -1,5 +1,6 @@
 import {
   AcCmColor,
+  AcDbDatabase,
   AcDbLine,
   AcGePoint3dLike,
   AcGiLineWeight
@@ -40,12 +41,19 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
   private _line: AcDbLine
   private _p1: AcGePoint3dLike
   private _view: AcEdBaseView
+  private _db: AcDbDatabase
   private _badge: HTMLDivElement
 
-  constructor(view: AcEdBaseView, p1: AcGePoint3dLike, color: AcCmColor) {
+  constructor(
+    view: AcEdBaseView,
+    db: AcDbDatabase,
+    p1: AcGePoint3dLike,
+    color: AcCmColor
+  ) {
     super(view)
     this._p1 = p1
     this._view = view
+    this._db = db
     this._line = new AcDbLine(p1, p1)
     this._line.color = color
     this._line.lineWeight = AcGiLineWeight.LineWeight070
@@ -67,7 +75,10 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
       return
     }
 
-    this._badge.textContent = `~ ${dist.toFixed(3)} m`
+    this._badge.textContent = this._db.formatter.formatLength(dist, {
+      showUnits: true,
+      showApproximate: true
+    })
     this._badge.style.display = 'block'
 
     const mid = { x: (this._p1.x + p2.x) / 2, y: (this._p1.y + p2.y) / 2 }
@@ -99,7 +110,8 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
 
   async execute(context: AcApContext) {
     const editor = context.view.editor
-    const color = measurementColor(context.doc.database)
+    const db = context.doc.database
+    const color = measurementColor(db)
 
     await context.view.withMode(AcEdViewMode.SELECTION, () =>
       editor.withCursor(AcEdCorsorType.Crosshair, async () => {
@@ -114,7 +126,7 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
           AcApI18n.t('jig.measureDistance.secondPoint')
         )
         p2Prompt.useBasePoint = true
-        p2Prompt.jig = new AcApMeasureDistanceJig(context.view, p1, color)
+        p2Prompt.jig = new AcApMeasureDistanceJig(context.view, db, p1, color)
         const p2Result = await editor.getPoint(p2Prompt)
         if (p2Result.status !== AcEdPromptStatus.OK) return
         const p2 = p2Result.value!
@@ -136,7 +148,13 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
         htManager.add(`${id}-dot2`, makeDot(color), p2, 'measurement')
         htManager.add(
           `${id}-badge`,
-          makeBadge(color, `~ ${dist.toFixed(3)} m`),
+          makeBadge(
+            color,
+            db.formatter.formatLength(dist, {
+              showUnits: true,
+              showApproximate: true
+            })
+          ),
           mid,
           'measurement'
         )

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -267,8 +267,7 @@ export class AcEdInputManager {
   }
 
   /**
-   * Format a number for display in input box.
-   * Default: 3 decimal places for points/distance, 2 decimal places for angles.
+   * Format a number for display in dynamic input boxes using the drawing formatter.
    * @param value The numeric value
    * @param type Optional type: 'point' | 'distance' | 'angle'
    */
@@ -276,13 +275,26 @@ export class AcEdInputManager {
     value: number,
     type: 'point' | 'distance' | 'angle'
   ): string {
+    const db = AcApDocManager.instance.curDocument?.database
+    if (!db) {
+      switch (type) {
+        case 'angle':
+          return value.toFixed(2)
+        case 'distance':
+        case 'point':
+        default:
+          return value.toFixed(3)
+      }
+    }
     switch (type) {
       case 'angle':
-        return value.toFixed(2)
+        return db.formatter.formatAngle((value * Math.PI) / 180, {
+          applyAngbaseAngdir: false
+        })
       case 'distance':
       case 'point':
       default:
-        return value.toFixed(3)
+        return db.formatter.formatLength(value)
     }
   }
 

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdRubberBand.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdRubberBand.ts
@@ -1,5 +1,6 @@
 import { AcGePoint2dLike, AcGePoint3d } from '@mlightcad/data-model'
 
+import { AcApDocManager } from '../../../app'
 import { AcEdBaseView } from '../../view'
 
 /**
@@ -262,7 +263,10 @@ export class AcEdRubberBand {
           (targetPoint.y - this.basePoint.y) ** 2
       )
 
-      this.labelEl.textContent = dist.toFixed(3)
+      const db = AcApDocManager.instance.curDocument?.database
+      this.labelEl.textContent = db
+        ? db.formatter.formatLength(dist)
+        : dist.toFixed(3)
       this.labelEl.style.left = `${midX - 20}px`
       this.labelEl.style.top = `${midY}px`
       this.labelEl.style.display = ''
@@ -321,7 +325,6 @@ export class AcEdRubberBand {
       let angleRad = targetAngleRad - baseAngleRadScreen
       while (angleRad <= -Math.PI) angleRad += Math.PI * 2
       while (angleRad > Math.PI) angleRad -= Math.PI * 2
-      const angleDeg = (angleRad * 180) / Math.PI
 
       // mid-angle for placing label (middle of arc)
       const midAngle = baseAngleRadScreen + angleRad / 2
@@ -355,9 +358,14 @@ export class AcEdRubberBand {
       const d = `M ${sx} ${sy} A ${radius} ${radius} 0 ${largeArcFlag} ${sweepFlag} ${ex} ${ey}`
       this.anglePath.setAttribute('d', d)
 
-      // angle label (absolute degrees)
-      const angleValueDeg = Math.abs(angleDeg)
-      const angleText = `${angleValueDeg.toFixed(1)}°`
+      const angleValueRad = Math.abs(angleRad)
+      const db = AcApDocManager.instance.curDocument?.database
+      const angleText = db
+        ? db.formatter.formatAngle(angleValueRad, {
+            showUnits: true,
+            applyAngbaseAngdir: false
+          })
+        : `${((angleValueRad * 180) / Math.PI).toFixed(1)}°`
 
       // midpoint of arc in screen coords
       const midScreenX = centerScreenX + radius * Math.cos(midAngle)

--- a/packages/cad-simple-viewer/src/i18n/en/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/command.ts
@@ -7,8 +7,23 @@ export default {
     '-layer': {
       description: 'Manages layers through command-line options'
     },
+    angbase: {
+      description:
+        'Sets the base angle 0 direction with respect to the current UCS'
+    },
+    angdir: {
+      description:
+        'Sets whether positive angles are measured clockwise or counterclockwise'
+    },
     arc: {
       description: 'Creates an arc'
+    },
+    aunits: {
+      description: 'Sets the display format for angles'
+    },
+    auprec: {
+      description:
+        'Sets the display precision for angles, used together with AUNITS'
     },
     cdxf: {
       description: 'Exports current drawing to DXF'
@@ -20,8 +35,14 @@ export default {
       description:
         'Controls the linetype scale factor for newly created objects'
     },
+    celtype: {
+      description: 'Sets the linetype for newly created objects'
+    },
     celweight: {
       description: 'Sets the default lineweight for newly created objects'
+    },
+    cetranparency: {
+      description: 'Sets the transparency for newly created objects'
     },
     circle: {
       description: 'Creates one circle by center and radius'
@@ -53,21 +74,11 @@ export default {
     dimlinear: {
       description: 'Creates linear dimensions'
     },
-    measurearea: {
-      description:
-        'Calculates the area and perimeter of selected objects or points'
+    dynmode: {
+      description: 'Controls Dynamic Input settings at the cursor'
     },
-    measureangle: {
-      description: 'Measures the angle between two lines or three points'
-    },
-    measurearc: {
-      description: 'Measures the length of an arc segment'
-    },
-    measuredistance: {
-      description: 'Measures the distance and delta values between two points'
-    },
-    measurementcolor: {
-      description: 'Sets the color used for measurement overlays'
+    dynprompt: {
+      description: 'Controls display of prompts in Dynamic Input tooltips'
     },
     ellipse: {
       description:
@@ -121,6 +132,10 @@ export default {
       description:
         'Sets the default transparency for newly created hatches and fills'
     },
+    insunits: {
+      description:
+        'Specifies drawing units for automatic scaling of inserted blocks, images, or xrefs'
+    },
     laycur: {
       description:
         'Changes the layer property of selected objects to the current layer',
@@ -171,8 +186,35 @@ export default {
     log: {
       description: 'Logs debug information in console'
     },
+    lunits: {
+      description: 'Sets the display format for coordinates and distances'
+    },
+    luprec: {
+      description:
+        'Sets the display precision for linear units, used together with LUNITS'
+    },
     lwdisplay: {
       description: 'Controls whether lineweights are displayed in the drawing'
+    },
+    measurearea: {
+      description:
+        'Calculates the area and perimeter of selected objects or points'
+    },
+    measureangle: {
+      description: 'Measures the angle between two lines or three points'
+    },
+    measurearc: {
+      description: 'Measures the length of an arc segment'
+    },
+    measuredistance: {
+      description: 'Measures the distance and delta values between two points'
+    },
+    measurement: {
+      description:
+        'Sets whether the drawing uses English (imperial) or metric units'
+    },
+    measurementcolor: {
+      description: 'Sets the color used for measurement overlays'
     },
     mline: {
       description: 'Creates multiple parallel lines as one multiline object'
@@ -186,6 +228,9 @@ export default {
     },
     open: {
       description: 'Opens an existing drawing file'
+    },
+    osmode: {
+      description: 'Sets running Object Snap modes using a bitcode value'
     },
     pan: {
       description:
@@ -231,12 +276,23 @@ export default {
     select: {
       description: 'Selects entities'
     },
+    shortcutmenu: {
+      description:
+        'Controls the availability of shortcut menus in the drawing area'
+    },
     sketch: {
       description:
         'Creates a sketch line using polyline that tracks mouse movement'
     },
     spline: {
       description: 'Creates a smooth spline curve by specifying control points'
+    },
+    textstyle: {
+      description: 'Sets the name of the current text style'
+    },
+    unitmode: {
+      description:
+        'Controls fractional display of coordinates when LUNITS is Architectural or Fractional'
     },
     whitebkcolor: {
       description: 'Toggles the drawing area background between white and black'

--- a/packages/cad-simple-viewer/src/i18n/zh/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/command.ts
@@ -6,8 +6,20 @@ export default {
     '-layer': {
       description: '通过命令行选项管理图层'
     },
+    angbase: {
+      description: '设置当前 UCS 中 0 度的基准角方向'
+    },
+    angdir: {
+      description: '设置正角度的方向为顺时针或逆时针'
+    },
     arc: {
       description: '创建圆弧'
+    },
+    aunits: {
+      description: '设置角度显示格式'
+    },
+    auprec: {
+      description: '设置角度显示精度（小数位数），与 AUNITS 配合使用'
     },
     cdxf: {
       description: '导出当前图纸为DXF格式'
@@ -18,8 +30,14 @@ export default {
     celtscale: {
       description: '控制新创建对象的线型比例系数'
     },
+    celtype: {
+      description: '设置新创建对象的线型'
+    },
     celweight: {
       description: '设置新创建对象的默认线宽'
+    },
+    cetranparency: {
+      description: '设置新创建对象的透明度'
     },
     circle: {
       description: '使用圆心和半径创建圆'
@@ -49,20 +67,11 @@ export default {
     dimlinear: {
       description: '创建线性尺寸标注'
     },
-    measurearea: {
-      description: '计算所选对象或点定义区域的面积和周长'
+    dynmode: {
+      description: '控制光标处的动态输入设置'
     },
-    measureangle: {
-      description: '测量两条线或三个点之间的夹角'
-    },
-    measurearc: {
-      description: '测量圆弧段的弧长'
-    },
-    measuredistance: {
-      description: '测量两点之间的距离及坐标增量'
-    },
-    measurementcolor: {
-      description: '设置测量标注覆盖图形使用的颜色'
+    dynprompt: {
+      description: '控制动态输入工具提示中提示的显示'
     },
     ellipse: {
       description: '通过轴端点或中心点创建椭圆或椭圆弧'
@@ -106,6 +115,10 @@ export default {
     },
     hptransparency: {
       description: '设置新创建填充和填充区域的默认透明度'
+    },
+    insunits: {
+      description:
+        '指定插入块、图像或外部参照时用于自动缩放的图形单位'
     },
     laycur: {
       description: '将所选对象的图层属性更改为当前图层',
@@ -155,8 +168,32 @@ export default {
     log: {
       description: '在控制台输出调试信息'
     },
+    lunits: {
+      description: '设置坐标和距离的显示格式'
+    },
+    luprec: {
+      description: '设置线性单位的显示精度（小数位数），与 LUNITS 配合使用'
+    },
     lwdisplay: {
       description: '用于控制是否在图纸中显示线宽效果'
+    },
+    measurearea: {
+      description: '计算所选对象或点定义区域的面积和周长'
+    },
+    measureangle: {
+      description: '测量两条线或三个点之间的夹角'
+    },
+    measurearc: {
+      description: '测量圆弧段的弧长'
+    },
+    measuredistance: {
+      description: '测量两点之间的距离及坐标增量'
+    },
+    measurement: {
+      description: '设置图形使用英制或公制单位'
+    },
+    measurementcolor: {
+      description: '设置测量标注覆盖图形使用的颜色'
     },
     mline: {
       description: '创建由多条平行线组成的多线对象'
@@ -170,6 +207,9 @@ export default {
     },
     open: {
       description: '打开图纸'
+    },
+    osmode: {
+      description: '使用位码设置运行中的对象捕捉模式'
     },
     pan: {
       description: '平移视图'
@@ -211,11 +251,21 @@ export default {
     select: {
       description: '选择图元'
     },
+    shortcutmenu: {
+      description: '控制图形区域中快捷菜单的可用性'
+    },
     sketch: {
       description: '使用多段线创建手绘线，跟踪鼠标移动'
     },
     spline: {
       description: '通过指定控制点创建平滑的样条曲线'
+    },
+    textstyle: {
+      description: '设置当前文字样式的名称'
+    },
+    unitmode: {
+      description:
+        '当 LUNITS 为建筑或分数格式时，控制坐标的分数显示格式'
     },
     whitebkcolor: {
       description: '切换绘图区域背景颜色，在白色和黑色背景之间切换'

--- a/packages/cad-viewer/src/composable/useCurrentPos.ts
+++ b/packages/cad-viewer/src/composable/useCurrentPos.ts
@@ -1,44 +1,29 @@
+import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { AcEdBaseView, AcEdMouseEventArgs } from '@mlightcad/cad-simple-viewer'
+import { AcGePoint2d } from '@mlightcad/data-model'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 
-function formatNumberSmart(num: number, locale = 'en-US') {
-  // threshold can be adjusted
-  const ABS = Math.abs(num)
-  if (ABS !== 0 && (ABS < 1e-3 || ABS >= 1e6)) {
-    // use scientific notation
-    const [coefficient, exponent] = num.toExponential(3).split('e')
-    const formattedCoeff = new Intl.NumberFormat(locale, {
-      maximumFractionDigits: 3
-    }).format(Number(coefficient))
-    return `${formattedCoeff}e${exponent}`
-  } else {
-    // normal localized formatting
-    return new Intl.NumberFormat(locale, {
-      maximumFractionDigits: 6
-    }).format(num)
+function formatCoordinatePair(x: number, y: number): string {
+  const db = AcApDocManager.instance.curDocument?.database
+  if (!db) {
+    return `${x.toFixed(3)}, ${y.toFixed(3)}`
   }
+  return db.formatter.formatPoint2d(new AcGePoint2d(x, y))
 }
 
 export function useCurrentPos(view: AcEdBaseView) {
-  // state encapsulated and managed by the composable
   const x = ref(0)
   const y = ref(0)
 
-  // a composable can update its managed state over time.
   function update(event: AcEdMouseEventArgs) {
     x.value = event.x
     y.value = event.y
   }
 
-  // a composable can also hook into its owner component's
-  // lifecycle to setup and teardown side effects.
   onMounted(() => view.events.mouseMove.addEventListener(update))
   onUnmounted(() => view.events.mouseMove.removeEventListener(update))
 
-  const text = computed(() => {
-    return `${formatNumberSmart(x.value)}, ${formatNumberSmart(y.value)}`
-  })
+  const text = computed(() => formatCoordinatePair(x.value, y.value))
 
-  // expose managed state as return value
   return { x, y, text }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.7.35
-  '@mlightcad/libredwg-converter': ^3.5.35
+  '@mlightcad/data-model': ^1.7.36
+  '@mlightcad/libredwg-converter': ^3.5.36
   '@mlightcad/mtext-input-box': ^0.2.11
   '@mlightcad/mtext-renderer': ^0.10.14
   '@mlightcad/ribbon': ^0.1.9
@@ -107,8 +107,8 @@ importers:
   packages/cad-simple-viewer:
     dependencies:
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.35
-        version: 3.5.35(@mlightcad/data-model@1.7.35)
+        specifier: ^3.5.36
+        version: 3.5.36(@mlightcad/data-model@1.7.36)
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
@@ -117,8 +117,8 @@ importers:
         version: 4.0.1
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.35
-        version: 1.7.35
+        specifier: ^1.7.36
+        version: 1.7.36
       '@mlightcad/mtext-input-box':
         specifier: ^0.2.11
         version: 0.2.11(@mlightcad/mtext-renderer@0.10.14(three@0.172.0))(three@0.172.0)
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.35
-        version: 1.7.35
+        specifier: ^1.7.36
+        version: 1.7.36
       three:
         specifier: ^0.172.0
         version: 0.172.0
@@ -175,8 +175,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.35
-        version: 1.7.35
+        specifier: ^1.7.36
+        version: 1.7.36
       '@mlightcad/ribbon':
         specifier: ^0.1.9
         version: 0.1.9(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
@@ -244,8 +244,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.35
-        version: 1.7.35
+        specifier: ^1.7.36
+        version: 1.7.36
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -302,14 +302,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.35
-        version: 1.7.35
+        specifier: ^1.7.36
+        version: 1.7.36
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.35
-        version: 1.7.35
+        specifier: ^1.7.36
+        version: 1.7.36
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.14
         version: 0.10.14(three@0.172.0)
@@ -1382,30 +1382,30 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.4.35':
-    resolution: {integrity: sha512-ScIY4KFbMMC9jvgv0j/dsQf7FoGYv5GskBWWuEzdvwHxEKzLcr+1Iyi7kV0RzZ51bcFnjCWZLN9rHMLL1cXkJg==}
+  '@mlightcad/common@1.4.36':
+    resolution: {integrity: sha512-FplcElR6K2tYD8qWn6iywg70JJIwGRDW/YeAFyaHVLd5AthhIpRVj1cFSdwngfcYmOzOK6HW5pZgeIk0F/1zsQ==}
 
-  '@mlightcad/data-model@1.7.35':
-    resolution: {integrity: sha512-mUWk75LKo0McqucK1PXnmKPJ1WqQbyomQqQYKau5ApxHOW20IcDXiappB/x3VdBgqjYs+B4xu36bpIIOOwL3Zw==}
+  '@mlightcad/data-model@1.7.36':
+    resolution: {integrity: sha512-CJ/C0xbGISSoGea6Fx/+qcGTXr4gLjTO7X9siiM74G9f2VGiTbwQxCAX46Ejc+lDNk4y7YTlMxoce6XNkH7TwQ==}
 
   '@mlightcad/dxf-json@1.2.0':
     resolution: {integrity: sha512-pfKFSMi84wmV1C4EAq4Axq20K1+12tXGI5epggxWZE++NeZBCQM5yuQYKYD/P8oSWz3c2nFHe9KhithAKUSnfQ==}
 
-  '@mlightcad/geometry-engine@3.2.35':
-    resolution: {integrity: sha512-DSqny8nGYAKuqK5Ew0wsKtkqKGR9LUJe3u8pMsYGKE8WR1TE5xIW6oAry/Vw0ZsuFifLv6hzWFcr0XuWgDw7sQ==}
+  '@mlightcad/geometry-engine@3.2.36':
+    resolution: {integrity: sha512-19ckGy7HmujryCnasILxDt8qlstjt3eDGgkQdBcpESb3rmmOiajJ6TqYWdCEew62M/5tGsVsaA3NnpVb5AyJ7A==}
     peerDependencies:
-      '@mlightcad/common': 1.4.35
+      '@mlightcad/common': 1.4.36
 
-  '@mlightcad/graphic-interface@3.3.35':
-    resolution: {integrity: sha512-rx47Yq84R4junNwZgDInhu70+m9YJgCeqYTkzx5ce8cpKkWXrrdEq8nepbrGBeFAff9h5wiTvbY+AXVgB8E/Bg==}
+  '@mlightcad/graphic-interface@3.3.36':
+    resolution: {integrity: sha512-PJidtnR9mTKZlc0bGoB/wf6vGUxcWCVCHrMBzXnPdM3DA53te5+7pM1Kr2T8BO8vjcKzixOnHsZEg5cmAuJdJg==}
     peerDependencies:
-      '@mlightcad/common': 1.4.35
-      '@mlightcad/geometry-engine': 3.2.35
+      '@mlightcad/common': 1.4.36
+      '@mlightcad/geometry-engine': 3.2.36
 
-  '@mlightcad/libredwg-converter@3.5.35':
-    resolution: {integrity: sha512-bwn+M4iSqrs40/eBubqsUBG9g+3++02Q5mQ7hCnvrLZZB5l60cO5zlmiBU1/wp2YCYVIFJJnoaWZawA3TvHkAQ==}
+  '@mlightcad/libredwg-converter@3.5.36':
+    resolution: {integrity: sha512-9zT811YcWCX4t64xm18I/kpG3HVS0fxeLW3/jsCr3CwVuaxRN6SU9wDiXf6Xt48EKPbNFEGZl3akbyUfTFqxHg==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.35
+      '@mlightcad/data-model': ^1.7.36
 
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
@@ -6164,16 +6164,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.4.35':
+  '@mlightcad/common@1.4.36':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.7.35':
+  '@mlightcad/data-model@1.7.36':
     dependencies:
-      '@mlightcad/common': 1.4.35
+      '@mlightcad/common': 1.4.36
       '@mlightcad/dxf-json': 1.2.0
-      '@mlightcad/geometry-engine': 3.2.35(@mlightcad/common@1.4.35)
-      '@mlightcad/graphic-interface': 3.3.35(@mlightcad/common@1.4.35)(@mlightcad/geometry-engine@3.2.35(@mlightcad/common@1.4.35))
+      '@mlightcad/geometry-engine': 3.2.36(@mlightcad/common@1.4.36)
+      '@mlightcad/graphic-interface': 3.3.36(@mlightcad/common@1.4.36)(@mlightcad/geometry-engine@3.2.36(@mlightcad/common@1.4.36))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
@@ -6181,18 +6181,18 @@ snapshots:
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.2.35(@mlightcad/common@1.4.35)':
+  '@mlightcad/geometry-engine@3.2.36(@mlightcad/common@1.4.36)':
     dependencies:
-      '@mlightcad/common': 1.4.35
+      '@mlightcad/common': 1.4.36
 
-  '@mlightcad/graphic-interface@3.3.35(@mlightcad/common@1.4.35)(@mlightcad/geometry-engine@3.2.35(@mlightcad/common@1.4.35))':
+  '@mlightcad/graphic-interface@3.3.36(@mlightcad/common@1.4.36)(@mlightcad/geometry-engine@3.2.36(@mlightcad/common@1.4.36))':
     dependencies:
-      '@mlightcad/common': 1.4.35
-      '@mlightcad/geometry-engine': 3.2.35(@mlightcad/common@1.4.35)
+      '@mlightcad/common': 1.4.36
+      '@mlightcad/geometry-engine': 3.2.36(@mlightcad/common@1.4.36)
 
-  '@mlightcad/libredwg-converter@3.5.35(@mlightcad/data-model@1.7.35)':
+  '@mlightcad/libredwg-converter@3.5.36(@mlightcad/data-model@1.7.36)':
     dependencies:
-      '@mlightcad/data-model': 1.7.35
+      '@mlightcad/data-model': 1.7.36
       '@mlightcad/libredwg-web': 0.7.1
 
   '@mlightcad/libredwg-web@0.7.1': {}


### PR DESCRIPTION
## Summary

Wire measurement tools, dynamic input, rubber-band labels, and the status-bar cursor position to `AcDbDatabase.formatter`, so lengths, angles, areas, and coordinates follow the active drawing’s unit settings (e.g. `LUNITS`, `LUPREC`, `AUNITS`, `AUPREC`) instead of hard-coded metric strings and fixed decimal places.

## Changes

### Measurement commands (`cad-simple-viewer`)
- **Distance / arc / area / angle**: Live preview badges and final measurement badges use `db.formatter.formatLength()` and `db.formatter.formatAngle()` with `showUnits` / `showApproximate` where appropriate.
- **Area**: Square units are shown by appending `²` to the formatted length string (replacing fixed `m²` text).
- **Angle jig**: Passes `AcDbDatabase` into `AcApMeasureAngleJig` so preview matches final badge formatting; `applyAngbaseAngdir: false` keeps measurement display independent of `ANGBASE`/`ANGDIR`.

### Editor UI (`cad-simple-viewer`)
- **`AcEdInputManager`**: Dynamic input numeric display uses the drawing formatter for point, distance, and angle fields, with a simple `toFixed` fallback when no document is open.
- **`AcEdRubberBand`**: Distance and angle rubber-band labels use `formatLength` / `formatAngle` instead of raw `toFixed` values.

### Viewer shell (`cad-viewer`)
- **`useCurrentPos`**: Status-bar coordinates use `formatter.formatPoint2d()` instead of locale/scientific `Intl` formatting.

### i18n
- Add and reorder command descriptions for drawing-unit-related system variables (`LUNITS`, `AUNITS`, `ANGBASE`, `ANGDIR`, `INSUNITS`, `MEASUREMENT`, `DYNMODE`, etc.) in EN/ZH `command.ts`.

### Dependencies
- Promote `@mlightcad/data-model` usage in `cad-simple-viewer` (formatter API).
- **Note:** The current staged `package.json` / `pnpm-lock.yaml` overrides point `@mlightcad/data-model` and `@mlightcad/libredwg-converter` at local `realdwg-web` paths. **Revert these to published semver ranges before opening the PR** (e.g. bump to the release that ships `formatter.formatLength` / `formatAngle` / `formatPoint2d`).

## Motivation

After the Drawing Units (UNITS) dialog (#273), users expect all on-screen numeric readouts to stay consistent with drawing settings. Hard-coded `~ 1.234 m` / `45.00°` labels ignored `LUNITS`/`AUNITS` and broke parity with AutoCAD-style behavior.
