### PR TITLE
feat: refactor pr 218 and put it in one lazy-loaded PDF plugin

### DIFF
--- a/packages/cad-pdf-plugin/package.json
+++ b/packages/cad-pdf-plugin/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@mlightcad/cad-pdf-plugin",
+  "private": true,
+  "version": "1.5.1",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mlightcad/cad-viewer.git"
+  },
+  "files": [
+    "dist",
+    "lib",
+    "README.md",
+    "package.json"
+  ],
+  "main": "./dist/index.umd.cjs",
+  "module": "./dist/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
+  },
+  "scripts": {
+    "clean": "rimraf dist lib tsconfig.tsbuildinfo",
+    "build": "tsc && vite build",
+    "lint": "eslint src/",
+    "lint:fix": "eslint --fix --quiet src/"
+  },
+  "dependencies": {
+    "jspdf": "^4.2.1",
+    "pdfjs-dist": "^5.6.205",
+    "svg2pdf.js": "^2.7.0"
+  },
+  "devDependencies": {
+    "@mlightcad/cad-simple-viewer": "workspace:*",
+    "@mlightcad/data-model": "^1.7.40",
+    "@mlightcad/svg-renderer": "workspace:*"
+  },
+  "peerDependencies": {
+    "@mlightcad/cad-simple-viewer": "workspace:*",
+    "@mlightcad/data-model": "^1.7.40",
+    "@mlightcad/svg-renderer": "workspace:*"
+  }
+}

--- a/packages/cad-pdf-plugin/project.json
+++ b/packages/cad-pdf-plugin/project.json
@@ -1,0 +1,43 @@
+{
+  "name": "@mlightcad/cad-pdf-plugin",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/cad-pdf-plugin/src",
+  "projectType": "library",
+  "tags": [
+    "npm:private"
+  ],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc && vite build",
+        "cwd": "packages/cad-pdf-plugin"
+      },
+      "dependsOn": [
+        "^build"
+      ],
+      "cache": true
+    },
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "rimraf dist lib tsconfig.tsbuildinfo",
+        "cwd": "packages/cad-pdf-plugin"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint src/",
+        "cwd": "packages/cad-pdf-plugin"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint --fix --quiet src/",
+        "cwd": "packages/cad-pdf-plugin"
+      }
+    }
+  }
+}

--- a/packages/cad-pdf-plugin/src/AcApConvertToPdfCmd.ts
+++ b/packages/cad-pdf-plugin/src/AcApConvertToPdfCmd.ts
@@ -1,0 +1,19 @@
+import { AcApContext, AcEdCommand } from '@mlightcad/cad-simple-viewer'
+
+import { AcApPdfConvertor } from './AcApPdfConvertor'
+
+/**
+ * Command for converting the current CAD drawing to PDF format.
+ * The command name is `cpdf`.
+ */
+export class AcApConvertToPdfCmd extends AcEdCommand {
+  /**
+   * Renders the current drawing to PDF and downloads it in the browser.
+   *
+   * @param context - Application context for the active document
+   */
+  async execute(context: AcApContext) {
+    const converter = new AcApPdfConvertor()
+    await converter.convert(context)
+  }
+}

--- a/packages/cad-pdf-plugin/src/AcApImportPdfCmd.ts
+++ b/packages/cad-pdf-plugin/src/AcApImportPdfCmd.ts
@@ -1,0 +1,19 @@
+import { AcApContext, AcEdCommand } from '@mlightcad/cad-simple-viewer'
+
+import { AcApPdfImportConvertor } from './AcApPdfImportConvertor'
+
+/**
+ * Command for importing vector geometry from a PDF file.
+ * The command name is `ipdf`.
+ */
+export class AcApImportPdfCmd extends AcEdCommand {
+  /**
+   * Opens a file picker and imports vector geometry from the selected PDF.
+   *
+   * @param context - Application context for the target document
+   */
+  async execute(context: AcApContext) {
+    const convertor = new AcApPdfImportConvertor()
+    convertor.importFromFilePicker(context)
+  }
+}

--- a/packages/cad-pdf-plugin/src/AcApPdfConvertor.ts
+++ b/packages/cad-pdf-plugin/src/AcApPdfConvertor.ts
@@ -1,0 +1,59 @@
+import type { AcApContext } from '@mlightcad/cad-simple-viewer'
+import { AcSvgRenderer } from '@mlightcad/svg-renderer'
+import { jsPDF } from 'jspdf'
+import { svg2pdf } from 'svg2pdf.js'
+
+/**
+ * Utility class for converting CAD drawings to PDF format.
+ *
+ * Reuses the SVG renderer pipeline and converts the resulting SVG to a
+ * vector PDF using jsPDF + svg2pdf.js.
+ */
+export class AcApPdfConvertor {
+  /**
+   * Renders the current drawing to PDF and triggers a browser download.
+   *
+   * @param context - Application context for the drawing to export
+   */
+  async convert(context: AcApContext) {
+    const svgString = this.buildSvg(context)
+    await this.downloadAsPdf(svgString)
+  }
+
+  private buildSvg(context: AcApContext): string {
+    const entities =
+      context.doc.database.tables.blockTable.modelSpace.newIterator()
+    const renderer = new AcSvgRenderer()
+    for (const entity of entities) {
+      entity.worldDraw(renderer)
+    }
+    return renderer.export()
+  }
+
+  private async downloadAsPdf(svgString: string) {
+    const parser = new DOMParser()
+    const svgDoc = parser.parseFromString(svgString, 'image/svg+xml')
+    const svgEl = svgDoc.documentElement as unknown as SVGSVGElement
+
+    const vb = svgEl.getAttribute('viewBox')?.split(' ').map(Number)
+    const vbWidth = vb && vb.length === 4 ? Math.abs(vb[2]) : 297
+    const vbHeight = vb && vb.length === 4 ? Math.abs(vb[3]) : 210
+
+    const orientation = vbWidth >= vbHeight ? 'landscape' : 'portrait'
+
+    const pdf = new jsPDF({
+      orientation,
+      unit: 'mm',
+      format: [vbWidth, vbHeight]
+    })
+
+    await svg2pdf(svgEl, pdf, {
+      x: 0,
+      y: 0,
+      width: vbWidth,
+      height: vbHeight
+    })
+
+    pdf.save('drawing.pdf')
+  }
+}

