### PR TITLE
fix: prevent status bar progress from jumping backward after reaching 100% when opening DXF/DWG

### DIFF
--- a/packages/cad-html-exporter/__tests__/AcExOsnapGeometry.spec.ts
+++ b/packages/cad-html-exporter/__tests__/AcExOsnapGeometry.spec.ts
@@ -23,12 +23,12 @@ describe('collectPrimitiveSnapCandidates', () => {
       5.1,
       modes
     )
-    expect(candidates.some(c => c.mode === 'center' && c.x === 5 && c.y === 5)).toBe(
-      true
-    )
-    expect(candidates.some(c => c.mode === 'quadrant' && c.x === 7 && c.y === 5)).toBe(
-      true
-    )
+    expect(
+      candidates.some(c => c.mode === 'center' && c.x === 5 && c.y === 5)
+    ).toBe(true)
+    expect(
+      candidates.some(c => c.mode === 'quadrant' && c.x === 7 && c.y === 5)
+    ).toBe(true)
   })
 
   it('snaps to arc endpoints and center', () => {
@@ -47,9 +47,9 @@ describe('collectPrimitiveSnapCandidates', () => {
       0.2,
       modes
     )
-    expect(candidates.some(c => c.mode === 'endpoint' && c.x === 10 && c.y === 0)).toBe(
-      true
-    )
+    expect(
+      candidates.some(c => c.mode === 'endpoint' && c.x === 10 && c.y === 0)
+    ).toBe(true)
     expect(candidates.some(c => c.mode === 'center')).toBe(true)
   })
 

--- a/packages/cad-html-exporter/project.json
+++ b/packages/cad-html-exporter/project.json
@@ -3,7 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/cad-html-exporter/src",
   "projectType": "library",
-  "tags": ["npm:private"],
+  "tags": [
+    "npm:private"
+  ],
   "targets": {
     "build": {
       "executor": "nx:run-commands",
@@ -11,7 +13,9 @@
         "command": "tsc && vite build && vite build --config vite.viewer.config.ts",
         "cwd": "packages/cad-html-exporter"
       },
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "cache": true
     },
     "clean": {

--- a/packages/cad-html-exporter/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-exporter/src/AcExHtmlI18n.ts
@@ -123,10 +123,8 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       ready: '就绪',
       measureDistanceHint: '点击两点以测量距离（已启用对象捕捉）。',
       measureAngleHint: '依次点击顶点与两条边上的点（已启用对象捕捉）。',
-      measureArcHint:
-        '依次点击弧起点、弧上一点与弧端点（已启用对象捕捉）。',
-      measureAreaHint:
-        '依次点击多边形顶点；靠近首点或按 Enter 完成。',
+      measureArcHint: '依次点击弧起点、弧上一点与弧端点（已启用对象捕捉）。',
+      measureAreaHint: '依次点击多边形顶点；靠近首点或按 Enter 完成。',
       measureCoordinateHint: '点击一点以读取其 X/Y 坐标（已启用对象捕捉）。',
       distance: '距离：{value}',
       coordinates: 'X：{x}  Y：{y}',

--- a/packages/cad-html-exporter/src/AcExHtmlShell.ts
+++ b/packages/cad-html-exporter/src/AcExHtmlShell.ts
@@ -350,17 +350,25 @@ export function buildAcExHtmlShellBody(loadingBg: string): string {
           'data-i18n-key': 'toolbar.measureArea',
           'data-i18n-attr': 'title aria-label'
         })}
