### PR TITLE
feat(svg-renderer): implement SVG export with styled geometry, MTEXT, and UI integration

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,8 +5,19 @@ const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest'
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.js$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          allowJs: true
+        }
+      }
+    ]
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!.*mtext-parser)'
+  ],
   testPathIgnorePatterns: ['packages/dxf-json/', '/e2e/'],
   moduleNameMapper: {
     '^lodash-es$': 'lodash',

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",
+      "core-js",
       "esbuild",
       "nx",
       "unrs-resolver",

--- a/packages/cad-pdf-plugin/src/AcApPdfConvertor.ts
+++ b/packages/cad-pdf-plugin/src/AcApPdfConvertor.ts
@@ -1,4 +1,5 @@
 import type { AcApContext } from '@mlightcad/cad-simple-viewer'
+import { AcApSettingManager } from '@mlightcad/cad-simple-viewer'
 import { AcSvgRenderer } from '@mlightcad/svg-renderer'
 import { jsPDF } from 'jspdf'
 import { svg2pdf } from 'svg2pdf.js'
@@ -12,22 +13,35 @@ import { svg2pdf } from 'svg2pdf.js'
 export class AcApPdfConvertor {
   /**
    * Renders the current drawing to PDF and triggers a browser download.
-   *
-   * @param context - Application context for the drawing to export
    */
   async convert(context: AcApContext) {
-    const svgString = this.buildSvg(context)
+    const svgString = await this.buildSvg(context)
     await this.downloadAsPdf(svgString)
   }
 
-  private buildSvg(context: AcApContext): string {
+  private async buildSvg(context: AcApContext): Promise<string> {
     const entities =
       context.doc.database.tables.blockTable.modelSpace.newIterator()
     const renderer = new AcSvgRenderer()
+    this.configureRenderer(renderer, context)
+
     for (const entity of entities) {
       entity.worldDraw(renderer)
     }
-    return renderer.export()
+    return renderer.exportAsync()
+  }
+
+  private configureRenderer(renderer: AcSvgRenderer, context: AcApContext) {
+    const db = context.doc.database
+    renderer.ltscale = db.ltscale
+    renderer.celtscale = db.celtscale
+    renderer.showLineWeight = !!db.lwdisplay
+    renderer.setFontMapping(AcApSettingManager.instance.fontMapping)
+
+    const view = context.view as { backgroundColor?: number } | undefined
+    const bg = view?.backgroundColor ?? 0xffffff
+    renderer.currentBackgroundColor = bg
+    renderer.changeForeground(bg === 0 ? 0xffffff : 0x000000)
   }
 
   private async downloadAsPdf(svgString: string) {

--- a/packages/cad-simple-viewer/src/command/convert/AcApConvertToSvgCmd.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApConvertToSvgCmd.ts
@@ -31,6 +31,6 @@ export class AcApConvertToSvgCmd extends AcEdCommand {
    */
   async execute(_context: AcApContext) {
     const converter = new AcApSvgConvertor()
-    converter.convert()
+    await converter.convert()
   }
 }

--- a/packages/cad-simple-viewer/src/command/convert/AcApSvgConvertor.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApSvgConvertor.ts
@@ -1,6 +1,7 @@
 import { AcSvgRenderer } from '@mlightcad/svg-renderer'
 
 import { AcApDocManager } from '../../app'
+import { AcApSettingManager } from '../../app/AcApSettingManager'
 
 /**
  * Utility class for converting CAD drawings to SVG format.
@@ -8,77 +9,60 @@ import { AcApDocManager } from '../../app'
  * This class provides functionality to export the current CAD drawing
  * to SVG format and download it as a file. It iterates through all
  * entities in the model space and renders them using the SVG renderer.
- *
- * The conversion process:
- * 1. Gets all entities from the current document's model space
- * 2. Uses the SVG renderer to convert each entity to SVG markup
- * 3. Exports the complete SVG content
- * 4. Creates a downloadable file for the user
- *
- * @example
- * ```typescript
- * const converter = new AcApSvgConvertor();
- *
- * // Convert and download current drawing as SVG
- * converter.convert();
- * ```
  */
 export class AcApSvgConvertor {
   /**
    * Converts the current CAD drawing to SVG format and initiates download.
-   *
-   * This method:
-   * - Retrieves all entities from the current document's model space
-   * - Renders each entity using the SVG renderer
-   * - Exports the complete SVG markup
-   * - Automatically downloads the SVG file as 'example.svg'
-   *
-   * @example
-   * ```typescript
-   * const converter = new AcApSvgConvertor();
-   * converter.convert(); // Downloads the drawing as SVG
-   * ```
    */
-  convert() {
-    const entities =
-      AcApDocManager.instance.curDocument.database.tables.blockTable.modelSpace.newIterator()
+  async convert() {
+    const doc = AcApDocManager.instance.curDocument
     const renderer = new AcSvgRenderer()
+    this.configureRenderer(renderer)
+
+    const entities = doc.database.tables.blockTable.modelSpace.newIterator()
     for (const entity of entities) {
       entity.worldDraw(renderer)
     }
-    this.createFileAndDownloadIt(renderer.export())
+
+    const svgContent = await renderer.exportAsync()
+    this.createFileAndDownloadIt(svgContent)
   }
 
   /**
-   * Creates a downloadable SVG file and triggers the download.
-   *
-   * This method:
-   * - Creates a Blob from the SVG content with proper MIME type
-   * - Generates a temporary download URL
-   * - Creates and triggers a download link
-   * - Cleans up the temporary elements
-   *
-   * @param svgContent - The SVG markup content to download
-   * @private
+   * Configures export renderer scales, colours, and font substitution.
    */
+  configureRenderer(renderer: AcSvgRenderer) {
+    const doc = AcApDocManager.instance.curDocument
+    const view = AcApDocManager.instance.curView
+
+    renderer.ltscale = doc.database.ltscale
+    renderer.celtscale = doc.database.celtscale
+    renderer.showLineWeight = !!doc.database.lwdisplay
+    renderer.setFontMapping(AcApSettingManager.instance.fontMapping)
+
+    const bg =
+      view && 'backgroundColor' in view
+        ? (view as { backgroundColor: number }).backgroundColor
+        : 0xffffff
+    renderer.currentBackgroundColor = bg
+    renderer.changeForeground(bg === 0 ? 0xffffff : 0x000000)
+  }
+
   private createFileAndDownloadIt(svgContent: string) {
-    // Convert the SVG content into a Blob
     const svgBlob = new Blob([svgContent], {
       type: 'image/svg+xml;charset=utf-8'
     })
 
-    // Create a URL for the Blob
     const url = URL.createObjectURL(svgBlob)
 
-    // Create a download link and trigger the download
     const downloadLink = document.createElement('a')
     downloadLink.href = url
-    downloadLink.download = 'example.svg'
+    downloadLink.download = 'drawing.svg'
 
-    // Append the link to the body (it needs to be in the DOM to work in some browsers)
     document.body.appendChild(downloadLink)
-
-    // Trigger the download
     downloadLink.click()
+    document.body.removeChild(downloadLink)
+    // Keep the blob URL alive briefly so an optional preview tab can load it.
+    window.setTimeout(() => URL.revokeObjectURL(url), 60_000)
   }
 }

--- a/packages/cad-viewer/src/component/layout/MlMainMenu.vue
+++ b/packages/cad-viewer/src/component/layout/MlMainMenu.vue
@@ -25,6 +25,9 @@
         <el-dropdown-item command="ExportPdf">{{
           t('main.mainMenu.exportPdf')
         }}</el-dropdown-item>
+        <el-dropdown-item command="ExportSvg">{{
+          t('main.mainMenu.exportSvg')
+        }}</el-dropdown-item>
       </el-dropdown-menu>
     </template>
   </el-dropdown>
@@ -60,6 +63,8 @@ const handleCommand = async (command: string) => {
   } else if (command === 'ExportPdf') {
     await AcApDocManager.instance.pluginManager.loadByTrigger('cpdf')
     AcApDocManager.instance.sendStringToExecute('cpdf')
+  } else if (command === 'ExportSvg') {
+    AcApDocManager.instance.sendStringToExecute('csvg')
   } else if (command === 'QNew') {
     const cmd = new AcApQNewCmd()
     cmd.trigger(AcApDocManager.instance.context)

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -1507,6 +1507,10 @@ const fileMenuItems = computed<FileMenuItemModel[]>(() => {
       label: t('main.mainMenu.exportPdf')
     },
     {
+      id: 'ExportSvg',
+      label: t('main.mainMenu.exportSvg')
+    },
+    {
       id: 'PngOut',
       label: t('main.mainMenu.exportImage')
     }
@@ -1555,6 +1559,8 @@ const handleFileMenuSelect = async (command: string) => {
     AcApDocManager.instance.sendStringToExecute('chtml')
   } else if (command === 'ExportPdf') {
     await runLazyCommand('cpdf')
+  } else if (command === 'ExportSvg') {
+    AcApDocManager.instance.sendStringToExecute('csvg')
   } else if (command === 'PngOut') {
     AcApDocManager.instance.sendStringToExecute('pngout')
   } else if (command === 'QNew') {

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -6,6 +6,7 @@ export default {
     export: 'Export to DXF',
     exportHtml: 'Export to HTML',
     exportPdf: 'Export to PDF',
+    exportSvg: 'Export to SVG',
     exportImage: 'Export to Image'
   },
   ribbon: {

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -6,6 +6,7 @@ export default {
     export: '导出为DXF',
     exportHtml: '导出为 HTML',
     exportPdf: '导出为PDF',
+    exportSvg: '导出为 SVG',
     exportImage: '导出图片'
   },
   ribbon: {

--- a/packages/svg-renderer/README.md
+++ b/packages/svg-renderer/README.md
@@ -1,6 +1,6 @@
 # svg-renderer
 
-This package implements the SVG-based rendering engine for MLightCAD. It converts DWG/DXF entities into SVG graphics for SVG exporting. For now, this module isn't fullly implemented yet.
+This package implements the SVG-based rendering engine for MLightCAD. It converts DWG/DXF entities into SVG graphics for SVG and PDF exporting.
 
 ## Key Features
 - Renders CAD entities as SVG elements

--- a/packages/svg-renderer/__tests__/AcSvgEntity.spec.ts
+++ b/packages/svg-renderer/__tests__/AcSvgEntity.spec.ts
@@ -1,0 +1,109 @@
+import { AcGeMatrix3d } from '@mlightcad/data-model'
+
+import { AcSvgGroup } from '../src/AcSvgGroup'
+import { AcSvgLine } from '../src/AcSvgLine'
+import { AcSvgRenderer } from '../src/AcSvgRenderer'
+import { AcSvgStyleContext } from '../src/AcSvgStyleUtil'
+
+const ctx: AcSvgStyleContext = {
+  ltscale: 1,
+  celtscale: 1,
+  backgroundColor: 0xffffff,
+  foregroundColor: 0x000000,
+  showLineWeight: false
+}
+
+const defaultTraits = () => new AcSvgRenderer().subEntityTraits
+
+describe('AcSvgEntity transforms', () => {
+  it('wraps geometry with applyMatrix transform at export time', () => {
+    const line = new AcSvgLine(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 }
+      ],
+      defaultTraits(),
+      ctx
+    )
+    const matrix = new AcGeMatrix3d().makeTranslation(100, 200, 0)
+    line.applyMatrix(matrix)
+
+    expect(line.getLocalSvg()).not.toContain('matrix(')
+    const rendered = line.renderSvg()
+    expect(rendered).toContain('matrix(')
+    expect(rendered).toContain('100')
+    expect(rendered).toContain('200')
+    expect(line.box.min.x).toBeCloseTo(100)
+    expect(line.box.min.y).toBeCloseTo(200)
+    expect(line.box.max.x).toBeCloseTo(110)
+  })
+
+  it('groups block children and applies insert transform once', () => {
+    const child = new AcSvgLine(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 5, y: 0, z: 0 }
+      ],
+      defaultTraits(),
+      ctx
+    )
+    const group = new AcSvgGroup([child])
+    group.applyMatrix(new AcGeMatrix3d().makeTranslation(50, 75, 0))
+
+    const svg = group.renderSvg()
+    expect(svg).toContain('matrix(')
+    expect(svg).toContain('50')
+    expect(svg).toContain('75')
+    expect(group.box.min.x).toBeCloseTo(50)
+    expect(group.box.max.x).toBeCloseTo(55)
+  })
+
+  it('defers transform until renderer export', () => {
+    const renderer = new AcSvgRenderer()
+    const line = renderer.lines([
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 1, z: 0 }
+    ])
+    line.applyMatrix(new AcGeMatrix3d().makeTranslation(20, 30, 0))
+
+    const exported = renderer.export()
+    expect(exported).toContain('matrix(')
+    expect(exported).toContain('20')
+    expect(exported).toContain('30')
+  })
+
+  it('merges grouped children without duplicating flat primitives', () => {
+    const renderer = new AcSvgRenderer()
+    const a = renderer.lines([
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0 }
+    ])
+    const b = renderer.lines([
+      { x: 0, y: 1, z: 0 },
+      { x: 1, y: 1, z: 0 }
+    ])
+    const group = renderer.group([a, b])
+    group.applyMatrix(new AcGeMatrix3d().makeTranslation(10, 0, 0))
+
+    const exported = renderer.export()
+    const pathCount = (exported.match(/<path /g) ?? []).length
+    expect(pathCount).toBe(2)
+    expect(exported).toContain('matrix(')
+  })
+
+  it('embeds a background rect from currentBackgroundColor', () => {
+    const renderer = new AcSvgRenderer()
+    renderer.currentBackgroundColor = 0x000000
+    renderer.changeForeground(0xffffff)
+    renderer.lines([
+      { x: 0, y: 0, z: 0 },
+      { x: 10, y: 10, z: 0 }
+    ])
+
+    const exported = renderer.export()
+    expect(exported).toMatch(
+      /<rect[^>]*fill="#000000"[^>]*\/>/
+    )
+    expect(exported.indexOf('<rect')).toBeLessThan(exported.indexOf('<g transform'))
+  })
+})

--- a/packages/svg-renderer/__tests__/AcSvgExportUtil.spec.ts
+++ b/packages/svg-renderer/__tests__/AcSvgExportUtil.spec.ts
@@ -1,0 +1,30 @@
+import { AcSvgExportUtil } from '../src/AcSvgExportUtil'
+
+describe('AcSvgExportUtil', () => {
+  it('allows data URLs and in-document fragments', () => {
+    expect(AcSvgExportUtil.isSafeEmbeddedUrl('data:image/png;base64,abc')).toBe(
+      true
+    )
+    expect(AcSvgExportUtil.isSafeEmbeddedUrl('#glyph-1')).toBe(true)
+    expect(AcSvgExportUtil.isSafeEmbeddedUrl('file:///C:/x.svg')).toBe(false)
+    expect(AcSvgExportUtil.isSafeEmbeddedUrl('icons.svg#menu')).toBe(false)
+    expect(AcSvgExportUtil.isSafeEmbeddedUrl('blob:http://localhost/x')).toBe(
+      false
+    )
+  })
+
+  it('removes image and use elements with external href values', () => {
+    const input = [
+      '<image href="data:image/png;base64,abc" width="1" height="1"/>',
+      '<image href="file:///C:/Users/test/example.svg" width="1" height="1"/>',
+      '<use xlink:href="icons.svg#menu"/>',
+      '<use xlink:href="#local-id"/>'
+    ].join('\n')
+
+    const output = AcSvgExportUtil.sanitizeExternalReferences(input)
+    expect(output).toContain('data:image/png')
+    expect(output).not.toContain('file:///')
+    expect(output).not.toContain('icons.svg')
+    expect(output).toContain('#local-id')
+  })
+})

--- a/packages/svg-renderer/__tests__/AcSvgMText.spec.ts
+++ b/packages/svg-renderer/__tests__/AcSvgMText.spec.ts
@@ -1,0 +1,352 @@
+import {
+  AcCmColor,
+  AcCmTransparency,
+  AcGiLineWeight,
+  AcGiMTextAttachmentPoint,
+  AcGiMTextFlowDirection,
+  AcGiSubEntityTraits
+} from '@mlightcad/data-model'
+
+import {
+  buildSvgMText,
+  resolveSvgFontFamily,
+  setSvgFontMapping
+} from '../src/AcSvgMTextUtil'
+import { AcSvgStyleContext } from '../src/AcSvgStyleUtil'
+
+const ctx: AcSvgStyleContext = {
+  ltscale: 1,
+  celtscale: 1,
+  backgroundColor: 0xffffff,
+  foregroundColor: 0x000000,
+  showLineWeight: false
+}
+
+function createTraits(): AcGiSubEntityTraits {
+  return {
+    color: new AcCmColor(),
+    rgbColor: 0xff0000,
+    lineType: {
+      type: 'ByLayer',
+      name: 'Continuous',
+      standardFlag: 0,
+      description: 'Solid line',
+      totalPatternLength: 0
+    },
+    lineTypeScale: 1,
+    lineWeight: AcGiLineWeight.LineWeight013,
+    fillType: {
+      solidFill: true,
+      patternAngle: 0,
+      definitionLines: []
+    },
+    transparency: new AcCmTransparency(),
+    thickness: 0,
+    layer: '0',
+    drawOrder: 0
+  }
+}
+
+describe('buildSvgMText', () => {
+  it('splits paragraphs into tspans', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'Line1\\PLine2\\PLine3',
+        height: 2.5,
+        position: { x: 10, y: 20, z: 0 },
+        rotation: 0
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('<tspan')
+    expect(localSvg).toContain('Line1')
+    expect(localSvg).toContain('Line2')
+    expect(localSvg).toContain('Line3')
+    expect(localSvg).toContain('translate(10,20)')
+  })
+
+  it('renders special characters from the parser', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: '%%c45%%d',
+        height: 1,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'sans-serif' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('Ø')
+    expect(localSvg).toContain('°')
+  })
+
+  it('uses entity text height for default font size', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'Hello',
+        height: 2.5,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('font-size="2.5"')
+    expect(localSvg).not.toMatch(/font-size="1"/)
+  })
+
+  it('applies inline height formatting', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: '\\H5;Large',
+        height: 2.5,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('font-size="5"')
+  })
+
+  it('wraps long lines to the mtext width', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'AAAA AAAA AAAA',
+        height: 10,
+        width: 30,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    const dyValues = [...localSvg.matchAll(/\sdy="([^"]+)"/g)].map(match => Number(match[1]))
+    expect(dyValues.filter(value => value > 0).length).toBeGreaterThan(0)
+    expect(localSvg).toMatch(/<tspan[^>]*x="0"[^>]*dy="0"/)
+    expect(localSvg).toMatch(/<tspan[^>]*x="0"[^>]*dy="14\.1/)
+  })
+
+  it('wraps continuous latin text without spaces', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'AAAAAAAAAAAAAAAA',
+        height: 10,
+        width: 30,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    const dyValues = [...localSvg.matchAll(/\sdy="([^"]+)"/g)].map(match => Number(match[1]))
+    expect(dyValues.filter(value => value > 0).length).toBeGreaterThan(0)
+  })
+
+  it('wraps cjk text inside the mtext width', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: '这是一段测试文字',
+        height: 10,
+        width: 30,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'SimSun' } as never,
+      createTraits(),
+      ctx
+    )
+
+    const dyValues = [...localSvg.matchAll(/\sdy="([^"]+)"/g)].map(match => Number(match[1]))
+    expect(dyValues.filter(value => value > 0).length).toBeGreaterThan(0)
+  })
+
+  it('anchors top-left attachment at the insertion point', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'Hello',
+        height: 10,
+        width: 100,
+        position: { x: 50, y: 50, z: 0 },
+        attachmentPoint: AcGiMTextAttachmentPoint.TopLeft
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('translate(50,50)')
+    expect(localSvg).toContain('translate(0,-10)')
+  })
+
+  it('keeps baseline-left attachment on the first baseline', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'Hello',
+        height: 10,
+        width: 100,
+        position: { x: 0, y: 0, z: 0 },
+        attachmentPoint: AcGiMTextAttachmentPoint.BaselineLeft
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).not.toMatch(/translate\(0,-10\)/)
+    expect(localSvg).toContain('translate(0,0)')
+  })
+
+  it('applies attachment point offset for middle-center anchoring', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'Hello',
+        height: 10,
+        width: 100,
+        position: { x: 50, y: 50, z: 0 },
+        attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('translate(50,50)')
+    expect(localSvg).toMatch(/translate\(-?\d+(\.\d+)?,-?\d+(\.\d+)?\)/)
+  })
+
+  it('uses directionVector for rotation when provided', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'Rotated',
+        height: 10,
+        width: 100,
+        position: { x: 0, y: 0, z: 0 },
+        directionVector: { x: 0, y: 1, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('rotate(-90')
+  })
+
+  it('lays out bottom-to-top vertical text for TEXT-style flow', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'ABC',
+        height: 10,
+        width: 100,
+        position: { x: 0, y: 0, z: 0 },
+        drawingDirection: AcGiMTextFlowDirection.BOTTOM_TO_TOP
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    const yValues = [...localSvg.matchAll(/\sy="([^"]+)"/g)].map(match => Number(match[1]))
+    expect(yValues.length).toBeGreaterThan(1)
+    expect(yValues[0]).toBeGreaterThan(yValues[yValues.length - 1])
+  })
+
+  it('applies inline color formatting', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: '\\c255;Red',
+        height: 1,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'sans-serif' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('fill="#')
+    expect(localSvg).toContain('Red')
+  })
+
+  it('wraps output in a transformed group', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'Hello',
+        height: 2.5,
+        position: { x: 1, y: 2, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toMatch(/<g transform="[^"]*translate\(1,2\)[^"]*scale\(1,-1\)"/)
+    expect(localSvg).toContain('<text')
+  })
+
+  it('maps SHX font names to CSS font families', () => {
+    expect(resolveSvgFontFamily('romans.shx')).toContain('Times New Roman')
+    expect(resolveSvgFontFamily('txt.shx')).toContain('monospace')
+  })
+
+  it('honours custom font mapping overrides', () => {
+    setSvgFontMapping({ customcad: 'Custom Font, sans-serif' })
+    expect(resolveSvgFontFamily('customcad.shx')).toBe('Custom Font, sans-serif')
+    setSvgFontMapping({})
+  })
+
+  it('applies underline, overline, and strikethrough formatting', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: '\\LUnder\\OOver\\KStrike',
+        height: 10,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('text-decoration="underline"')
+    expect(localSvg).toContain('overline')
+    expect(localSvg).toContain('line-through')
+  })
+
+  it('renders fraction stacks with a divider line', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'A\\S1#2;B',
+        height: 10,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('<line')
+    expect(localSvg).toContain('1')
+    expect(localSvg).toContain('2')
+  })
+
+  it('renders superscript stacks with smaller text', () => {
+    const { localSvg } = buildSvgMText(
+      {
+        text: 'E=mc\\S2^;',
+        height: 10,
+        position: { x: 0, y: 0, z: 0 }
+      } as never,
+      { font: 'Arial' } as never,
+      createTraits(),
+      ctx
+    )
+
+    expect(localSvg).toContain('font-size="7"')
+  })
+})

--- a/packages/svg-renderer/__tests__/AcSvgStyleUtil.spec.ts
+++ b/packages/svg-renderer/__tests__/AcSvgStyleUtil.spec.ts
@@ -1,0 +1,124 @@
+import {
+  AcCmColor,
+  AcCmTransparency,
+  AcGiLineWeight,
+  AcGiSubEntityTraits
+} from '@mlightcad/data-model'
+import { AcSvgStyleContext, AcSvgStyleUtil } from '../src/AcSvgStyleUtil'
+
+function createTraits(
+  overrides: Partial<AcGiSubEntityTraits> = {}
+): AcGiSubEntityTraits {
+  return {
+    color: new AcCmColor(),
+    rgbColor: 0xff0000,
+    lineType: {
+      type: 'ByLayer',
+      name: 'Continuous',
+      standardFlag: 0,
+      description: 'Solid line',
+      totalPatternLength: 0
+    },
+    lineTypeScale: 1,
+    lineWeight: AcGiLineWeight.LineWeight013,
+    fillType: {
+      solidFill: true,
+      patternAngle: 0,
+      definitionLines: []
+    },
+    transparency: new AcCmTransparency(),
+    thickness: 0,
+    layer: '0',
+    drawOrder: 0,
+    ...overrides
+  }
+}
+
+const ctx: AcSvgStyleContext = {
+  ltscale: 1,
+  celtscale: 2,
+  backgroundColor: 0xffffff,
+  foregroundColor: 0x000000,
+  showLineWeight: false
+}
+
+describe('AcSvgStyleUtil', () => {
+  it('converts rgb to hex', () => {
+    expect(AcSvgStyleUtil.rgbToHex(0xff8040)).toBe('#ff8040')
+  })
+
+  it('applies entity stroke colour from traits', () => {
+    const attrs = AcSvgStyleUtil.strokeAttributes(createTraits(), ctx)
+    expect(attrs.stroke).toBe('#ff0000')
+    expect(attrs.fill).toBe('none')
+  })
+
+  it('uses foreground colour for ACI 7 linework', () => {
+    const attrs = AcSvgStyleUtil.strokeAttributes(
+      createTraits({
+        color: new AcCmColor().setForeground(),
+        rgbColor: 0xffffff
+      }),
+      ctx
+    )
+    expect(attrs.stroke).toBe('#000000')
+  })
+
+  it('uses background colour for ACI 7 solid hatch fills', () => {
+    const attrs = AcSvgStyleUtil.fillAttributes(
+      createTraits({
+        color: new AcCmColor().setForeground(),
+        rgbColor: 0xffffff,
+        drawOrder: -1,
+        fillType: {
+          solidFill: true,
+          patternAngle: 0,
+          definitionLines: []
+        }
+      }),
+      ctx
+    )
+    expect(attrs.fill).toBe('#ffffff')
+  })
+
+  it('uses non-scaling hairline when showLineWeight is false', () => {
+    const attrs = AcSvgStyleUtil.strokeAttributes(createTraits(), ctx)
+    expect(attrs['stroke-width']).toBe('1')
+    expect(attrs['vector-effect']).toBe('non-scaling-stroke')
+  })
+
+  it('applies stroke-width when showLineWeight is true', () => {
+    const attrs = AcSvgStyleUtil.strokeAttributes(createTraits(), {
+      ...ctx,
+      showLineWeight: true
+    })
+    expect(attrs['stroke-width']).toBe('0.13')
+    expect(attrs['vector-effect']).toBeUndefined()
+  })
+
+  it('builds stroke-dasharray from linetype pattern', () => {
+    const attrs = AcSvgStyleUtil.strokeAttributes(
+      createTraits({
+        lineType: {
+          type: 'ByLayer',
+          name: 'Dashed',
+          standardFlag: 0,
+          description: 'Dash',
+          totalPatternLength: 10,
+          pattern: [
+            { elementLength: 5, elementTypeFlag: 0 },
+            { elementLength: -3, elementTypeFlag: 0 }
+          ]
+        }
+      }),
+      ctx
+    )
+    expect(attrs['stroke-dasharray']).toBe('10 6')
+  })
+
+  it('renders path tags with attributes', () => {
+    const tag = AcSvgStyleUtil.tag('path', { d: 'M0,0 L1,1', stroke: '#000' })
+    expect(tag).toContain('d="M0,0 L1,1"')
+    expect(tag).toContain('stroke="#000"')
+  })
+})

--- a/packages/svg-renderer/package.json
+++ b/packages/svg-renderer/package.json
@@ -30,7 +30,12 @@
     "lint": "eslint src/",
     "lint:fix": "eslint --fix --quiet src/"
   },
+  "devDependencies": {
+    "@mlightcad/data-model": "^1.7.40",
+    "@mlightcad/mtext-parser": "^1.4.1"
+  },
   "peerDependencies": {
-    "@mlightcad/data-model": "^1.7.40"
+    "@mlightcad/data-model": "^1.7.40",
+    "@mlightcad/mtext-parser": "^1.4.1"
   }
 }

--- a/packages/svg-renderer/src/AcSvgArea.ts
+++ b/packages/svg-renderer/src/AcSvgArea.ts
@@ -1,6 +1,7 @@
-import { AcGeArea2d } from '@mlightcad/data-model'
+import { AcGeArea2d, AcGiSubEntityTraits } from '@mlightcad/data-model'
 
 import { AcSvgEntity } from './AcSvgEntity'
+import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
 
 /** Segments per arc when approximating curves in area loops. */
 const ARC_SEGMENTS = 32
@@ -10,7 +11,11 @@ const ARC_SEGMENTS = 32
  * Uses even-odd fill rule so inner loops (holes) render as transparent cutouts.
  */
 export class AcSvgArea extends AcSvgEntity {
-  constructor(area: AcGeArea2d) {
+  constructor(
+    area: AcGeArea2d,
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ) {
     super()
     const loopPointArrays = area.getPoints(ARC_SEGMENTS)
     let d = ''
@@ -28,6 +33,13 @@ export class AcSvgArea extends AcSvgEntity {
       }
     }
 
-    this.svg = `<path d="${d}" fill-rule="evenodd"/>`
+    if (d) {
+      const attrs = {
+        d,
+        'fill-rule': 'evenodd',
+        ...AcSvgStyleUtil.fillAttributes(traits, ctx)
+      }
+      this.svg = AcSvgStyleUtil.tag('path', attrs)
+    }
   }
 }