--- a/packages/cad-pdf-plugin/src/AcApPdfImportConvertor.ts
+++ b/packages/cad-pdf-plugin/src/AcApPdfImportConvertor.ts
@@ -1,0 +1,265 @@
+import type { AcApContext } from '@mlightcad/cad-simple-viewer'
+import {
+  AcDbLine,
+  AcDbPolyline,
+  AcGePoint2d,
+  AcGePoint3d,
+  log
+} from '@mlightcad/data-model'
+import * as pdfjsLib from 'pdfjs-dist'
+import type { PDFOperatorList } from 'pdfjs-dist/types/src/display/api'
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = ''
+
+/** 1 PDF point in mm (1 pt = 1/72 inch = 25.4/72 mm) */
+const PT_TO_MM = 25.4 / 72
+
+/** Bezier approximation resolution (line segments per curve) */
+const BEZIER_STEPS = 8
+
+/** 2D point in PDF user space before conversion to model-space mm. */
+type Point2 = { x: number; y: number }
+
+/**
+ * Converts a PDF file into CAD entities appended to the current document's
+ * model space.
+ */
+export class AcApPdfImportConvertor {
+  /**
+   * Prompts the user to pick a PDF file and imports vector geometry.
+   *
+   * @param context - Application context for the target document
+   */
+  importFromFilePicker(context: AcApContext) {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.pdf'
+    input.style.display = 'none'
+    document.body.appendChild(input)
+
+    input.addEventListener('change', async () => {
+      const file = input.files?.[0]
+      document.body.removeChild(input)
+      if (!file) return
+      const buffer = await file.arrayBuffer()
+      await this.convert(context, buffer)
+    })
+
+    input.click()
+  }
+
+  /**
+   * Converts the first page of a PDF ArrayBuffer into CAD entities.
+   * @param context - Application context for the target document
+   * @param data - Raw PDF bytes
+   * @param pageNumber - 1-based page number (default: 1)
+   */
+  async convert(context: AcApContext, data: ArrayBuffer, pageNumber = 1) {
+    try {
+      const pdf = await pdfjsLib.getDocument({ data }).promise
+      const page = await pdf.getPage(pageNumber)
+      const viewport = page.getViewport({ scale: 1 })
+      const pageHeight = viewport.height
+
+      const operatorList = await page.getOperatorList()
+      const entities = this.extractEntities(operatorList, pageHeight)
+
+      if (entities.length === 0) {
+        log.warn('[PdfImport] No vector paths found in PDF page.')
+        return
+      }
+
+      const modelSpace =
+        context.doc.database.tables.blockTable.modelSpace
+
+      for (const entity of entities) {
+        modelSpace.appendEntity(entity)
+      }
+
+      log.info(`[PdfImport] Imported ${entities.length} entities from PDF.`)
+    } catch (err) {
+      log.error('[PdfImport] Failed to import PDF:', err)
+    }
+  }
+
+  private extractEntities(
+    opList: PDFOperatorList,
+    pageHeight: number
+  ): (AcDbPolyline | AcDbLine)[] {
+    const { OPS } = pdfjsLib
+    const { fnArray, argsArray } = opList
+    const result: (AcDbPolyline | AcDbLine)[] = []
+
+    let subpaths: Point2[][] = []
+    let current: Point2[] = []
+    let curX = 0
+    let curY = 0
+
+    const flush = () => {
+      if (current.length > 1) subpaths.push(current)
+      current = []
+    }
+
+    const commit = () => {
+      flush()
+      for (const sp of subpaths) {
+        const entity = this.subpathToEntity(sp)
+        if (entity) result.push(entity)
+      }
+      subpaths = []
+    }
+
+    const tx = (x: number, _y: number) => x * PT_TO_MM
+    const ty = (_x: number, y: number) => (pageHeight - y) * PT_TO_MM
+
+    for (let i = 0; i < fnArray.length; i++) {
+      const fn = fnArray[i]
+      const args = argsArray[i] as number[]
+
+      switch (fn) {
+        case OPS.moveTo: {
+          flush()
+          curX = args[0]
+          curY = args[1]
+          current = [{ x: tx(curX, curY), y: ty(curX, curY) }]
+          break
+        }
+        case OPS.lineTo: {
+          curX = args[0]
+          curY = args[1]
+          current.push({ x: tx(curX, curY), y: ty(curX, curY) })
+          break
+        }
+        case OPS.curveTo: {
+          const [x1, y1, x2, y2, x3, y3] = args
+          const pts = cubicBezier(
+            { x: curX, y: curY },
+            { x: x1, y: y1 },
+            { x: x2, y: y2 },
+            { x: x3, y: y3 },
+            BEZIER_STEPS
+          )
+          for (const p of pts) {
+            current.push({ x: tx(p.x, p.y), y: ty(p.x, p.y) })
+          }
+          curX = x3
+          curY = y3
+          break
+        }
+        case OPS.curveTo2: {
+          const [x2, y2, x3, y3] = args
+          const pts = cubicBezier(
+            { x: curX, y: curY },
+            { x: curX, y: curY },
+            { x: x2, y: y2 },
+            { x: x3, y: y3 },
+            BEZIER_STEPS
+          )
+          for (const p of pts) {
+            current.push({ x: tx(p.x, p.y), y: ty(p.x, p.y) })
+          }
+          curX = x3
+          curY = y3
+          break
+        }
+        case OPS.curveTo3: {
+          const [x1, y1, x3, y3] = args
+          const pts = cubicBezier(
+            { x: curX, y: curY },
+            { x: x1, y: y1 },
+            { x: x3, y: y3 },
+            { x: x3, y: y3 },
+            BEZIER_STEPS
+          )
+          for (const p of pts) {
+            current.push({ x: tx(p.x, p.y), y: ty(p.x, p.y) })
+          }
+          curX = x3
+          curY = y3
+          break
+        }
+        case OPS.closePath: {
+          if (current.length > 0 && subpaths.length === 0) {
+            current.push({ ...current[0] })
+          }
+          flush()
+          break
+        }
+        case OPS.stroke:
+        case OPS.fill:
+        case OPS.eoFill:
+        case OPS.fillStroke:
+        case OPS.eoFillStroke:
+        case OPS.endPath: {
+          commit()
+          break
+        }
+      }
+    }
+
+    commit()
+    return result
+  }
+
+  private subpathToEntity(pts: Point2[]): AcDbPolyline | AcDbLine | null {
+    if (pts.length < 2) return null
+
+    if (pts.length === 2) {
+      return new AcDbLine(
+        new AcGePoint3d(pts[0].x, pts[0].y, 0),
+        new AcGePoint3d(pts[1].x, pts[1].y, 0)
+      )
+    }
+
+    const poly = new AcDbPolyline()
+    for (let i = 0; i < pts.length; i++) {
+      poly.addVertexAt(i, new AcGePoint2d(pts[i].x, pts[i].y))
+    }
+
+    const first = pts[0]
+    const last = pts[pts.length - 1]
+    const dx = first.x - last.x
+    const dy = first.y - last.y
+    if (Math.sqrt(dx * dx + dy * dy) < 1e-6) {
+      poly.closed = true
+    }
+
+    return poly
+  }
+}
+
+/**
+ * Approximates a cubic Bézier curve as a polyline.
+ *
+ * @param p0 - Start point
+ * @param p1 - First control point
+ * @param p2 - Second control point
+ * @param p3 - End point
+ * @param steps - Number of line segments to generate
+ * @returns Sampled points along the curve (excluding `p0`)
+ */
+function cubicBezier(
+  p0: Point2,
+  p1: Point2,
+  p2: Point2,
+  p3: Point2,
+  steps: number
+): Point2[] {
+  const pts: Point2[] = []
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps
+    const mt = 1 - t
+    const x =
+      mt * mt * mt * p0.x +
+      3 * mt * mt * t * p1.x +
+      3 * mt * t * t * p2.x +
+      t * t * t * p3.x
+    const y =
+      mt * mt * mt * p0.y +
+      3 * mt * mt * t * p1.y +
+      3 * mt * t * t * p2.y +
+      t * t * t * p3.y
+    pts.push({ x, y })
+  }
+  return pts
+}

