### PR TITLE
fix(three-renderer): resolve false "Failed to convert hatch boundaries!" warnings when loading DXF

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
       "vue-demi"
     ],
     "overrides": {
-      "@mlightcad/data-model": "^1.7.39",
-      "@mlightcad/libredwg-converter": "^3.5.39",
+      "@mlightcad/data-model": "^1.7.40",
+      "@mlightcad/libredwg-converter": "^3.5.40",
       "@mlightcad/mtext-input-box": "^0.2.11",
       "@mlightcad/mtext-renderer": "^0.10.14",
       "@mlightcad/ribbon": "^0.1.9",

--- a/packages/cad-viewer-example/e2e/tests/draw-after-load.spec.ts
+++ b/packages/cad-viewer-example/e2e/tests/draw-after-load.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const fixturePath = path.resolve(
+  currentDir,
+  '..',
+  'fixtures',
+  'minimal-line.dxf'
+)
+
+async function uploadFixture(page: Page) {
+  const fileInput = page.locator('input[type="file"]').first()
+  await expect(fileInput).toBeAttached()
+  await fileInput.setInputFiles(fixturePath)
+}
+
+/**
+ * Counts non-background canvas pixels. Used as a coarse signal that newly
+ * committed linework is actually rendered, not only present in the scene graph.
+ */
+async function countNonBackgroundPixels(page: Page) {
+  const canvas = page.locator('.ml-cad-container canvas').first()
+  const pngBase64 = (await canvas.screenshot()).toString('base64')
+
+  return page.evaluate(async imageBase64 => {
+    const image = new Image()
+    image.src = `data:image/png;base64,${imageBase64}`
+    await image.decode()
+
+    const probe = document.createElement('canvas')
+    probe.width = image.naturalWidth
+    probe.height = image.naturalHeight
+    const ctx = probe.getContext('2d')
+    if (!ctx) {
+      throw new Error('Failed to create 2d context for screenshot probe')
+    }
+
+    ctx.drawImage(image, 0, 0)
+    const { data } = ctx.getImageData(0, 0, probe.width, probe.height)
+
+    let count = 0
+    for (let i = 0; i < data.length; i += 8) {
+      const r = data[i]
+      const g = data[i + 1]
+      const b = data[i + 2]
+      const a = data[i + 3]
+      if (a < 200) continue
+      if (r + g + b > 60) count++
+    }
+    return count
+  }, pngBase64)
+}
+
+/**
+ * Regression for https://github.com/mlightcad/cad-viewer/issues/286
+ *
+ * Entities committed after the initial load must render without requiring a
+ * camera change (pan/resize) to refresh the batched renderer.
+ */
+test('drawn lines appear immediately without panning the view', async ({
+  page
+}) => {
+  await page.goto('/')
+  await uploadFixture(page)
+  await expect(page.locator('.ml-cad-container')).toBeVisible({ timeout: 30000 })
+  await page.waitForTimeout(1500)
+
+  const beforeDraw = await countNonBackgroundPixels(page)
+
+  const canvas = page.locator('.ml-cad-container canvas').first()
+  const box = await canvas.boundingBox()
+  if (!box) {
+    throw new Error('Canvas bounding box is unavailable')
+  }
+
+  const commandInput = page.getByRole('textbox', { name: 'Type command' })
+  await commandInput.click()
+  await commandInput.fill('line')
+  await commandInput.press('Enter')
+  await page.waitForTimeout(300)
+
+  const clickPoint = async (xRatio: number, yRatio: number) => {
+    await page.mouse.click(
+      box.x + box.width * xRatio,
+      box.y + box.height * yRatio
+    )
+    await page.waitForTimeout(200)
+  }
+
+  await clickPoint(0.35, 0.55)
+  await clickPoint(0.45, 0.45)
+  await clickPoint(0.55, 0.55)
+  await clickPoint(0.65, 0.45)
+  await clickPoint(0.75, 0.55)
+  await page.keyboard.press('Enter')
+  await page.waitForTimeout(800)
+
+  const afterDrawNoPan = await countNonBackgroundPixels(page)
+  const gainWithoutPan = afterDrawNoPan - beforeDraw
+
+  expect(gainWithoutPan).toBeGreaterThan(1000)
+})

--- a/packages/three-renderer/src/object/AcTrPolygon.ts
+++ b/packages/three-renderer/src/object/AcTrPolygon.ts
@@ -14,6 +14,18 @@ import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
 import { AcTrEntity } from './AcTrEntity'
 
+function toVector2(points: AcGePoint2dLike[]): THREE.Vector2[] {
+  return points.map(point => new THREE.Vector2(point.x, point.y))
+}
+
+function hasFillVertices(geometry: THREE.BufferGeometry | undefined): boolean {
+  if (!geometry) {
+    return false
+  }
+  const position = geometry.getAttribute('position')
+  return !!position && position.count > 0
+}
+
 export class AcTrPolygon extends AcTrEntity {
   constructor(
     area: AcGeArea2d,
@@ -24,18 +36,19 @@ export class AcTrPolygon extends AcTrEntity {
 
     const pointBoundaries = area.getPoints(100)
     const hierarchy = area.buildHierarchy()
+    const hasRenderableBoundaries = pointBoundaries.some(loop => loop.length >= 3)
 
     const geometries: THREE.BufferGeometry[] = []
     this.buildHatchGeometry(pointBoundaries, hierarchy, geometries)
 
     let geometry: THREE.BufferGeometry | undefined
-    if (geometries.length > 0) {
-      geometry = mergeGeometries(geometries)
+    if (geometries.length === 1) {
+      geometry = geometries[0]
+    } else if (geometries.length > 1) {
+      geometry = mergeGeometries(geometries) ?? undefined
     }
 
-    if (!geometry || !geometry.getIndex() || geometry.getIndex()?.count === 0) {
-      log.warn('Failed to convert hatch boundaries!')
-    } else {
+    if (geometry && hasFillVertices(geometry)) {
       geometry.computeBoundingBox()
       this.box = geometry.boundingBox!
 
@@ -53,6 +66,8 @@ export class AcTrPolygon extends AcTrEntity {
         gradientBounds
       )
       this.add(new THREE.Mesh(geometry, material))
+    } else if (hasRenderableBoundaries) {
+      log.warn('Failed to convert hatch boundaries!')
     }
   }
 
@@ -130,10 +145,10 @@ export class AcTrPolygon extends AcTrEntity {
 
     noHoles.forEach(index => {
       const points = pointBoundaries[index]
-      if (points.length === 0) {
+      if (points.length < 3) {
         return
       }
-      const shape = new THREE.Shape(points as unknown as THREE.Vector2[])
+      const shape = new THREE.Shape(toVector2(points))
       createGeometry(shape)
     })
 
@@ -141,9 +156,11 @@ export class AcTrPolygon extends AcTrEntity {
       vecs.map(p => p.toArray() as [number, number])
 
     for (const pair of holes) {
-      const shape = new THREE.Shape(
-        pointBoundaries[pair[0]] as unknown as THREE.Vector2[]
-      )
+      const outerPoints = pointBoundaries[pair[0]]
+      if (outerPoints.length < 3) {
+        continue
+      }
+      const shape = new THREE.Shape(toVector2(outerPoints))
       // merge holes
       let mergedHoles: {
         regions: number[][][]
@@ -202,9 +219,11 @@ export class AcTrPolygon extends AcTrEntity {
       for (let i = 0; i < pair[1].length; i++) {
         const idx = pair[1][i]
         if (!ignoreHoleIndexArr.includes(idx)) {
-          shape.holes.push(
-            new THREE.Path(pointBoundaries[idx] as unknown as THREE.Vector2[])
-          )
+          const holePoints = pointBoundaries[idx]
+          if (holePoints.length < 3) {
+            continue
+          }
+          shape.holes.push(new THREE.Path(toVector2(holePoints)))
         }
       }
       createGeometry(shape)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.7.39
-  '@mlightcad/libredwg-converter': ^3.5.39
+  '@mlightcad/data-model': ^1.7.40
+  '@mlightcad/libredwg-converter': ^3.5.40
   '@mlightcad/mtext-input-box': ^0.2.11
   '@mlightcad/mtext-renderer': ^0.10.14
   '@mlightcad/ribbon': ^0.1.9
@@ -111,8 +111,8 @@ importers:
         version: 0.8.2
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.39
-        version: 1.7.39
+        specifier: ^1.7.40
+        version: 1.7.40
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -135,11 +135,11 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.39
-        version: 1.7.39
+        specifier: ^1.7.40
+        version: 1.7.40
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.39
-        version: 3.5.39(@mlightcad/data-model@1.7.39)
+        specifier: ^3.5.40
+        version: 3.5.40(@mlightcad/data-model@1.7.40)
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.14
         version: 0.10.14(three@0.172.0)
@@ -169,8 +169,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-html-exporter
       '@mlightcad/libredwg-converter':
-        specifier: ^3.5.39
-        version: 3.5.39(@mlightcad/data-model@1.7.39)
+        specifier: ^3.5.40
+        version: 3.5.40(@mlightcad/data-model@1.7.40)
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
@@ -179,8 +179,8 @@ importers:
         version: 4.0.1
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.39
-        version: 1.7.39
+        specifier: ^1.7.40
+        version: 1.7.40
       '@mlightcad/mtext-input-box':
         specifier: ^0.2.11
         version: 0.2.11(@mlightcad/mtext-renderer@0.10.14(three@0.172.0))(three@0.172.0)
@@ -221,8 +221,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.39
-        version: 1.7.39
+        specifier: ^1.7.40
+        version: 1.7.40
       three:
         specifier: ^0.172.0
         version: 0.172.0
@@ -240,8 +240,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.39
-        version: 1.7.39
+        specifier: ^1.7.40
+        version: 1.7.40
       '@mlightcad/ribbon':
         specifier: ^0.1.9
         version: 0.1.9(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
@@ -312,8 +312,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.7.39
-        version: 1.7.39
+        specifier: ^1.7.40
+        version: 1.7.40
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -370,14 +370,14 @@ importers:
   packages/svg-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.39
-        version: 1.7.39
+        specifier: ^1.7.40
+        version: 1.7.40
 
   packages/three-renderer:
     dependencies:
       '@mlightcad/data-model':
-        specifier: ^1.7.39
-        version: 1.7.39
+        specifier: ^1.7.40
+        version: 1.7.40
       '@mlightcad/mtext-renderer':
         specifier: ^0.10.14
         version: 0.10.14(three@0.172.0)
@@ -1450,30 +1450,30 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.4.39':
-    resolution: {integrity: sha512-48cgQ4v+6ChdemdtVH6CvRjgJLjGQ2GgPsYB+0mwnPXAw63q/U/ONLRP5vjR+yDq+kwnodVxWM4s/5Rc47+9mg==}
+  '@mlightcad/common@1.4.40':
+    resolution: {integrity: sha512-RQDG7j6MiwVNbCAmszNLRzOJNc/pMilPnNzS2wnVTRI9k8wtINQmvEyEJjBQGSGK7p/2gmY1JwoKjYH36izcsw==}
 
-  '@mlightcad/data-model@1.7.39':
-    resolution: {integrity: sha512-T/M34lNGQce6AjHT+404Yn5O1nz5U1HLX48nd5UDo4u9vY5BZwJPWvRwXbN63kv27HzzL/rYCXxoospoAubSiw==}
+  '@mlightcad/data-model@1.7.40':
+    resolution: {integrity: sha512-QWJA1CyNByt68FPVv4mi1e7hsJbyNzpkII4NBuJPCwzTwSonR97ix7m2JPEftV9bq0wMCcOg0uAbrTU/zAbJNQ==}
 
   '@mlightcad/dxf-json@1.2.0':
     resolution: {integrity: sha512-pfKFSMi84wmV1C4EAq4Axq20K1+12tXGI5epggxWZE++NeZBCQM5yuQYKYD/P8oSWz3c2nFHe9KhithAKUSnfQ==}
 
-  '@mlightcad/geometry-engine@3.2.39':
-    resolution: {integrity: sha512-Zccd9g5+Bm0p/+iY3uoG2l0xAXTyOcONvIAM5YEfMC65L5OP6EI8ERHq5eu9yy2lQXK2l2JVuX0tn0X3Md0/9g==}
+  '@mlightcad/geometry-engine@3.2.40':
+    resolution: {integrity: sha512-dAs2kaW3BlL2sDmmLoHSY78k1mv2e5LMz6GPZKhlK2j+ttk2gfVYaNPx8VSCu5txCVmSYTJVTzkn/PR+ZlBzWw==}
     peerDependencies:
-      '@mlightcad/common': 1.4.39
+      '@mlightcad/common': 1.4.40
 
-  '@mlightcad/graphic-interface@3.3.39':
-    resolution: {integrity: sha512-8SMyIJwnCl4uh455/U9Zh6VPfzQmgxYrF8TRF1EX1X7AzzEy/yFiuuF5sO5cropiAhWHpOlE+1XoXbXds+mLvQ==}
+  '@mlightcad/graphic-interface@3.3.40':
+    resolution: {integrity: sha512-uDO4OHmCWE/kEPCvG3fzb1H1MBi0mHkfXRZFk55lwrYrJEQccmYmfCTsHK+YvzAbrRVbWX0vpshhPya8ltCWvg==}
     peerDependencies:
-      '@mlightcad/common': 1.4.39
-      '@mlightcad/geometry-engine': 3.2.39
+      '@mlightcad/common': 1.4.40
+      '@mlightcad/geometry-engine': 3.2.40
 
-  '@mlightcad/libredwg-converter@3.5.39':
-    resolution: {integrity: sha512-ezVRnC7evcewB3cK4OZ0RCYA7/qJ6kWBbCdX7a/VHOrikWpNQ0MkZ591Sc1OHeSVnLnsSFHYe8wqIC8A8crhxA==}
+  '@mlightcad/libredwg-converter@3.5.40':
+    resolution: {integrity: sha512-CDLDI7viYBGQTXxZVdhd3KoyB+XucQ18LDWoLKOrYwz5gLtslTG2yNPjd50kQKaXCKgvBmrk1aKKjy1hsxl9fg==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.39
+      '@mlightcad/data-model': ^1.7.40
 
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
@@ -6242,16 +6242,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.4.39':
+  '@mlightcad/common@1.4.40':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.7.39':
+  '@mlightcad/data-model@1.7.40':
     dependencies:
-      '@mlightcad/common': 1.4.39
+      '@mlightcad/common': 1.4.40
       '@mlightcad/dxf-json': 1.2.0
-      '@mlightcad/geometry-engine': 3.2.39(@mlightcad/common@1.4.39)
-      '@mlightcad/graphic-interface': 3.3.39(@mlightcad/common@1.4.39)(@mlightcad/geometry-engine@3.2.39(@mlightcad/common@1.4.39))
+      '@mlightcad/geometry-engine': 3.2.40(@mlightcad/common@1.4.40)
+      '@mlightcad/graphic-interface': 3.3.40(@mlightcad/common@1.4.40)(@mlightcad/geometry-engine@3.2.40(@mlightcad/common@1.4.40))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
@@ -6259,18 +6259,18 @@ snapshots:
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.2.39(@mlightcad/common@1.4.39)':
+  '@mlightcad/geometry-engine@3.2.40(@mlightcad/common@1.4.40)':
     dependencies:
-      '@mlightcad/common': 1.4.39
+      '@mlightcad/common': 1.4.40
 
-  '@mlightcad/graphic-interface@3.3.39(@mlightcad/common@1.4.39)(@mlightcad/geometry-engine@3.2.39(@mlightcad/common@1.4.39))':
+  '@mlightcad/graphic-interface@3.3.40(@mlightcad/common@1.4.40)(@mlightcad/geometry-engine@3.2.40(@mlightcad/common@1.4.40))':
     dependencies:
-      '@mlightcad/common': 1.4.39
-      '@mlightcad/geometry-engine': 3.2.39(@mlightcad/common@1.4.39)
+      '@mlightcad/common': 1.4.40
+      '@mlightcad/geometry-engine': 3.2.40(@mlightcad/common@1.4.40)
 
-  '@mlightcad/libredwg-converter@3.5.39(@mlightcad/data-model@1.7.39)':
+  '@mlightcad/libredwg-converter@3.5.40(@mlightcad/data-model@1.7.40)':
     dependencies:
-      '@mlightcad/data-model': 1.7.39
+      '@mlightcad/data-model': 1.7.40
       '@mlightcad/libredwg-web': 0.7.1
 
   '@mlightcad/libredwg-web@0.7.1': {}


### PR DESCRIPTION
## Summary

Fixes spurious browser warnings (`Failed to convert hatch boundaries!`) when opening DXF files in the viewer. The issue affected filled-area rendering for hatch, SOLID, and TRACE entities.

This PR updates `@mlightcad/three-renderer` to triangulate hatch boundaries more reliably and to validate geometry correctly. It is intended to be used together with an updated `@mlightcad/data-model` release that fixes SOLID/TRACE boundary vertex ordering (see **Related changes** below).

## Problem

When loading DXF files, the console repeatedly logged:
