### PR TITLE
feat(html-exporter): analytic object-snap primitives for offline HTML viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,11 @@
       "vue-demi"
     ],
     "overrides": {
-      "@mlightcad/data-model": "^1.7.36",
-      "@mlightcad/libredwg-converter": "^3.5.36",
+      "@mlightcad/data-model": "^1.7.37",
+      "@mlightcad/libredwg-converter": "^3.5.37",
       "@mlightcad/mtext-input-box": "^0.2.11",
-      "@mlightcad/mtext-renderer": "^0.10.14",      "@mlightcad/ribbon": "^0.1.9",
+      "@mlightcad/mtext-renderer": "^0.10.14",
+      "@mlightcad/ribbon": "^0.1.9",
       "element-plus": "^2.12.0",
       "three": "^0.172.0",
       "vue": "^3.4.21",

--- a/packages/cad-html-exporter/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-exporter/__tests__/AcExOsnap.spec.ts
@@ -42,4 +42,48 @@ describe('AcExOsnapIndex', () => {
     index.rebuild(layout, name => name !== '0')
     expect(index.findSnap(0.1, 0.1, 1)).toBeUndefined()
   })
+
+  it('uses analytic primitives instead of tessellated segments', () => {
+    const primitiveLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'circle' as const,
+            layer: '0',
+            cx: 50,
+            cy: 0,
+            r: 10,
+            normalSign: 1 as const
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['center'])
+    index.rebuild(primitiveLayout, () => true)
+    const snap = index.findSnap(50.2, 0.1, 2)
+    expect(snap).toEqual({ x: 50, y: 0, mode: 'center' })
+  })
+
+  it('prefers center over nearest on a circle primitive', () => {
+    const primitiveLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'circle' as const,
+            layer: '0',
+            cx: 0,
+            cy: 0,
+            r: 10,
+            normalSign: 1 as const
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['center', 'nearest'])
+    index.rebuild(primitiveLayout, () => true)
+    const snap = index.findSnap(0.5, 0.5, 5)
+    expect(snap?.mode).toBe('center')
+  })
 })

--- a/packages/cad-html-exporter/__tests__/AcExOsnapGeometry.spec.ts
+++ b/packages/cad-html-exporter/__tests__/AcExOsnapGeometry.spec.ts
@@ -1,0 +1,73 @@
+import { collectPrimitiveSnapCandidates } from '../src/AcExOsnapGeometry'
+
+describe('collectPrimitiveSnapCandidates', () => {
+  const modes = new Set([
+    'endpoint',
+    'midpoint',
+    'center',
+    'quadrant',
+    'nearest'
+  ] as const)
+
+  it('snaps to circle center and quadrants', () => {
+    const candidates = collectPrimitiveSnapCandidates(
+      {
+        kind: 'circle',
+        layer: '0',
+        cx: 5,
+        cy: 5,
+        r: 2,
+        normalSign: 1
+      },
+      5.1,
+      5.1,
+      modes
+    )
+    expect(candidates.some(c => c.mode === 'center' && c.x === 5 && c.y === 5)).toBe(
+      true
+    )
+    expect(candidates.some(c => c.mode === 'quadrant' && c.x === 7 && c.y === 5)).toBe(
+      true
+    )
+  })
+
+  it('snaps to arc endpoints and center', () => {
+    const candidates = collectPrimitiveSnapCandidates(
+      {
+        kind: 'arc',
+        layer: '0',
+        cx: 0,
+        cy: 0,
+        r: 10,
+        startAngle: 0,
+        endAngle: Math.PI / 2,
+        normalSign: 1
+      },
+      0.2,
+      0.2,
+      modes
+    )
+    expect(candidates.some(c => c.mode === 'endpoint' && c.x === 10 && c.y === 0)).toBe(
+      true
+    )
+    expect(candidates.some(c => c.mode === 'center')).toBe(true)
+  })
+
+  it('finds nearest point on a line segment', () => {
+    const candidates = collectPrimitiveSnapCandidates(
+      {
+        kind: 'line',
+        layer: '0',
+        x0: 0,
+        y0: 0,
+        x1: 10,
+        y1: 0
+      },
+      4,
+      1,
+      new Set(['nearest'])
+    )
+    const near = candidates.find(c => c.mode === 'nearest')
+    expect(near).toEqual({ x: 4, y: 0, mode: 'nearest' })
+  })
+})

--- a/packages/cad-html-exporter/src/AcExMeasurement.ts
+++ b/packages/cad-html-exporter/src/AcExMeasurement.ts
@@ -775,8 +775,7 @@ export class AcExMeasureController {
   handlePointerDown(clientX: number, clientY: number): boolean {
     if (!this._mode) return false
     this._lastPointer = { x: clientX, y: clientY }
-    const { point, snap } = this._view.resolvePoint(clientX, clientY)
-    this._onOsnapMarker(snap, snap ? this._view.wcsToScreen(point) : null)
+    const point = this._resolvePointerWithOsnap(clientX, clientY)
 
     switch (this._mode) {
       case 'distance':
@@ -802,9 +801,7 @@ export class AcExMeasureController {
   handlePointerMove(clientX: number, clientY: number): void {
     if (!this._mode) return
     this._lastPointer = { x: clientX, y: clientY }
-    const { point, snap } = this._view.resolvePoint(clientX, clientY)
-    const screen = this._view.wcsToScreen(point)
-    this._onOsnapMarker(snap, snap ? screen : null)
+    const point = this._resolvePointerWithOsnap(clientX, clientY)
 
     switch (this._mode) {
       case 'distance':
@@ -944,13 +941,26 @@ export class AcExMeasureController {
   }
 
   /**
-   * Redraws in-progress preview overlays after pan/zoom using the last pointer sample.
+   * Resolves the WCS pick (with object snap) and refreshes the on-screen snap marker.
+   * @internal
+   */
+  private _resolvePointerWithOsnap(
+    clientX: number,
+    clientY: number
+  ): THREE.Vector2 {
+    const { point, snap } = this._view.resolvePoint(clientX, clientY)
+    this._onOsnapMarker(snap, snap ? this._view.wcsToScreen(point) : null)
+    return point
+  }
+
+  /**
+   * Redraws in-progress preview and object-snap marker after pan/zoom using the last pointer sample.
    * @internal
    */
   private _refreshActivePreview(): void {
     if (!this._mode || !this._lastPointer) return
     const { x, y } = this._lastPointer
-    const { point } = this._view.resolvePoint(x, y)
+    const point = this._resolvePointerWithOsnap(x, y)
 
     switch (this._mode) {
       case 'distance':

--- a/packages/cad-html-exporter/src/AcExOsnap.ts
+++ b/packages/cad-html-exporter/src/AcExOsnap.ts
@@ -1,28 +1,21 @@
+import { collectPrimitiveSnapCandidates, distSq } from './AcExOsnapGeometry'
+import type {
+  AcExOsnapMode,
+  AcExOsnapPoint,
+  AcExOsnapPrimitive
+} from './AcExOsnapPrimitiveTypes'
+import { ACEX_DEFAULT_OSNAP_MODES } from './AcExOsnapPrimitiveTypes'
 import type {
   AcExLayoutSnapshot,
   AcExLineBatch,
   AcExMeshBatch
 } from './AcExSnapshotTypes'
 
-/** Object snap modes supported by the offline HTML viewer. */
-export type AcExOsnapMode = 'endpoint' | 'midpoint' | 'nearest'
-
-/** A snap candidate in world coordinates (WCS, XY plane). */
-export interface AcExOsnapPoint {
-  x: number
-  y: number
-  mode: AcExOsnapMode
-}
-
-/** Default snap modes (matches common AutoCAD defaults for measure workflows). */
-export const ACEX_DEFAULT_OSNAP_MODES: readonly AcExOsnapMode[] = [
-  'endpoint',
-  'midpoint',
-  'nearest'
-] as const
+export type { AcExOsnapMode, AcExOsnapPoint } from './AcExOsnapPrimitiveTypes'
+export { ACEX_DEFAULT_OSNAP_MODES } from './AcExOsnapPrimitiveTypes'
 
 /**
- * One line segment in WCS (XY) indexed for object snap.
+ * One line segment in WCS (XY) indexed for legacy tessellated object snap.
  * @internal
  */
 interface AcExOsnapSegment {
@@ -36,18 +29,18 @@ function modePriority(mode: AcExOsnapMode): number {
   switch (mode) {
     case 'endpoint':
     case 'midpoint':
+    case 'center':
       return 0
+    case 'quadrant':
+    case 'focus':
+    case 'control':
+    case 'node':
+      return 1
     case 'nearest':
       return 2
     default:
       return 1
   }
-}
-
-function distSq(ax: number, ay: number, bx: number, by: number): number {
-  const dx = ax - bx
-  const dy = ay - by
-  return dx * dx + dy * dy
 }
 
 function closestPointOnSegment(
@@ -138,12 +131,65 @@ function cellKey(cx: number, cy: number): string {
   return `${cx},${cy}`
 }
 
+function primitiveBounds(
+  prim: AcExOsnapPrimitive
+): { minX: number; minY: number; maxX: number; maxY: number } {
+  switch (prim.kind) {
+    case 'line':
+      return {
+        minX: Math.min(prim.x0, prim.x1),
+        minY: Math.min(prim.y0, prim.y1),
+        maxX: Math.max(prim.x0, prim.x1),
+        maxY: Math.max(prim.y0, prim.y1)
+      }
+    case 'circle':
+    case 'arc':
+      return {
+        minX: prim.cx - prim.r,
+        minY: prim.cy - prim.r,
+        maxX: prim.cx + prim.r,
+        maxY: prim.cy + prim.r
+      }
+    case 'ellipse':
+      return {
+        minX: prim.cx - prim.majorR,
+        minY: prim.cy - prim.majorR,
+        maxX: prim.cx + prim.majorR,
+        maxY: prim.cy + prim.majorR
+      }
+    case 'spline': {
+      let minX = Infinity
+      let minY = Infinity
+      let maxX = -Infinity
+      let maxY = -Infinity
+      for (let i = 0; i + 1 < prim.controlPoints.length; i += 2) {
+        const x = prim.controlPoints[i]!
+        const y = prim.controlPoints[i + 1]!
+        minX = Math.min(minX, x)
+        minY = Math.min(minY, y)
+        maxX = Math.max(maxX, x)
+        maxY = Math.max(maxY, y)
+      }
+      return { minX, minY, maxX, maxY }
+    }
+    case 'point':
+      return { minX: prim.x, minY: prim.y, maxX: prim.x, maxY: prim.y }
+  }
+}
+
 /**
- * Geometry index for object snap in the offline HTML viewer.
- * Built from exported line/mesh batches; respects per-layer visibility.
+ * Spatial index for object snap in the offline HTML viewer.
+ *
+ * On {@link AcExOsnapIndex.rebuild}, if {@link AcExLayoutSnapshot.osnap} contains
+ * primitives, snapping is computed from analytic curves via
+ * {@link collectPrimitiveSnapCandidates}. Otherwise the index falls back to
+ * line segments extracted from tessellated {@link AcExLineBatch} and mesh edges
+ * (legacy snapshots).
  */
 export class AcExOsnapIndex {
   private segments: AcExOsnapSegment[] = []
+  private primitives: AcExOsnapPrimitive[] = []
+  private usePrimitives = false
   private grid = new Map<string, number[]>()
   private cellSize = 1
   private modes: Set<AcExOsnapMode>
@@ -156,53 +202,92 @@ export class AcExOsnapIndex {
   }
 
   /**
-   * Rebuilds the segment index from layout batches.
+   * Rebuilds the snap index from the active layout snapshot.
    *
-   * @param layout - Active layout geometry.
-   * @param isLayerVisible - Returns whether a layer participates in snapping.
+   * When `layout.osnap.primitives` is non-empty, only those WCS primitives are
+   * indexed (curves are not approximated from render batches). When absent or
+   * empty, tessellated `lineBatches` and `meshBatches` are used instead.
+   *
+   * @param layout - Active layout snapshot (batches + optional {@link AcExLayoutSnapshot.osnap}).
+   * @param isLayerVisible - When `false`, primitives/batches on that layer are excluded.
    */
   rebuild(
     layout: AcExLayoutSnapshot,
     isLayerVisible: (layerName: string) => boolean
   ): void {
-    const segments: AcExOsnapSegment[] = []
-    for (const batch of layout.lineBatches) {
-      if (!isLayerVisible(batch.layer)) continue
-      for (const seg of iterLineSegments(batch)) {
-        segments.push(seg)
+    const catalog = layout.osnap
+    if (catalog && catalog.primitives.length > 0) {
+      this.usePrimitives = true
+      this.primitives = catalog.primitives.filter(p =>
+        isLayerVisible(p.layer)
+      )
+      this.segments = []
+    } else {
+      this.usePrimitives = false
+      this.primitives = []
+      const segments: AcExOsnapSegment[] = []
+      for (const batch of layout.lineBatches) {
+        if (!isLayerVisible(batch.layer)) continue
+        for (const seg of iterLineSegments(batch)) {
+          segments.push(seg)
+        }
       }
-    }
-    for (const batch of layout.meshBatches) {
-      if (!isLayerVisible(batch.layer)) continue
-      for (const seg of iterMeshEdges(batch)) {
-        segments.push(seg)
+      for (const batch of layout.meshBatches) {
+        if (!isLayerVisible(batch.layer)) continue
+        for (const seg of iterMeshEdges(batch)) {
+          segments.push(seg)
+        }
       }
+      this.segments = segments
     }
 
-    this.segments = segments
     this.grid.clear()
-
-    if (segments.length === 0) return
+    const items = this.usePrimitives ? this.primitives : this.segments
+    if (items.length === 0) return
 
     let minX = Infinity
     let minY = Infinity
     let maxX = -Infinity
     let maxY = -Infinity
-    for (const seg of segments) {
-      minX = Math.min(minX, seg.x0, seg.x1)
-      minY = Math.min(minY, seg.y0, seg.y1)
-      maxX = Math.max(maxX, seg.x0, seg.x1)
-      maxY = Math.max(maxY, seg.y0, seg.y1)
+
+    if (this.usePrimitives) {
+      for (const prim of this.primitives) {
+        const b = primitiveBounds(prim)
+        minX = Math.min(minX, b.minX)
+        minY = Math.min(minY, b.minY)
+        maxX = Math.max(maxX, b.maxX)
+        maxY = Math.max(maxY, b.maxY)
+      }
+    } else {
+      for (const seg of this.segments) {
+        minX = Math.min(minX, seg.x0, seg.x1)
+        minY = Math.min(minY, seg.y0, seg.y1)
+        maxX = Math.max(maxX, seg.x0, seg.x1)
+        maxY = Math.max(maxY, seg.y0, seg.y1)
+      }
     }
+
     const span = Math.max(maxX - minX, maxY - minY, 1)
     this.cellSize = Math.max(span / 200, 1e-6)
 
-    for (let i = 0; i < segments.length; i++) {
-      const seg = segments[i]!
-      const segMinX = Math.min(seg.x0, seg.x1)
-      const segMaxX = Math.max(seg.x0, seg.x1)
-      const segMinY = Math.min(seg.y0, seg.y1)
-      const segMaxY = Math.max(seg.y0, seg.y1)
+    for (let i = 0; i < items.length; i++) {
+      let segMinX: number
+      let segMinY: number
+      let segMaxX: number
+      let segMaxY: number
+      if (this.usePrimitives) {
+        const b = primitiveBounds(this.primitives[i]!)
+        segMinX = b.minX
+        segMinY = b.minY
+        segMaxX = b.maxX
+        segMaxY = b.maxY
+      } else {
+        const seg = this.segments[i]!
+        segMinX = Math.min(seg.x0, seg.x1)
+        segMaxX = Math.max(seg.x0, seg.x1)
+        segMinY = Math.min(seg.y0, seg.y1)
+        segMaxY = Math.max(seg.y0, seg.y1)
+      }
       const c0x = Math.floor(segMinX / this.cellSize)
       const c1x = Math.floor(segMaxX / this.cellSize)
       const c0y = Math.floor(segMinY / this.cellSize)
@@ -222,14 +307,20 @@ export class AcExOsnapIndex {
   }
 
   /**
-   * Finds the best snap point near the cursor, using AutoCAD-style mode priority.
+   * Finds the best snap point near the cursor in WCS.
    *
-   * @param px - Cursor WCS X.
-   * @param py - Cursor WCS Y.
-   * @param threshold - Maximum distance in drawing units.
+   * Uses AutoCAD-style mode priority: endpoint / midpoint / center beat
+   * quadrant / focus / control / node, which beat nearest. Within the same
+   * priority tier, the closest candidate within `threshold` wins.
+   *
+   * @param px - Cursor X in drawing units (WCS).
+   * @param py - Cursor Y in drawing units (WCS).
+   * @param threshold - Maximum snap distance in drawing units (aperture radius).
+   * @returns The winning snap point, or `undefined` if nothing is within range.
    */
   findSnap(px: number, py: number, threshold: number): AcExOsnapPoint | undefined {
-    if (this.segments.length === 0 || threshold <= 0) return undefined
+    const items = this.usePrimitives ? this.primitives : this.segments
+    if (items.length === 0 || threshold <= 0) return undefined
 
     const threshSq = threshold * threshold
     const cx = Math.floor(px / this.cellSize)
@@ -260,26 +351,38 @@ export class AcExOsnapIndex {
       for (let dy = -radiusCells; dy <= radiusCells; dy++) {
         const list = this.grid.get(cellKey(cx + dx, cy + dy))
         if (!list) continue
-        for (const segIndex of list) {
-          if (seen.has(segIndex)) continue
-          seen.add(segIndex)
-          const seg = this.segments[segIndex]!
+        for (const index of list) {
+          if (seen.has(index)) continue
+          seen.add(index)
 
-          if (this.modes.has('endpoint')) {
-            consider(seg.x0, seg.y0, 'endpoint')
-            consider(seg.x1, seg.y1, 'endpoint')
-          }
-          if (this.modes.has('midpoint')) {
-            consider(
-              (seg.x0 + seg.x1) * 0.5,
-              (seg.y0 + seg.y1) * 0.5,
-              'midpoint'
-            )
-          }
-          if (this.modes.has('nearest')) {
-            const near = closestPointOnSegment(px, py, seg)
-            if (near.distSq <= threshSq) {
-              consider(near.x, near.y, 'nearest')
+          if (this.usePrimitives) {
+            const prim = this.primitives[index]!
+            for (const candidate of collectPrimitiveSnapCandidates(
+              prim,
+              px,
+              py,
+              this.modes
+            )) {
+              consider(candidate.x, candidate.y, candidate.mode)
+            }
+          } else {
+            const seg = this.segments[index]!
+            if (this.modes.has('endpoint')) {
+              consider(seg.x0, seg.y0, 'endpoint')
+              consider(seg.x1, seg.y1, 'endpoint')
+            }
+            if (this.modes.has('midpoint')) {
+              consider(
+                (seg.x0 + seg.x1) * 0.5,
+                (seg.y0 + seg.y1) * 0.5,
+                'midpoint'
+              )
+            }
+            if (this.modes.has('nearest')) {
+              const near = closestPointOnSegment(px, py, seg)
+              if (near.distSq <= threshSq) {
+                consider(near.x, near.y, 'nearest')
+              }
             }
           }
         }
@@ -290,17 +393,29 @@ export class AcExOsnapIndex {
   }
 }
 
-/** Maps a snap mode to the marker shape used in the offline viewer. */
+/**
+ * Maps an {@link AcExOsnapMode} to the on-screen marker glyph in the offline viewer.
+ *
+ * @param mode - Active snap mode from {@link findSnap} or measurement UI.
+ * @returns CSS shape key used by {@link AcExOsnapMarker}.
+ */
 export function acExOsnapModeToMarkerType(
   mode: AcExOsnapMode
-): 'rect' | 'triangle' | 'x' {
+): 'rect' | 'triangle' | 'x' | 'circle' | 'diamond' {
   switch (mode) {
     case 'endpoint':
       return 'rect'
     case 'midpoint':
       return 'triangle'
+    case 'center':
+      return 'circle'
+    case 'quadrant':
+    case 'focus':
+      return 'diamond'
     case 'nearest':
       return 'x'
+    case 'control':
+    case 'node':
     default:
       return 'rect'
   }

--- a/packages/cad-html-exporter/src/AcExOsnapGeometry.ts
+++ b/packages/cad-html-exporter/src/AcExOsnapGeometry.ts
@@ -1,0 +1,175 @@
+/**
+ * Object snap candidate collection for exported analytic primitives.
+ *
+ * Thin orchestration layer: converts {@link AcExOsnapPrimitive} via
+ * {@link primitiveToAcGeCurve}, then calls `AcGeLine2d`, `AcGeCircArc2d`,
+ * `AcGeEllipseArc2d`, and `AcGeNurbsCurve` from `@mlightcad/data-model`
+ * (geometry-engine) for all snap math.
+ *
+ * @packageDocumentation
+ */
+
+import type { AcGePoint2dLike } from '@mlightcad/data-model'
+
+import { primitiveToAcGeCurve } from './AcExOsnapPrimitiveToAcGe'
+import type {
+  AcExOsnapMode,
+  AcExOsnapPrimitive
+} from './AcExOsnapPrimitiveTypes'
+
+/**
+ * Squared Euclidean distance between two XY points.
+ *
+ * @param ax - First point X.
+ * @param ay - First point Y.
+ * @param bx - Second point X.
+ * @param by - Second point Y.
+ */
+export function distSq(ax: number, ay: number, bx: number, by: number): number {
+  const dx = ax - bx
+  const dy = ay - by
+  return dx * dx + dy * dy
+}
+
+function pushPoint(
+  out: AcExOsnapCandidate[],
+  p: AcGePoint2dLike,
+  mode: AcExOsnapMode
+): void {
+  out.push({ x: p.x, y: p.y, mode })
+}
+
+/** One snap candidate before distance filtering in {@link AcExOsnapIndex}. */
+export interface AcExOsnapCandidate {
+  x: number
+  y: number
+  mode: AcExOsnapMode
+}
+
+/**
+ * Collects snap candidates for one primitive using `AcGe*` geometry.
+ *
+ * @param prim - Exported primitive in WCS.
+ * @param px - Pick X in WCS.
+ * @param py - Pick Y in WCS.
+ * @param modes - Enabled OSNAP modes.
+ */
+export function collectPrimitiveSnapCandidates(
+  prim: AcExOsnapPrimitive,
+  px: number,
+  py: number,
+  modes: Set<AcExOsnapMode>
+): AcExOsnapCandidate[] {
+  const out: AcExOsnapCandidate[] = []
+  const pick = { x: px, y: py, z: 0 }
+  const geo = primitiveToAcGeCurve(prim)
+
+  switch (geo.kind) {
+    case 'line': {
+      const line = geo.curve
+      if (modes.has('endpoint')) {
+        pushPoint(out, line.startPoint, 'endpoint')
+        pushPoint(out, line.endPoint, 'endpoint')
+      }
+      if (modes.has('midpoint')) {
+        pushPoint(
+          out,
+          {
+            x: (line.startPoint.x + line.endPoint.x) * 0.5,
+            y: (line.startPoint.y + line.endPoint.y) * 0.5
+          },
+          'midpoint'
+        )
+      }
+      if (modes.has('nearest')) {
+        pushPoint(out, line.nearestPoint(pick), 'nearest')
+      }
+      break
+    }
+    case 'circArc': {
+      const arc = geo.curve
+      if (modes.has('endpoint') && !arc.closed) {
+        pushPoint(out, arc.startPoint, 'endpoint')
+        pushPoint(out, arc.endPoint, 'endpoint')
+      }
+      if (modes.has('center')) {
+        pushPoint(out, arc.center, 'center')
+      }
+      if (modes.has('midpoint') && !arc.closed) {
+        pushPoint(out, arc.midPoint, 'midpoint')
+      }
+      if (modes.has('quadrant')) {
+        for (const p of arc.getQuadrantPoints()) {
+          pushPoint(out, p, 'quadrant')
+        }
+      }
+      if (modes.has('nearest')) {
+        pushPoint(out, arc.nearestPoint(pick), 'nearest')
+      }
+      break
+    }
+    case 'ellipse': {
+      const ellipse = geo.curve
+      if (modes.has('endpoint') && !ellipse.closed) {
+        pushPoint(out, ellipse.startPoint, 'endpoint')
+        pushPoint(out, ellipse.endPoint, 'endpoint')
+      }
+      if (modes.has('center')) {
+        pushPoint(out, ellipse.center, 'center')
+      }
+      if (modes.has('midpoint') && !ellipse.closed) {
+        pushPoint(out, ellipse.getPoint(0.5), 'midpoint')
+      }
+      if (modes.has('quadrant')) {
+        for (const p of ellipse.getQuadrantPoints()) {
+          pushPoint(out, p, 'quadrant')
+        }
+      }
+      if (modes.has('focus')) {
+        for (const p of ellipse.getFocusPoints()) {
+          pushPoint(out, p, 'focus')
+        }
+      }
+      if (modes.has('nearest')) {
+        pushPoint(out, ellipse.nearestPoint(pick), 'nearest')
+      }
+      break
+    }
+    case 'spline': {
+      const spline = geo.curve
+      const { start, end } = spline.getParameterRange()
+      const startPt = spline.point(start)
+      const endPt = spline.point(end)
+      if (modes.has('endpoint')) {
+        pushPoint(out, { x: startPt[0]!, y: startPt[1]! }, 'endpoint')
+        pushPoint(out, { x: endPt[0]!, y: endPt[1]! }, 'endpoint')
+      }
+      if (modes.has('control')) {
+        for (const cp of spline.controlPoints()) {
+          pushPoint(out, cp, 'control')
+        }
+      }
+      if (modes.has('node') && prim.kind === 'spline') {
+        const seen = new Set<number>()
+        for (const k of prim.knots) {
+          if (seen.has(k)) continue
+          seen.add(k)
+          const p = spline.point(k)
+          pushPoint(out, { x: p[0]!, y: p[1]! }, 'node')
+        }
+      }
+      if (modes.has('nearest')) {
+        pushPoint(out, spline.nearestPoint(pick), 'nearest')
+      }
+      break
+    }
+    case 'point': {
+      if (modes.has('node') || modes.has('endpoint')) {
+        pushPoint(out, geo.point, 'node')
+      }
+      break
+    }
+  }
+
+  return out
+}

--- a/packages/cad-html-exporter/src/AcExOsnapMarker.ts
+++ b/packages/cad-html-exporter/src/AcExOsnapMarker.ts
@@ -1,12 +1,29 @@
 import type { AcExOsnapMode } from './AcExOsnap'
 import { acExOsnapModeToMarkerType } from './AcExOsnap'
 
-/** Visual shape of an object-snap marker in the offline HTML viewer. */
-export type AcExOsnapMarkerShape = 'rect' | 'triangle' | 'x'
+/**
+ * Visual shape of an object-snap marker in the offline HTML viewer.
+ *
+ * Selected by {@link acExOsnapModeToMarkerType} from {@link AcExOsnapMode}:
+ * - `rect` — endpoint, control, node
+ * - `triangle` — midpoint
+ * - `circle` — center
+ * - `diamond` — quadrant, focus
+ * - `x` — nearest
+ */
+export type AcExOsnapMarkerShape =
+  | 'rect'
+  | 'triangle'
+  | 'x'
+  | 'circle'
+  | 'diamond'
 
 /**
  * Screen-space object snap marker for the offline HTML viewer.
- * Mirrors the main viewer marker shapes (square, triangle, X).
+ *
+ * Renders a small glyph at the snapped screen position during measurement.
+ * Shape follows {@link acExOsnapModeToMarkerType} so behavior matches the
+ * main CAD viewer (square, triangle, circle, diamond, X).
  */
 export class AcExOsnapMarker {
   private readonly el: HTMLDivElement
@@ -84,6 +101,18 @@ export class AcExOsnapMarker {
         border-right: 6px solid transparent;
         border-bottom: 10px solid currentColor;
         transform: translate(-50%, -100%);
+      }
+      .mlcad-osnap-marker--circle {
+        width: 12px; height: 12px;
+        border: 2px solid currentColor;
+        border-radius: 50%;
+        background: transparent;
+      }
+      .mlcad-osnap-marker--diamond {
+        width: 10px; height: 10px;
+        border: 2px solid currentColor;
+        background: transparent;
+        transform: translate(-50%, -50%) rotate(45deg);
       }
       .mlcad-osnap-marker--x {
         width: 12px; height: 12px;

--- a/packages/cad-html-exporter/src/AcExOsnapPrimitiveBuilder.ts
+++ b/packages/cad-html-exporter/src/AcExOsnapPrimitiveBuilder.ts
@@ -1,0 +1,460 @@
+/**
+ * Builds {@link AcExOsnapCatalog} from an open `AcDbDatabase`.
+ *
+ * Walks layout block table records recursively, expands `AcDbBlockReference`
+ * (INSERT) with full insertion transforms, and emits compact analytic primitives
+ * for the offline HTML viewer. This path preserves circle/arc/ellipse/spline
+ * definitions that would otherwise be lost after tessellation into line batches.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  AcDbArc,
+  AcDbBlockReference,
+  type AcDbBlockTableRecord,
+  AcDbCircle,
+  type AcDbDatabase,
+  AcDbEllipse,
+  AcDbEntity,
+  AcDbLine,
+  type AcDbObjectId,
+  AcDbPoint,
+  AcDbPolyline,
+  AcDbSpline,
+  AcGeCircArc2d,
+  type AcGePoint3dLike,
+  type AcGeVector3dLike
+} from '@mlightcad/data-model'
+import * as THREE from 'three'
+
+import type {
+  AcExOsnapArcPrimitive,
+  AcExOsnapCatalog,
+  AcExOsnapCirclePrimitive,
+  AcExOsnapEllipsePrimitive,
+  AcExOsnapLinePrimitive,
+  AcExOsnapPrimitive,
+  AcExOsnapSplinePrimitive
+} from './AcExOsnapPrimitiveTypes'
+
+const TAU = Math.PI * 2
+const EPS = 1e-9
+
+/** Maps entity extrusion normal to arc/circle winding sign. @internal */
+function normalSignFromVector(normal: AcGeVector3dLike): 1 | -1 {
+  return normal.z >= 0 ? 1 : -1
+}
+
+/** Applies a 4×4 layout/block matrix to a 3D point; returns XY. @internal */
+function transformPoint(
+  matrix: THREE.Matrix4,
+  p: AcGePoint3dLike
+): { x: number; y: number } {
+  const v = new THREE.Vector3(p.x, p.y, p.z ?? 0).applyMatrix4(matrix)
+  return { x: v.x, y: v.y }
+}
+
+/** Applies a 4×4 matrix to a direction vector (no translation); returns normalized XY. @internal */
+function transformVector(
+  matrix: THREE.Matrix4,
+  v: AcGeVector3dLike
+): { x: number; y: number } {
+  const out = new THREE.Vector3(v.x, v.y, v.z ?? 0)
+    .transformDirection(matrix)
+    .normalize()
+  return { x: out.x, y: out.y }
+}
+
+/**
+ * Returns whether the XY scale factors of `matrix` are equal.
+ *
+ * Circles/arcs stay circular only under uniform XY scale; otherwise they are
+ * exported as {@link AcExOsnapEllipsePrimitive}.
+ *
+ * @internal
+ */
+function scaleIsUniform(matrix: THREE.Matrix4): boolean {
+  const sx = new THREE.Vector3(matrix.elements[0], matrix.elements[1], matrix.elements[2]).length()
+  const sy = new THREE.Vector3(matrix.elements[4], matrix.elements[5], matrix.elements[6]).length()
+  return Math.abs(sx - sy) <= EPS * Math.max(sx, sy, 1)
+}
+
+/** Appends a WCS line primitive after transforming endpoints. @internal */
+function pushLine(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  start: AcGePoint3dLike,
+  end: AcGePoint3dLike
+) {
+  const a = transformPoint(matrix, start)
+  const b = transformPoint(matrix, end)
+  const prim: AcExOsnapLinePrimitive = {
+    kind: 'line',
+    layer,
+    x0: a.x,
+    y0: a.y,
+    x1: b.x,
+    y1: b.y
+  }
+  out.push(prim)
+}
+
+/** Appends a WCS circle primitive (uniform scale on radius). @internal */
+function pushCircle(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  center: AcGePoint3dLike,
+  radius: number,
+  normal: AcGeVector3dLike
+) {
+  const c = transformPoint(matrix, center)
+  const sx = new THREE.Vector3(matrix.elements[0], matrix.elements[1], matrix.elements[2]).length()
+  const prim: AcExOsnapCirclePrimitive = {
+    kind: 'circle',
+    layer,
+    cx: c.x,
+    cy: c.y,
+    r: radius * sx,
+    normalSign: normalSignFromVector(normal)
+  }
+  out.push(prim)
+}
+
+/** Appends a WCS arc primitive from `AcDbArc` (uniform XY scale). @internal */
+function pushArc(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbArc
+) {
+  const center = transformPoint(matrix, entity.center)
+  const sx = new THREE.Vector3(matrix.elements[0], matrix.elements[1], matrix.elements[2]).length()
+  const prim: AcExOsnapArcPrimitive = {
+    kind: 'arc',
+    layer,
+    cx: center.x,
+    cy: center.y,
+    r: entity.radius * sx,
+    startAngle: entity.startAngle,
+    endAngle: entity.endAngle,
+    normalSign: normalSignFromVector(entity.normal)
+  }
+  out.push(prim)
+}
+
+/** Appends a WCS ellipse primitive from `AcDbEllipse`. @internal */
+function pushEllipse(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbEllipse
+) {
+  const center = transformPoint(matrix, entity.center)
+  const geo = (
+    entity as unknown as { _geo?: { majorAxis?: AcGeVector3dLike } }
+  )._geo
+  const majorAxis = geo?.majorAxis ?? { x: 1, y: 0, z: 0 }
+  const axis = transformVector(matrix, majorAxis)
+  const len = Math.hypot(axis.x, axis.y) || 1
+  const sx = new THREE.Vector3(matrix.elements[0], matrix.elements[1], matrix.elements[2]).length()
+  const sy = new THREE.Vector3(matrix.elements[4], matrix.elements[5], matrix.elements[6]).length()
+  const prim: AcExOsnapEllipsePrimitive = {
+    kind: 'ellipse',
+    layer,
+    cx: center.x,
+    cy: center.y,
+    majorX: axis.x / len,
+    majorY: axis.y / len,
+    majorR: entity.majorAxisRadius * sx,
+    minorR: entity.minorAxisRadius * sy,
+    startAngle: entity.startAngle,
+    endAngle: entity.endAngle,
+    closed: entity.closed
+  }
+  out.push(prim)
+}
+
+/**
+ * Appends a WCS spline primitive from `AcDbSpline` control/fit data.
+ *
+ * Reads internal `_geo` fields from the data model (control points, knots,
+ * weights, degree). Skips the entity when no control points are available.
+ *
+ * @internal
+ */
+function pushSpline(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbSpline
+) {
+  const geo = (
+    entity as unknown as {
+      _geo?: {
+        degree?: number
+        knots?: number[]
+        weights?: number[]
+        controlPoints?: AcGePoint3dLike[]
+        fitPoints?: AcGePoint3dLike[]
+        closed?: boolean
+      }
+    }
+  )._geo
+  if (!geo?.controlPoints?.length) return
+
+  const controlPoints: number[] = []
+  for (const cp of geo.controlPoints) {
+    const p = transformPoint(matrix, cp)
+    controlPoints.push(p.x, p.y)
+  }
+
+  const prim: AcExOsnapSplinePrimitive = {
+    kind: 'spline',
+    layer,
+    controlPoints,
+    degree: geo.degree ?? 3,
+    knots: [...(geo.knots ?? [])],
+    weights: [...(geo.weights ?? [])],
+    closed: geo.closed ?? false
+  }
+  if (geo.fitPoints?.length) {
+    prim.fitPoints = []
+    for (const fp of geo.fitPoints) {
+      const p = transformPoint(matrix, fp)
+      prim.fitPoints.push(p.x, p.y)
+    }
+  }
+  out.push(prim)
+}
+
+/**
+ * Decomposes `AcDbPolyline` into line and arc primitives.
+ *
+ * Straight segments become {@link AcExOsnapLinePrimitive}; bulge segments are
+ * converted with {@link AcGeCircArc2d} in WCS (endpoints transformed first so
+ * rotation/translation of INSERT is respected; bulge is invariant under similarity).
+ *
+ * @internal
+ */
+function pushPolyline(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbPolyline
+) {
+  const runtimeVertices = (
+    entity as unknown as {
+      _geo?: { vertices?: Array<{ x: number; y: number; bulge?: number }> }
+    }
+  )._geo?.vertices
+
+  const vertices =
+    runtimeVertices && runtimeVertices.length > 1
+      ? runtimeVertices.map(v => ({ x: v.x, y: v.y, bulge: v.bulge }))
+      : Array.from({ length: entity.numberOfVertices }, (_, i) => {
+          const p = entity.getPoint2dAt(i)
+          return { x: p.x, y: p.y, bulge: 0 as number | undefined }
+        })
+
+  const count = vertices.length
+  if (count < 2) return
+
+  const segmentCount = entity.closed ? count : count - 1
+  for (let i = 0; i < segmentCount; i++) {
+    const start = vertices[i]!
+    const end = vertices[(i + 1) % count]!
+    const bulge = start.bulge ?? 0
+    if (Math.abs(bulge) > EPS) {
+      const startW = transformPoint(matrix, { x: start.x, y: start.y, z: 0 })
+      const endW = transformPoint(matrix, { x: end.x, y: end.y, z: 0 })
+      const arc2d = new AcGeCircArc2d(startW, endW, bulge)
+      const center = arc2d.center
+      out.push({
+        kind: 'arc',
+        layer,
+        cx: center.x,
+        cy: center.y,
+        r: arc2d.radius,
+        startAngle: arc2d.startAngle,
+        endAngle: arc2d.endAngle,
+        normalSign: arc2d.clockwise ? -1 : 1
+      })
+    } else {
+      pushLine(
+        out,
+        layer,
+        matrix,
+        { x: start.x, y: start.y, z: 0 },
+        { x: end.x, y: end.y, z: 0 }
+      )
+    }
+  }
+}
+
+/**
+ * Resolves AutoCAD layer-0 inheritance inside blocks.
+ *
+ * @param entityLayer - Layer name stored on the entity in the block definition.
+ * @param insertLayer - Layer of the owning INSERT (or layout default).
+ * @returns Layer name written onto exported primitives.
+ * @internal
+ */
+function effectiveLayer(entityLayer: string, insertLayer: string): string {
+  return entityLayer === '0' ? insertLayer : entityLayer
+}
+
+/**
+ * Visits one database entity and appends zero or more WCS primitives.
+ *
+ * Recurses into {@link AcDbBlockReference} with accumulated transforms.
+ * Skips invisible entities and breaks cycles via `blockStack`.
+ *
+ * @internal
+ */
+function visitEntity(
+  entity: AcDbEntity,
+  matrix: THREE.Matrix4,
+  insertLayer: string,
+  out: AcExOsnapPrimitive[],
+  blockStack: Set<AcDbObjectId>
+) {
+  if (!entity.visibility) return
+
+  const layer = effectiveLayer(entity.layer, insertLayer)
+
+  if (entity instanceof AcDbBlockReference) {
+    const block = entity.blockTableRecord
+    if (!block || blockStack.has(block.objectId)) return
+    blockStack.add(block.objectId)
+    const insertMatrix = (
+      entity as unknown as { getFullInsertionTransform(): THREE.Matrix4 }
+    ).getFullInsertionTransform()
+    const nested = new THREE.Matrix4().multiplyMatrices(matrix, insertMatrix)
+    const blockInsertLayer = effectiveLayer(entity.layer, insertLayer)
+    visitBlock(block, nested, blockInsertLayer, out, blockStack)
+    blockStack.delete(block.objectId)
+    return
+  }
+
+  if (entity instanceof AcDbLine) {
+    pushLine(out, layer, matrix, entity.startPoint, entity.endPoint)
+    return
+  }
+
+  if (entity instanceof AcDbCircle) {
+    if (scaleIsUniform(matrix)) {
+      pushCircle(out, layer, matrix, entity.center, entity.radius, entity.normal)
+    } else {
+      pushEllipse(out, layer, matrix, ellipseFromCircle(entity))
+    }
+    return
+  }
+
+  if (entity instanceof AcDbArc) {
+    if (scaleIsUniform(matrix)) {
+      pushArc(out, layer, matrix, entity)
+    } else {
+      pushEllipse(out, layer, matrix, ellipseFromArc(entity))
+    }
+    return
+  }
+
+  if (entity instanceof AcDbEllipse) {
+    pushEllipse(out, layer, matrix, entity)
+    return
+  }
+
+  if (entity instanceof AcDbSpline) {
+    pushSpline(out, layer, matrix, entity)
+    return
+  }
+
+  if (entity instanceof AcDbPolyline) {
+    pushPolyline(out, layer, matrix, entity)
+    return
+  }
+
+  if (entity instanceof AcDbPoint) {
+    const p = transformPoint(matrix, entity.position)
+    out.push({ kind: 'point', layer, x: p.x, y: p.y })
+  }
+}
+
+/** Iterates all entities in a block BTR. @internal */
+function visitBlock(
+  block: AcDbBlockTableRecord,
+  matrix: THREE.Matrix4,
+  insertLayer: string,
+  out: AcExOsnapPrimitive[],
+  blockStack: Set<AcDbObjectId>
+) {
+  for (const entity of block.newIterator()) {
+    visitEntity(entity, matrix, insertLayer, out, blockStack)
+  }
+}
+
+/** Converts a circle to a temporary ellipse for non-uniform block transforms. @internal */
+function ellipseFromCircle(entity: AcDbCircle): AcDbEllipse {
+  return new AcDbEllipse(
+    entity.center,
+    entity.normal,
+    { x: 1, y: 0, z: 0 },
+    entity.radius,
+    entity.radius,
+    0,
+    TAU
+  )
+}
+
+/** Converts an arc to a temporary ellipse for non-uniform block transforms. @internal */
+function ellipseFromArc(entity: AcDbArc): AcDbEllipse {
+  return new AcDbEllipse(
+    entity.center,
+    entity.normal,
+    { x: 1, y: 0, z: 0 },
+    entity.radius,
+    entity.radius,
+    entity.startAngle,
+    entity.endAngle
+  )
+}
+
+/**
+ * Builds the object-snap catalog for one layout (model space or paper space).
+ *
+ * Traverses the layout's block table record (`layoutBtrId`), including all nested
+ * `AcDbBlockReference` entities with full WCS transforms. Entities on layer `0`
+ * inside blocks inherit the INSERT layer per AutoCAD rules.
+ *
+ * Supported entity types: `AcDbLine`, `AcDbCircle`, `AcDbArc`, `AcDbEllipse`,
+ * `AcDbSpline`, `AcDbPolyline` (lines + bulge arcs), `AcDbPoint`, and INSERT.
+ *
+ * @param database - Open drawing database (same instance used for HTML export).
+ * @param layoutBtrId - Object id of the layout's owning block table record
+ *   (e.g. model space BTR id from the renderer scene).
+ * @returns Catalog with {@link AcExOsnapCatalog.primitives} in WCS; empty array
+ *   when the BTR id is unknown or the layout has no snap-capable geometry.
+ *
+ * @example
+ * ```ts
+ * const osnap = buildOsnapCatalog(database, scene.modelSpaceBtrId)
+ * layoutSnapshot.osnap = osnap
+ * ```
+ */
+export function buildOsnapCatalog(
+  database: AcDbDatabase,
+  layoutBtrId: string
+): AcExOsnapCatalog {
+  const block = database.tables.blockTable.getIdAt(layoutBtrId)
+  if (!block) {
+    return { primitives: [] }
+  }
+
+  const primitives: AcExOsnapPrimitive[] = []
+  const identity = new THREE.Matrix4()
+  visitBlock(block, identity, '0', primitives, new Set())
+  return { primitives }
+}

--- a/packages/cad-html-exporter/src/AcExOsnapPrimitiveToAcGe.ts
+++ b/packages/cad-html-exporter/src/AcExOsnapPrimitiveToAcGe.ts
@@ -1,0 +1,125 @@
+/**
+ * Converts exported {@link AcExOsnapPrimitive} records into `AcGe*` curves
+ * for object snap evaluation in the offline HTML viewer.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  AcGeCircArc2d,
+  AcGeEllipseArc2d,
+  AcGeLine2d,
+  AcGeNurbsCurve,
+  AcGePoint2d,
+  TAU
+} from '@mlightcad/data-model'
+
+import type {
+  AcExOsnapArcPrimitive,
+  AcExOsnapCirclePrimitive,
+  AcExOsnapEllipsePrimitive,
+  AcExOsnapPrimitive,
+  AcExOsnapSplinePrimitive
+} from './AcExOsnapPrimitiveTypes'
+
+/** Discriminated result of {@link primitiveToAcGeCurve}. */
+export type AcExOsnapAcGeCurve =
+  | { kind: 'line'; curve: AcGeLine2d }
+  | { kind: 'circArc'; curve: AcGeCircArc2d }
+  | { kind: 'ellipse'; curve: AcGeEllipseArc2d }
+  | { kind: 'spline'; curve: AcGeNurbsCurve }
+  | { kind: 'point'; point: AcGePoint2d }
+
+/**
+ * Builds an `AcGeCircArc2d` from a circle or arc primitive.
+ *
+ * @param prim - Circle or arc in WCS.
+ */
+export function circleOrArcToAcGe(
+  prim: AcExOsnapCirclePrimitive | AcExOsnapArcPrimitive
+): AcGeCircArc2d {
+  if (prim.kind === 'circle') {
+    return new AcGeCircArc2d(
+      { x: prim.cx, y: prim.cy },
+      prim.r,
+      0,
+      TAU,
+      prim.normalSign === -1
+    )
+  }
+  return new AcGeCircArc2d(
+    { x: prim.cx, y: prim.cy },
+    prim.r,
+    prim.startAngle,
+    prim.endAngle,
+    prim.normalSign === -1
+  )
+}
+
+/**
+ * Builds an `AcGeEllipseArc2d` from an ellipse primitive.
+ *
+ * @param prim - Ellipse or elliptical arc in WCS.
+ */
+export function ellipseToAcGe(prim: AcExOsnapEllipsePrimitive): AcGeEllipseArc2d {
+  const rotation = Math.atan2(prim.majorY, prim.majorX)
+  return new AcGeEllipseArc2d(
+    { x: prim.cx, y: prim.cy, z: 0 },
+    prim.majorR,
+    prim.minorR,
+    prim.startAngle,
+    prim.endAngle,
+    false,
+    rotation
+  )
+}
+
+/**
+ * Builds an `AcGeNurbsCurve` from a spline primitive.
+ *
+ * @param prim - Serialized NURBS data in WCS.
+ */
+export function splineToAcGe(prim: AcExOsnapSplinePrimitive): AcGeNurbsCurve {
+  const controlPoints: { x: number; y: number; z: number }[] = []
+  for (let i = 0; i + 1 < prim.controlPoints.length; i += 2) {
+    controlPoints.push({
+      x: prim.controlPoints[i]!,
+      y: prim.controlPoints[i + 1]!,
+      z: 0
+    })
+  }
+  return new AcGeNurbsCurve(
+    prim.degree,
+    prim.knots,
+    controlPoints,
+    prim.weights.length > 0 ? prim.weights : undefined
+  )
+}
+
+/**
+ * Maps one snapshot primitive to the corresponding `AcGe` curve or point.
+ *
+ * @param prim - Exported primitive from {@link AcExOsnapCatalog}.
+ * @returns Wrapped geometry for snap evaluation.
+ */
+export function primitiveToAcGeCurve(prim: AcExOsnapPrimitive): AcExOsnapAcGeCurve {
+  switch (prim.kind) {
+    case 'line':
+      return {
+        kind: 'line',
+        curve: new AcGeLine2d(
+          { x: prim.x0, y: prim.y0 },
+          { x: prim.x1, y: prim.y1 }
+        )
+      }
+    case 'circle':
+    case 'arc':
+      return { kind: 'circArc', curve: circleOrArcToAcGe(prim) }
+    case 'ellipse':
+      return { kind: 'ellipse', curve: ellipseToAcGe(prim) }
+    case 'spline':
+      return { kind: 'spline', curve: splineToAcGe(prim) }
+    case 'point':
+      return { kind: 'point', point: new AcGePoint2d(prim.x, prim.y) }
+  }
+}

--- a/packages/cad-html-exporter/src/AcExOsnapPrimitiveTypes.ts
+++ b/packages/cad-html-exporter/src/AcExOsnapPrimitiveTypes.ts
@@ -1,0 +1,259 @@
+/**
+ * Object snap (OSNAP) types for the offline HTML viewer.
+ *
+ * These definitions describe **analytic** geometry in world coordinates (WCS, XY plane).
+ * They are serialized per layout in {@link AcExLayoutSnapshot.osnap} at export time
+ * (see {@link buildOsnapCatalog}) and consumed at runtime by {@link AcExOsnapIndex}
+ * instead of tessellated render batches.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Object snap modes supported by the offline HTML viewer.
+ *
+ * Names align with common AutoCAD OSNAP modes. Priority when multiple candidates
+ * are within the aperture is handled by {@link AcExOsnapIndex} (endpoint / midpoint /
+ * center beat quadrant / focus / control / node, which beat nearest).
+ *
+ * - `endpoint` — Line, arc, ellipse arc, and spline start/end vertices.
+ * - `midpoint` — Segment midpoint, arc midpoint, or open ellipse arc parameter midpoint.
+ * - `center` — Circle/arc/ellipse center (geometric center).
+ * - `quadrant` — 0° / 90° / 180° / 270° on circles; arc-limited on arcs; axis crossings on closed ellipses.
+ * - `nearest` — Closest point on the curve or segment to the pick point (not tessellated).
+ * - `node` — Spline knot locations; also used for `AcDbPoint` entities.
+ * - `focus` — Ellipse focal points (when major ≠ minor axis).
+ * - `control` — B-spline control vertices (CV).
+ *
+ * Tangent snap is not implemented in the offline viewer.
+ */
+export type AcExOsnapMode =
+  | 'endpoint'
+  | 'midpoint'
+  | 'center'
+  | 'quadrant'
+  | 'nearest'
+  | 'node'
+  | 'focus'
+  | 'control'
+
+/**
+ * A single object snap candidate returned to the measurement UI.
+ *
+ * Coordinates are in drawing WCS (XY); Z is not stored.
+ */
+export interface AcExOsnapPoint {
+  /** Snap X in world coordinates. */
+  x: number
+  /** Snap Y in world coordinates. */
+  y: number
+  /** Which OSNAP mode produced this point. */
+  mode: AcExOsnapMode
+}
+
+/**
+ * Default OSNAP modes enabled in the offline HTML viewer.
+ *
+ * Matches the subset commonly used for measure workflows in the main CAD viewer
+ * (endpoint, midpoint, center, quadrant, nearest). Additional modes such as
+ * `node`, `focus`, and `control` can be passed explicitly to {@link AcExOsnapIndex}.
+ */
+export const ACEX_DEFAULT_OSNAP_MODES: readonly AcExOsnapMode[] = [
+  'endpoint',
+  'midpoint',
+  'center',
+  'quadrant',
+  'nearest'
+] as const
+
+/**
+ * Fields shared by every exported snap primitive.
+ *
+ * All coordinates are already transformed into layout WCS, including geometry
+ * that originated inside block references.
+ */
+export interface AcExOsnapPrimitiveBase {
+  /**
+   * Effective layer name used for visibility filtering in the viewer.
+   *
+   * Follows AutoCAD block rules: entities on layer `0` inside a block inherit
+   * the INSERT layer assigned during export.
+   */
+  layer: string
+}
+
+/**
+ * A straight line segment (`AcDbLine`, or a non-bulge polyline edge).
+ *
+ * @see {@link AcExOsnapLinePrimitive.kind}
+ */
+export interface AcExOsnapLinePrimitive extends AcExOsnapPrimitiveBase {
+  /** Discriminator for {@link AcExOsnapPrimitive}. */
+  kind: 'line'
+  /** Start X in WCS. */
+  x0: number
+  /** Start Y in WCS. */
+  y0: number
+  /** End X in WCS. */
+  x1: number
+  /** End Y in WCS. */
+  y1: number
+}
+
+/**
+ * A full circle (`AcDbCircle`) in the XY plane.
+ *
+ * Snap support: center, quadrant (four cardinal directions), nearest on circumference.
+ * A full circle has no arc midpoint or endpoints.
+ */
+export interface AcExOsnapCirclePrimitive extends AcExOsnapPrimitiveBase {
+  /** Discriminator for {@link AcExOsnapPrimitive}. */
+  kind: 'circle'
+  /** Center X in WCS. */
+  cx: number
+  /** Center Y in WCS. */
+  cy: number
+  /** Radius in drawing units (after block scale). */
+  r: number
+  /**
+   * Extrusion / normal sign: `+1` = CCW positive angles (+Z normal),
+   * `-1` = CW (+Y mirrored, −Z normal).
+   */
+  normalSign: 1 | -1
+}
+
+/**
+ * A circular arc (`AcDbArc`, or a bulge segment from `AcDbPolyline`).
+ *
+ * Angles are in radians. When {@link AcExOsnapArcPrimitive.normalSign} is `+1`,
+ * increasing angle is counter-clockwise in WCS; when `-1`, the Y component is
+ * mirrored so snap math matches AutoCAD clockwise arcs.
+ */
+export interface AcExOsnapArcPrimitive extends AcExOsnapPrimitiveBase {
+  /** Discriminator for {@link AcExOsnapPrimitive}. */
+  kind: 'arc'
+  /** Arc center X in WCS. */
+  cx: number
+  /** Arc center Y in WCS. */
+  cy: number
+  /** Arc radius in drawing units. */
+  r: number
+  /** Start angle in radians (entity parameter, not degrees). */
+  startAngle: number
+  /** End angle in radians (entity parameter, not degrees). */
+  endAngle: number
+  /** See {@link AcExOsnapCirclePrimitive.normalSign}. */
+  normalSign: 1 | -1
+}
+
+/**
+ * An ellipse or elliptical arc (`AcDbEllipse`).
+ *
+ * Used when the source entity is an ellipse, or when a circle/arc is transformed
+ * by a non-uniform block scale and can no longer be represented as a circular arc.
+ *
+ * Parameter angles follow the AutoCAD / `AcGeEllipseArc` convention (not geometric
+ * polar angle from the center).
+ */
+export interface AcExOsnapEllipsePrimitive extends AcExOsnapPrimitiveBase {
+  /** Discriminator for {@link AcExOsnapPrimitive}. */
+  kind: 'ellipse'
+  /** Ellipse center X in WCS. */
+  cx: number
+  /** Ellipse center Y in WCS. */
+  cy: number
+  /** Unit vector — major axis direction in WCS (XY). */
+  majorX: number
+  /** Unit vector — major axis direction in WCS (XY). */
+  majorY: number
+  /** Semi-major axis length in drawing units. */
+  majorR: number
+  /** Semi-minor axis length in drawing units. */
+  minorR: number
+  /** Start parameter angle in radians. */
+  startAngle: number
+  /** End parameter angle in radians. */
+  endAngle: number
+  /** `true` for a closed ellipse; `false` for an elliptical arc. */
+  closed: boolean
+}
+
+/**
+ * A B-spline / NURBS curve (`AcDbSpline`) serialized for runtime evaluation.
+ *
+ * Control data is copied from the entity geometry at export time and transformed
+ * into WCS. The offline viewer evaluates the curve with de Boor (not render
+ * tessellation) for nearest-point snap.
+ */
+export interface AcExOsnapSplinePrimitive extends AcExOsnapPrimitiveBase {
+  /** Discriminator for {@link AcExOsnapPrimitive}. */
+  kind: 'spline'
+  /**
+   * Control polygon vertices in WCS: `[x0, y0, x1, y1, …]`.
+   *
+   * Length is always even; may be empty if the source spline had no control points.
+   */
+  controlPoints: number[]
+  /** Spline degree (typically 3 for cubic splines). */
+  degree: number
+  /** Knot vector (clamped), same length rules as AutoCAD `AcDbSpline`. */
+  knots: number[]
+  /**
+   * Per-control-point weights for rational splines.
+   *
+   * When empty at runtime, unit weights are assumed.
+   */
+  weights: number[]
+  /** Whether the spline is closed in parameter space. */
+  closed: boolean
+  /**
+   * Optional fit points in WCS: `[x0, y0, …]`.
+   *
+   * Reserved for future snap modes; not required for current OSNAP logic.
+   */
+  fitPoints?: number[]
+}
+
+/**
+ * A point entity (`AcDbPoint`) in WCS.
+ *
+ * Contributes `node` (and legacy `endpoint`) snap when those modes are enabled.
+ */
+export interface AcExOsnapPointPrimitive extends AcExOsnapPrimitiveBase {
+  /** Discriminator for {@link AcExOsnapPrimitive}. */
+  kind: 'point'
+  /** Point X in WCS. */
+  x: number
+  /** Point Y in WCS. */
+  y: number
+}
+
+/**
+ * Discriminated union of all analytic primitives stored in a layout snapshot.
+ *
+ * Select on {@link AcExOsnapPrimitive.kind} before reading geometry fields.
+ */
+export type AcExOsnapPrimitive =
+  | AcExOsnapLinePrimitive
+  | AcExOsnapCirclePrimitive
+  | AcExOsnapArcPrimitive
+  | AcExOsnapEllipsePrimitive
+  | AcExOsnapSplinePrimitive
+  | AcExOsnapPointPrimitive
+
+/**
+ * Per-layout catalog of analytic geometry used for object snap.
+ *
+ * Embedded on {@link AcExLayoutSnapshot.osnap} when exporting HTML. When
+ * {@link AcExOsnapCatalog.primitives} is non-empty, {@link AcExOsnapIndex} ignores
+ * tessellated `lineBatches` / `meshBatches` for snapping.
+ */
+export interface AcExOsnapCatalog {
+  /**
+   * All snap-capable primitives for this layout in WCS.
+   *
+   * Includes entities nested inside block references (INSERT), each with an
+   * effective {@link AcExOsnapPrimitiveBase.layer}.
+   */
+  primitives: AcExOsnapPrimitive[]
+}

--- a/packages/cad-html-exporter/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-exporter/src/AcExSnapshotTypes.ts
@@ -1,3 +1,5 @@
+import type { AcExOsnapCatalog } from './AcExOsnapPrimitiveTypes'
+
 /**
  * Current snapshot schema version.
  * Increment when breaking changes are introduced to {@link AcExSnapshotV1}.
@@ -123,6 +125,19 @@ export interface AcExLayoutSnapshot {
   lineBatches: AcExLineBatch[]
   /** All mesh/fill batches belonging to this layout. */
   meshBatches: AcExMeshBatch[]
+  /**
+   * Analytic geometry for object snap (OSNAP) in the offline viewer.
+   *
+   * Populated at export time by {@link buildOsnapCatalog} from the drawing database
+   * (not from tessellated THREE batches). Includes lines, arcs, circles, ellipses,
+   * splines, and points in WCS, including entities inside block references.
+   *
+   * When {@link AcExOsnapCatalog.primitives} is non-empty, {@link AcExOsnapIndex}
+   * uses these definitions exclusively and does **not** snap to discretized
+   * {@link AcExLineBatch} / {@link AcExMeshBatch} vertices. Older HTML files
+   * without this field continue to use batch-based snapping.
+   */
+  osnap?: AcExOsnapCatalog
 }
 
 /**

--- a/packages/cad-html-exporter/src/AcExViewerMetadata.ts
+++ b/packages/cad-html-exporter/src/AcExViewerMetadata.ts
@@ -18,6 +18,10 @@ export interface AcExViewerMetadata {
  * Extracts viewer metadata from an open drawing database (units, extents).
  * Does not serialize entities or DXF/DWG content.
  *
+ * Object-snap (OSNAP) curve and line definitions are **not** part of this
+ * metadata object. They are stored per layout in
+ * {@link AcExLayoutSnapshot.osnap}, built by {@link buildOsnapCatalog} at export time.
+ *
  * @param database - Open `AcDbDatabase` to read sysvars and extents from.
  * @param options - Optional title override and background color (default `0x000000`).
  * @returns Metadata object suitable for {@link AcExSnapshotV1.meta}.

--- a/packages/cad-html-exporter/src/index.ts
+++ b/packages/cad-html-exporter/src/index.ts
@@ -6,6 +6,24 @@ export * from './AcExSnapshotCodec'
 export * from './AcExSceneBatchCollector'
 /** Database metadata extraction for snapshot `meta` fields. */
 export * from './AcExViewerMetadata'
+/**
+ * Analytic OSNAP primitive types ({@link AcExOsnapPrimitive}, {@link AcExOsnapCatalog})
+ * and mode definitions for the offline HTML viewer.
+ */
+export * from './AcExOsnapPrimitiveTypes'
+/**
+ * Builds per-layout {@link AcExOsnapCatalog} from an open `AcDbDatabase`
+ * (lines, curves, splines, nested blocks in WCS).
+ */
+export { buildOsnapCatalog } from './AcExOsnapPrimitiveBuilder'
+/** Maps snapshot primitives to `AcGe*` curves for OSNAP. */
+export {
+  circleOrArcToAcGe,
+  ellipseToAcGe,
+  primitiveToAcGeCurve,
+  splineToAcGe,
+  type AcExOsnapAcGeCurve
+} from './AcExOsnapPrimitiveToAcGe'
 export { packHtml, type AcExPackHtmlOptions } from './AcExHtmlPackager'
 export {
   AcExHtmlI18n,

--- a/packages/cad-simple-viewer/src/command/convert/AcApHtmlSnapshotBuilder.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApHtmlSnapshotBuilder.ts
@@ -5,6 +5,7 @@ import {
   type AcExLineBatch,
   type AcExMeshBatch,
   type AcExSnapshotV1,
+  buildOsnapCatalog,
   buildViewerMetadata,
   collectBatchesFromObject3D
 } from '@mlightcad/cad-html-exporter'
@@ -108,7 +109,8 @@ export class AcApHtmlSnapshotBuilder {
         name: resolveLayoutName(database, btrId),
         isModelSpace: btrId === scene.modelSpaceBtrId,
         lineBatches,
-        meshBatches
+        meshBatches,
+        osnap: buildOsnapCatalog(database, btrId)
       })
       await yieldToMain()
     }
@@ -159,7 +161,8 @@ export class AcApHtmlSnapshotBuilder {
         name: resolveLayoutName(database, btrId),
         isModelSpace: btrId === scene.modelSpaceBtrId,
         lineBatches,
-        meshBatches
+        meshBatches,
+        osnap: buildOsnapCatalog(database, btrId)
       })
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.7.36
-  '@mlightcad/libredwg-converter': ^3.5.36
+  '@mlightcad/data-model': ^1.7.37
+  '@mlightcad/libredwg-converter': ^3.5.37
   '@mlightcad/mtext-input-box': ^0.2.11
   '@mlightcad/mtext-renderer': ^0.10.14
   '@mlightcad/ribbon': ^0.1.9
@@ -111,8 +111,8 @@ importers:
         version: 0.8.2
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.36
-        version: 1.7.36
+        specifier: ^1.7.37
+        version: 1.7.37
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -135,11 +135,11 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.36
-        version: 1.7.36
+        specifier: ^1.7.37
+        version: 1.7.37
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.36
-        version: 3.5.36(@mlightcad/data-model@1.7.36)
+        specifier: ^3.5.37
+        version: 3.5.37(@mlightcad/data-model@1.7.37)
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.14
         version: 0.10.14(three@0.172.0)
@@ -169,8 +169,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-html-exporter
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.36
-        version: 3.5.36(@mlightcad/data-model@1.7.36)
+        specifier: ^3.5.37
+        version: 3.5.37(@mlightcad/data-model@1.7.37)
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
@@ -179,8 +179,8 @@ importers:
         version: 4.0.1
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.36
-        version: 1.7.36
+        specifier: ^1.7.37
+        version: 1.7.37
       '@mlightcad/mtext-input-box':
         specifier: ^0.2.11
         version: 0.2.11(@mlightcad/mtext-renderer@0.10.14(three@0.172.0))(three@0.172.0)
@@ -221,8 +221,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.36
-        version: 1.7.36
+        specifier: ^1.7.37
+        version: 1.7.37
       three:
         specifier: ^0.172.0
         version: 0.172.0
@@ -240,8 +240,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.36
-        version: 1.7.36
+        specifier: ^1.7.37
+        version: 1.7.37
       '@mlightcad/ribbon':
         specifier: ^0.1.9
         version: 0.1.9(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
@@ -312,8 +312,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.36
-        version: 1.7.36
+        specifier: ^1.7.37
+        version: 1.7.37
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -370,14 +370,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.36
-        version: 1.7.36
+        specifier: ^1.7.37
+        version: 1.7.37
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.36
-        version: 1.7.36
+        specifier: ^1.7.37
+        version: 1.7.37
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.14
         version: 0.10.14(three@0.172.0)
@@ -1450,30 +1450,30 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.4.36':
-    resolution: {integrity: sha512-FplcElR6K2tYD8qWn6iywg70JJIwGRDW/YeAFyaHVLd5AthhIpRVj1cFSdwngfcYmOzOK6HW5pZgeIk0F/1zsQ==}
+  '@mlightcad/common@1.4.37':
+    resolution: {integrity: sha512-cgA8xs/5zByowomNUFDRyc8K7zCTs1yxh5N6K9dSKVEGwM6nq/yO2xpy411wcEc4ZZ/u/D7Lp2SwfEJqtiCPlg==}
 
-  '@mlightcad/data-model@1.7.36':
-    resolution: {integrity: sha512-CJ/C0xbGISSoGea6Fx/+qcGTXr4gLjTO7X9siiM74G9f2VGiTbwQxCAX46Ejc+lDNk4y7YTlMxoce6XNkH7TwQ==}
+  '@mlightcad/data-model@1.7.37':
+    resolution: {integrity: sha512-v4C1bwWY9ygzJlTtXI6bQAiGOVl+yYyFCaAFUh4n41lgYSQVL6DPfua3alaWWVytWRlBY1BVItxmWEJXZbIcmg==}
 
   '@mlightcad/dxf-json@1.2.0':
     resolution: {integrity: sha512-pfKFSMi84wmV1C4EAq4Axq20K1+12tXGI5epggxWZE++NeZBCQM5yuQYKYD/P8oSWz3c2nFHe9KhithAKUSnfQ==}
 
-  '@mlightcad/geometry-engine@3.2.36':
-    resolution: {integrity: sha512-19ckGy7HmujryCnasILxDt8qlstjt3eDGgkQdBcpESb3rmmOiajJ6TqYWdCEew62M/5tGsVsaA3NnpVb5AyJ7A==}
+  '@mlightcad/geometry-engine@3.2.37':
+    resolution: {integrity: sha512-83Y+IC7Nt0T1SBWTmp01bOMJ4NDeqH/V2x0Me6cJFwoNuiRJ89U7dpyCrkiQxOA/FI9Us33zeG/j9XaAeCiAMA==}
     peerDependencies:
-      '@mlightcad/common': 1.4.36
+      '@mlightcad/common': 1.4.37
 
-  '@mlightcad/graphic-interface@3.3.36':
-    resolution: {integrity: sha512-PJidtnR9mTKZlc0bGoB/wf6vGUxcWCVCHrMBzXnPdM3DA53te5+7pM1Kr2T8BO8vjcKzixOnHsZEg5cmAuJdJg==}
+  '@mlightcad/graphic-interface@3.3.37':
+    resolution: {integrity: sha512-P907f5QPSBgQvp9GsxwHjaOUwA4+6NlrEUo/zxXZs3SPdyu26Gz7skB8owJE4v402xaHIAla0qyhr33AzSiGXg==}
     peerDependencies:
-      '@mlightcad/common': 1.4.36
-      '@mlightcad/geometry-engine': 3.2.36
+      '@mlightcad/common': 1.4.37
+      '@mlightcad/geometry-engine': 3.2.37
 
-  '@mlightcad/libredwg-converter@3.5.36':
-    resolution: {integrity: sha512-9zT811YcWCX4t64xm18I/kpG3HVS0fxeLW3/jsCr3CwVuaxRN6SU9wDiXf6Xt48EKPbNFEGZl3akbyUfTFqxHg==}
+  '@mlightcad/libredwg-converter@3.5.37':
+    resolution: {integrity: sha512-Bfe28/R1MZoJGTsVC+nELfQIkqrhrJO3KqEX2nSU0sZv9K7UkaE+zVjvFP+gYGfFlOOjJQgbWYRfAZDEx/M5Lg==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.36
+      '@mlightcad/data-model': ^1.7.37
 
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
@@ -6236,16 +6236,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.4.36':
+  '@mlightcad/common@1.4.37':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.7.36':
+  '@mlightcad/data-model@1.7.37':
     dependencies:
-      '@mlightcad/common': 1.4.36
+      '@mlightcad/common': 1.4.37
       '@mlightcad/dxf-json': 1.2.0
-      '@mlightcad/geometry-engine': 3.2.36(@mlightcad/common@1.4.36)
-      '@mlightcad/graphic-interface': 3.3.36(@mlightcad/common@1.4.36)(@mlightcad/geometry-engine@3.2.36(@mlightcad/common@1.4.36))
+      '@mlightcad/geometry-engine': 3.2.37(@mlightcad/common@1.4.37)
+      '@mlightcad/graphic-interface': 3.3.37(@mlightcad/common@1.4.37)(@mlightcad/geometry-engine@3.2.37(@mlightcad/common@1.4.37))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
@@ -6253,18 +6253,18 @@ snapshots:
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.2.36(@mlightcad/common@1.4.36)':
+  '@mlightcad/geometry-engine@3.2.37(@mlightcad/common@1.4.37)':
     dependencies:
-      '@mlightcad/common': 1.4.36
+      '@mlightcad/common': 1.4.37
 
-  '@mlightcad/graphic-interface@3.3.36(@mlightcad/common@1.4.36)(@mlightcad/geometry-engine@3.2.36(@mlightcad/common@1.4.36))':
+  '@mlightcad/graphic-interface@3.3.37(@mlightcad/common@1.4.37)(@mlightcad/geometry-engine@3.2.37(@mlightcad/common@1.4.37))':
     dependencies:
-      '@mlightcad/common': 1.4.36
-      '@mlightcad/geometry-engine': 3.2.36(@mlightcad/common@1.4.36)
+      '@mlightcad/common': 1.4.37
+      '@mlightcad/geometry-engine': 3.2.37(@mlightcad/common@1.4.37)
 
-  '@mlightcad/libredwg-converter@3.5.36(@mlightcad/data-model@1.7.36)':
+  '@mlightcad/libredwg-converter@3.5.37(@mlightcad/data-model@1.7.37)':
     dependencies:
-      '@mlightcad/data-model': 1.7.36
+      '@mlightcad/data-model': 1.7.37
       '@mlightcad/libredwg-web': 0.7.1
 
   '@mlightcad/libredwg-web@0.7.1': {}


### PR DESCRIPTION
## Summary

Improves object snap (OSNAP) in the offline HTML viewer by exporting **analytic geometry** at snapshot build time instead of relying only on tessellated line/mesh batches. Circles, arcs, ellipses, splines, polylines (including bulge arcs), and block references now snap to true centers, quadrants, and nearest-on-curve points—matching AutoCAD-style behavior more closely than segment approximations.

## What changed

### Export pipeline
- Added `buildOsnapCatalog()` to walk layout block table records, expand `AcDbBlockReference` with full WCS transforms, and emit compact `AcExOsnapPrimitive` records (line, circle, arc, ellipse, spline, point).
- Wired catalog generation into `AcApHtmlSnapshotBuilder` so each `AcExLayoutSnapshot` includes an optional `osnap` field.
- Handles layer `0` inheritance inside blocks, non-uniform INSERT scale (circles/arcs → ellipses), and polyline bulge segments via `AcGeCircArc2d`.

### Runtime (offline viewer)
- `AcExOsnapIndex` prefers `layout.osnap.primitives` when present; otherwise falls back to legacy tessellated `lineBatches` / `meshBatches` (backward compatible with older HTML exports).
- Snap math delegated to `AcGe*` curves through `AcExOsnapGeometry` and `primitiveToAcGeCurve`.
- Extended OSNAP modes: **center**, **quadrant**, **nearest** (on curves), plus **focus**, **control**, and **node** for ellipses/splines/points.
- AutoCAD-style mode priority: endpoint / midpoint / center beat quadrant / focus / control / node, which beat nearest.
- New on-screen marker glyphs: circle (center) and diamond (quadrant / focus).
- Measurement controller: shared `_resolvePointerWithOsnap()` so snap markers refresh correctly after pan/zoom.

### Dependencies
- Bump `@mlightcad/data-model` to `^1.7.37` and `@mlightcad/libredwg-converter` to `^3.5.37`.