--- a/packages/cad-pdf-plugin/src/AcApPdfPlugin.ts
+++ b/packages/cad-pdf-plugin/src/AcApPdfPlugin.ts
@@ -1,0 +1,55 @@
+import {
+  AcApContext,
+  AcApPlugin,
+  AcEdCommandStack
+} from '@mlightcad/cad-simple-viewer'
+
+import { AcApConvertToPdfCmd } from './AcApConvertToPdfCmd'
+import { AcApImportPdfCmd } from './AcApImportPdfCmd'
+
+/**
+ * PDF export/import plugin for cad-simple-viewer.
+ *
+ * Registers `cpdf` and `ipdf` commands when loaded. Register this plugin
+ * lazily via {@link registerLazyPdfPlugin} so PDF libraries are fetched on demand.
+ */
+export class AcApPdfPlugin implements AcApPlugin {
+  /** @inheritdoc */
+  name = 'PdfPlugin'
+  /** @inheritdoc */
+  version = '1.0.0'
+  /** @inheritdoc */
+  description = 'PDF export (cpdf) and import (ipdf) commands'
+
+  /** Commands registered in {@link onLoad} for cleanup in {@link onUnload}. */
+  private registeredCommands: Array<{ group: string; name: string }> = []
+
+  /**
+   * Registers `cpdf` and `ipdf` system commands.
+   *
+   * @param _context - Application context (unused)
+   * @param commandManager - Command stack used to register PDF commands
+   */
+  onLoad(_context: AcApContext, commandManager: AcEdCommandStack): void {
+    const group = AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME
+    commandManager.addCommand(group, 'cpdf', 'cpdf', new AcApConvertToPdfCmd())
+    commandManager.addCommand(group, 'ipdf', 'ipdf', new AcApImportPdfCmd())
+    this.registeredCommands.push(
+      { group, name: 'cpdf' },
+      { group, name: 'ipdf' }
+    )
+  }
+
+  /**
+   * Removes commands registered in {@link onLoad}.
+   *
+   * @param _context - Application context (unused)
+   * @param commandManager - Command stack used to unregister PDF commands
+   */
+  onUnload(_context: AcApContext, commandManager: AcEdCommandStack): void {
+    for (const cmd of this.registeredCommands) {
+      commandManager.removeCmd(cmd.group, cmd.name)
+    }
+    this.registeredCommands = []
+  }
+}

--- a/packages/cad-pdf-plugin/src/index.ts
+++ b/packages/cad-pdf-plugin/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * PDF export and import plugin for cad-simple-viewer.
+ *
+ * @packageDocumentation
+ */
+
+export { AcApConvertToPdfCmd } from './AcApConvertToPdfCmd'
+export { AcApImportPdfCmd } from './AcApImportPdfCmd'
+export { AcApPdfConvertor } from './AcApPdfConvertor'
+export { AcApPdfImportConvertor } from './AcApPdfImportConvertor'
+export {
+  createPdfPlugin,
+  PDF_PLUGIN_NAME,
+  PDF_PLUGIN_TRIGGERS,
+  registerLazyPdfPlugin
+} from './registerLazyPdfPlugin'