--- a/packages/svg-renderer/src/AcSvgCircArc.ts
+++ b/packages/svg-renderer/src/AcSvgCircArc.ts
@@ -1,18 +1,33 @@
-import { AcGeCircArc3d } from '@mlightcad/data-model'
+import { AcGeCircArc3d, AcGiSubEntityTraits } from '@mlightcad/data-model'
 
 import { AcSvgEntity } from './AcSvgEntity'
+import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
+
+/** Tessellation segment count for arc approximation. */
+const ARC_SEGMENTS = 100
 
 export class AcSvgCircArc extends AcSvgEntity {
-  constructor(arc: AcGeCircArc3d) {
+  constructor(
+    arc: AcGeCircArc3d,
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ) {
     super()
-    if (arc.closed) {
-      this.svg = `\n<circle cx="${arc.center.x}" cy="${arc.center.y}" r="${arc.radius}"/>`
-    } else {
-      const start = arc.startPoint
-      const end = arc.endPoint
-      const sweepFlag = arc.clockwise ? 0 : 1
-      this.svg = `\n<path d="M${start.x},${start.y} A${arc.radius},${arc.radius} 0 ${arc.isLargeArc},${sweepFlag} ${end.x},${end.y}"/>`
+    const points = arc.getPoints(ARC_SEGMENTS)
+    const d = points.reduce((acc, point, i) => {
+      acc += i === 0 ? 'M' : 'L'
+      acc += `${point.x},${point.y}`
+      return acc
+    }, '')
+
+    if (d) {
+      const attrs = {
+        d,
+        ...AcSvgStyleUtil.strokeAttributes(traits, ctx)
+      }
+      this.svg = AcSvgStyleUtil.tag('path', attrs)
     }
+
     const box = arc.box
     this._box.min.copy(box.min)
     this._box.max.copy(box.max)

--- a/packages/svg-renderer/src/AcSvgEllipticalArc.ts
+++ b/packages/svg-renderer/src/AcSvgEllipticalArc.ts
@@ -1,28 +1,33 @@
-import {
-  AcGeEllipseArc3d,
-  AcGeMathUtil,
-  AcGeVector3d
-} from '@mlightcad/data-model'
+import { AcGeEllipseArc3d, AcGiSubEntityTraits } from '@mlightcad/data-model'
 
 import { AcSvgEntity } from './AcSvgEntity'
+import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
+
+/** Tessellation segment count for elliptical arc approximation. */
+const ARC_SEGMENTS = 100
 
 export class AcTrEllipticalArc extends AcSvgEntity {
-  constructor(ellipseArc: AcGeEllipseArc3d) {
+  constructor(
+    ellipseArc: AcGeEllipseArc3d,
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ) {
     super()
-    if (ellipseArc.closed) {
-      // TODO: Considering rotation
-      this.svg = `\n<ellipse cx="${ellipseArc.center.x}" cy="${ellipseArc.center.y}" rx="${ellipseArc.majorAxisRadius}" ry="${ellipseArc.minorAxisRadius}"/>`
-    } else {
-      const start = ellipseArc.startPoint
-      const end = ellipseArc.endPoint
+    const points = ellipseArc.getPoints(ARC_SEGMENTS)
+    const d = points.reduce((acc, point, i) => {
+      acc += i === 0 ? 'M' : 'L'
+      acc += `${point.x},${point.y}`
+      return acc
+    }, '')
 
-      // Calculate sweepFlag
-      const xAxisRotation = AcGeMathUtil.radToDeg(
-        ellipseArc.majorAxis.angleTo(AcGeVector3d.X_AXIS)
-      )
-      const sweepFlag = ellipseArc.clockwise ? 0 : 1
-      this.svg = `\n<path d="M${start.x},${start.y} A${ellipseArc.majorAxisRadius},${ellipseArc.minorAxisRadius} ${xAxisRotation} ${ellipseArc.isLargeArc},${sweepFlag} ${end.x},${end.y}"/>`
+    if (d) {
+      const attrs = {
+        d,
+        ...AcSvgStyleUtil.strokeAttributes(traits, ctx)
+      }
+      this.svg = AcSvgStyleUtil.tag('path', attrs)
     }
+
     const box = ellipseArc.box
     this._box.min.copy(box.min)
     this._box.max.copy(box.max)

--- a/packages/svg-renderer/src/AcSvgEntity.ts
+++ b/packages/svg-renderer/src/AcSvgEntity.ts
@@ -5,6 +5,8 @@ import {
   AcGiEntity
 } from '@mlightcad/data-model'
 
+import { AcSvgMatrixUtil } from './AcSvgMatrixUtil'
+
 /**
  * Represent the display object of one drawing entity.
  */
@@ -15,7 +17,8 @@ export class AcSvgEntity implements AcGiEntity {
   private _visible: boolean
   private _userData: object
   protected _box: AcGeBox2d
-  private _svg: string
+  protected _localSvg: string
+  private _matrix?: AcGeMatrix3d
   protected _basePoint?: AcGePoint3d
 
   constructor() {
@@ -25,11 +28,11 @@ export class AcSvgEntity implements AcGiEntity {
     this._visible = true
     this._userData = {}
     this._box = new AcGeBox2d()
-    this._svg = ''
+    this._localSvg = ''
   }
 
   /**
-   * The bounding box of this object
+   * The bounding box of this object in world coordinates (includes transforms).
    */
   get box() {
     return this._box
@@ -38,16 +41,6 @@ export class AcSvgEntity implements AcGiEntity {
     this._box.copy(value)
   }
 
-  /**
-   * JavaScript (and WebGL) use 64‑bit floating point numbers for CPU-side calculations,
-   * but GPU shaders typically use 32‑bit floats. A 32-bit float has ~7.2 decimal digits
-   * of precision. If passing 64-bit floating vertices data to GPU directly, it will
-   * destroy number preciesion.
-   *
-   * So we adopt a simpler but effective version of the “origin-shift” idea. Recompute
-   * geometry using re-centered coordinates and apply offset to its position. The base
-   * point is extractly offset value.
-   */
   get basePoint() {
     return this._basePoint
   }
@@ -62,18 +55,36 @@ export class AcSvgEntity implements AcGiEntity {
   }
 
   /**
-   * SVG string of this entity
+   * SVG markup including any transforms applied via {@link applyMatrix}.
    */
   get svg() {
-    return this._svg
+    return this.renderSvg()
   }
   set svg(value: string) {
-    this._svg = value
+    this._localSvg = value
   }
 
   /**
-   * @inheritdoc
+   * Local SVG markup without wrapping transforms.
    */
+  getLocalSvg(): string {
+    return this._localSvg
+  }
+
+  /**
+   * Final SVG fragment with accumulated transforms applied.
+   */
+  renderSvg(): string {
+    if (!this._localSvg) {
+      return ''
+    }
+    if (!this._matrix) {
+      return this._localSvg
+    }
+    const transform = AcSvgMatrixUtil.toSvgTransform(this._matrix)
+    return `<g transform="${transform}">\n${this._localSvg}\n</g>`
+  }
+
   get objectId() {
     return this._objectId
   }
@@ -81,9 +92,6 @@ export class AcSvgEntity implements AcGiEntity {
     this._objectId = value
   }
 
-  /**
-   * @inheritdoc
-   */
   get ownerId() {
     return this._ownerId
   }
@@ -91,9 +99,6 @@ export class AcSvgEntity implements AcGiEntity {
     this._ownerId = value
   }
 
-  /**
-   * @inheritdoc
-   */
   get layerName() {
     return this._layerName
   }
@@ -101,9 +106,6 @@ export class AcSvgEntity implements AcGiEntity {
     this._layerName = value
   }
 
-  /**
-   * @inheritdoc
-   */
   get visible() {
     return this._visible
   }
@@ -111,9 +113,6 @@ export class AcSvgEntity implements AcGiEntity {
     this._visible = value
   }
 
-  /**
-   * @inheritdoc
-   */
   get userData(): object {
     return this._userData
   }
@@ -124,49 +123,35 @@ export class AcSvgEntity implements AcGiEntity {
   /**
    * @inheritdoc
    */
-  applyMatrix(_matrix: AcGeMatrix3d) {
-    // Do nothing
+  applyMatrix(matrix: AcGeMatrix3d) {
+    if (!this._matrix) {
+      this._matrix = matrix.clone()
+    } else {
+      this._matrix = matrix.clone().multiply(this._matrix)
+    }
+    AcSvgMatrixUtil.transformBox(this._box, matrix)
   }
 
-  /**
-   * @inheritdoc
-   */
   recomputeBoundingBox() {
-    // Do nothing
+    // Bounding boxes are maintained during draw and applyMatrix.
   }
 
-  /**
-   * @inheritdoc
-   */
   highlight() {
     // Do nothing
   }
 
-  /**
-   * @inheritdoc
-   */
   unhighlight() {
     // Do nothing
   }
 
-  /**
-   * @inheritdoc
-   */
   fastDeepClone() {
-    // TODO: Implement it correctly
     return this
   }
 
-  /**
-   * @inheritdoc
-   */
   addChild(_entity: AcGiEntity) {
     // Do nothing for now
   }
 
-  /**
-   * @inheritdoc
-   */
   bakeTransformToChildren() {
     // Do nothing for now
   }

--- a/packages/svg-renderer/src/AcSvgExportUtil.ts
+++ b/packages/svg-renderer/src/AcSvgExportUtil.ts
@@ -1,0 +1,54 @@
+/**
+ * Post-processing helpers so exported SVG opens cleanly via file:// in browsers.
+ */
+export class AcSvgExportUtil {
+  /**
+   * Only in-document fragments and data URLs are safe in a downloaded SVG.
+   */
+  static isSafeEmbeddedUrl(url: string): boolean {
+    const trimmed = url.trim()
+    return trimmed.startsWith('data:') || trimmed.startsWith('#')
+  }
+
+  /**
+   * Removes elements whose href/xlink:href points outside the document.
+   * Browsers block these under the file:// origin and may log errors such as
+   * "Unsafe attempt to load URL file:///…/drawing.svg".
+   */
+  static sanitizeExternalReferences(markup: string): string {
+    return markup.replace(
+      /<(?:image|use)\b[^>]*\s(?:xlink:)?href="(?!data:|#)[^"]*"[^>]*\/?>\s*/gi,
+      ''
+    )
+  }
+
+  /**
+   * Rasterizes an SVG data URL to PNG so nested SVG cannot reference external files.
+   */
+  static async rasterizeSvgDataUrl(dataUrl: string): Promise<string> {
+    if (typeof document === 'undefined') {
+      return dataUrl
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const img = new Image()
+      img.onload = () => {
+        const width = Math.max(1, img.naturalWidth || 1)
+        const height = Math.max(1, img.naturalHeight || 1)
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        const ctx = canvas.getContext('2d')
+        if (!ctx) {
+          reject(new Error('Canvas 2D context unavailable'))
+          return
+        }
+        ctx.drawImage(img, 0, 0, width, height)
+        resolve(canvas.toDataURL('image/png'))
+      }
+      img.onerror = () =>
+        reject(new Error('Failed to rasterize embedded SVG image'))
+      img.src = dataUrl
+    })
+  }
+}

--- a/packages/svg-renderer/src/AcSvgFontMap.ts
+++ b/packages/svg-renderer/src/AcSvgFontMap.ts
@@ -1,0 +1,123 @@
+/**
+ * Maps AutoCAD / DXF font names to CSS {@code font-family} stacks for SVG text.
+ *
+ * SVG relies on the host environment's font renderer; this module approximates
+ * DWG/DXF appearance by translating SHX/TTF style names to commonly available
+ * system or web fonts.
+ */
+export type AcSvgFontMapping = Record<string, string>
+
+const SHX_SUFFIX = /\.(shx|ttf|otf|woff2?)$/i
+
+/** Built-in CAD font name → CSS font-family (first match wins in the UA). */
+const DEFAULT_CAD_FONT_MAP: AcSvgFontMapping = {
+  txt: 'Lucida Console, Courier New, monospace',
+  simplex: 'Arial, Helvetica, sans-serif',
+  romans: '"Times New Roman", Times, serif',
+  romanc: '"Times New Roman", Times, serif',
+  romand: '"Times New Roman", Times, serif',
+  romant: '"Times New Roman", Times, serif',
+  italic: '"Times New Roman", Times, serif',
+  italict: '"Times New Roman", Times, serif',
+  italicc: '"Times New Roman", Times, serif',
+  monotxt: '"Courier New", Courier, monospace',
+  isocp: 'Arial, Helvetica, sans-serif',
+  isocp2: 'Arial, Helvetica, sans-serif',
+  isocp3: 'Arial, Helvetica, sans-serif',
+  isoct: 'Arial, Helvetica, sans-serif',
+  isoct2: 'Arial, Helvetica, sans-serif',
+  isoct3: 'Arial, Helvetica, sans-serif',
+  gdt: 'Arial, Helvetica, sans-serif',
+  greekc: '"Times New Roman", Times, serif',
+  greeks: '"Times New Roman", Times, serif',
+  simsun: 'SimSun, "Songti SC", STSong, serif',
+  simhei: 'SimHei, "Heiti SC", STHeiti, sans-serif',
+  simkai: 'KaiTi, "Kaiti SC", STKaiti, serif',
+  simfang: 'FangSong, "Fangsong SC", STFangsong, serif',
+  msyh: '"Microsoft YaHei", "PingFang SC", sans-serif',
+  dengxian: 'DengXian, "Microsoft YaHei", sans-serif',
+  arial: 'Arial, Helvetica, sans-serif',
+  'times new roman': '"Times New Roman", Times, serif',
+  courier: '"Courier New", Courier, monospace',
+  tahoma: 'Tahoma, Geneva, sans-serif',
+  verdana: 'Verdana, Geneva, sans-serif'
+}
+
+/** Optional per-font size scale to better match SHX cap height in SVG. */
+const DEFAULT_FONT_SIZE_SCALE: AcSvgFontMapping = {
+  arial: '1',
+  romans: '1.05',
+  txt: '1.1',
+  simplex: '1.05',
+  isocp: '1'
+}
+
+let customFontMap: AcSvgFontMapping = {}
+let customSizeScale: AcSvgFontMapping = {}
+
+function normalizeFontKey(name: string): string {
+  return name.trim().replace(SHX_SUFFIX, '').toLowerCase()
+}
+
+/**
+ * Resolves a CAD font name to a CSS {@code font-family} value.
+ */
+export function resolveSvgFontFamily(
+  cadFontName: string | undefined,
+  fallback?: string
+): string {
+  const fallbackFamily = fallback?.trim() || 'sans-serif'
+  if (!cadFontName?.trim()) {
+    return resolveSvgFontFamily(fallbackFamily, 'sans-serif')
+  }
+
+  const key = normalizeFontKey(cadFontName)
+  const mapped =
+    customFontMap[key] ??
+    DEFAULT_CAD_FONT_MAP[key] ??
+    customFontMap[cadFontName.toLowerCase()]
+
+  if (mapped) {
+    return mapped
+  }
+
+  if (SHX_SUFFIX.test(cadFontName)) {
+    return fallbackFamily
+  }
+
+  return cadFontName.includes(',') ? cadFontName : `"${cadFontName}", ${fallbackFamily}`
+}
+
+/**
+ * Returns a font-size multiplier for the given CAD font (default {@code 1}).
+ */
+export function resolveSvgFontSizeScale(cadFontName: string | undefined): number {
+  if (!cadFontName?.trim()) {
+    return 1
+  }
+  const key = normalizeFontKey(cadFontName)
+  const raw =
+    customSizeScale[key] ??
+    DEFAULT_FONT_SIZE_SCALE[key] ??
+    customSizeScale[cadFontName.toLowerCase()]
+  if (raw == null) {
+    return 1
+  }
+  const scale = Number(raw)
+  return Number.isFinite(scale) && scale > 0 ? scale : 1
+}
+
+/** Overrides or extends the built-in CAD → CSS font mapping. */
+export function setSvgFontMapping(mapping: AcSvgFontMapping): void {
+  customFontMap = { ...mapping }
+}
+
+/** Overrides per-font cap-height scale factors. Values are numeric strings. */
+export function setSvgFontSizeScales(scales: AcSvgFontMapping): void {
+  customSizeScale = { ...scales }
+}
+
+/** Strips SHX/TTF extensions and lowercases a CAD font file name. */
+export function normalizeCadFontName(fontName: string): string {
+  return normalizeFontKey(fontName)
+}

--- a/packages/svg-renderer/src/AcSvgGroup.ts
+++ b/packages/svg-renderer/src/AcSvgGroup.ts
@@ -1,13 +1,13 @@
 import { AcSvgEntity } from './AcSvgEntity'
 
 /**
- * SVG group entity: wraps a set of child SVG strings inside a `<g>` element.
+ * SVG group entity: wraps child SVG markup inside a `<g>` element.
  */
 export class AcSvgGroup extends AcSvgEntity {
   constructor(entities: AcSvgEntity[]) {
     super()
-    const inner = entities.map(e => e.svg).join('\n')
-    this.svg = `<g>${inner}</g>`
+    const inner = entities.map(e => e.renderSvg()).filter(Boolean).join('\n')
+    this._localSvg = inner
     for (const e of entities) {
       this._box.union(e.box)
     }

--- a/packages/svg-renderer/src/AcSvgImage.ts
+++ b/packages/svg-renderer/src/AcSvgImage.ts
@@ -1,21 +1,26 @@
-import { AcGiImageStyle } from '@mlightcad/data-model'
+import { AcGiImageStyle, AcGiSubEntityTraits } from '@mlightcad/data-model'
 
 import { AcSvgEntity } from './AcSvgEntity'
+import { AcSvgExportUtil } from './AcSvgExportUtil'
+import { AcSvgStyleContext } from './AcSvgStyleUtil'
 
 /**
  * SVG image entity: embeds a raster image as a base64 `<image>` element.
- * The boundary array is expected to contain the corner points of the image.
  */
 export class AcSvgImage extends AcSvgEntity {
-  constructor(dataUrl: string, style: AcGiImageStyle) {
+  constructor(
+    dataUrl: string,
+    style: AcGiImageStyle,
+    _traits: AcGiSubEntityTraits,
+    _ctx: AcSvgStyleContext
+  ) {
     super()
     const { boundary } = style
 
-    if (boundary.length < 2) {
+    if (boundary.length < 2 || !AcSvgExportUtil.isSafeEmbeddedUrl(dataUrl)) {
       return
     }
 
-    // Compute axis-aligned bounding rect from boundary points
     let minX = Infinity,
       minY = Infinity,
       maxX = -Infinity,
@@ -30,20 +35,29 @@ export class AcSvgImage extends AcSvgEntity {
 
     const w = maxX - minX
     const h = maxY - minY
+    const href = escapeAttr(dataUrl)
 
-    // Parent <g> flips Y; compensate so the image renders right-side-up
-    this.svg = `<image x="${minX}" y="${minY}" width="${w}" height="${h}" href="${dataUrl}" transform="scale(1,-1) translate(0,${-(minY * 2 + h)})"/>`
+    this._localSvg = `<image x="${minX}" y="${minY}" width="${w}" height="${h}" href="${href}" xlink:href="${href}" transform="scale(1,-1) translate(0,${-(minY * 2 + h)})"/>`
   }
 
-  /**
-   * Async factory: converts a Blob to a data URL, then creates the entity.
-   */
   static async fromBlob(
     blob: Blob,
-    style: AcGiImageStyle
+    style: AcGiImageStyle,
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
   ): Promise<AcSvgImage> {
-    const dataUrl = await blobToDataUrl(blob)
-    return new AcSvgImage(dataUrl, style)
+    let dataUrl = await blobToDataUrl(blob)
+    if (
+      blob.type === 'image/svg+xml' ||
+      dataUrl.startsWith('data:image/svg+xml')
+    ) {
+      try {
+        dataUrl = await AcSvgExportUtil.rasterizeSvgDataUrl(dataUrl)
+      } catch {
+        return new AcSvgImage('', style, traits, ctx)
+      }
+    }
+    return new AcSvgImage(dataUrl, style, traits, ctx)
   }
 }
 
@@ -54,4 +68,8 @@ function blobToDataUrl(blob: Blob): Promise<string> {
     reader.onerror = reject
     reader.readAsDataURL(blob)
   })
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
 }

--- a/packages/svg-renderer/src/AcSvgLine.ts
+++ b/packages/svg-renderer/src/AcSvgLine.ts
@@ -1,9 +1,14 @@
-import { AcGePoint3dLike } from '@mlightcad/data-model'
+import { AcGePoint3dLike, AcGiSubEntityTraits } from '@mlightcad/data-model'
 
 import { AcSvgEntity } from './AcSvgEntity'
+import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
 
 export class AcSvgLine extends AcSvgEntity {
-  constructor(points: AcGePoint3dLike[]) {
+  constructor(
+    points: AcGePoint3dLike[],
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ) {
     super()
     const d = points.reduce(
       (acc: string, point: AcGePoint3dLike, i: number) => {
@@ -16,7 +21,11 @@ export class AcSvgLine extends AcSvgEntity {
     )
 
     if (d) {
-      this.svg = `<path d="${d}" />`
+      const attrs = {
+        d,
+        ...AcSvgStyleUtil.strokeAttributes(traits, ctx)
+      }
+      this.svg = AcSvgStyleUtil.tag('path', attrs)
     }
   }
 }

--- a/packages/svg-renderer/src/AcSvgLineSegments.ts
+++ b/packages/svg-renderer/src/AcSvgLineSegments.ts
@@ -1,16 +1,22 @@
+import { AcGiSubEntityTraits } from '@mlightcad/data-model'
+
 import { AcSvgEntity } from './AcSvgEntity'
+import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
 
 /**
  * SVG line-segments entity: renders pairs of vertices from an indexed
  * Float32Array as individual `<line>` elements.
- *
- * @param array   - Flat vertex buffer (x0,y0,z0, x1,y1,z1, …)
- * @param itemSize - Number of components per vertex (typically 3)
- * @param indices  - Pairs of vertex indices defining each segment
  */
 export class AcSvgLineSegments extends AcSvgEntity {
-  constructor(array: Float32Array, itemSize: number, indices: Uint16Array) {
+  constructor(
+    array: Float32Array,
+    itemSize: number,
+    indices: Uint16Array,
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ) {
     super()
+    const strokeAttrs = AcSvgStyleUtil.strokeAttributes(traits, ctx)
     const lines: string[] = []
 
     for (let i = 0; i + 1 < indices.length; i += 2) {
@@ -20,7 +26,15 @@ export class AcSvgLineSegments extends AcSvgEntity {
       const y1 = array[ai + 1]
       const x2 = array[bi]
       const y2 = array[bi + 1]
-      lines.push(`<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}"/>`)
+      lines.push(
+        AcSvgStyleUtil.tag('line', {
+          x1: String(x1),
+          y1: String(y1),
+          x2: String(x2),
+          y2: String(y2),
+          ...strokeAttrs
+        })
+      )
       this._box.expandByPoint({ x: x1, y: y1 })
       this._box.expandByPoint({ x: x2, y: y2 })
     }

--- a/packages/svg-renderer/src/AcSvgMText.ts
+++ b/packages/svg-renderer/src/AcSvgMText.ts
@@ -1,49 +1,26 @@
-import { AcGiMTextData, AcGiTextStyle } from '@mlightcad/data-model'
+import {
+  AcGiMTextData,
+  AcGiSubEntityTraits,
+  AcGiTextStyle
+} from '@mlightcad/data-model'
 
 import { AcSvgEntity } from './AcSvgEntity'
+import { buildSvgMText } from './AcSvgMTextUtil'
+import { AcSvgStyleContext } from './AcSvgStyleUtil'
 
 /**
- * SVG mtext entity: renders multiline text as a `<text>` SVG element.
- * This is an MVP implementation that handles plain-text content
- * without full MText format-code parsing.
+ * SVG mtext entity rendered from parsed MTEXT tokens via {@link @mlightcad/mtext-parser}.
  */
 export class AcSvgMText extends AcSvgEntity {
-  constructor(mtext: AcGiMTextData, style: AcGiTextStyle) {
+  constructor(
+    mtext: AcGiMTextData,
+    style: AcGiTextStyle,
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ) {
     super()
-    const { text, height, position, rotation } = mtext
-    const x = position.x
-    const y = position.y
-
-    // Strip simple MText format codes (e.g. {\fArial;...}, \P, \~)
-    const plain = text
-      .replace(/\{\\[^}]*\}/g, '')
-      .replace(/\\[PpNn]/g, ' ')
-      .replace(/\\~/g, '\u00A0')
-      .trim()
-
-    const fontFamily = style.extendedFont || style.font || 'sans-serif'
-    const rotDeg = rotation != null ? (rotation * 180) / Math.PI : 0
-
-    // SVG coordinate system is Y-down; the parent <g> already flips Y with
-    // matrix(1,0,0,-1,0,0), so we need to re-flip the text to keep it readable.
-    const transform =
-      rotDeg !== 0
-        ? `translate(${x},${y}) scale(1,-1) rotate(${-rotDeg})`
-        : `translate(${x},${y}) scale(1,-1)`
-
-    this.svg = `<text font-size="${height}" font-family="${fontFamily}" transform="${transform}">${escapeXml(plain)}</text>`
-
-    // Approximate bounding box
-    const w = plain.length * height * 0.6
-    this._box.expandByPoint({ x, y })
-    this._box.expandByPoint({ x: x + w, y: y + height })
+    const built = buildSvgMText(mtext, style, traits, ctx)
+    this._localSvg = built.localSvg
+    this._box = built.box
   }
-}
-
-function escapeXml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
 }

--- a/packages/svg-renderer/src/AcSvgMTextUtil.ts
+++ b/packages/svg-renderer/src/AcSvgMTextUtil.ts
@@ -1,0 +1,1160 @@
+import {
+  AcCmColor,
+  AcGeBox2d,
+  AcGiMTextAttachmentPoint,
+  AcGiMTextData,
+  AcGiMTextFlowDirection,
+  AcGiSubEntityTraits,
+  AcGiTextStyle
+} from '@mlightcad/data-model'
+import {
+  ChangedProperties,
+  MTextColor,
+  MTextContext,
+  MTextParagraphAlignment,
+  MTextParser,
+  MTextToken,
+  Properties,
+  TokenType
+} from '@mlightcad/mtext-parser'
+
+import {
+  normalizeCadFontName,
+  resolveSvgFontFamily,
+  resolveSvgFontSizeScale
+} from './AcSvgFontMap'
+import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
+
+const DEFAULT_LINE_SPACE_FACTOR = 0.25
+const LINE_SPACING_SCALE_FACTOR = 1.666666
+const STACK_VERTICAL_SHIFT_FACTOR = 0.3
+const LATIN_CHAR_WIDTH_FACTOR = 0.6
+const WIDE_CHAR_WIDTH_FACTOR = 1
+const DEFAULT_TAB_WIDTH_FACTOR = 4
+const STACK_SCRIPT_SCALE = 0.7
+
+function isWideCharacter(char: string): boolean {
+  if (!char || char.length !== 1) {
+    return false
+  }
+  const code = char.codePointAt(0) ?? 0
+  return (
+    (code >= 0x1100 && code <= 0x11ff) ||
+    (code >= 0x2e80 && code <= 0x9fff) ||
+    (code >= 0xf900 && code <= 0xfaff) ||
+    (code >= 0xfe10 && code <= 0xfe6f) ||
+    (code >= 0xff00 && code <= 0xff60) ||
+    (code >= 0x20000 && code <= 0x2ffff)
+  )
+}
+
+interface LayoutSpan {
+  text: string
+  x: number
+  y: number
+  fontSize: number
+  tokenCtx: MTextContext
+}
+
+interface DecorationLine {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  stroke: string
+  lineIndex: number
+}
+
+interface LayoutLine {
+  spans: LayoutSpan[]
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+  baselineY: number
+  columnLeft: number
+  paragraphAlign: MTextParagraphAlignment
+}
+
+interface LayoutBounds {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+  firstBaselineY: number
+}
+
+enum FlowMode {
+  HorizontalLtr,
+  HorizontalRtl,
+  VerticalTtb,
+  VerticalBtt
+}
+
+export interface AcSvgMTextBuildResult {
+  localSvg: string
+  box: AcGeBox2d
+}
+
+function resolveLineAdvance(baseHeight: number, mtext: AcGiMTextData): number {
+  const factor =
+    typeof mtext.lineSpaceFactor === 'number'
+      ? mtext.lineSpaceFactor
+      : DEFAULT_LINE_SPACE_FACTOR
+  return baseHeight * (1 + factor * LINE_SPACING_SCALE_FACTOR)
+}
+
+function resolveWrapWidth(mtext: AcGiMTextData): number | null {
+  if (!Number.isFinite(mtext.width) || mtext.width <= 0) {
+    return null
+  }
+  return mtext.width
+}
+
+function resolveFlowMode(
+  drawingDirection?: AcGiMTextFlowDirection
+): FlowMode {
+  switch (drawingDirection) {
+    case AcGiMTextFlowDirection.RIGHT_TO_LEFT:
+      return FlowMode.HorizontalRtl
+    case AcGiMTextFlowDirection.TOP_TO_BOTTOM:
+      return FlowMode.VerticalTtb
+    case AcGiMTextFlowDirection.BOTTOM_TO_TOP:
+      return FlowMode.VerticalBtt
+    case AcGiMTextFlowDirection.LEFT_TO_RIGHT:
+    case AcGiMTextFlowDirection.BY_STYLE:
+    default:
+      return FlowMode.HorizontalLtr
+  }
+}
+
+function resolveRotation(mtext: AcGiMTextData): number {
+  const dir = mtext.directionVector
+  if (dir && (dir.x !== 0 || dir.y !== 0)) {
+    return Math.atan2(dir.y, dir.x)
+  }
+  return mtext.rotation ?? 0
+}
+
+function resolveParagraphAlignment(
+  mtext: AcGiMTextData
+): MTextParagraphAlignment {
+  const width = mtext.width
+  if (!Number.isFinite(width) || width <= 0 || mtext.attachmentPoint == null) {
+    return MTextParagraphAlignment.LEFT
+  }
+
+  switch (mtext.attachmentPoint) {
+    case AcGiMTextAttachmentPoint.TopCenter:
+    case AcGiMTextAttachmentPoint.MiddleCenter:
+    case AcGiMTextAttachmentPoint.BottomCenter:
+    case AcGiMTextAttachmentPoint.BaselineCenter:
+      return MTextParagraphAlignment.CENTER
+    case AcGiMTextAttachmentPoint.TopRight:
+    case AcGiMTextAttachmentPoint.MiddleRight:
+    case AcGiMTextAttachmentPoint.BottomRight:
+    case AcGiMTextAttachmentPoint.BaselineRight:
+      return MTextParagraphAlignment.RIGHT
+    default:
+      return MTextParagraphAlignment.LEFT
+  }
+}
+
+interface AnchorMetrics {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+  baselineY: number
+}
+
+function layoutBoundsToAnchorMetrics(bounds: LayoutBounds): AnchorMetrics {
+  return {
+    minX: bounds.minX,
+    maxX: bounds.maxX,
+    minY: -bounds.maxY,
+    maxY: -bounds.minY,
+    baselineY: -bounds.firstBaselineY
+  }
+}
+
+function computeAttachmentOffset(
+  attachmentPoint: AcGiMTextAttachmentPoint | undefined,
+  bounds: LayoutBounds
+): { x: number; y: number } {
+  const m = layoutBoundsToAnchorMetrics(bounds)
+  const centerX = (m.minX + m.maxX) / 2
+  const centerY = (m.minY + m.maxY) / 2
+
+  switch (attachmentPoint) {
+    case AcGiMTextAttachmentPoint.TopCenter:
+      return { x: -centerX, y: -m.maxY }
+    case AcGiMTextAttachmentPoint.TopRight:
+      return { x: -m.maxX, y: -m.maxY }
+    case AcGiMTextAttachmentPoint.MiddleLeft:
+      return { x: -m.minX, y: -centerY }
+    case AcGiMTextAttachmentPoint.MiddleCenter:
+      return { x: -centerX, y: -centerY }
+    case AcGiMTextAttachmentPoint.MiddleRight:
+      return { x: -m.maxX, y: -centerY }
+    case AcGiMTextAttachmentPoint.BottomLeft:
+      return { x: -m.minX, y: -m.minY }
+    case AcGiMTextAttachmentPoint.BottomCenter:
+      return { x: -centerX, y: -m.minY }
+    case AcGiMTextAttachmentPoint.BottomRight:
+      return { x: -m.maxX, y: -m.minY }
+    case AcGiMTextAttachmentPoint.BaselineCenter:
+      return { x: -centerX, y: -m.baselineY }
+    case AcGiMTextAttachmentPoint.BaselineRight:
+      return { x: -m.maxX, y: -m.baselineY }
+    case AcGiMTextAttachmentPoint.BaselineLeft:
+      return { x: -m.minX, y: -m.baselineY }
+    case AcGiMTextAttachmentPoint.TopLeft:
+    default:
+      return { x: -m.minX, y: -m.maxY }
+  }
+}
+
+/**
+ * Builds SVG {@code <text>/<tspan>} output from raw MTEXT using {@link MTextParser}.
+ */
+export function buildSvgMText(
+  mtext: AcGiMTextData,
+  style: AcGiTextStyle,
+  traits: AcGiSubEntityTraits,
+  ctx: AcSvgStyleContext
+): AcSvgMTextBuildResult {
+  const box = new AcGeBox2d()
+  const { text, height, position } = mtext
+
+  if (!text || height <= 0) {
+    return { localSvg: '', box }
+  }
+
+  const baseHeight = height
+  const lineAdvance = resolveLineAdvance(baseHeight, mtext)
+  const wrapWidth = resolveWrapWidth(mtext)
+  const flowMode = resolveFlowMode(mtext.drawingDirection)
+  const defaultFont = resolveSvgFontFamily(
+    style.extendedFont || style.font,
+    'sans-serif'
+  )
+  const entityWidthFactor =
+    typeof mtext.widthFactor === 'number' && mtext.widthFactor > 0
+      ? mtext.widthFactor
+      : typeof style.widthFactor === 'number' && style.widthFactor > 0
+        ? style.widthFactor
+        : 1
+
+  const initialCtx = new MTextContext()
+  initialCtx.capHeight = { value: baseHeight, isRelative: false }
+  initialCtx.widthFactor = { value: entityWidthFactor, isRelative: false }
+  initialCtx.paragraph.align = resolveParagraphAlignment(mtext)
+  if (typeof style.obliqueAngle === 'number') {
+    initialCtx.oblique = style.obliqueAngle
+  }
+  initialCtx.fontFace.family = normalizeCadFontName(
+    style.extendedFont || style.font || defaultFont
+  )
+
+  const parser = new MTextParser(text, initialCtx, {
+    resetParagraphParameters: true,
+    yieldPropertyCommands: true
+  })
+  const layout = new MTextSvgLayout(
+    baseHeight,
+    lineAdvance,
+    wrapWidth,
+    flowMode,
+    defaultFont,
+    style,
+    traits,
+    ctx
+  )
+
+  for (const token of parser.parse()) {
+    layout.consume(token)
+  }
+  layout.finish()
+
+  const bounds = layout.bounds
+  const attachment = computeAttachmentOffset(mtext.attachmentPoint, bounds)
+  const { x, y } = position
+  const rotDeg = (resolveRotation(mtext) * 180) / Math.PI
+
+  const transformParts = [`translate(${x},${y})`]
+  if (rotDeg !== 0) {
+    transformParts.push(`rotate(${-rotDeg})`)
+  }
+  transformParts.push(`translate(${attachment.x},${attachment.y})`)
+  transformParts.push('scale(1,-1)')
+
+  const textAttrs = {
+    'font-size': String(baseHeight),
+    'font-family': defaultFont,
+    ...AcSvgStyleUtil.textAttributes(traits, ctx)
+  }
+
+  const innerMarkup = [
+    AcSvgStyleUtil.tag('text', textAttrs, layout.tspanMarkup),
+    layout.decorationMarkup
+  ].join('')
+
+  const localSvg = AcSvgStyleUtil.tag(
+    'g',
+    { transform: transformParts.join(' ') },
+    innerMarkup
+  )
+  expandBox(box, bounds, attachment, x, y)
+
+  return { localSvg, box }
+}
+
+function expandBox(
+  box: AcGeBox2d,
+  bounds: LayoutBounds,
+  attachment: { x: number; y: number },
+  originX: number,
+  originY: number
+) {
+  if (bounds.maxX <= bounds.minX && bounds.maxY <= bounds.minY) {
+    return
+  }
+  const corners = [
+    { x: bounds.minX + attachment.x, y: attachment.y - bounds.minY },
+    { x: bounds.maxX + attachment.x, y: attachment.y - bounds.minY },
+    { x: bounds.minX + attachment.x, y: attachment.y - bounds.maxY },
+    { x: bounds.maxX + attachment.x, y: attachment.y - bounds.maxY }
+  ]
+  for (const corner of corners) {
+    box.expandByPoint({ x: originX + corner.x, y: originY + corner.y })
+  }
+}
+
+class MTextSvgLayout {
+  private x = 0
+  private y = 0
+  private lineStartX = 0
+  private columnStartY = 0
+  private columnAdvance = 0
+  private isLineStart = true
+  private firstLineOfParagraph = true
+  private currentLine: LayoutLine | null = null
+  private readonly lines: LayoutLine[] = []
+  private readonly decorationLines: DecorationLine[] = []
+  private activeLineIndex = 0
+  private minX = 0
+  private maxX = 0
+  private minY = 0
+  private maxY = 0
+  private firstBaselineY = 0
+  private hasContent = false
+
+  constructor(
+    private readonly baseHeight: number,
+    private readonly lineAdvance: number,
+    private readonly wrapWidth: number | null,
+    private readonly flowMode: FlowMode,
+    private readonly defaultFont: string,
+    private readonly style: AcGiTextStyle,
+    private readonly traits: AcGiSubEntityTraits,
+    private readonly ctx: AcSvgStyleContext
+  ) {
+    this.resetParagraphPosition(new MTextContext())
+  }
+
+  get tspanMarkup(): string {
+    let markup = ''
+    let isFirstLine = true
+
+    for (const line of this.lines) {
+      let lineStartX: number | undefined
+      let expectedX: number | undefined
+
+      for (const span of line.spans) {
+        const attrs = this.tspanAttributes(span.tokenCtx, span.fontSize)
+        const isLineStart = lineStartX === undefined
+
+        if (this.isVertical()) {
+          attrs.x = String(span.x)
+          attrs.y = String(span.y)
+        } else if (isLineStart) {
+          lineStartX = span.x
+          attrs.x = String(span.x)
+          attrs.dy = isFirstLine ? '0' : String(this.lineAdvance)
+          isFirstLine = false
+          expectedX = span.x + this.measureText(span.text, span.fontSize, span.tokenCtx)
+        } else if (
+          expectedX != null &&
+          Math.abs(span.x - expectedX) > 1e-6
+        ) {
+          attrs.x = String(span.x)
+          expectedX = span.x + this.measureText(span.text, span.fontSize, span.tokenCtx)
+        } else {
+          expectedX =
+            (expectedX ?? span.x) +
+            this.measureText(span.text, span.fontSize, span.tokenCtx)
+        }
+
+        markup += AcSvgStyleUtil.tag('tspan', attrs, escapeXml(span.text))
+      }
+    }
+
+    return markup
+  }
+
+  get decorationMarkup(): string {
+    return this.decorationLines
+      .map(line =>
+        AcSvgStyleUtil.tag('line', {
+          x1: String(line.x1),
+          y1: String(line.y1),
+          x2: String(line.x2),
+          y2: String(line.y2),
+          stroke: line.stroke,
+          'stroke-width': String(Math.max(this.baseHeight * 0.05, 0.05)),
+          'stroke-linecap': 'butt'
+        })
+      )
+      .join('')
+  }
+
+  get bounds(): LayoutBounds {
+    return {
+      minX: this.minX,
+      maxX: this.maxX,
+      minY: this.minY,
+      maxY: this.maxY,
+      firstBaselineY: this.firstBaselineY
+    }
+  }
+
+  consume(token: MTextToken) {
+    switch (token.type) {
+      case TokenType.WORD:
+        this.emitText(String(token.data ?? ''), token.ctx)
+        break
+      case TokenType.SPACE:
+        this.emitSpace(token.ctx)
+        break
+      case TokenType.NBSP:
+        this.emitText('\u00A0', token.ctx)
+        break
+      case TokenType.TABULATOR:
+        this.advanceToTab(token.ctx)
+        break
+      case TokenType.NEW_PARAGRAPH:
+        this.newParagraph(token.ctx)
+        break
+      case TokenType.NEW_COLUMN:
+        this.newColumn(token.ctx)
+        break
+      case TokenType.WRAP_AT_DIMLINE:
+        this.wrapLine(token.ctx)
+        break
+      case TokenType.PROPERTIES_CHANGED:
+        this.applyPropertyChange(token.data as ChangedProperties, token.ctx)
+        break
+      case TokenType.STACK:
+        if (Array.isArray(token.data) && token.data.length === 3) {
+          this.emitStack(token.data as [string, string, string], token.ctx)
+        }
+        break
+      default:
+        break
+    }
+  }
+
+  finish() {
+    this.finalizeCurrentLine()
+    this.applyLineAlignment()
+    this.recomputeBoundsFromLines()
+  }
+
+  private applyPropertyChange(
+    item: ChangedProperties,
+    tokenCtx: MTextContext
+  ) {
+    if (item.changes.paragraph?.align != null && this.currentLine) {
+      this.currentLine.paragraphAlign = item.changes.paragraph.align
+    }
+
+    if (item.command === 'f' || item.command === 'F') {
+      this.applyFontFaceChange(item.changes.fontFace, tokenCtx)
+    } else if (item.command === 'p') {
+      if (item.changes.paragraph?.indent != null && this.firstLineOfParagraph) {
+        const indent = item.changes.paragraph.indent * this.baseHeight
+        if (this.isHorizontalRtl()) {
+          this.x -= indent
+        } else if (!this.isVertical()) {
+          this.x += indent
+        }
+      }
+    }
+  }
+
+  private applyFontFaceChange(
+    fontFace: Properties['fontFace'],
+    tokenCtx: MTextContext
+  ) {
+    if (!fontFace?.family) {
+      return
+    }
+    const family = normalizeCadFontName(fontFace.family)
+    tokenCtx.fontFace = { ...fontFace, family }
+    if (fontFace.style === 'Italic') {
+      tokenCtx.oblique = (this.style.obliqueAngle ?? 0) || 15
+    }
+  }
+
+  private applyLineAlignment() {
+    if (this.wrapWidth == null) {
+      return
+    }
+    for (let lineIndex = 0; lineIndex < this.lines.length; lineIndex++) {
+      const line = this.lines[lineIndex]
+      const lineWidth = line.maxX - line.minX
+      if (lineWidth <= 0) {
+        continue
+      }
+      const tokenCtx = line.spans[0]?.tokenCtx ?? new MTextContext()
+      const contentWidth =
+        this.wrapWidth - this.paragraphLeft(tokenCtx) - this.rightMargin(tokenCtx)
+      let shift = 0
+      switch (line.paragraphAlign) {
+        case MTextParagraphAlignment.CENTER:
+          shift = line.columnLeft + contentWidth / 2 - (line.minX + line.maxX) / 2
+          break
+        case MTextParagraphAlignment.RIGHT:
+          shift = line.columnLeft + contentWidth - line.maxX
+          break
+        case MTextParagraphAlignment.JUSTIFIED:
+        case MTextParagraphAlignment.DISTRIBUTED:
+        case MTextParagraphAlignment.LEFT:
+        case MTextParagraphAlignment.DEFAULT:
+        default:
+          shift = 0
+          break
+      }
+      if (shift === 0) {
+        continue
+      }
+      for (const span of line.spans) {
+        span.x += shift
+      }
+      line.minX += shift
+      line.maxX += shift
+      for (const decoration of this.decorationLines) {
+        if (decoration.lineIndex === lineIndex) {
+          decoration.x1 += shift
+          decoration.x2 += shift
+        }
+      }
+    }
+  }
+
+  private recomputeBoundsFromLines() {
+    this.minX = 0
+    this.maxX = 0
+    this.minY = 0
+    this.maxY = 0
+    this.hasContent = false
+    for (const line of this.lines) {
+      for (const span of line.spans) {
+        this.includeSpanBounds(span)
+      }
+    }
+  }
+
+  private emitSpace(tokenCtx: MTextContext) {
+    const width = this.spaceWidth(tokenCtx)
+    if (this.isLineStart) {
+      return
+    }
+    if (this.isHorizontal()) {
+      this.ensureFits(width, tokenCtx)
+      if (this.isLineStart) {
+        return
+      }
+    }
+    this.advancePosition(width, this.resolveCapHeight(tokenCtx))
+  }
+
+  private emitText(value: string, tokenCtx: MTextContext) {
+    if (!value) {
+      return
+    }
+    if (this.isVertical()) {
+      for (const char of value) {
+        this.emitTextRun(char, tokenCtx)
+      }
+      return
+    }
+    if (this.wrapWidth == null) {
+      this.emitTextRun(value, tokenCtx)
+      return
+    }
+
+    const fontSize = this.resolveCapHeight(tokenCtx)
+    const wordWidth = this.measureText(value, fontSize, tokenCtx)
+    if (
+      !this.isLineStart &&
+      wordWidth > 0 &&
+      this.penOffset(tokenCtx) + wordWidth > this.maxLineWidth(tokenCtx)
+    ) {
+      this.wrapLine(tokenCtx)
+    }
+
+    for (const char of value) {
+      this.emitTextRun(char, tokenCtx)
+    }
+  }
+
+  private emitTextRun(value: string, tokenCtx: MTextContext) {
+    if (!value) {
+      return
+    }
+    const fontSize = this.resolveCapHeight(tokenCtx)
+    const width = this.measureText(value, fontSize, tokenCtx)
+    const advance = this.isVertical() ? fontSize : width
+    this.ensureFits(advance, tokenCtx)
+
+    const pos = this.currentPosition()
+    const span: LayoutSpan = {
+      text: value,
+      x: pos.x,
+      y: pos.y,
+      fontSize,
+      tokenCtx: tokenCtx.copy()
+    }
+    this.currentLine?.spans.push(span)
+    this.includeSpanBounds(span)
+    this.advancePosition(width, fontSize)
+    this.firstLineOfParagraph = false
+  }
+
+  private emitStack(
+    data: [string, string, string],
+    tokenCtx: MTextContext
+  ) {
+    const [numerator, denominator, divider] = data
+    const start = this.currentPosition()
+    const wasLineStart = this.isLineStart
+    const baseFontSize = this.resolveCapHeight(tokenCtx)
+
+    if (divider === '^') {
+      const scriptCtx = tokenCtx.copy()
+      scriptCtx.capHeight = {
+        value: STACK_SCRIPT_SCALE,
+        isRelative: true
+      }
+      if (numerator && !denominator) {
+        this.setPosition(start.x, start.y - baseFontSize * 0.35)
+        this.isLineStart = true
+        this.emitText(numerator, scriptCtx)
+        const width = this.measureHorizontalSpan(start, this.currentPosition())
+        this.setPosition(start.x + width, start.y)
+      } else if (!numerator && denominator) {
+        this.setPosition(start.x, start.y + baseFontSize * 0.2)
+        this.isLineStart = true
+        this.emitText(denominator, scriptCtx)
+        const width = this.measureHorizontalSpan(start, this.currentPosition())
+        this.setPosition(start.x + width, start.y)
+      } else if (numerator && denominator) {
+        this.setPosition(start.x, start.y - baseFontSize * 0.2)
+        this.isLineStart = true
+        this.emitText(numerator, scriptCtx)
+        const width = this.measureHorizontalSpan(start, this.currentPosition())
+        this.setPosition(start.x + width, start.y)
+      }
+
+      this.isLineStart = wasLineStart
+      return
+    }
+
+    if (divider === '/') {
+      this.emitText(`${numerator}/${denominator}`, tokenCtx)
+      return
+    }
+
+    const numWidth = this.measureText(numerator, baseFontSize, tokenCtx)
+    const denWidth = this.measureText(denominator, baseFontSize, tokenCtx)
+    const fractionWidth = Math.max(numWidth, denWidth)
+    const numOffset = (fractionWidth - numWidth) / 2
+    const denOffset = (fractionWidth - denWidth) / 2
+    const stroke = resolveMTextFill(tokenCtx.color, this.traits, this.ctx)
+
+    this.setPosition(start.x + numOffset, start.y - baseFontSize * 0.35)
+    this.isLineStart = true
+    this.emitText(numerator, tokenCtx)
+
+    this.setPosition(start.x + denOffset, start.y + baseFontSize * 0.2)
+    this.isLineStart = true
+    this.emitText(denominator, tokenCtx)
+
+    if (divider === '/' || divider === '#') {
+      const lineY =
+        start.y -
+        baseFontSize * 0.05 +
+        this.baseHeight * STACK_VERTICAL_SHIFT_FACTOR
+      this.decorationLines.push({
+        x1: start.x,
+        y1: lineY,
+        x2: start.x + fractionWidth,
+        y2: lineY,
+        stroke,
+        lineIndex: this.activeLineIndex
+      })
+    }
+
+    const nextX = this.isHorizontalRtl()
+      ? start.x - fractionWidth
+      : start.x + fractionWidth
+    this.setPosition(nextX, start.y)
+    this.isLineStart = wasLineStart
+  }
+
+  private newParagraph(tokenCtx: MTextContext) {
+    this.finalizeCurrentLine()
+    if (this.isVertical()) {
+      this.newColumn(tokenCtx)
+      return
+    }
+    this.y += this.lineAdvance
+    this.columnStartY = this.y
+    this.resetParagraphPosition(tokenCtx)
+  }
+
+  private wrapLine(tokenCtx: MTextContext) {
+    this.finalizeCurrentLine()
+    if (this.isVertical()) {
+      this.newColumn(tokenCtx)
+      return
+    }
+    this.y += this.lineAdvance
+    this.columnStartY = this.y
+    this.resetLinePosition(tokenCtx)
+  }
+
+  private newColumn(tokenCtx: MTextContext) {
+    this.finalizeCurrentLine()
+    if (this.isVertical()) {
+      this.x += this.columnAdvance > 0 ? this.columnAdvance : this.baseHeight
+      this.columnAdvance = 0
+      if (this.isVerticalTtb()) {
+        this.columnStartY = 0
+      }
+      this.resetParagraphPosition(tokenCtx)
+      return
+    }
+    this.x += this.wrapWidth ?? this.baseHeight * 4
+    this.resetParagraphPosition(tokenCtx)
+  }
+
+  private finalizeCurrentLine() {
+    if (this.currentLine && this.currentLine.spans.length > 0) {
+      this.lines.push(this.currentLine)
+      this.activeLineIndex = this.lines.length
+    }
+    this.currentLine = null
+  }
+
+  private resetParagraphPosition(tokenCtx: MTextContext) {
+    this.firstLineOfParagraph = true
+    this.resetLinePosition(tokenCtx)
+  }
+
+  private resetLinePosition(tokenCtx: MTextContext) {
+    const left = this.paragraphLeft(tokenCtx)
+    const indent = this.firstLineOfParagraph ? this.firstLineIndent(tokenCtx) : 0
+    const limits = this.lineLimits(tokenCtx)
+
+    if (this.isHorizontalRtl()) {
+      this.x = limits.right - indent
+      this.y = this.columnStartY
+    } else if (this.isVerticalTtb()) {
+      this.x = left
+      this.y = this.columnStartY + indent
+    } else if (this.isVerticalBtt()) {
+      this.x = left
+      this.y =
+        (this.wrapWidth != null ? this.wrapWidth : this.baseHeight * 10) -
+        indent
+      this.columnStartY = this.y
+    } else {
+      this.x = left + indent
+      this.y = this.columnStartY
+    }
+
+    this.lineStartX = left
+    this.isLineStart = true
+    this.currentLine = {
+      spans: [],
+      minX: this.x,
+      maxX: this.x,
+      minY: this.y,
+      maxY: this.y,
+      baselineY: this.y,
+      columnLeft: left,
+      paragraphAlign: tokenCtx.paragraph.align
+    }
+  }
+
+  private wouldOverflow(width: number, tokenCtx: MTextContext): boolean {
+    if (this.wrapWidth == null || width <= 0 || this.isLineStart) {
+      return false
+    }
+
+    if (this.isHorizontal()) {
+      return this.penOffset(tokenCtx) + width > this.maxLineWidth(tokenCtx)
+    }
+
+    const limits = this.verticalLimits(tokenCtx)
+    return this.isVerticalTtb()
+      ? this.y + width > limits.bottom
+      : this.y - width < limits.top
+  }
+
+  private penOffset(tokenCtx: MTextContext): number {
+    if (this.isHorizontalRtl()) {
+      return this.lineLimits(tokenCtx).right - this.x
+    }
+    return this.x - this.paragraphLeft(tokenCtx)
+  }
+
+  private maxLineWidth(tokenCtx: MTextContext): number {
+    if (this.wrapWidth == null) {
+      return Number.POSITIVE_INFINITY
+    }
+    return (
+      this.wrapWidth -
+      this.paragraphLeft(tokenCtx) -
+      this.rightMargin(tokenCtx)
+    )
+  }
+
+  private ensureFits(width: number, tokenCtx: MTextContext) {
+    if (
+      this.wrapWidth != null &&
+      this.isHorizontal() &&
+      !this.isLineStart &&
+      this.penOffset(tokenCtx) > this.maxLineWidth(tokenCtx)
+    ) {
+      this.wrapLine(tokenCtx)
+    }
+    if (!this.wouldOverflow(width, tokenCtx)) {
+      return
+    }
+    this.wrapLine(tokenCtx)
+  }
+
+  private advancePosition(width: number, fontSize: number) {
+    if (this.isHorizontalRtl()) {
+      this.x -= width
+    } else if (this.isVerticalTtb()) {
+      this.y += fontSize
+    } else if (this.isVerticalBtt()) {
+      this.y -= fontSize
+    } else {
+      this.x += width
+    }
+    this.isLineStart = false
+    this.columnAdvance = Math.max(this.columnAdvance, width)
+  }
+
+  private advanceToTab(tokenCtx: MTextContext) {
+    const tabWidth = this.baseHeight * DEFAULT_TAB_WIDTH_FACTOR
+    const tabs = tokenCtx.paragraph.tabs
+    if (tabs.length === 0) {
+      const target = this.isHorizontalRtl()
+        ? Math.floor(this.x / tabWidth) * tabWidth
+        : Math.ceil((this.x + 1) / tabWidth) * tabWidth
+      const delta = this.isHorizontalRtl() ? this.x - target : target - this.x
+      this.advancePosition(Math.max(0, delta), this.resolveCapHeight(tokenCtx))
+      return
+    }
+    for (const stop of tabs) {
+      const pos =
+        this.lineStartX +
+        (typeof stop === 'number'
+          ? stop * this.baseHeight
+          : parseFloat(String(stop)) * this.baseHeight)
+      if (this.isHorizontalRtl()) {
+        if (!Number.isNaN(pos) && pos < this.x) {
+          this.advancePosition(this.x - pos, this.resolveCapHeight(tokenCtx))
+          return
+        }
+      } else if (!Number.isNaN(pos) && pos > this.x) {
+        this.advancePosition(pos - this.x, this.resolveCapHeight(tokenCtx))
+        return
+      }
+    }
+    this.advancePosition(tabWidth, this.resolveCapHeight(tokenCtx))
+  }
+
+  private lineLimits(tokenCtx: MTextContext): { left: number; right: number } {
+    const left = this.paragraphLeft(tokenCtx)
+    const rightMargin = tokenCtx.paragraph.right * this.baseHeight
+    const right =
+      this.wrapWidth != null ? left + this.wrapWidth - rightMargin : Number.POSITIVE_INFINITY
+    return { left, right }
+  }
+
+  private verticalLimits(tokenCtx: MTextContext): { top: number; bottom: number } {
+    if (this.isVerticalBtt()) {
+      const bottom = this.columnStartY - tokenCtx.paragraph.right * this.baseHeight
+      const top =
+        this.wrapWidth != null
+          ? this.columnStartY - this.wrapWidth + this.firstLineIndent(tokenCtx)
+          : Number.NEGATIVE_INFINITY
+      return { top, bottom }
+    }
+    const top = this.columnStartY + this.firstLineIndent(tokenCtx)
+    const bottom =
+      this.wrapWidth != null
+        ? this.columnStartY + this.wrapWidth - tokenCtx.paragraph.right * this.baseHeight
+        : Number.POSITIVE_INFINITY
+    return { top, bottom }
+  }
+
+  private currentPosition(): { x: number; y: number } {
+    return { x: this.x, y: this.y }
+  }
+
+  private setPosition(x: number, y: number) {
+    this.x = x
+    this.y = y
+  }
+
+  private includeSpanBounds(span: LayoutSpan) {
+    const width = this.measureText(span.text, span.fontSize, span.tokenCtx)
+    const spanMinX = this.isHorizontalRtl() ? span.x - width : span.x
+    const spanMaxX = this.isHorizontalRtl() ? span.x : span.x + width
+    const spanMinY = span.y - span.fontSize
+    const spanMaxY = span.y
+
+    if (!this.hasContent) {
+      this.minX = spanMinX
+      this.maxX = spanMaxX
+      this.minY = spanMinY
+      this.maxY = spanMaxY
+      this.firstBaselineY = span.y
+      this.hasContent = true
+    } else {
+      this.minX = Math.min(this.minX, spanMinX)
+      this.maxX = Math.max(this.maxX, spanMaxX)
+      this.minY = Math.min(this.minY, spanMinY)
+      this.maxY = Math.max(this.maxY, spanMaxY)
+    }
+
+    if (this.currentLine) {
+      this.currentLine.minX = Math.min(this.currentLine.minX, spanMinX)
+      this.currentLine.maxX = Math.max(this.currentLine.maxX, spanMaxX)
+      this.currentLine.minY = Math.min(this.currentLine.minY, spanMinY)
+      this.currentLine.maxY = Math.max(this.currentLine.maxY, spanMaxY)
+    }
+  }
+
+  private measureHorizontalSpan(
+    start: { x: number; y: number },
+    end: { x: number; y: number }
+  ): number {
+    return Math.abs(end.x - start.x)
+  }
+
+  private spaceWidth(tokenCtx: MTextContext): number {
+    const fontSize = this.resolveCapHeight(tokenCtx)
+    return this.measureText(' ', fontSize, tokenCtx)
+  }
+
+  private measureCharWidth(
+    char: string,
+    fontSize: number,
+    tokenCtx: MTextContext
+  ): number {
+    const widthFactor = this.resolveWidthFactor(tokenCtx)
+    const tracking = this.resolveTracking(tokenCtx)
+    const baseFactor = isWideCharacter(char)
+      ? WIDE_CHAR_WIDTH_FACTOR
+      : LATIN_CHAR_WIDTH_FACTOR
+    return fontSize * baseFactor * widthFactor * tracking
+  }
+
+  private measureText(
+    value: string,
+    fontSize: number,
+    tokenCtx: MTextContext
+  ): number {
+    let width = 0
+    for (const char of value) {
+      width += this.measureCharWidth(char, fontSize, tokenCtx)
+    }
+    return width
+  }
+
+  private paragraphLeft(tokenCtx: MTextContext): number {
+    return tokenCtx.paragraph.left * this.baseHeight
+  }
+
+  private firstLineIndent(tokenCtx: MTextContext): number {
+    return tokenCtx.paragraph.indent * this.baseHeight
+  }
+
+  private rightMargin(tokenCtx?: MTextContext): number {
+    return (tokenCtx?.paragraph.right ?? 0) * this.baseHeight
+  }
+
+  private resolveCapHeight(tokenCtx: MTextContext): number {
+    const cap = tokenCtx.capHeight
+    const size = cap.isRelative ? this.baseHeight * cap.value : cap.value
+    const cadFont = tokenCtx.fontFace.family || this.defaultFont
+    return size * resolveSvgFontSizeScale(cadFont)
+  }
+
+  private resolveWidthFactor(tokenCtx: MTextContext): number {
+    const wf = tokenCtx.widthFactor
+    if (wf.isRelative) {
+      const ref = this.wrapWidth ?? this.baseHeight * 4
+      return wf.value * ref
+    }
+    return wf.value * 0.85
+  }
+
+  private resolveTracking(tokenCtx: MTextContext): number {
+    const tf = tokenCtx.charTrackingFactor
+    if (tf.isRelative) {
+      return tf.value + 1
+    }
+    return tf.value
+  }
+
+  private isHorizontal(): boolean {
+    return (
+      this.flowMode === FlowMode.HorizontalLtr ||
+      this.flowMode === FlowMode.HorizontalRtl
+    )
+  }
+
+  private isHorizontalRtl(): boolean {
+    return this.flowMode === FlowMode.HorizontalRtl
+  }
+
+  private isVertical(): boolean {
+    return (
+      this.flowMode === FlowMode.VerticalTtb ||
+      this.flowMode === FlowMode.VerticalBtt
+    )
+  }
+
+  private isVerticalTtb(): boolean {
+    return this.flowMode === FlowMode.VerticalTtb
+  }
+
+  private isVerticalBtt(): boolean {
+    return this.flowMode === FlowMode.VerticalBtt
+  }
+
+  private tspanAttributes(
+    tokenCtx: MTextContext,
+    fontSize: number
+  ): Record<string, string> {
+    const attrs: Record<string, string> = {}
+
+    if (Math.abs(fontSize - this.baseHeight) > 1e-9) {
+      attrs['font-size'] = String(fontSize)
+    }
+
+    const cadFont = tokenCtx.fontFace.family
+    attrs['font-family'] = resolveSvgFontFamily(cadFont, this.defaultFont)
+
+    if (tokenCtx.bold) {
+      attrs['font-weight'] = '700'
+    }
+    if (tokenCtx.italic) {
+      attrs['font-style'] = 'italic'
+    }
+
+    const widthFactor = this.resolveWidthFactor(tokenCtx)
+    const tracking = this.resolveTracking(tokenCtx)
+    if (tracking !== 1) {
+      attrs['letter-spacing'] = `${((tracking - 1) * fontSize * 0.25).toFixed(3)}`
+    }
+
+    const oblique = tokenCtx.oblique
+    if (oblique !== 0) {
+      const transforms: string[] = [`skewX(${-oblique})`]
+      if (widthFactor !== 1) {
+        transforms.unshift(`scale(${widthFactor},1)`)
+      }
+      attrs.transform = transforms.join(' ')
+    } else if (widthFactor !== 1) {
+      attrs.transform = `scale(${widthFactor},1)`
+    }
+
+    attrs.fill = resolveMTextFill(tokenCtx.color, this.traits, this.ctx)
+
+    const decorations: string[] = []
+    if (tokenCtx.underline) {
+      decorations.push('underline')
+    }
+    if (tokenCtx.overline) {
+      decorations.push('overline')
+    }
+    if (tokenCtx.strikeThrough) {
+      decorations.push('line-through')
+    }
+    if (decorations.length > 0) {
+      attrs['text-decoration'] = decorations.join(' ')
+    }
+
+    return attrs
+  }
+}
+
+function resolveMTextFill(
+  color: MTextColor,
+  traits: AcGiSubEntityTraits,
+  ctx: AcSvgStyleContext
+): string {
+  if (color.isRgb && color.rgbValue != null) {
+    return AcSvgStyleUtil.rgbToHex(color.rgbValue)
+  }
+
+  if (color.aci === 256 || color.aci == null) {
+    return AcSvgStyleUtil.rgbToHex(
+      AcSvgStyleUtil.resolveRgb(traits, ctx, 'text')
+    )
+  }
+
+  if (color.aci === 0) {
+    return AcSvgStyleUtil.rgbToHex(
+      AcSvgStyleUtil.resolveRgb(traits, ctx, 'text')
+    )
+  }
+
+  const aciColor = new AcCmColor()
+  aciColor.colorIndex = color.aci
+  const rgb = aciColor.RGB
+  if (typeof rgb === 'number') {
+    return AcSvgStyleUtil.rgbToHex(rgb)
+  }
+  return AcSvgStyleUtil.rgbToHex(
+    AcSvgStyleUtil.resolveRgb(traits, ctx, 'text')
+  )
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export {
+  normalizeCadFontName,
+  resolveSvgFontFamily,
+  resolveSvgFontSizeScale,
+  setSvgFontMapping,
+  setSvgFontSizeScales
+} from './AcSvgFontMap'

--- a/packages/svg-renderer/src/AcSvgMatrixUtil.ts
+++ b/packages/svg-renderer/src/AcSvgMatrixUtil.ts
@@ -1,0 +1,57 @@
+import { AcGeBox2d, AcGeMatrix3d, AcGePoint3dLike } from '@mlightcad/data-model'
+
+/**
+ * Converts CAD 4×4 matrices to SVG transforms and transforms 2D boxes.
+ */
+export class AcSvgMatrixUtil {
+  /**
+   * SVG `matrix(a,b,c,d,e,f)` for 2D geometry (CAD Y-up, applied before root Y-flip).
+   */
+  static toSvgTransform(matrix: AcGeMatrix3d): string {
+    const e = matrix.elements
+    return `matrix(${e[0]},${e[1]},${e[4]},${e[5]},${e[12]},${e[13]})`
+  }
+
+  static transformPoint(
+    matrix: AcGeMatrix3d,
+    point: AcGePoint3dLike
+  ): { x: number; y: number } {
+    const e = matrix.elements
+    const x = point.x
+    const y = point.y
+    const z = point.z ?? 0
+    const w = e[3] * x + e[7] * y + e[11] * z + e[15]
+    const invW = w === 0 ? 1 : 1 / w
+    return {
+      x: (e[0] * x + e[4] * y + e[8] * z + e[12]) * invW,
+      y: (e[1] * x + e[5] * y + e[9] * z + e[13]) * invW
+    }
+  }
+
+  static transformBox(box: AcGeBox2d, matrix: AcGeMatrix3d): void {
+    if (box.isEmpty()) {
+      return
+    }
+    const min = box.min
+    const max = box.max
+    const corners: AcGePoint3dLike[] = [
+      { x: min.x, y: min.y, z: 0 },
+      { x: max.x, y: min.y, z: 0 },
+      { x: max.x, y: max.y, z: 0 },
+      { x: min.x, y: max.y, z: 0 }
+    ]
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+    for (const corner of corners) {
+      const p = this.transformPoint(matrix, corner)
+      minX = Math.min(minX, p.x)
+      minY = Math.min(minY, p.y)
+      maxX = Math.max(maxX, p.x)
+      maxY = Math.max(maxY, p.y)
+    }
+    box.min.set(minX, minY)
+    box.max.set(maxX, maxY)
+  }
+}

--- a/packages/svg-renderer/src/AcSvgPoint.ts
+++ b/packages/svg-renderer/src/AcSvgPoint.ts
@@ -1,20 +1,31 @@
-import { AcGePoint3d, AcGiPointStyle } from '@mlightcad/data-model'
+import { AcGePoint3d, AcGiPointStyle, AcGiSubEntityTraits } from '@mlightcad/data-model'
 
 import { AcSvgEntity } from './AcSvgEntity'
+import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
 
 /** Default point radius in drawing units when displaySize is 0 or not set. */
 const DEFAULT_POINT_RADIUS = 0.5
 
 /**
  * SVG point entity: renders as a small filled circle.
- * Honours `AcGiPointStyle.displaySize` when positive (absolute units).
  */
 export class AcSvgPoint extends AcSvgEntity {
-  constructor(point: AcGePoint3d, style: AcGiPointStyle) {
+  constructor(
+    point: AcGePoint3d,
+    style: AcGiPointStyle,
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ) {
     super()
     const r =
       style.displaySize > 0 ? style.displaySize / 2 : DEFAULT_POINT_RADIUS
-    this.svg = `<circle cx="${point.x}" cy="${point.y}" r="${r}" fill="currentColor" stroke="none"/>`
+    const attrs = {
+      cx: String(point.x),
+      cy: String(point.y),
+      r: String(r),
+      ...AcSvgStyleUtil.pointAttributes(traits, ctx)
+    }
+    this.svg = AcSvgStyleUtil.tag('circle', attrs)
     this._box.expandByPoint(point)
   }
 }

--- a/packages/svg-renderer/src/AcSvgRenderer.ts
+++ b/packages/svg-renderer/src/AcSvgRenderer.ts
@@ -21,22 +21,32 @@ import { AcSvgArea } from './AcSvgArea'
 import { AcSvgCircArc } from './AcSvgCircArc'
 import { AcTrEllipticalArc } from './AcSvgEllipticalArc'
 import { AcSvgEntity } from './AcSvgEntity'
+import { AcSvgExportUtil } from './AcSvgExportUtil'
 import { AcSvgGroup } from './AcSvgGroup'
+import { AcSvgImage } from './AcSvgImage'
 import { AcSvgLine } from './AcSvgLine'
 import { AcSvgLineSegments } from './AcSvgLineSegments'
 import { AcSvgMText } from './AcSvgMText'
 import { AcSvgPoint } from './AcSvgPoint'
+import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
 
 export class AcSvgRenderer implements AcGiRenderer<AcSvgEntity> {
-  private _container: Array<string>
+  private _entities: AcSvgEntity[]
   private _bbox: AcGeBox2d
   private _subEntityTraits: AcGiSubEntityTraits
   private _fontMapping: AcGiFontMapping
+  private _ltscale = 1
+  private _celtscale = 1
+  private _currentBackgroundColor = 0x000000
+  private _foregroundColor = 0x000000
+  private _showLineWeight = false
+  private _pendingImages: Promise<void>[]
 
   constructor() {
-    this._container = new Array<string>()
+    this._entities = []
     this._bbox = new AcGeBox2d()
     this._fontMapping = {}
+    this._pendingImages = []
     this._subEntityTraits = {
       color: new AcCmColor(),
       rgbColor: 0x000000,
@@ -76,115 +86,207 @@ export class AcSvgRenderer implements AcGiRenderer<AcSvgEntity> {
   }
 
   /**
-   * Sets global ltscale
+   * Sets global ltscale for linetype dash scaling.
    */
-  set ltscale(_scale: number) {
-    // Reserved for future linetype dash-pattern scaling
+  set ltscale(scale: number) {
+    this._ltscale = scale
   }
 
   /**
-   * Sets global celtscale
+   * Sets global celtscale for linetype dash scaling.
    */
-  set celtscale(_scale: number) {
-    // Reserved for future linetype dash-pattern scaling
+  set celtscale(scale: number) {
+    this._celtscale = scale
+  }
+
+  /**
+   * Canvas background colour tracked for ACI 7 resolution and SVG export.
+   *
+   * Mirrors {@link AcTrRenderer.currentBackgroundColor}.
+   */
+  get currentBackgroundColor(): number {
+    return this._currentBackgroundColor
+  }
+
+  set currentBackgroundColor(value: number) {
+    this._currentBackgroundColor = value
+  }
+
+  /**
+   * Foreground colour used when resolving ACI 7 linework and patterned hatches.
+   * Mirrors {@link AcTrRenderer.changeForeground}.
+   */
+  changeForeground(color: number) {
+    this._foregroundColor = color
+  }
+
+  /**
+   * Whether lineweights are rendered. Mirrors the LWDISPLAY system variable.
+   */
+  get showLineWeight(): boolean {
+    return this._showLineWeight
+  }
+
+  set showLineWeight(value: boolean) {
+    this._showLineWeight = value
+  }
+
+  private get styleContext(): AcSvgStyleContext {
+    return {
+      ltscale: this._ltscale,
+      celtscale: this._celtscale,
+      backgroundColor: this._currentBackgroundColor,
+      foregroundColor: this._foregroundColor,
+      showLineWeight: this._showLineWeight
+    }
+  }
+
+  private pushEntity(entity: AcSvgEntity) {
+    this._entities.push(entity)
+    return entity
+  }
+
+  private removeEntities(entities: AcSvgEntity[]) {
+    for (const entity of entities) {
+      const index = this._entities.indexOf(entity)
+      if (index >= 0) {
+        this._entities.splice(index, 1)
+      }
+    }
   }
 
   /**
    * @inheritdoc
    */
   group(entities: AcSvgEntity[]) {
-    const entity = new AcSvgGroup(entities)
-    this._container.push(entity.svg)
-    this._bbox.union(entity.box)
-    return entity
+    this.removeEntities(entities)
+    return this.pushEntity(new AcSvgGroup(entities))
   }
 
   /**
    * @inheritdoc
    */
   point(point: AcGePoint3d, style: AcGiPointStyle) {
-    const entity = new AcSvgPoint(point, style)
-    this._container.push(entity.svg)
-    this._bbox.union(entity.box)
-    return entity
+    return this.pushEntity(
+      new AcSvgPoint(point, style, this._subEntityTraits, this.styleContext)
+    )
   }
 
   /**
    * @inheritdoc
    */
   circularArc(arc: AcGeCircArc3d) {
-    const entity = new AcSvgCircArc(arc)
-    this._container.push(entity.svg)
-    this._bbox.union(entity.box)
-    return entity
+    return this.pushEntity(
+      new AcSvgCircArc(arc, this._subEntityTraits, this.styleContext)
+    )
   }
 
   /**
    * @inheritdoc
    */
   ellipticalArc(ellipseArc: AcGeEllipseArc3d) {
-    const entity = new AcTrEllipticalArc(ellipseArc)
-    this._container.push(entity.svg)
-    this._bbox.union(entity.box)
-    return entity
+    return this.pushEntity(
+      new AcTrEllipticalArc(
+        ellipseArc,
+        this._subEntityTraits,
+        this.styleContext
+      )
+    )
   }
 
   /**
    * @inheritdoc
    */
   lines(points: AcGePoint3dLike[]) {
-    const entity = new AcSvgLine(points)
-    this._container.push(entity.svg)
-    this._bbox.union(entity.box)
-    return entity
+    return this.pushEntity(
+      new AcSvgLine(points, this._subEntityTraits, this.styleContext)
+    )
   }
 
   /**
    * @inheritdoc
    */
   lineSegments(array: Float32Array, itemSize: number, indices: Uint16Array) {
-    const entity = new AcSvgLineSegments(array, itemSize, indices)
-    this._container.push(entity.svg)
-    this._bbox.union(entity.box)
-    return entity
+    return this.pushEntity(
+      new AcSvgLineSegments(
+        array,
+        itemSize,
+        indices,
+        this._subEntityTraits,
+        this.styleContext
+      )
+    )
   }
 
   /**
    * @inheritdoc
    */
   area(area: AcGeArea2d) {
-    const entity = new AcSvgArea(area)
-    this._container.push(entity.svg)
-    this._bbox.union(entity.box)
-    return entity
+    return this.pushEntity(
+      new AcSvgArea(area, this._subEntityTraits, this.styleContext)
+    )
   }
 
   /**
    * @inheritdoc
    */
   mtext(mtext: AcGiMTextData, style: AcGiTextStyle, _delay?: boolean) {
-    // Apply font mapping when available
     const mappedFont = this._fontMapping[style.font] ?? style.font
     const resolvedStyle: AcGiTextStyle =
       mappedFont !== style.font ? { ...style, font: mappedFont } : style
-    const entity = new AcSvgMText(mtext, resolvedStyle)
-    this._container.push(entity.svg)
-    this._bbox.union(entity.box)
-    return entity
+    return this.pushEntity(
+      new AcSvgMText(
+        mtext,
+        resolvedStyle,
+        this._subEntityTraits,
+        this.styleContext
+      )
+    )
   }
 
   /**
    * @inheritdoc
-   * Note: image rendering is async (Blob → base64). A placeholder empty entity
-   * is returned synchronously; callers that need the rendered image should use
-   * `AcSvgImage.fromBlob()` directly.
    */
-  image(_blob: Blob, _style: AcGiImageStyle) {
+  image(blob: Blob, style: AcGiImageStyle) {
+    const traits = { ...this._subEntityTraits }
+    const ctx = this.styleContext
+    const pending = AcSvgImage.fromBlob(blob, style, traits, ctx).then(entity =>
+      this.pushEntity(entity)
+    )
+    this._pendingImages.push(pending.then(() => undefined))
     return _tempEntity
   }
 
+  /**
+   * Exports accumulated SVG markup. Awaits any pending raster images first.
+   */
+  async exportAsync(): Promise<string> {
+    await Promise.all(this._pendingImages)
+    return this.export()
+  }
+
+  /**
+   * Synchronous export. Raster images added via {@link image} may be missing
+   * unless {@link exportAsync} is used.
+   */
   export() {
-    const elements = this._container.join('\n')
+    const parts: string[] = []
+    const bbox = new AcGeBox2d()
+    for (const entity of this._entities) {
+      const svg = entity.renderSvg()
+      if (svg) {
+        parts.push(svg)
+        bbox.union(entity.box)
+      }
+    }
+    this._bbox = bbox
+    const elements = parts.join('\n')
+    const padding = this._bbox.isEmpty()
+      ? 0
+      : Math.max(
+          this._bbox.max.x - this._bbox.min.x,
+          this._bbox.max.y - this._bbox.min.y
+        ) * 0.02
     const viewBox = this._bbox.isEmpty()
       ? {
           x: 0,
@@ -193,23 +295,39 @@ export class AcSvgRenderer implements AcGiRenderer<AcSvgEntity> {
           height: 0
         }
       : {
-          x: this._bbox.min.x,
-          y: -this._bbox.max.y,
-          width: this._bbox.max.x - this._bbox.min.x,
-          height: this._bbox.max.y - this._bbox.min.y
+          x: this._bbox.min.x - padding,
+          y: -(this._bbox.max.y + padding),
+          width: this._bbox.max.x - this._bbox.min.x + padding * 2,
+          height: this._bbox.max.y - this._bbox.min.y + padding * 2
         }
-    return `<?xml version="1.0"?>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"
-      preserveAspectRatio="xMinYMin meet"
-      viewBox="${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}"
-      width="100%" height="100%"
-    >
-      <g stroke="#000000" stroke-width="0.1%" fill="none" transform="matrix(1,0,0,-1,0,0)">
-        ${elements}
-      </g>
-    </svg>`
+    const width = Math.max(viewBox.width, 1)
+    const height = Math.max(viewBox.height, 1)
+    const backgroundRect = this.buildBackgroundRect(viewBox)
+    const svgMarkup = AcSvgExportUtil.sanitizeExternalReferences(
+      `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"
+  preserveAspectRatio="xMinYMin meet"
+  viewBox="${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}"
+  width="${width}" height="${height}">
+${backgroundRect}
+  <g transform="matrix(1,0,0,-1,0,0)">
+${elements}
+  </g>
+</svg>`
+    )
+    return svgMarkup
+  }
+
+  private buildBackgroundRect(viewBox: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }): string {
+    const fill = AcSvgStyleUtil.rgbToHex(this._currentBackgroundColor)
+    const width = Math.max(viewBox.width, 1)
+    const height = Math.max(viewBox.height, 1)
+    return `  <rect x="${viewBox.x}" y="${viewBox.y}" width="${width}" height="${height}" fill="${fill}"/>`
   }
 }
 

--- a/packages/svg-renderer/src/AcSvgStyleUtil.ts
+++ b/packages/svg-renderer/src/AcSvgStyleUtil.ts
@@ -1,0 +1,219 @@
+import {
+  AcGiLineTypePatternElement,
+  AcGiLineWeight,
+  AcGiSubEntityTraits
+} from '@mlightcad/data-model'
+
+/** Runtime style options passed from {@link AcSvgRenderer}. */
+export interface AcSvgStyleContext {
+  ltscale: number
+  celtscale: number
+  /** Canvas / export background (24-bit RGB). Used for ACI 7 solid hatches. */
+  backgroundColor: number
+  /** Resolved foreground colour for ACI 7 linework (24-bit RGB). */
+  foregroundColor: number
+  /** Mirrors LWDISPLAY: when false, lineweights are not rendered. */
+  showLineWeight: boolean
+}
+
+export type AcSvgPrimitiveKind = 'line' | 'fill' | 'text' | 'point'
+
+/**
+ * Converts entity traits and export context into SVG presentation attributes.
+ */
+export class AcSvgStyleUtil {
+  static rgbToHex(rgb: number): string {
+    const r = (rgb >> 16) & 0xff
+    const g = (rgb >> 8) & 0xff
+    const b = rgb & 0xff
+    return `#${r.toString(16).padStart(2, '0')}${g
+      .toString(16)
+      .padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+  }
+
+  static resolveRgb(
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext,
+    kind: AcSvgPrimitiveKind
+  ): number {
+    if (!traits.color.isForeground) {
+      return traits.rgbColor
+    }
+    if (
+      kind === 'fill' &&
+      this.isSolidBackgroundHatch(traits)
+    ) {
+      return ctx.backgroundColor
+    }
+    return ctx.foregroundColor
+  }
+
+  static strokeAttributes(
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ): Record<string, string> {
+    const color = this.rgbToHex(this.resolveRgb(traits, ctx, 'line'))
+    const attrs: Record<string, string> = {
+      stroke: color,
+      fill: 'none'
+    }
+
+    if (!ctx.showLineWeight) {
+      // LWDISPLAY=0: 1 device-pixel hairlines (matches three-renderer LineBasicMaterial).
+      attrs['stroke-width'] = '1'
+      attrs['vector-effect'] = 'non-scaling-stroke'
+    } else {
+      const width = this.resolveStrokeWidth(traits.lineWeight)
+      if (width != null) {
+        attrs['stroke-width'] = String(width)
+      }
+    }
+
+    const opacity = this.resolveOpacity(traits)
+    if (opacity != null && opacity < 1) {
+      attrs['stroke-opacity'] = String(opacity)
+    }
+
+    const dasharray = this.strokeDasharray(traits, ctx)
+    if (dasharray) {
+      attrs['stroke-dasharray'] = dasharray
+    }
+
+    return attrs
+  }
+
+  static fillAttributes(
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ): Record<string, string> {
+    const color = this.rgbToHex(this.resolveRgb(traits, ctx, 'fill'))
+    const attrs: Record<string, string> = {
+      fill: color,
+      stroke: 'none'
+    }
+
+    const opacity = this.resolveOpacity(traits)
+    if (opacity != null && opacity < 1) {
+      attrs['fill-opacity'] = String(opacity)
+    }
+
+    return attrs
+  }
+
+  static textAttributes(
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ): Record<string, string> {
+    const color = this.rgbToHex(this.resolveRgb(traits, ctx, 'text'))
+    const attrs: Record<string, string> = {
+      fill: color,
+      stroke: 'none'
+    }
+
+    const opacity = this.resolveOpacity(traits)
+    if (opacity != null && opacity < 1) {
+      attrs['fill-opacity'] = String(opacity)
+    }
+
+    return attrs
+  }
+
+  static pointAttributes(
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ): Record<string, string> {
+    return this.textAttributes(traits, ctx)
+  }
+
+  static formatAttributes(attrs: Record<string, string>): string {
+    return Object.entries(attrs)
+      .map(([key, value]) => `${key}="${escapeAttr(value)}"`)
+      .join(' ')
+  }
+
+  static tag(
+    name: string,
+    attrs: Record<string, string>,
+    inner?: string
+  ): string {
+    const attrStr = this.formatAttributes(attrs)
+    if (inner == null) {
+      return `<${name} ${attrStr}/>`
+    }
+    return `<${name} ${attrStr}>${inner}</${name}>`
+  }
+
+  private static isSolidBackgroundHatch(traits: AcGiSubEntityTraits): boolean {
+    if ((traits.drawOrder ?? 0) >= 0) {
+      return false
+    }
+    const style = traits.fillType
+    if (style.gradient) {
+      return false
+    }
+    return !style.definitionLines || style.definitionLines.length === 0
+  }
+
+  private static resolveStrokeWidth(
+    lineWeight: AcGiLineWeight
+  ): number | null {
+    if (lineWeight < 0) {
+      return null
+    }
+    // AutoCAD lineweights are in 0.01 mm; drawings are typically model units in mm.
+    return Math.max(0.01, lineWeight / 100)
+  }
+
+  private static resolveOpacity(traits: AcGiSubEntityTraits): number | null {
+    const alpha = traits.transparency?.alpha
+    if (alpha == null || Number.isNaN(alpha)) {
+      return null
+    }
+    return Math.min(1, Math.max(0, alpha))
+  }
+
+  private static strokeDasharray(
+    traits: AcGiSubEntityTraits,
+    ctx: AcSvgStyleContext
+  ): string | undefined {
+    const pattern = traits.lineType.pattern
+    if (!pattern || pattern.length === 0) {
+      return undefined
+    }
+
+    const scale = ctx.ltscale * ctx.celtscale * traits.lineTypeScale
+    const segments = this.patternToDashSegments(pattern, scale)
+    if (segments.length === 0) {
+      return undefined
+    }
+    return segments.join(' ')
+  }
+
+  private static patternToDashSegments(
+    pattern: AcGiLineTypePatternElement[],
+    scale: number
+  ): number[] {
+    const segments: number[] = []
+
+    for (const element of pattern) {
+      let len = element.elementLength
+      if (len < 0 && element.elementTypeFlag !== 0) {
+        len = Math.abs(len)
+      }
+      len *= scale
+      if (len === 0) {
+        len = 0.5 * scale
+      }
+      segments.push(Math.abs(len))
+    }
+
+    return segments
+  }
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,10 +397,13 @@ importers:
         version: 14.2.6
 
   packages/svg-renderer:
-    dependencies:
+    devDependencies:
       '@mlightcad/data-model':
         specifier: ^1.7.40
         version: 1.7.40
+      '@mlightcad/mtext-parser':
+        specifier: ^1.4.1
+        version: 1.4.1
 
   packages/three-renderer:
     dependencies:


### PR DESCRIPTION
## Summary

This PR turns `@mlightcad/svg-renderer` from a minimal prototype into a production-ready export pipeline for SVG and PDF output. It adds proper entity styling, MTEXT rendering, transform support, and wires SVG export into the viewer UI and existing convertors.

- **SVG renderer overhaul** — Introduces `AcSvgStyleUtil`, `AcSvgMTextUtil`, `AcSvgMatrixUtil`, and `AcSvgExportUtil` to handle stroke/fill colours, linetypes, lineweights, MTEXT layout, matrix transforms, and safe embedded references in exported SVG.
- **Entity rendering improvements** — All SVG primitives (lines, arcs, ellipses, areas, points, images, groups) now apply sub-entity traits and drawing context (`ltscale`, `celtscale`, `LWDISPLAY`, background/foreground colours). `AcSvgEntity` defers transforms until export time via `applyMatrix`.
- **MTEXT support** — Renders MTEXT using `@mlightcad/mtext-parser`, including paragraph breaks, inline formatting (`\H`, `\c`, special characters), text wrapping (Latin and CJK), attachment points, rotation, and vertical flow direction.
- **Export integration** — `AcApSvgConvertor` and `AcApPdfConvertor` configure the renderer from the active drawing (font mapping, scales, colours) and use async `exportAsync()` for raster images. SVG downloads as `drawing.svg`.
- **UI entry points** — Adds **Export to SVG** to the file menu and ribbon (`csvg` command), with English and Chinese locale strings.
- **Tests** — Adds unit tests for entity transforms, export sanitization, MTEXT layout, and style utilities. Updates Jest config to transpile `mtext-parser`.

## Motivation

SVG export is a core workflow for sharing and publishing CAD drawings. The previous renderer produced unstyled geometry with no MTEXT or transform support, making exports unsuitable for real drawings. This change aligns SVG/PDF export output more closely with on-screen rendering and exposes it directly in the application UI.

## Test plan

- [ ] Open a DWG/DXF with lines, arcs, hatches, images, and MTEXT; run **Export to SVG** from the file menu and ribbon
- [ ] Verify exported SVG preserves colours, linetypes, lineweights (when `LWDISPLAY` is on), and MTEXT formatting/positioning
- [ ] Verify block inserts and entity transforms render correctly in the exported file
- [ ] Export to PDF and confirm SVG-based PDF output still works with the updated renderer configuration
- [ ] Run unit tests: `pnpm test -- packages/svg-renderer`
- [ ] Smoke-test on a drawing with a dark background to confirm foreground/background colour resolution (ACI 7)