### PR TITLE
fix: stabilize render loop, hatch cache keys, and material clone state

### DIFF
--- a/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
@@ -191,12 +191,13 @@ export class AcTrLayoutView extends AcTrBaseView {
    */
   render(scene: AcTrScene) {
     this._renderer.clear()
-    this._renderer.render(scene.internalScene, this._camera)
+    const needsRedraw = this._renderer.render(scene.internalScene, this._camera)
     const modelSpaceLayout = scene.modelSpaceLayout
     if (modelSpaceLayout) {
       this.drawViewports(modelSpaceLayout.internalObject)
     }
     this._axesGizmo?.update()
+    return needsRedraw
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrLayoutViewManager.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayoutViewManager.ts
@@ -114,8 +114,10 @@ export class AcTrLayoutViewManager {
    * Only renders the currently active layout view, if one is set.
    *
    * @param scene - Input the scene to render
+   * @returns `true` when the renderer applied new RTE shader patches and another
+   * frame should be drawn.
    */
-  render(scene: AcTrScene) {
-    this.activeLayoutView?.render(scene)
+  render(scene: AcTrScene): boolean {
+    return this.activeLayoutView?.render(scene) ?? false
   }
 }

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -893,12 +893,7 @@ export class AcTrView2d extends AcEdBaseView {
     // 2) For each drill-through viewport, resolve hits against the
     //    model-space layout using the viewport's own camera/raycaster.
     if (drillThroughViewports.length > 0) {
-      this.pickThroughViewports(
-        point,
-        paperBox,
-        drillThroughViewports,
-        results
-      )
+      this.pickThroughViewports(point, paperBox, drillThroughViewports, results)
     }
 
     const sortedResults = sortPickResults(results, point)
@@ -935,8 +930,7 @@ export class AcTrView2d extends AcEdBaseView {
     // model-WCS radius that the per-viewport raycaster threshold and the
     // spatial-index probe both use. This keeps the hit area visually
     // consistent across viewports at different zoom levels.
-    const paperHalfRadius =
-      (paperBox.size.width + paperBox.size.height) / 4
+    const paperHalfRadius = (paperBox.size.width + paperBox.size.height) / 4
 
     for (const vpView of viewports) {
       const modelPt = vpView.paperPointToModel(paperPoint)
@@ -1310,13 +1304,15 @@ export class AcTrView2d extends AcEdBaseView {
       camera: this.internalCamera
     })
 
-    if (!this._isDirty) return
-    this._layoutViewManager.render(this._scene)
+    const stillLoading = this._numOfEntitiesToProcess > 0
+    if (!this._isDirty && !stillLoading) return
+
+    const needsRedraw = this._layoutViewManager.render(this._scene)
     if (this.internalCamera) {
       this._css2dRenderer.render(this._scene.internalScene, this.internalCamera)
     }
     this._stats?.update()
-    this._isDirty = false
+    this._isDirty = stillLoading || needsRedraw
   }
 
   private startAnimationLoop() {

--- a/packages/cad-viewer-example/e2e/tests/draw-after-load.spec.ts
+++ b/packages/cad-viewer-example/e2e/tests/draw-after-load.spec.ts
@@ -64,7 +64,9 @@ test('drawn lines appear immediately without panning the view', async ({
 }) => {
   await page.goto('/')
   await uploadFixture(page)
-  await expect(page.locator('.ml-cad-container')).toBeVisible({ timeout: 30000 })
+  await expect(page.locator('.ml-cad-container')).toBeVisible({
+    timeout: 30000
+  })
   await page.waitForTimeout(1500)
 
   const beforeDraw = await countNonBackgroundPixels(page)

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -92,9 +92,11 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
     this._renderer.clearDepth()
   }
 
-  render(scene: THREE.Object3D, camera: AcTrCamera) {
+  render(scene: THREE.Object3D, camera: AcTrCamera): boolean {
     this.updateCameraZoomUniform(camera.zoom)
     this._renderer.render(scene, camera.internalCamera)
+    // RTE frame scheduling is added in the large-coordinate feature branch.
+    return false
   }
 
   /**

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -387,7 +387,17 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
       })
       .join('|')
 
-    return `hatch_${traits.layer}_${traits.rgbColor}_${style.patternAngle}_${patternHash}${sideSuffix}${drawOrderSuffix}`
+    return [
+      'hatch',
+      traits.layer,
+      traits.rgbColor,
+      style.patternAngle,
+      options.rebaseOffset.x,
+      options.rebaseOffset.y,
+      patternHash,
+      sideSuffix,
+      drawOrderSuffix
+    ].join('_')
   }
 
   /**

--- a/packages/three-renderer/src/util/AcTrMaterialUtil.ts
+++ b/packages/three-renderer/src/util/AcTrMaterialUtil.ts
@@ -1,5 +1,8 @@
 import * as THREE from 'three'
 
+const RTE_MATERIAL_FLAG = '__acTrRteMaterialEnabled'
+const RTE_SHADER_REF = '__acTrRteShader'
+
 /**
  * Highlight color.
  */
@@ -38,11 +41,11 @@ export class AcTrMaterialUtil {
     if (Array.isArray(material)) {
       const materials: THREE.Material[] = []
       material.forEach(mat => {
-        materials.push(mat.clone())
+        materials.push(this.cloneSingleMaterial(mat))
       })
       return materials
     }
-    return (material as THREE.Material).clone()
+    return this.cloneSingleMaterial(material as THREE.Material)
   }
 
   public static setMaterialColor(
@@ -96,5 +99,25 @@ export class AcTrMaterialUtil {
     material: THREE.Material
   ): material is MaterialWithUniforms {
     return 'uniforms' in material && material.uniforms !== undefined
+  }
+
+  private static cloneSingleMaterial(material: THREE.Material) {
+    const clonedMaterial = material.clone()
+    this.resetRuntimeShaderState(clonedMaterial)
+    return clonedMaterial
+  }
+
+  /**
+   * Cloned highlight materials must not inherit runtime-only shader state from
+   * the source instance, otherwise the clone can keep using stale RTE shader
+   * uniforms/program keys bound to another render object.
+   */
+  private static resetRuntimeShaderState(material: THREE.Material) {
+    delete material.userData[RTE_MATERIAL_FLAG]
+    delete material.userData[RTE_SHADER_REF]
+    material.onBeforeCompile = THREE.Material.prototype.onBeforeCompile
+    material.customProgramCacheKey =
+      THREE.Material.prototype.customProgramCacheKey
+    material.needsUpdate = true
   }
 }


### PR DESCRIPTION
## Summary

Fixes several rendering issues that could leave the canvas stale, reuse the wrong hatch fill material, or carry stale shader state into cloned highlight materials.

- **Render loop / dirty flag**: Propagate a `boolean` from `AcTrRenderer.render()` through layout views so the 2D view can schedule another frame when the renderer reports pending work. Keep the animation loop active while entities are still loading, and only clear `_isDirty` when loading is finished and no redraw is requested.
- **Hatch material cache**: Include `rebaseOffset` (`x`, `y`) in the hatch material cache key so hatches at different world offsets do not share the same cached material.
- **Material clone hygiene**: When cloning materials (e.g. for highlighting), reset runtime-only RTE shader hooks and `userData` flags so clones do not inherit stale `onBeforeCompile` / `customProgramCacheKey` state from the source.

## Changes

| Area | File(s) | What changed |
|------|---------|----------------|
| Viewer render pipeline | `AcTrView2d.ts`, `AcTrLayoutView.ts`, `AcTrLayoutViewManager.ts` | `render()` returns whether another frame is needed; dirty state respects in-flight loading and renderer feedback |
| Renderer API | `AcTrRenderer.ts` | `render()` return type is `boolean` (returns `false` until RTE frame scheduling lands on the large-coordinate branch) |
| Hatch caching | `AcTrFillMaterialManager.ts` | Cache key includes pattern rebase offset |
| Highlight clones | `AcTrMaterialUtil.ts` | Centralized single-material clone with RTE runtime state reset |
| E2E | `draw-after-load.spec.ts` | Formatting only |

## Motivation

- Drawn geometry could fail to appear until the user panned/zoomed because the view cleared `_isDirty` while work was still in progress or before a follow-up frame was scheduled.
- Hatches with the same layer/color/pattern but different rebase offsets could incorrectly share materials.
- Cloned materials used for selection/highlight could retain RTE-specific shader customization from the original mesh, leading to incorrect or unstable rendering.

## Test plan

- [ ] Open a DXF/DWG in the example app; draw lines immediately after load — geometry should appear without panning (covers `draw-after-load` e2e intent).
- [ ] Load a drawing with multiple hatches that share pattern/layer/color but differ in placement; verify fill patterns align correctly.
- [ ] Select/highlight entities with hatch or custom fill materials; confirm colors and patterns stay correct and do not flicker or use wrong shaders.
- [ ] Pan/zoom during progressive entity load; confirm the view keeps updating until loading completes.
- [ ] Run e2e: `draw-after-load.spec.ts` (if CI runs the example package tests).

## Notes

- `AcTrRenderer.render()` currently always returns `false`; the return path is wired through the viewer so the large-coordinate / RTE branch can request extra frames without further API changes.