-        ${acExToolbarButton(acExHtmlIcons.measureCoordinate, 'Measure coordinates', {
-          'data-action': 'measure',
-          'data-measure-mode': 'coordinate',
-          'data-i18n-key': 'toolbar.measureCoordinate',
-          'data-i18n-attr': 'title aria-label'
-        })}
-        ${acExToolbarButton(acExHtmlIcons.clearMeasurements, 'Clear measurements', {
-          'data-action': 'clear-measurements',
-          'data-i18n-key': 'toolbar.clearMeasurements',
-          'data-i18n-attr': 'title aria-label'
-        })}
+        ${acExToolbarButton(
+          acExHtmlIcons.measureCoordinate,
+          'Measure coordinates',
+          {
+            'data-action': 'measure',
+            'data-measure-mode': 'coordinate',
+            'data-i18n-key': 'toolbar.measureCoordinate',
+            'data-i18n-attr': 'title aria-label'
+          }
+        )}
+        ${acExToolbarButton(
+          acExHtmlIcons.clearMeasurements,
+          'Clear measurements',
+          {
+            'data-action': 'clear-measurements',
+            'data-i18n-key': 'toolbar.clearMeasurements',
+            'data-i18n-attr': 'title aria-label'
+          }
+        )}
         <div class="mlcad-tool-separator" aria-hidden="true"></div>
         ${acExToolbarButton(acExHtmlIcons.layer, 'Layers', {
           id: 'mlcad-layers-btn',

--- a/packages/cad-html-exporter/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-exporter/src/AcExHtmlViewerRuntime.ts
@@ -4,10 +4,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import { AcExHtmlI18n, detectAcExHtmlLocale } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import { computeLayerExtentsMap } from './AcExLayerExtents'
-import {
-  AcExMeasureController,
-  type AcExMeasureMode
-} from './AcExMeasurement'
+import { AcExMeasureController, type AcExMeasureMode } from './AcExMeasurement'
 import { AcExOsnapIndex } from './AcExOsnap'
 import { AcExOsnapMarker } from './AcExOsnapMarker'
 import { decodeSnapshot } from './AcExSnapshotCodec'
@@ -219,9 +216,7 @@ function startViewer(): void {
   const resolveMeasurePoint = (clientX: number, clientY: number) => {
     const raw = screenToWcs(clientX, clientY)
     const snap = osnapIndex.findSnap(raw.x, raw.y, osnapThresholdWcs())
-    const point = snap
-      ? new THREE.Vector2(snap.x, snap.y)
-      : raw
+    const point = snap ? new THREE.Vector2(snap.x, snap.y) : raw
     return { point, snap: snap ?? null }
   }
 

--- a/packages/cad-html-exporter/src/AcExMeasurement.ts
+++ b/packages/cad-html-exporter/src/AcExMeasurement.ts
@@ -220,17 +220,15 @@ function distPointToPolylinePx(
   verts: { x: number; y: number }[]
 ): number {
   if (verts.length < 2) {
-    if (verts.length === 1) return Math.hypot(px - verts[0]!.x, py - verts[0]!.y)
+    if (verts.length === 1)
+      return Math.hypot(px - verts[0]!.x, py - verts[0]!.y)
     return Infinity
   }
   let best = Infinity
   for (let i = 0; i < verts.length - 1; i++) {
     const a = verts[i]!
     const b = verts[i + 1]!
-    best = Math.min(
-      best,
-      distPointToSegmentPx(px, py, a.x, a.y, b.x, b.y)
-    )
+    best = Math.min(best, distPointToSegmentPx(px, py, a.x, a.y, b.x, b.y))
   }
   return best
 }
@@ -255,9 +253,7 @@ function distPointToArcPx(
   const total = Math.abs(span)
   for (let i = 0; i <= samples; i++) {
     const t = i / samples
-    const a = antiClockwise
-      ? startAngle - t * total
-      : startAngle + t * total
+    const a = antiClockwise ? startAngle - t * total : startAngle + t * total
     const x = cx + r * Math.cos(a)
     const y = cy + r * Math.sin(a)
     best = Math.min(best, Math.hypot(px - x, py - y))
@@ -311,9 +307,7 @@ function hitTestAngleMeasure(
   wcsToScreen: (wcs: THREE.Vector2) => { x: number; y: number }
 ): boolean {
   const screenVerts = [vertex, arm1, vertex, arm2].map(p => wcsToScreen(p))
-  if (
-    distPointToPolylinePx(clientX, clientY, screenVerts) <= thresholdPx
-  ) {
+  if (distPointToPolylinePx(clientX, clientY, screenVerts) <= thresholdPx) {
     return true
   }
 
@@ -334,9 +328,7 @@ function hitTestAngleMeasure(
   }
 
   const badge = wcsToScreen(badgePos)
-  if (
-    Math.hypot(clientX - badge.x, clientY - badge.y) <= thresholdPx + 14
-  ) {
+  if (Math.hypot(clientX - badge.x, clientY - badge.y) <= thresholdPx + 14) {
     return true
   }
 
@@ -862,9 +854,7 @@ export class AcExMeasureController {
 
     for (let i = this._committed.length - 1; i >= 0; i--) {
       const measure = this._committed[i]!
-      if (
-        measure.hitTest(clientX, clientY, MEASURE_HIT_THRESHOLD_PX)
-      ) {
+      if (measure.hitTest(clientX, clientY, MEASURE_HIT_THRESHOLD_PX)) {
         const changed = measure.id !== this._selectedId
         this._select(measure.id)
         return changed
@@ -1441,11 +1431,7 @@ export class AcExMeasureController {
     this._setPreviewLine(pts)
     if (pts.length >= 3) {
       const area = shoelaceArea(pts)
-      this._showLiveLabel(
-        `${this._view.formatLength(area)}²`,
-        clientX,
-        clientY
-      )
+      this._showLiveLabel(`${this._view.formatLength(area)}²`, clientX, clientY)
       this._drawPreviewArea(pts)
     }
     this._requestRender()
@@ -1556,11 +1542,7 @@ export class AcExMeasureController {
 
   /** @internal */
   private _finishCommit(
-    hitTest: (
-      clientX: number,
-      clientY: number,
-      thresholdPx: number
-    ) => boolean
+    hitTest: (clientX: number, clientY: number, thresholdPx: number) => boolean
   ): void {
     const parts = this._commitParts
     if (!parts) return
@@ -1584,9 +1566,7 @@ export class AcExMeasureController {
   }
 
   /** @internal */
-  private _screenPolyline(
-    points: THREE.Vector2[]
-  ): { x: number; y: number }[] {
+  private _screenPolyline(points: THREE.Vector2[]): { x: number; y: number }[] {
     return points.map(p => {
       const s = this._view.wcsToScreen(p)
       return { x: s.x, y: s.y }
@@ -1613,7 +1593,10 @@ export class AcExMeasureController {
   }
 
   /** @internal */
-  private _applyMeasureSelection(parts: AcExCommitParts, selected: boolean): void {
+  private _applyMeasureSelection(
+    parts: AcExCommitParts,
+    selected: boolean
+  ): void {
     for (const line of parts.lines) {
       const material = line.material
       if (material instanceof THREE.LineBasicMaterial) {
@@ -1699,25 +1682,15 @@ export class AcExMeasureController {
     ctx.save()
     ctx.scale(dpr, dpr)
 
-    const arc = interiorAngleArcScreenMetrics(
-      vertex,
-      arm1,
-      arm2,
-      wcs => this._view.wcsToScreen(wcs)
+    const arc = interiorAngleArcScreenMetrics(vertex, arm1, arm2, wcs =>
+      this._view.wcsToScreen(wcs)
     )
     const rootRect = this._root.getBoundingClientRect()
     const vx = arc.cx - rootRect.left
     const vy = arc.cy - rootRect.top
 
     ctx.beginPath()
-    ctx.arc(
-      vx,
-      vy,
-      arc.r,
-      arc.startAngle,
-      arc.endAngle,
-      arc.antiClockwise
-    )
+    ctx.arc(vx, vy, arc.r, arc.startAngle, arc.endAngle, arc.antiClockwise)
     ctx.strokeStyle = MEASURE_CSS
     ctx.lineWidth = 2
     ctx.stroke()
@@ -1768,12 +1741,7 @@ export class AcExMeasureController {
     const screenR = Math.hypot(sx - cx, sy - cy)
     const sa = Math.atan2(sy - cy, sx - cx)
     const ea = Math.atan2(ey - cy, ex - cx)
-    const { counterClockwise } = arcSweepThroughMiddle(
-      start,
-      through,
-      end,
-      g
-    )
+    const { counterClockwise } = arcSweepThroughMiddle(start, through, end, g)
 
     ctx.beginPath()
     ctx.arc(cx, cy, screenR, sa, ea, counterClockwise)

--- a/packages/cad-html-exporter/src/AcExOsnap.ts
+++ b/packages/cad-html-exporter/src/AcExOsnap.ts
@@ -131,9 +131,12 @@ function cellKey(cx: number, cy: number): string {
   return `${cx},${cy}`
 }
 
-function primitiveBounds(
-  prim: AcExOsnapPrimitive
-): { minX: number; minY: number; maxX: number; maxY: number } {
+function primitiveBounds(prim: AcExOsnapPrimitive): {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+} {
   switch (prim.kind) {
     case 'line':
       return {
@@ -218,9 +221,7 @@ export class AcExOsnapIndex {
     const catalog = layout.osnap
     if (catalog && catalog.primitives.length > 0) {
       this.usePrimitives = true
-      this.primitives = catalog.primitives.filter(p =>
-        isLayerVisible(p.layer)
-      )
+      this.primitives = catalog.primitives.filter(p => isLayerVisible(p.layer))
       this.segments = []
     } else {
       this.usePrimitives = false
@@ -318,7 +319,11 @@ export class AcExOsnapIndex {
    * @param threshold - Maximum snap distance in drawing units (aperture radius).
    * @returns The winning snap point, or `undefined` if nothing is within range.
    */
-  findSnap(px: number, py: number, threshold: number): AcExOsnapPoint | undefined {
+  findSnap(
+    px: number,
+    py: number,
+    threshold: number
+  ): AcExOsnapPoint | undefined {
     const items = this.usePrimitives ? this.primitives : this.segments
     if (items.length === 0 || threshold <= 0) return undefined
 

--- a/packages/cad-html-exporter/src/AcExOsnapPrimitiveBuilder.ts
+++ b/packages/cad-html-exporter/src/AcExOsnapPrimitiveBuilder.ts
@@ -75,8 +75,16 @@ function transformVector(
  * @internal
  */
 function scaleIsUniform(matrix: THREE.Matrix4): boolean {
-  const sx = new THREE.Vector3(matrix.elements[0], matrix.elements[1], matrix.elements[2]).length()
-  const sy = new THREE.Vector3(matrix.elements[4], matrix.elements[5], matrix.elements[6]).length()
+  const sx = new THREE.Vector3(
+    matrix.elements[0],
+    matrix.elements[1],
+    matrix.elements[2]
+  ).length()
+  const sy = new THREE.Vector3(
+    matrix.elements[4],
+    matrix.elements[5],
+    matrix.elements[6]
+  ).length()
   return Math.abs(sx - sy) <= EPS * Math.max(sx, sy, 1)
 }
 
@@ -111,7 +119,11 @@ function pushCircle(
   normal: AcGeVector3dLike
 ) {
   const c = transformPoint(matrix, center)
-  const sx = new THREE.Vector3(matrix.elements[0], matrix.elements[1], matrix.elements[2]).length()
+  const sx = new THREE.Vector3(
+    matrix.elements[0],
+    matrix.elements[1],
+    matrix.elements[2]
+  ).length()
   const prim: AcExOsnapCirclePrimitive = {
     kind: 'circle',
     layer,
@@ -131,7 +143,11 @@ function pushArc(
   entity: AcDbArc
 ) {
   const center = transformPoint(matrix, entity.center)
-  const sx = new THREE.Vector3(matrix.elements[0], matrix.elements[1], matrix.elements[2]).length()
+  const sx = new THREE.Vector3(
+    matrix.elements[0],
+    matrix.elements[1],
+    matrix.elements[2]
+  ).length()
   const prim: AcExOsnapArcPrimitive = {
     kind: 'arc',
     layer,
@@ -153,14 +169,21 @@ function pushEllipse(
   entity: AcDbEllipse
 ) {
   const center = transformPoint(matrix, entity.center)
-  const geo = (
-    entity as unknown as { _geo?: { majorAxis?: AcGeVector3dLike } }
-  )._geo
+  const geo = (entity as unknown as { _geo?: { majorAxis?: AcGeVector3dLike } })
+    ._geo
   const majorAxis = geo?.majorAxis ?? { x: 1, y: 0, z: 0 }
   const axis = transformVector(matrix, majorAxis)
   const len = Math.hypot(axis.x, axis.y) || 1
-  const sx = new THREE.Vector3(matrix.elements[0], matrix.elements[1], matrix.elements[2]).length()
-  const sy = new THREE.Vector3(matrix.elements[4], matrix.elements[5], matrix.elements[6]).length()
+  const sx = new THREE.Vector3(
+    matrix.elements[0],
+    matrix.elements[1],
+    matrix.elements[2]
+  ).length()
+  const sy = new THREE.Vector3(
+    matrix.elements[4],
+    matrix.elements[5],
+    matrix.elements[6]
+  ).length()
   const prim: AcExOsnapEllipsePrimitive = {
     kind: 'ellipse',
     layer,
@@ -346,7 +369,14 @@ function visitEntity(
 
   if (entity instanceof AcDbCircle) {
     if (scaleIsUniform(matrix)) {
-      pushCircle(out, layer, matrix, entity.center, entity.radius, entity.normal)
+      pushCircle(
+        out,
+        layer,
+        matrix,
+        entity.center,
+        entity.radius,
+        entity.normal
+      )
     } else {
       pushEllipse(out, layer, matrix, ellipseFromCircle(entity))
     }

--- a/packages/cad-html-exporter/src/AcExOsnapPrimitiveToAcGe.ts
+++ b/packages/cad-html-exporter/src/AcExOsnapPrimitiveToAcGe.ts
@@ -61,7 +61,9 @@ export function circleOrArcToAcGe(
  *
  * @param prim - Ellipse or elliptical arc in WCS.
  */
-export function ellipseToAcGe(prim: AcExOsnapEllipsePrimitive): AcGeEllipseArc2d {
+export function ellipseToAcGe(
+  prim: AcExOsnapEllipsePrimitive
+): AcGeEllipseArc2d {
   const rotation = Math.atan2(prim.majorY, prim.majorX)
   return new AcGeEllipseArc2d(
     { x: prim.cx, y: prim.cy, z: 0 },
@@ -102,7 +104,9 @@ export function splineToAcGe(prim: AcExOsnapSplinePrimitive): AcGeNurbsCurve {
  * @param prim - Exported primitive from {@link AcExOsnapCatalog}.
  * @returns Wrapped geometry for snap evaluation.
  */
-export function primitiveToAcGeCurve(prim: AcExOsnapPrimitive): AcExOsnapAcGeCurve {
+export function primitiveToAcGeCurve(
+  prim: AcExOsnapPrimitive
+): AcExOsnapAcGeCurve {
   switch (prim.kind) {
     case 'line':
       return {

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -340,6 +340,10 @@ export class AcApDocManager {
    * registering built-in and system-variable commands.
    */
   private _commandAliasOverrides: Map<string, string[]>
+  /** Peak open-file percentage for the current open operation (monotonic) */
+  private _openFileProgressPeak = 0
+  /** Last open-file progress stage (FETCH_FILE or CONVERSION) */
+  private _openFileProgressStage?: AcDbProgressdEventArgs['stage']
   /** Singleton instance */
   private static _instance?: AcApDocManager
 
@@ -374,17 +378,21 @@ export class AcApDocManager {
       AcTrMTextRenderer.getInstance().setRenderMode('worker')
     }
 
+    this.events.documentToBeOpened.addEventListener(() => {
+      this.resetOpenFileProgress()
+    })
+
     // Create one empty drawing
     const doc = new AcApDocument()
     doc.database.events.openProgress.addEventListener(args => {
-      const progress = {
+      const progress = this.normalizeOpenFileProgress({
         database: doc.database,
         percentage: args.percentage,
         stage: args.stage,
         subStage: args.subStage,
         subStageStatus: args.subStageStatus,
         data: args.data
-      }
+      })
       eventBus.emit('open-file-progress', progress)
       this.updateProgress(progress)
 
@@ -1176,6 +1184,49 @@ export class AcApDocManager {
   }
 
   /**
+   * Resets tracked open-file progress for a new open operation.
+   */
+  private resetOpenFileProgress() {
+    this._openFileProgressPeak = 0
+    this._openFileProgressStage = undefined
+  }
+
+  /**
+   * Returns monotonic open-file progress for UI display.
+   *
+   * Entity conversion reports 0–100% within the ENTITY sub-stage while the
+   * pipeline accumulator is still ~33%; sub-stage END callbacks can therefore
+   * briefly report a lower percentage after IN-PROGRESS already reached 100%.
+   */
+  private normalizeOpenFileProgress(
+    data: AcDbProgressdEventArgs
+  ): AcDbProgressdEventArgs {
+    const stage = data.stage
+    if (stage !== this._openFileProgressStage) {
+      if (
+        this._openFileProgressStage === 'FETCH_FILE' &&
+        stage === 'CONVERSION'
+      ) {
+        this._openFileProgressPeak = 0
+      }
+      this._openFileProgressStage = stage
+    }
+    this._openFileProgressPeak = Math.max(
+      this._openFileProgressPeak,
+      data.percentage
+    )
+    return { ...data, percentage: this._openFileProgressPeak }
+  }
+
+  private isOpenFileProgressComplete(data: AcDbProgressdEventArgs) {
+    return (
+      data.percentage >= 100 &&
+      data.subStage === 'END' &&
+      data.subStageStatus === 'END'
+    )
+  }
+
+  /**
    * Shows progress animation and progress message
    * @param data - Progress data
    */
@@ -1190,9 +1241,9 @@ export class AcApDocManager {
       this._progress.setMessage(AcApI18n.t('main.message.fetchingDrawingFile'))
     }
 
-    const percentage = data.percentage
-    if (percentage >= 100) {
+    if (this.isOpenFileProgressComplete(data)) {
       this._progress.hide()
+      this.resetOpenFileProgress()
     } else {
       this._progress.show()
     }

--- a/packages/cad-viewer/src/component/statusBar/MlProgress.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlProgress.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts" setup>
-import { eventBus } from '@mlightcad/cad-simple-viewer'
+import { AcApDocManager, eventBus } from '@mlightcad/cad-simple-viewer'
 import {
   AcDbParsingTaskStats,
   AcDbProgressdEventArgs
@@ -25,6 +25,11 @@ const { t } = useI18n()
 const percentage = ref(0)
 const visible = ref(false)
 const { warning } = useNotificationCenter()
+
+const resetProgress = () => {
+  percentage.value = 0
+  visible.value = false
+}
 
 const updateProgress = (data: AcDbProgressdEventArgs) => {
   if (data.stage === 'CONVERSION') {
@@ -47,11 +52,11 @@ const updateProgress = (data: AcDbProgressdEventArgs) => {
     }
   }
   percentage.value = data.percentage
-  if (percentage.value < 100) {
-    visible.value = true
-  } else {
-    visible.value = false
-  }
+  const isComplete =
+    data.percentage >= 100 &&
+    data.subStage === 'END' &&
+    data.subStageStatus === 'END'
+  visible.value = !isComplete
 }
 
 const format = (percentage: number) => {
@@ -60,10 +65,18 @@ const format = (percentage: number) => {
 
 onMounted(() => {
   eventBus.on('open-file-progress', updateProgress)
+  eventBus.on('failed-to-open-file', resetProgress)
+  AcApDocManager.instance.events.documentToBeOpened.addEventListener(
+    resetProgress
+  )
 })
 
 onUnmounted(() => {
   eventBus.off('open-file-progress', updateProgress)
+  eventBus.off('failed-to-open-file', resetProgress)
+  AcApDocManager.instance.events.documentToBeOpened.removeEventListener(
+    resetProgress
+  )
 })
 </script>
 


### PR DESCRIPTION
## Summary

Fixes a regression where the status bar progress bar could reach **100%** and then suddenly drop to a lower value (often around **32%**) while opening a DXF or DWG file.

The root cause is in how `@mlightcad/data-model` reports open progress: during the **ENTITY** sub-stage, `IN-PROGRESS` events interpolate from the pipeline accumulator (~33%) up to 100%, but the sub-stage **END** callback still emits the pre-step accumulator value (~33%) before the ENTITY weight is applied. The UI treated any `percentage >= 100` as “done,” so it hid the bar at 100% and then showed it again at the lower value.

## Changes

### `packages/cad-simple-viewer` — `AcApDocManager.ts`

- Track a **monotonic peak** percentage per open operation and normalize all `open-file-progress` events before emitting them on the event bus.
- Reset progress tracking on `documentToBeOpened`, and when transitioning from `FETCH_FILE` to `CONVERSION` (URL opens).
- Only hide the fullscreen loading overlay when the pipeline reports the final completion signal (`subStage === 'END'`, `subStageStatus === 'END'`, `percentage >= 100`), not on intermediate 100% values during ENTITY processing.

### `packages/cad-viewer` — `MlProgress.vue`

- Align visibility logic with the same completion criteria so the status bar progress bar stays visible through ENTITY processing and hides only when the file is fully loaded.
- Reset progress state on `documentToBeOpened` and `failed-to-open-file`.
- Use `AcApDocManager.instance` for lifecycle binding (safe here because the component mounts only after the viewer is initialized).