--- a/packages/cad-pdf-plugin/src/registerLazyPdfPlugin.ts
+++ b/packages/cad-pdf-plugin/src/registerLazyPdfPlugin.ts
@@ -1,0 +1,37 @@
+import type { AcApPluginManager } from '@mlightcad/cad-simple-viewer'
+
+/** Lazy plugin name for PDF export/import. */
+export const PDF_PLUGIN_NAME = 'PdfPlugin'
+
+/**
+ * Trigger commands handled by {@link PDF_PLUGIN_NAME}.
+ *
+ * - `cpdf` — export drawing to PDF
+ * - `ipdf` — import vector geometry from PDF
+ */
+export const PDF_PLUGIN_TRIGGERS = ['cpdf', 'ipdf'] as const
+
+/**
+ * Creates a PDF plugin instance after loading the plugin module chunk.
+ *
+ * @returns A loaded {@link AcApPdfPlugin} instance
+ */
+export async function createPdfPlugin() {
+  const { AcApPdfPlugin } = await import('./AcApPdfPlugin')
+  return new AcApPdfPlugin()
+}
+
+/**
+ * Registers the PDF plugin for lazy loading.
+ *
+ * The plugin bundle is not fetched until one of its trigger commands runs.
+ *
+ * @param pluginManager - Plugin manager that receives the lazy registration
+ */
+export function registerLazyPdfPlugin(pluginManager: AcApPluginManager): void {
+  pluginManager.registerLazyPlugin({
+    name: PDF_PLUGIN_NAME,
+    triggers: [...PDF_PLUGIN_TRIGGERS],
+    loader: createPdfPlugin
+  })
+}

--- a/packages/cad-pdf-plugin/tsconfig.json
+++ b/packages/cad-pdf-plugin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/cad-pdf-plugin/vite.config.ts
+++ b/packages/cad-pdf-plugin/vite.config.ts
@@ -1,0 +1,16 @@
+import peerDepsExternal from 'rollup-plugin-peer-deps-external'
+import { defineConfig, PluginOption } from 'vite'
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    lib: {
+      entry: 'src/index.ts',
+      name: 'cad-pdf-plugin',
+      fileName: 'index'
+    },
+    minify: true
+  },
+  plugins: [peerDepsExternal() as PluginOption]
+})

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1020,6 +1020,8 @@ export class AcApDocManager {
    * Executes a command by its string name.
    *
    * This method looks up a registered command by name and executes it with the current context.
+   * If the command is not registered yet, it attempts to load a lazy plugin whose trigger
+   * matches the command name (see {@link AcApPluginManager.loadByTrigger}).
    * It checks if the command's required mode is compatible with the document's current mode.
    * If the command is not found or not compatible, an error is thrown.
    *
@@ -1033,6 +1035,18 @@ export class AcApDocManager {
    * ```
    */
   sendStringToExecute(cmdStr: string) {
+    void this.executeCommandString(cmdStr)
+  }
+
+  /**
+   * Executes a command script, loading lazy plugins when needed.
+   *
+   * When the command is missing from the command stack, {@link AcApPluginManager.loadByTrigger}
+   * is invoked so plugins registered via {@link AcApPluginManager.registerLazyPlugin} can load.
+   *
+   * @param cmdStr - Command script (first line is the command name)
+   */
+  private async executeCommandString(cmdStr: string) {
     const lines = this.splitCommandScript(cmdStr)
     if (!lines.length) {
       throw new Error('Command string is empty')
@@ -1040,9 +1054,18 @@ export class AcApDocManager {
 
     const [cmdName, ...scriptInputs] = lines
     const documentMode = this.context.doc.openMode
-    const cmd =
+    let cmd =
       this._commandManager.lookupGlobalCmd(cmdName) ??
       this._commandManager.lookupLocalCmd(cmdName, documentMode)
+
+    if (!cmd) {
+      const loaded = await this._pluginManager.loadByTrigger(cmdName)
+      if (loaded) {
+        cmd =
+          this._commandManager.lookupGlobalCmd(cmdName) ??
+          this._commandManager.lookupLocalCmd(cmdName, documentMode)
+      }
+    }
 
     if (!cmd) {
       throw new Error(`Command '${cmdName}' not found`)
@@ -1057,7 +1080,7 @@ export class AcApDocManager {
 
     this.editor.clearScriptInputs()
     this.editor.enqueueScriptInputs(scriptInputs)
-    void cmd.trigger(this.context).finally(() => {
+    await cmd.trigger(this.context).finally(() => {
       this.editor.clearScriptInputs()
     })
   }

--- a/packages/cad-simple-viewer/src/i18n/en/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/command.ts
@@ -28,6 +28,9 @@ export default {
     cdxf: {
       description: 'Exports current drawing to DXF'
     },
+    cpdf: {
+      description: 'Exports current drawing to PDF'
+    },
     cecolor: {
       description: 'Sets the current default color for newly created objects'
     },
@@ -94,6 +97,9 @@ export default {
     hatch: {
       description:
         'Fills an enclosed area or selected objects with a hatch pattern'
+    },
+    ipdf: {
+      description: 'Imports vector geometry from a PDF file'
     },
     hpang: {
       description:

--- a/packages/cad-simple-viewer/src/i18n/zh/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/command.ts
@@ -24,6 +24,9 @@ export default {
     cdxf: {
       description: '导出当前图纸为DXF格式'
     },
+    cpdf: {
+      description: '导出当前图纸为PDF格式'
+    },
     cecolor: {
       description: '设置新创建对象的当前默认颜色'
     },
@@ -85,6 +88,9 @@ export default {
     },
     hatch: {
       description: '用填充图案填充封闭区域或所选对象'
+    },
+    ipdf: {
+      description: '从 PDF 文件导入矢量几何'
     },
     hpang: {
       description: '设置新创建填充图案的默认角度（弧度）'

--- a/packages/cad-simple-viewer/src/plugin/AcApLazyPluginRegistration.ts
+++ b/packages/cad-simple-viewer/src/plugin/AcApLazyPluginRegistration.ts
@@ -1,0 +1,28 @@
+import { AcApPlugin } from './AcApPlugin'
+
+/**
+ * Descriptor for a plugin that is registered up front but loaded only when triggered.
+ *
+ * Register with {@link AcApPluginManager.registerLazyPlugin}. The plugin module is not
+ * fetched until the user runs one of the {@link triggers} commands.
+ *
+ * @example
+ * ```typescript
+ * pluginManager.registerLazyPlugin({
+ *   name: 'PdfPlugin',
+ *   triggers: ['cpdf', 'ipdf'],
+ *   loader: async () => {
+ *     const { createPdfPlugin } = await import('@mlightcad/cad-pdf-plugin')
+ *     return createPdfPlugin()
+ *   }
+ * })
+ * ```
+ */
+export interface AcApLazyPluginRegistration {
+  /** Unique plugin identifier; must match {@link AcApPlugin.name} returned by {@link loader}. */
+  name: string
+  /** Command names that load this plugin when executed (case-insensitive). */
+  triggers: string[]
+  /** Factory that creates the plugin instance when a trigger command runs. */
+  loader: () => AcApPlugin | Promise<AcApPlugin>
+}

--- a/packages/cad-simple-viewer/src/plugin/AcApPluginManager.ts
+++ b/packages/cad-simple-viewer/src/plugin/AcApPluginManager.ts
@@ -2,6 +2,7 @@ import { log } from '@mlightcad/data-model'
 
 import { AcApContext } from '../app/AcApContext'
 import { AcEdCommandStack } from '../editor/command/AcEdCommandStack'
+import { AcApLazyPluginRegistration } from './AcApLazyPluginRegistration'
 import { AcApPlugin } from './AcApPlugin'
 
 /**
@@ -38,6 +39,12 @@ import { AcApPlugin } from './AcApPlugin'
 export class AcApPluginManager {
   /** Map of loaded plugins by name */
   private _plugins: Map<string, AcApPlugin>
+  /** Lazy plugin registrations keyed by plugin name */
+  private _lazyRegistrations: Map<string, AcApLazyPluginRegistration>
+  /** Maps trigger command names to lazy plugin names */
+  private _triggerToPluginName: Map<string, string>
+  /** In-flight lazy plugin loads keyed by plugin name */
+  private _lazyLoadPromises: Map<string, Promise<boolean>>
   /** The application context */
   private _context: AcApContext
   /** The command manager */
@@ -51,6 +58,9 @@ export class AcApPluginManager {
    */
   constructor(context: AcApContext, commandManager: AcEdCommandStack) {
     this._plugins = new Map()
+    this._lazyRegistrations = new Map()
+    this._triggerToPluginName = new Map()
+    this._lazyLoadPromises = new Map()
     this._context = context
     this._commandManager = commandManager
   }
@@ -94,6 +104,130 @@ export class AcApPluginManager {
 
     // Store plugin
     this._plugins.set(pluginName, plugin)
+  }
+
+  /**
+   * Registers a lazy plugin without loading it.
+   *
+   * The plugin is loaded automatically when one of its trigger commands is
+   * requested via {@link loadByTrigger} or {@link AcApDocManager.sendStringToExecute}.
+   *
+   * @param registration - Lazy plugin descriptor (name, triggers, loader)
+   */
+  registerLazyPlugin(registration: AcApLazyPluginRegistration): void {
+    const pluginName = registration.name
+
+    if (!pluginName) {
+      throw new Error('[AcApPluginManager] Lazy plugin name is required')
+    }
+
+    if (this._lazyRegistrations.has(pluginName)) {
+      throw new Error(
+        `[AcApPluginManager] Lazy plugin '${pluginName}' is already registered`
+      )
+    }
+
+    if (!registration.triggers.length) {
+      throw new Error(
+        `[AcApPluginManager] Lazy plugin '${pluginName}' requires at least one trigger`
+      )
+    }
+
+    this._lazyRegistrations.set(pluginName, registration)
+
+    for (const trigger of registration.triggers) {
+      const normalizedTrigger = trigger.trim().toUpperCase()
+      if (!normalizedTrigger) {
+        continue
+      }
+
+      if (this._triggerToPluginName.has(normalizedTrigger)) {
+        throw new Error(
+          `[AcApPluginManager] Trigger '${trigger}' is already registered to lazy plugin '${this._triggerToPluginName.get(normalizedTrigger)}'`
+        )
+      }
+
+      this._triggerToPluginName.set(normalizedTrigger, pluginName)
+    }
+  }
+
+  /**
+   * Returns whether a trigger command is registered to a lazy plugin.
+   *
+   * @param trigger - Command name to check (case-insensitive)
+   * @returns `true` if the trigger loads a lazy plugin
+   */
+  isLazyPluginTrigger(trigger: string): boolean {
+    return this._triggerToPluginName.has(trigger.trim().toUpperCase())
+  }
+
+  /**
+   * Gets all trigger command names registered for lazy plugins.
+   *
+   * @returns Normalized (uppercase) trigger command names
+   */
+  getLazyPluginTriggers(): string[] {
+    return Array.from(this._triggerToPluginName.keys())
+  }
+
+  /**
+   * Loads the lazy plugin associated with a trigger command, if registered.
+   *
+   * Concurrent calls for the same plugin share one in-flight load promise.
+   *
+   * @param trigger - Command name that triggers lazy load (case-insensitive)
+   * @returns `true` when the plugin is loaded after this call, otherwise `false`
+   */
+  async loadByTrigger(trigger: string): Promise<boolean> {
+    const normalizedTrigger = trigger.trim().toUpperCase()
+    const pluginName = this._triggerToPluginName.get(normalizedTrigger)
+
+    if (!pluginName) {
+      return false
+    }
+
+    if (this.isPluginLoaded(pluginName)) {
+      return true
+    }
+
+    const inFlight = this._lazyLoadPromises.get(pluginName)
+    if (inFlight) {
+      return inFlight
+    }
+
+    const registration = this._lazyRegistrations.get(pluginName)
+    if (!registration) {
+      return false
+    }
+
+    const loadPromise = (async () => {
+      try {
+        const plugin = await registration.loader()
+
+        if (plugin.name !== pluginName) {
+          throw new Error(
+            `[AcApPluginManager] Lazy plugin '${pluginName}' loader returned plugin '${plugin.name}'`
+          )
+        }
+
+        if (!this.isPluginLoaded(pluginName)) {
+          await this.loadPlugin(plugin)
+        }
+
+        return true
+      } catch (error) {
+        log.error(
+          `[AcApPluginManager] Failed to load lazy plugin '${pluginName}' for trigger '${trigger}':`,
+          error
+        )
+        return false
+      } finally {
+        this._lazyLoadPromises.delete(pluginName)
+      }
+    })()
+
+    this._lazyLoadPromises.set(pluginName, loadPromise)
+    return loadPromise
   }
 
   /**

--- a/packages/cad-simple-viewer/src/plugin/index.ts
+++ b/packages/cad-simple-viewer/src/plugin/index.ts
@@ -1,3 +1,4 @@
 export * from './AcApPlugin'
 export * from './AcApPluginManager'
 export * from './AcApPluginExample'
+export * from './AcApLazyPluginRegistration'

--- a/packages/cad-viewer-example/package.json
+++ b/packages/cad-viewer-example/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",
     "@mlightcad/cad-html-exporter": "workspace:*",
+    "@mlightcad/cad-pdf-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/cad-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.7.40",

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -43,6 +43,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
+    "@mlightcad/cad-pdf-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.7.40",
     "@mlightcad/ribbon": "^0.1.9",
@@ -69,6 +70,7 @@
     "lodash-es": "4.17.21"
   },
   "peerDependencies": {
+    "@mlightcad/cad-pdf-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.7.40",
     "@vueuse/core": "^11.1.0",
@@ -76,5 +78,10 @@
     "three": "^0.172.0",
     "vue": "^3.4.21",
     "vue-i18n": "^11.4.4"
+  },
+  "peerDependenciesMeta": {
+    "@mlightcad/cad-pdf-plugin": {
+      "optional": true
+    }
   }
 }

--- a/packages/cad-viewer/src/app/app.ts
+++ b/packages/cad-viewer/src/app/app.ts
@@ -10,6 +10,7 @@ import {
 import {
   registerCmds,
   registerDialogs,
+  registerLazyPlugins,
   registerMTextColorPicker
 } from './register'
 
@@ -18,4 +19,5 @@ export const initializeCadViewer = (options: AcApDocManagerOptions = {}) => {
   registerCmds()
   registerDialogs()
   registerMTextColorPicker()
+  registerLazyPlugins()
 }

--- a/packages/cad-viewer/src/app/register.ts
+++ b/packages/cad-viewer/src/app/register.ts
@@ -110,3 +110,29 @@ export const registerMTextColorPicker = () => {
     isMTextColorPickerRegistered = true
   }
 }
+
+let isLazyPluginRegistered = false
+
+/**
+ * Registers lazy plugins that load on first use of their trigger commands.
+ *
+ * Currently registers the PDF plugin (`cpdf`, `ipdf`), which is fetched only
+ * when one of those commands runs. Safe to call multiple times; registration
+ * runs once per application lifetime.
+ */
+export const registerLazyPlugins = () => {
+  if (isLazyPluginRegistered) {
+    return
+  }
+
+  AcApDocManager.instance.pluginManager.registerLazyPlugin({
+    name: 'PdfPlugin',
+    triggers: ['cpdf', 'ipdf'],
+    loader: async () => {
+      const { createPdfPlugin } = await import('@mlightcad/cad-pdf-plugin')
+      return createPdfPlugin()
+    }
+  })
+
+  isLazyPluginRegistered = true
+}

--- a/packages/cad-viewer/src/component/layout/MlMainMenu.vue
+++ b/packages/cad-viewer/src/component/layout/MlMainMenu.vue
@@ -22,6 +22,9 @@
         <el-dropdown-item command="ExportHtml">{{
           t('main.mainMenu.exportHtml')
         }}</el-dropdown-item>
+        <el-dropdown-item command="ExportPdf">{{
+          t('main.mainMenu.exportPdf')
+        }}</el-dropdown-item>
       </el-dropdown-menu>
     </template>
   </el-dropdown>
@@ -48,12 +51,15 @@ import { useSettings } from '../../composable'
 const { t } = useI18n()
 const features = useSettings()
 
-const handleCommand = (command: string) => {
+const handleCommand = async (command: string) => {
   if (command === 'Convert') {
     const cmd = new AcApConvertToDxfCmd()
     cmd.trigger(AcApDocManager.instance.context)
   } else if (command === 'ExportHtml') {
     AcApDocManager.instance.sendStringToExecute('chtml')
+  } else if (command === 'ExportPdf') {
+    await AcApDocManager.instance.pluginManager.loadByTrigger('cpdf')
+    AcApDocManager.instance.sendStringToExecute('cpdf')
   } else if (command === 'QNew') {
     const cmd = new AcApQNewCmd()
     cmd.trigger(AcApDocManager.instance.context)

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -1503,6 +1503,10 @@ const fileMenuItems = computed<FileMenuItemModel[]>(() => {
       label: t('main.mainMenu.exportHtml')
     },
     {
+      id: 'ExportPdf',
+      label: t('main.mainMenu.exportPdf')
+    },
+    {
       id: 'PngOut',
       label: t('main.mainMenu.exportImage')
     }
@@ -1536,13 +1540,21 @@ const handleRibbonItemClick = (payload: {
   AcApDocManager.instance.sendStringToExecute(command)
 }
 
-const handleFileMenuSelect = (command: string) => {
+const runLazyCommand = async (command: string) => {
+  const pluginManager = AcApDocManager.instance.pluginManager
+  await pluginManager.loadByTrigger(command)
+  AcApDocManager.instance.sendStringToExecute(command)
+}
+
+const handleFileMenuSelect = async (command: string) => {
   if (isRibbonDisabled.value) return
   if (command === 'Convert') {
     const cmd = new AcApConvertToDxfCmd()
     cmd.trigger(AcApDocManager.instance.context)
   } else if (command === 'ExportHtml') {
     AcApDocManager.instance.sendStringToExecute('chtml')
+  } else if (command === 'ExportPdf') {
+    await runLazyCommand('cpdf')
   } else if (command === 'PngOut') {
     AcApDocManager.instance.sendStringToExecute('pngout')
   } else if (command === 'QNew') {

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -5,6 +5,7 @@ export default {
     drawingUnits: 'Drawing Units',
     export: 'Export to DXF',
     exportHtml: 'Export to HTML',
+    exportPdf: 'Export to PDF',
     exportImage: 'Export to Image'
   },
   ribbon: {

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -5,6 +5,7 @@ export default {
     drawingUnits: '图形单位',
     export: '导出为DXF',
     exportHtml: '导出为 HTML',
+    exportPdf: '导出为PDF',
     exportImage: '导出图片'
   },
   ribbon: {

--- a/packages/cad-viewer/vite.config.ts
+++ b/packages/cad-viewer/vite.config.ts
@@ -36,7 +36,11 @@ export default defineConfig(({ mode }: ConfigEnv) => {
         fileName: 'index',
         formats: ['es'] as LibraryFormats[]
       },
-      minify: true
+      minify: true,
+      rollupOptions: {
+        // PDF plugin is a peer; loaded at runtime via dynamic import in registerLazyPlugins
+        external: ['@mlightcad/cad-pdf-plugin']
+      }
     },
     plugins
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,28 @@ importers:
         specifier: ^5.4.19
         version: 5.4.21(@types/node@20.19.37)(sass@1.98.0)
 
+  packages/cad-pdf-plugin:
+    dependencies:
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
+      pdfjs-dist:
+        specifier: ^5.6.205
+        version: 5.7.284
+      svg2pdf.js:
+        specifier: ^2.7.0
+        version: 2.7.0(jspdf@4.2.1)
+    devDependencies:
+      '@mlightcad/cad-simple-viewer':
+        specifier: workspace:*
+        version: link:../cad-simple-viewer
+      '@mlightcad/data-model':
+        specifier: ^1.7.40
+        version: 1.7.40
+      '@mlightcad/svg-renderer':
+        specifier: workspace:*
+        version: link:../svg-renderer
+
   packages/cad-simple-viewer:
     dependencies:
       '@mlightcad/cad-html-exporter':
@@ -237,6 +259,9 @@ importers:
         specifier: 4.17.21
         version: 4.17.21
     devDependencies:
+      '@mlightcad/cad-pdf-plugin':
+        specifier: workspace:*
+        version: link:../cad-pdf-plugin
       '@mlightcad/cad-simple-viewer':
         specifier: workspace:*
         version: link:../cad-simple-viewer
@@ -306,6 +331,9 @@ importers:
       '@mlightcad/cad-html-exporter':
         specifier: workspace:*
         version: link:../cad-html-exporter
+      '@mlightcad/cad-pdf-plugin':
+        specifier: workspace:*
+        version: link:../cad-pdf-plugin
       '@mlightcad/cad-simple-viewer':
         specifier: workspace:*
         version: link:../cad-simple-viewer
@@ -1547,6 +1575,81 @@ packages:
       element-plus: ^2.12.0
       vue: ^3.4.21
 
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
+
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
@@ -2037,8 +2140,14 @@ packages:
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/rbush@3.0.4':
     resolution: {integrity: sha512-knSt9cCW8jj1ZSFcFeBZaX++OucmfPxxHiRwTahZfJlnQsek7O0bazTJHWD2RVj9LEoejUYF2de3/stf+QXcXw==}
@@ -2056,6 +2165,9 @@ packages:
 
   '@types/three@0.172.0':
     resolution: {integrity: sha512-LrUtP3FEG26Zg5WiF0nbg8VoXiKokBLTcqM2iLvM9vzcfEiYmmBAPGdBgV0OYx9fvWlY3R/3ERTZcD9X5sc0NA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2553,6 +2665,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2641,6 +2757,10 @@ packages:
 
   caniuse-lite@1.0.30001784:
     resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   chalk-template@0.4.0:
     resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
@@ -2787,6 +2907,9 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cosmiconfig@6.0.0:
     resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
     engines: {node: '>=8'}
@@ -2797,6 +2920,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -2920,6 +3046,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.7:
+    resolution: {integrity: sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3180,6 +3309,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -3243,6 +3375,9 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  font-family-papandreou@0.2.0-patch2:
+    resolution: {integrity: sha512-l/YiRdBSH/eWv6OF3sLGkwErL+n0MqCICi9mppTZBOCL5vixWGDqCYvRcuxB2h7RGCTzaTKOHT2caHvCXQPRlw==}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -3378,6 +3513,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -3437,6 +3576,9 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -3744,6 +3886,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4125,6 +4270,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4170,6 +4318,13 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdfjs-dist@5.7.284:
+    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4277,6 +4432,9 @@ packages:
   quickselect@3.0.0:
     resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -4316,6 +4474,9 @@ packages:
 
   regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   regexpu-core@6.4.0:
     resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
@@ -4374,6 +4535,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
@@ -4491,12 +4656,20 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  specificity@0.4.1:
+    resolution: {integrity: sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==}
+    hasBin: true
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -4568,10 +4741,22 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
+  svg2pdf.js@2.7.0:
+    resolution: {integrity: sha512-nXK4Wx28H0KtOktanm5nsphl1KMEoLNMelAT/776qxPAj9DshwYcqgdpKuBnY1nrcYOriQFHVQLE4tIag+aDJA==}
+    peerDependencies:
+      jspdf: ^4.0.0 || ^3.0.0 || ^2.0.0
+
   svgo@3.3.3:
     resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  svgpath@2.6.0:
+    resolution: {integrity: sha512-OIWR6bKzXvdXYyO4DK/UWa1VA1JeKq8E+0ug2DG98Y/vOmMpfZNj+TIG988HjfYSqtcy/hFOtZq/n/j5GSESNg==}
 
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
@@ -4592,6 +4777,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   three@0.172.0:
     resolution: {integrity: sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==}
@@ -4773,6 +4961,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -6495,6 +6686,54 @@ snapshots:
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
+
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -6938,7 +7177,12 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/pako@2.0.4': {}
+
   '@types/parse-json@4.0.2': {}
+
+  '@types/raf@3.4.3':
+    optional: true
 
   '@types/rbush@3.0.4': {}
 
@@ -6958,6 +7202,9 @@ snapshots:
       '@webgpu/types': 0.1.69
       fflate: 0.8.2
       meshoptimizer: 0.18.1
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@3.0.3': {}
 
@@ -7512,6 +7759,9 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-arraybuffer@1.0.2:
+    optional: true
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.13: {}
@@ -7599,6 +7849,18 @@ snapshots:
   camelcase@7.0.1: {}
 
   caniuse-lite@1.0.30001784: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   chalk-template@0.4.0:
     dependencies:
@@ -7731,6 +7993,9 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
 
+  core-js@3.49.0:
+    optional: true
+
   cosmiconfig@6.0.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -7746,6 +8011,11 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   css-select@5.2.2:
     dependencies:
@@ -7838,6 +8108,11 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
 
   domutils@3.2.2:
     dependencies:
@@ -8160,6 +8435,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.1.0
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -8212,6 +8493,8 @@ snapshots:
   flatted@3.4.2: {}
 
   follow-redirects@1.15.11: {}
+
+  font-family-papandreou@0.2.0-patch2: {}
 
   form-data@4.0.5:
     dependencies:
@@ -8347,6 +8630,12 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   human-id@4.1.3: {}
 
   human-signals@2.1.0: {}
@@ -8386,6 +8675,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  iobuffer@5.4.0: {}
 
   is-arrayish@0.2.1: {}
 
@@ -8875,6 +9166,17 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 3.4.7
+      html2canvas: 1.4.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -9269,6 +9571,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  pako@2.1.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -9306,6 +9610,13 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pdfjs-dist@5.7.284:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -9393,6 +9704,11 @@ snapshots:
 
   quickselect@3.0.0: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   range-parser@1.2.0: {}
 
   rbush@4.0.1:
@@ -9434,6 +9750,9 @@ snapshots:
       regenerate: 1.4.2
 
   regenerate@1.4.2: {}
+
+  regenerator-runtime@0.13.11:
+    optional: true
 
   regexpu-core@6.4.0:
     dependencies:
@@ -9490,6 +9809,9 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rimraf@6.1.3:
     dependencies:
@@ -9635,11 +9957,16 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  specificity@0.4.1: {}
+
   sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stackblur-canvas@2.7.0:
+    optional: true
 
   string-argv@0.3.2: {}
 
@@ -9702,6 +10029,17 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
+  svg2pdf.js@2.7.0(jspdf@4.2.1):
+    dependencies:
+      cssesc: 3.0.0
+      font-family-papandreou: 0.2.0-patch2
+      jspdf: 4.2.1
+      specificity: 0.4.1
+      svgpath: 2.6.0
+
   svgo@3.3.3:
     dependencies:
       commander: 7.2.0
@@ -9711,6 +10049,8 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.0
+
+  svgpath@2.6.0: {}
 
   synckit@0.11.12:
     dependencies:
@@ -9736,6 +10076,11 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 13.0.6
       minimatch: 3.1.5
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   three@0.172.0: {}
 
@@ -9913,6 +10258,11 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Summary

This PR consolidates PDF export/import work (previously spread across #218) into a dedicated **`@mlightcad/cad-pdf-plugin`** package and wires it into the viewer through a new **lazy plugin** mechanism so PDF libraries are not loaded until needed.

### New `@mlightcad/cad-pdf-plugin` package

- **`cpdf`** — exports the current drawing to a vector PDF by rendering model space through the SVG pipeline (`AcSvgRenderer`) and converting with **jsPDF** + **svg2pdf.js**.
- **`ipdf`** — imports vector geometry from a user-selected PDF (first page) via **pdfjs-dist**, mapping path operators to `AcDbLine` / `AcDbPolyline` entities in model space (including Bézier approximation).
- Exposes `AcApPdfPlugin`, converters, and `registerLazyPdfPlugin` / `createPdfPlugin` for consumers.

### Lazy plugin infrastructure (`cad-simple-viewer`)

- Adds `AcApLazyPluginRegistration` and extends `AcApPluginManager` with:
  - `registerLazyPlugin`
  - `loadByTrigger` (deduplicated in-flight loads)
  - trigger lookup helpers
- Updates `AcApDocManager.sendStringToExecute` to load a lazy plugin automatically when a command is missing from the command stack, then re-resolve and run the command.

### Viewer integration (`cad-viewer` / example)

- Registers the PDF plugin lazily on app init (`registerLazyPlugins`).
- Adds **Export to PDF** to the main menu and ribbon file menu (EN/ZH strings).
- Marks `@mlightcad/cad-pdf-plugin` as an **optional peer** and externalizes it in the Vite library build so it is fetched via dynamic import at runtime.

## Motivation

- Keep the main viewer bundle smaller by deferring **jspdf**, **pdfjs-dist**, and related code until the user runs `cpdf` or `ipdf`.
- Isolate PDF concerns in one plugin package with a clear plugin lifecycle (`onLoad` / `onUnload` command registration).

## Test plan

- [ ] Build workspace: `pnpm nx run @mlightcad/cad-pdf-plugin:build` and `cad-viewer` / `cad-viewer-example`.
- [ ] Open a drawing in **cad-viewer-example**; confirm initial load does not pull the PDF chunk until export/import is used.
- [ ] **Export to PDF** (menu / ribbon): verify `drawing.pdf` downloads and vector content matches the drawing.
- [ ] Run **`cpdf`** from the command line: same export behavior after lazy load.
- [ ] Run **`ipdf`**: pick a PDF with vector paths; confirm lines/polylines appear in model space and the view updates.
- [ ] Run **`ipdf`** on a raster-only PDF: expect a warning, no entities added.
- [ ] EN/ZH UI labels for “Export to PDF” display correctly.
- [ ] Consumers that omit `@mlightcad/cad-pdf-plugin` still build; PDF features load only when the peer is present and lazy registration runs.

## Notes

- PDF import currently processes the **first page** only and focuses on vector path operators supported by the pdf.js operator list.
- Relates to prior PDF work in #218; functionality is now delivered as a single lazy-loaded plugin.