### PR TITLE
feat(html-plugin): switch snapshot to v2 binary codec with typed-array geometry buffers

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExLayerExtents.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExLayerExtents.spec.ts
@@ -1,5 +1,9 @@
 import { computeLayerExtentsMap } from '../src/AcExLayerExtents'
 
+function f32(values: number[]): Float32Array {
+  return Float32Array.from(values)
+}
+
 describe('AcExLayerExtents', () => {
   it('computes per-layer bounds from batches', () => {
     const map = computeLayerExtentsMap(
@@ -8,7 +12,7 @@ describe('AcExLayerExtents', () => {
           layer: 'A',
           color: 0,
           offset: [0, 0, 0],
-          positions: [0, 0, 0, 10, 5, 0]
+          positions: f32([0, 0, 0, 10, 5, 0])
         }
       ],
       [
@@ -16,7 +20,7 @@ describe('AcExLayerExtents', () => {
           layer: 'B',
           color: 0,
           offset: [1, 2, 0],
-          positions: [0, 0, 0, 2, 2, 0]
+          positions: f32([0, 0, 0, 2, 2, 0])
         }
       ]
     )

--- a/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
@@ -14,6 +14,14 @@ describe('mergeConnectedSegments', () => {
   })
 })
 
+function f32(values: number[]): Float32Array {
+  return Float32Array.from(values)
+}
+
+function u32(values: number[]): Uint32Array {
+  return Uint32Array.from(values)
+}
+
 describe('AcExOsnapIndex', () => {
   const layout = {
     btrId: 'model',
@@ -24,7 +32,7 @@ describe('AcExOsnapIndex', () => {
         layer: '0',
         color: 0xffffff,
         offset: [0, 0, 0] as [number, number, number],
-        positions: [0, 0, 0, 10, 0, 0, 10, 10, 0, 0, 10, 0]
+        positions: f32([0, 0, 0, 10, 0, 0, 10, 10, 0, 0, 10, 0])
       }
     ],
     meshBatches: []
@@ -106,8 +114,8 @@ describe('AcExOsnapIndex', () => {
       layer: '0',
       color: 0xffffff,
       offset: [0, 0, 0] as [number, number, number],
-      positions: [0, 0, 0, 5, 0, 0, 10, 0, 0],
-      indices: [0, 1, 1, 2],
+      positions: f32([0, 0, 0, 5, 0, 0, 10, 0, 0]),
+      indices: u32([0, 1, 1, 2]),
       linePattern: {
         pattern: [4, -2],
         patternLength: 6,
@@ -136,8 +144,8 @@ describe('AcExOsnapIndex', () => {
           layer: '0',
           color: 0xffffff,
           offset: [0, 0, 0] as [number, number, number],
-          positions: [0, 0, 0, 2, 0, 0, 4, 0, 0],
-          indices: [0, 1, 1, 2],
+          positions: f32([0, 0, 0, 2, 0, 0, 4, 0, 0]),
+          indices: u32([0, 1, 1, 2]),
           linePattern: {
             pattern: [1, -1],
             patternLength: 2,

--- a/packages/cad-html-plugin/__tests__/AcExPatternSnapshot.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPatternSnapshot.spec.ts
@@ -66,7 +66,11 @@ describe('AcExPatternSnapshot', () => {
 
   it('computes cumulative line distances for segment pairs', () => {
     expect(
-      computeLineDistancesForSegments([0, 0, 0, 3, 4, 0, 3, 4, 0, 6, 8, 0])
+      Array.from(
+        computeLineDistancesForSegments(
+          Float32Array.from([0, 0, 0, 3, 4, 0, 3, 4, 0, 6, 8, 0])
+        )
+      )
     ).toEqual([0, 5, 5, 10])
   })
 
@@ -97,7 +101,7 @@ describe('AcExPatternSnapshot', () => {
       layer: '0',
       color: 0xff0000,
       offset: [0, 0, 0],
-      positions: [0, 0, 0, 1, 0, 0],
+      positions: Float32Array.from([0, 0, 0, 1, 0, 0]),
       linePattern: {
         pattern: [4, -2],
         patternLength: 6,
@@ -110,7 +114,7 @@ describe('AcExPatternSnapshot', () => {
       layer: '0',
       color: 0x00ff00,
       offset: [0, 0, 0],
-      positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      positions: Float32Array.from([0, 0, 0, 1, 0, 0, 0, 1, 0]),
       hatchPattern: {
         patternAngle: 0,
         patternLines: [
@@ -133,7 +137,7 @@ describe('AcExPatternSnapshot', () => {
       layer: '0',
       color: 0xff0000,
       offset: [0, 0, 0],
-      positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      positions: Float32Array.from([0, 0, 0, 1, 0, 0, 0, 1, 0]),
       gradientFill: {
         startColor: 0xff0000,
         endColor: 0x0000ff,
@@ -141,7 +145,7 @@ describe('AcExPatternSnapshot', () => {
         shift: 0.1,
         gradientType: 0
       },
-      gradientPositions: [-1, 0, 1, 0, 0, 1]
+      gradientPositions: Float32Array.from([-1, 0, 1, 0, 0, 1])
     })
     expect(gradientMaterial).toBeInstanceOf(THREE.ShaderMaterial)
     expect((gradientMaterial as THREE.ShaderMaterial).vertexShader).toContain(

--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -20,7 +20,7 @@ describe('exportBufferGeometrySlice', () => {
 
     const slice = exportBufferGeometrySlice(geometry)
 
-    expect(slice.positions).toEqual([0, 0, 0, 1, 0, 0])
+    expect(Array.from(slice.positions)).toEqual([0, 0, 0, 1, 0, 0])
     expect(slice.indices).toBeUndefined()
   })
 
@@ -38,8 +38,8 @@ describe('exportBufferGeometrySlice', () => {
 
     const slice = exportBufferGeometrySlice(geometry)
 
-    expect(slice.positions).toEqual([0, 0, 0, 1, 0, 0, 2, 0, 0])
-    expect(slice.indices).toEqual([0, 1, 2])
+    expect(Array.from(slice.positions)).toEqual([0, 0, 0, 1, 0, 0, 2, 0, 0])
+    expect(Array.from(slice.indices!)).toEqual([0, 1, 2])
   })
 
   it('honors a finite draw range on non-indexed geometry', () => {
@@ -55,6 +55,6 @@ describe('exportBufferGeometrySlice', () => {
 
     const slice = exportBufferGeometrySlice(geometry)
 
-    expect(slice.positions).toEqual([1, 0, 0, 2, 0, 0])
+    expect(Array.from(slice.positions)).toEqual([1, 0, 0, 2, 0, 0])
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
@@ -1,6 +1,10 @@
 import { decodeSnapshot, encodeSnapshot } from '../src/AcExSnapshotCodec'
 import { ACEX_SNAPSHOT_VERSION } from '../src/AcExSnapshotTypes'
 
+function f32(values: number[]): Float32Array {
+  return Float32Array.from(values)
+}
+
 describe('AcExSnapshotCodec', () => {
   it('round-trips a minimal snapshot', () => {
     const snapshot = {
@@ -37,5 +41,67 @@ describe('AcExSnapshotCodec', () => {
     const decoded = decodeSnapshot(encoded)
     expect(decoded.meta.extents.maxX).toBe(10)
     expect(decoded.layers[0]?.name).toBe('0')
+  })
+
+  it('round-trips binary geometry buffers', () => {
+    const snapshot = {
+      version: ACEX_SNAPSHOT_VERSION,
+      meta: {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        extents: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        units: {
+          insunits: 4,
+          lunits: 2,
+          luprec: 4,
+          aunits: 0,
+          auprec: 0,
+          measurement: 1,
+          ltscale: 1,
+          angbase: 0,
+          angdir: 0
+        },
+        background: 0
+      },
+      layers: [{ name: '0', color: 0xffffff, visible: true }],
+      layouts: [
+        {
+          btrId: 'ms',
+          name: '*Model_Space',
+          isModelSpace: true,
+          lineBatches: [
+            {
+              layer: '0',
+              color: 0xff0000,
+              offset: [1, 2, 0] as [number, number, number],
+              positions: f32([0, 0, 0, 10, 0, 0]),
+              indices: Uint32Array.from([0, 1]),
+              lineDistances: f32([0, 10])
+            }
+          ],
+          meshBatches: [
+            {
+              layer: '0',
+              color: 0x00ff00,
+              offset: [0, 0, 0] as [number, number, number],
+              positions: f32([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+              indices: Uint32Array.from([0, 1, 2]),
+              gradientPositions: f32([0, 0, 1, 0, 0, 1])
+            }
+          ]
+        }
+      ],
+      activeLayoutBtrId: 'ms'
+    }
+
+    const decoded = decodeSnapshot(encodeSnapshot(snapshot))
+    const line = decoded.layouts[0]!.lineBatches[0]!
+    expect(Array.from(line.positions)).toEqual([0, 0, 0, 10, 0, 0])
+    expect(Array.from(line.indices!)).toEqual([0, 1])
+    expect(Array.from(line.lineDistances!)).toEqual([0, 10])
+
+    const mesh = decoded.layouts[0]!.meshBatches[0]!
+    expect(Array.from(mesh.positions)).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0])
+    expect(Array.from(mesh.indices!)).toEqual([0, 1, 2])
+    expect(Array.from(mesh.gradientPositions!)).toEqual([0, 0, 1, 0, 0, 1])
   })
 })

--- a/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
+++ b/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
@@ -6,7 +6,7 @@ import { AcApHtmlConvertor } from './AcApHtmlConvertor'
  * Editor command that exports the active drawing as a self-contained HTML file.
  *
  * The command delegates to {@link AcApHtmlConvertor}, which serializes the
- * current Three.js scene into an {@link AcExSnapshotV1} HTML snapshot,
+ * current Three.js scene into an {@link AcExSnapshot} HTML snapshot,
  * bundles the offline viewer runtime, and triggers a browser download. No
  * prompts are shown; the output filename is derived from the document name.
  */

--- a/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
@@ -7,7 +7,7 @@ import {
 
 import { AcApHtmlSnapshotBuilder } from './AcApHtmlSnapshotBuilder'
 import { packHtml } from './AcExHtmlPackager'
-import type { AcExSnapshotV1 } from './AcExSnapshotTypes'
+import type { AcExSnapshot } from './AcExSnapshotTypes'
 
 /**
  * Relative URL of the bundled offline viewer script when no override is
@@ -19,7 +19,7 @@ const DEFAULT_RUNTIME_URL = './viewer-runtime.iife.js'
  * Orchestrates export of the active drawing to a downloadable HTML file.
  *
  * Workflow:
- * 1. Build a display-only {@link AcExSnapshotV1} from the current scene and database.
+ * 1. Build a display-only {@link AcExSnapshot} from the current scene and database.
  * 2. Fetch the IIFE viewer runtime (inlined into the HTML).
  * 3. Package snapshot + runtime via `packHtml` and trigger a browser download.
  *
@@ -94,7 +94,7 @@ export class AcApHtmlConvertor {
    *   include the `.html` extension).
    * @returns Resolves when packaging and download complete.
    */
-  async packSnapshot(snapshot: AcExSnapshotV1, downloadName: string) {
+  async packSnapshot(snapshot: AcExSnapshot, downloadName: string) {
     const docManager = AcApDocManager.instance
     docManager.showBusyIndicator()
 

--- a/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
@@ -13,7 +13,7 @@ import {
   type AcExLayoutSnapshot,
   type AcExLineBatch,
   type AcExMeshBatch,
-  type AcExSnapshotV1
+  type AcExSnapshot
 } from './AcExSnapshotTypes'
 import { buildViewerMetadata } from './AcExViewerMetadata'
 
@@ -39,7 +39,7 @@ export interface AcApHtmlSnapshotBuilderOptions {
 }
 
 /**
- * Serializes the live Three.js scene into a versioned {@link AcExSnapshotV1}.
+ * Serializes the live Three.js scene into a versioned {@link AcExSnapshot}.
  *
  * The snapshot contains layer visibility, per-layout line/mesh batches, and
  * viewer metadata (extents, units, background). It is display-only: no DXF/DWG
@@ -60,7 +60,7 @@ export class AcApHtmlSnapshotBuilder {
     scene: AcTrScene,
     database: AcDbDatabase,
     options: AcApHtmlSnapshotBuilderOptions = {}
-  ): AcExSnapshotV1 {
+  ): AcExSnapshot {
     return this.buildSync(scene, database, options)
   }
 
@@ -79,7 +79,7 @@ export class AcApHtmlSnapshotBuilder {
     scene: AcTrScene,
     database: AcDbDatabase,
     options: AcApHtmlSnapshotBuilderOptions = {}
-  ): Promise<AcExSnapshotV1> {
+  ): Promise<AcExSnapshot> {
     await yieldToMain()
 
     const meta = buildViewerMetadata(database, {
@@ -138,7 +138,7 @@ export class AcApHtmlSnapshotBuilder {
     scene: AcTrScene,
     database: AcDbDatabase,
     options: AcApHtmlSnapshotBuilderOptions
-  ): AcExSnapshotV1 {
+  ): AcExSnapshot {
     const meta = buildViewerMetadata(database, {
       title: options.title,
       background: options.background
@@ -183,7 +183,7 @@ export class AcApHtmlSnapshotBuilder {
  *
  * @param meta - Extents, units, and background from {@link buildViewerMetadata}.
  * @param options - User overrides (title is taken from `meta`; locale from options).
- * @returns The `meta` block stored on {@link AcExSnapshotV1}.
+ * @returns The `meta` block stored on {@link AcExSnapshot}.
  */
 function buildSnapshotMeta(
   meta: ReturnType<typeof buildViewerMetadata>,

--- a/packages/cad-html-plugin/src/AcExBatchBuffers.ts
+++ b/packages/cad-html-plugin/src/AcExBatchBuffers.ts
@@ -1,0 +1,60 @@
+/**
+ * Applies a world-space offset to a flat XYZ {@link Float32Array} position buffer.
+ *
+ * @param positions - Local-space vertex buffer (`itemSize` 3).
+ * @param offset - Translation added to every vertex.
+ * @returns A new buffer with the offset baked in.
+ */
+export function applyOffsetToPositions(
+  positions: Float32Array,
+  offset: [number, number, number]
+): Float32Array {
+  const result = new Float32Array(positions.length)
+  const [ox, oy, oz] = offset
+  for (let i = 0; i < positions.length; i += 3) {
+    result[i] = positions[i]! + ox
+    result[i + 1] = positions[i + 1]! + oy
+    result[i + 2] = positions[i + 2]! + oz
+  }
+  return result
+}
+
+/**
+ * Copies a contiguous span from an array-like source into a {@link Float32Array}.
+ *
+ * @internal
+ */
+export function copyFloat32Range(
+  array: ArrayLike<number>,
+  start: number,
+  count: number
+): Float32Array {
+  if (count <= 0) {
+    return new Float32Array(0)
+  }
+  const result = new Float32Array(count)
+  for (let i = 0; i < count; i++) {
+    result[i] = array[start + i]!
+  }
+  return result
+}
+
+/**
+ * Copies a contiguous span from an array-like source into a {@link Uint32Array}.
+ *
+ * @internal
+ */
+export function copyUint32Range(
+  array: ArrayLike<number>,
+  start: number,
+  count: number
+): Uint32Array {
+  if (count <= 0) {
+    return new Uint32Array(0)
+  }
+  const result = new Uint32Array(count)
+  for (let i = 0; i < count; i++) {
+    result[i] = array[start + i]!
+  }
+  return result
+}

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -168,7 +168,7 @@ export function resolveAcExHtmlLocale(
  * Chooses the initial locale for the offline viewer using, in order:
  * `localStorage`, snapshot preference, `<html lang>`, and `navigator.language`.
  *
- * @param preferred - Optional locale from {@link AcExSnapshotV1.meta.locale}.
+ * @param preferred - Optional locale from {@link AcExSnapshot.meta.locale}.
  * @returns Resolved locale, defaulting to `'en'`.
  */
 export function detectAcExHtmlLocale(

--- a/packages/cad-html-plugin/src/AcExHtmlPackager.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlPackager.ts
@@ -1,7 +1,7 @@
 import { resolveAcExHtmlLocale } from './AcExHtmlI18n'
 import { ACEX_HTML_SHELL_CSS, buildAcExHtmlShellBody } from './AcExHtmlShell'
 import { encodeSnapshot, snapshotMimeType } from './AcExSnapshotCodec'
-import type { AcExSnapshotV1 } from './AcExSnapshotTypes'
+import type { AcExSnapshot } from './AcExSnapshotTypes'
 
 /**
  * Options passed to {@link packHtml} when assembling a self-contained HTML file.
@@ -9,7 +9,7 @@ import type { AcExSnapshotV1 } from './AcExSnapshotTypes'
 export interface AcExPackHtmlOptions {
   /**
    * Page `<title>` and default download filename stem.
-   * Falls back to {@link AcExSnapshotV1.meta.title} or `"CAD Drawing"`.
+   * Falls back to {@link AcExSnapshot.meta.title} or `"CAD Drawing"`.
    */
   title?: string
   /**
@@ -28,7 +28,7 @@ export interface AcExPackHtmlOptions {
  * @returns Complete HTML document string (DOCTYPE, shell markup, snapshot, runtime).
  */
 export function packHtml(
-  snapshot: AcExSnapshotV1,
+  snapshot: AcExSnapshot,
   options: AcExPackHtmlOptions
 ): string {
   const title = options.title ?? snapshot.meta.title ?? 'CAD Drawing'

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -2,6 +2,7 @@ import { FLOAT_TOL } from '@mlightcad/data-model'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 
+import { applyOffsetToPositions } from './AcExBatchBuffers'
 import { AcExHtmlI18n, detectAcExHtmlLocale } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import { computeLayerExtentsMap } from './AcExLayerExtents'
@@ -18,7 +19,7 @@ import type {
   AcExExtents,
   AcExLineBatch,
   AcExMeshBatch,
-  AcExSnapshotV1
+  AcExSnapshot
 } from './AcExSnapshotTypes'
 
 /** Matches {@link AcTrBaseView} orthographic half-height in world units. */
@@ -50,7 +51,7 @@ function startViewer(): void {
   }
 
   const payload = snapshotEl.textContent?.trim() ?? ''
-  let snapshot: AcExSnapshotV1
+  let snapshot: AcExSnapshot
   try {
     snapshot = decodeSnapshot(payload)
   } catch (error) {
@@ -355,7 +356,7 @@ interface AcExLayerRowRefs {
 /** Dependencies passed into {@link setupLayerPanel}. */
 interface AcExLayerPanelContext {
   /** Full snapshot (layer table and metadata). */
-  snapshot: AcExSnapshotV1
+  snapshot: AcExSnapshot
   /** Mutable visibility map shared with the THREE layer groups. */
   layerVisible: Map<string, boolean>
   /** THREE groups keyed by layer name. */
@@ -525,16 +526,10 @@ function setupLayerPanel(
 function createLineObject(batch: AcExLineBatch): THREE.LineSegments | null {
   if (batch.positions.length < 6) return null
   const geometry = new THREE.BufferGeometry()
-  const positions = new Float32Array(batch.positions.length)
-  const [ox, oy, oz] = batch.offset
-  for (let i = 0; i < batch.positions.length; i += 3) {
-    positions[i] = batch.positions[i]! + ox
-    positions[i + 1] = batch.positions[i + 1]! + oy
-    positions[i + 2] = (batch.positions[i + 2] ?? 0) + oz
-  }
+  const positions = applyOffsetToPositions(batch.positions, batch.offset)
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
   if (batch.indices && batch.indices.length > 0) {
-    geometry.setIndex(batch.indices)
+    geometry.setIndex(new THREE.BufferAttribute(batch.indices, 1))
   }
   if (
     batch.linePattern &&
@@ -608,16 +603,10 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
     return null
   }
   const geometry = new THREE.BufferGeometry()
-  const positions = new Float32Array(batch.positions.length)
-  const [ox, oy, oz] = batch.offset
-  for (let i = 0; i < batch.positions.length; i += 3) {
-    positions[i] = batch.positions[i]! + ox
-    positions[i + 1] = batch.positions[i + 1]! + oy
-    positions[i + 2] = (batch.positions[i + 2] ?? 0) + oz
-  }
+  const positions = applyOffsetToPositions(batch.positions, batch.offset)
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
   if (batch.indices && batch.indices.length > 0) {
-    geometry.setIndex(batch.indices)
+    geometry.setIndex(new THREE.BufferAttribute(batch.indices, 1))
   } else if (positions.length >= 9) {
     geometry.setIndex([0, 1, 2])
   }

--- a/packages/cad-html-plugin/src/AcExLayerExtents.ts
+++ b/packages/cad-html-plugin/src/AcExLayerExtents.ts
@@ -43,7 +43,7 @@ export function createEmptyExtents(): AcExMutableExtents {
  */
 export function expandExtentsFromPositions(
   extents: AcExMutableExtents,
-  positions: number[],
+  positions: Float32Array,
   offset: [number, number, number]
 ): void {
   if (positions.length < 3) return

--- a/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
+++ b/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
@@ -6,6 +6,7 @@ import {
 } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 
+import { copyFloat32Range } from './AcExBatchBuffers'
 import type {
   AcExGradientFill,
   AcExHatchPattern,
@@ -136,12 +137,14 @@ function deserializeHatchPatternLine(
 /**
  * Computes cumulative `lineDistance` values for line-segment geometry.
  */
-export function computeLineDistancesForSegments(positions: number[]): number[] {
+export function computeLineDistancesForSegments(
+  positions: Float32Array
+): Float32Array {
   const vertexCount = positions.length / 3
   if (vertexCount < 2) {
-    return []
+    return new Float32Array(0)
   }
-  const lineDistances = new Array<number>(vertexCount)
+  const lineDistances = new Float32Array(vertexCount)
   for (let i = 0; i < vertexCount; i += 2) {
     if (i === 0) {
       lineDistances[i] = 0
@@ -168,7 +171,7 @@ export function computeLineDistancesForSegments(positions: number[]): number[] {
  */
 export function exportLineDistanceSlice(
   geometry: THREE.BufferGeometry
-): number[] | undefined {
+): Float32Array | undefined {
   const lineDistanceAttr = geometry.getAttribute('lineDistance') as
     | THREE.BufferAttribute
     | undefined
@@ -179,11 +182,7 @@ export function exportLineDistanceSlice(
   const indexAttr = geometry.getIndex()
   if (indexAttr) {
     const array = lineDistanceAttr.array as ArrayLike<number>
-    const result = new Array<number>(lineDistanceAttr.count)
-    for (let i = 0; i < lineDistanceAttr.count; i++) {
-      result[i] = array[i]!
-    }
-    return result
+    return copyFloat32Range(array, 0, lineDistanceAttr.count)
   }
 
   const drawRange = geometry.drawRange
@@ -199,11 +198,7 @@ export function exportLineDistanceSlice(
   }
 
   const array = lineDistanceAttr.array as ArrayLike<number>
-  const result = new Array<number>(drawCount)
-  for (let i = 0; i < drawCount; i++) {
-    result[i] = array[vertexStart + i]!
-  }
-  return result
+  return copyFloat32Range(array, vertexStart, drawCount)
 }
 
 /**
@@ -212,7 +207,7 @@ export function exportLineDistanceSlice(
 export function exportVertexAttributeSlice(
   geometry: THREE.BufferGeometry,
   attributeName: string
-): number[] | undefined {
+): Float32Array | undefined {
   const attribute = geometry.getAttribute(attributeName) as
     | THREE.BufferAttribute
     | undefined
@@ -224,11 +219,7 @@ export function exportVertexAttributeSlice(
   const indexAttr = geometry.getIndex()
   if (indexAttr) {
     const array = attribute.array as ArrayLike<number>
-    const result = new Array<number>(attribute.count * itemSize)
-    for (let i = 0; i < attribute.count * itemSize; i++) {
-      result[i] = array[i]!
-    }
-    return result
+    return copyFloat32Range(array, 0, attribute.count * itemSize)
   }
 
   const drawRange = geometry.drawRange
@@ -244,11 +235,7 @@ export function exportVertexAttributeSlice(
   }
 
   const array = attribute.array as ArrayLike<number>
-  const result = new Array<number>(drawCount * itemSize)
-  for (let i = 0; i < drawCount * itemSize; i++) {
-    result[i] = array[vertexStart * itemSize + i]!
-  }
-  return result
+  return copyFloat32Range(array, vertexStart * itemSize, drawCount * itemSize)
 }
 
 /**

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -6,6 +6,7 @@ import {
 } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 
+import { copyFloat32Range, copyUint32Range } from './AcExBatchBuffers'
 import {
   computeLineDistancesForSegments,
   exportLineDistanceSlice,
@@ -22,11 +23,11 @@ export interface AcExBufferGeometrySlice {
   /**
    * Flat vertex positions `[x0, y0, z0, …]` honoring the geometry draw range.
    */
-  positions: number[]
+  positions: Float32Array
   /**
    * Optional index buffer referencing vertices in {@link AcExBufferGeometrySlice.positions}.
    */
-  indices?: number[]
+  indices?: Uint32Array
 }
 
 /** Result of {@link collectBatchesFromObject3D}. */
@@ -71,26 +72,6 @@ function resolveRangeCount(
 }
 
 /**
- * Copies a contiguous numeric span from a typed array into a plain `number[]`.
- *
- * @internal
- */
-function copyNumberRange(
-  array: ArrayLike<number>,
-  start: number,
-  count: number
-): number[] {
-  if (count <= 0) {
-    return []
-  }
-  const result = new Array<number>(count)
-  for (let i = 0; i < count; i++) {
-    result[i] = array[start + i]!
-  }
-  return result
-}
-
-/**
  * Extracts the actively used portion of a batched buffer geometry,
  * respecting `geometry.drawRange` when set.
  *
@@ -104,7 +85,7 @@ export function exportBufferGeometrySlice(
     | THREE.BufferAttribute
     | undefined
   if (!positionAttr) {
-    return { positions: [] }
+    return { positions: new Float32Array(0) }
   }
 
   const drawRange = geometry.drawRange
@@ -113,7 +94,7 @@ export function exportBufferGeometrySlice(
   const indexAttr = geometry.getIndex()
 
   if (indexAttr) {
-    const positions = copyNumberRange(array, 0, positionAttr.count * itemSize)
+    const positions = copyFloat32Range(array, 0, positionAttr.count * itemSize)
     const indexArray = indexAttr.array
     const indexStart = clampRangeStart(drawRange.start, indexAttr.count)
     const indexCount = resolveRangeCount(
@@ -121,7 +102,7 @@ export function exportBufferGeometrySlice(
       indexAttr.count,
       indexStart
     )
-    const indices = copyNumberRange(indexArray, indexStart, indexCount)
+    const indices = copyUint32Range(indexArray, indexStart, indexCount)
     return { positions, indices }
   }
 
@@ -131,7 +112,7 @@ export function exportBufferGeometrySlice(
     positionAttr.count,
     vertexStart
   )
-  const positions = copyNumberRange(
+  const positions = copyFloat32Range(
     array,
     vertexStart * itemSize,
     vertexCount * itemSize

--- a/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
@@ -1,0 +1,395 @@
+import { strFromU8, strToU8 } from 'fflate'
+
+import {
+  ACEX_SNAPSHOT_VERSION,
+  type AcExLayoutSnapshot,
+  type AcExLineBatch,
+  type AcExMeshBatch,
+  type AcExSnapshot
+} from './AcExSnapshotTypes'
+
+const MAGIC = 0x58454341 // 'ACEX' little-endian
+
+const F_LINE_INDICES = 1
+const F_LINE_PATTERN = 2
+const F_LINE_DISTANCES = 4
+
+const F_MESH_INDICES = 1
+const F_MESH_HATCH = 2
+const F_MESH_GRADIENT_FILL = 4
+const F_MESH_GRADIENT_POS = 8
+const F_MESH_SIDE = 16
+
+/**
+ * Serializes a snapshot to a compact binary byte array.
+ *
+ * Metadata and small JSON-friendly fields are length-prefixed UTF-8 JSON;
+ * geometry buffers are stored as raw {@link Float32Array} / {@link Uint32Array} bytes.
+ *
+ * @param snapshot - Snapshot to encode; {@link AcExSnapshot.version} must match
+ *   {@link ACEX_SNAPSHOT_VERSION}.
+ */
+export function encodeSnapshotBinary(snapshot: AcExSnapshot): Uint8Array {
+  if (snapshot.version !== ACEX_SNAPSHOT_VERSION) {
+    throw new Error(`Unsupported snapshot version: ${snapshot.version}`)
+  }
+
+  const writer = new BinaryWriter()
+  writer.writeU32(MAGIC)
+  writer.writeU8(ACEX_SNAPSHOT_VERSION)
+  writer.writeU8(0)
+  writer.writeU8(0)
+  writer.writeU8(0)
+
+  writer.writeJson(snapshot.meta)
+  writer.writeJson(snapshot.layers)
+  writer.writeString(snapshot.activeLayoutBtrId)
+  writer.writeU32(snapshot.layouts.length)
+
+  for (const layout of snapshot.layouts) {
+    writeLayout(writer, layout)
+  }
+
+  return writer.toUint8Array()
+}
+
+/**
+ * Parses a binary snapshot byte array produced by {@link encodeSnapshotBinary}.
+ */
+export function decodeSnapshotBinary(bytes: Uint8Array): AcExSnapshot {
+  const reader = new BinaryReader(bytes)
+  const magic = reader.readU32()
+  if (magic !== MAGIC) {
+    throw new Error('Invalid snapshot magic')
+  }
+
+  const version = reader.readU8()
+  reader.readU8()
+  reader.readU8()
+  reader.readU8()
+  if (version !== ACEX_SNAPSHOT_VERSION) {
+    throw new Error(`Unsupported snapshot version: ${version}`)
+  }
+
+  const meta = reader.readJson<AcExSnapshot['meta']>()
+  const layers = reader.readJson<AcExSnapshot['layers']>()
+  const activeLayoutBtrId = reader.readString()
+  const layoutCount = reader.readU32()
+  const layouts: AcExLayoutSnapshot[] = []
+  for (let i = 0; i < layoutCount; i++) {
+    layouts.push(readLayout(reader))
+  }
+
+  return {
+    version: ACEX_SNAPSHOT_VERSION,
+    meta,
+    layers,
+    layouts,
+    activeLayoutBtrId
+  }
+}
+
+function writeLayout(writer: BinaryWriter, layout: AcExLayoutSnapshot): void {
+  writer.writeString(layout.btrId)
+  writer.writeString(layout.name)
+  writer.writeU8(layout.isModelSpace ? 1 : 0)
+  writer.writeJson(layout.osnap ?? null)
+
+  writer.writeU32(layout.lineBatches.length)
+  for (const batch of layout.lineBatches) {
+    writeLineBatch(writer, batch)
+  }
+
+  writer.writeU32(layout.meshBatches.length)
+  for (const batch of layout.meshBatches) {
+    writeMeshBatch(writer, batch)
+  }
+}
+
+function readLayout(reader: BinaryReader): AcExLayoutSnapshot {
+  const btrId = reader.readString()
+  const name = reader.readString()
+  const isModelSpace = reader.readU8() !== 0
+  const osnapValue = reader.readJson<AcExLayoutSnapshot['osnap'] | null>()
+  const osnap = osnapValue ?? undefined
+
+  const lineBatchCount = reader.readU32()
+  const lineBatches: AcExLineBatch[] = []
+  for (let i = 0; i < lineBatchCount; i++) {
+    lineBatches.push(readLineBatch(reader))
+  }
+
+  const meshBatchCount = reader.readU32()
+  const meshBatches: AcExMeshBatch[] = []
+  for (let i = 0; i < meshBatchCount; i++) {
+    meshBatches.push(readMeshBatch(reader))
+  }
+
+  return { btrId, name, isModelSpace, lineBatches, meshBatches, osnap }
+}
+
+function writeLineBatch(writer: BinaryWriter, batch: AcExLineBatch): void {
+  writer.writeString(batch.layer)
+  writer.writeU32(batch.color >>> 0)
+  writer.writeF32(batch.offset[0]!)
+  writer.writeF32(batch.offset[1]!)
+  writer.writeF32(batch.offset[2]!)
+  writer.writeFloat32Array(batch.positions)
+
+  let flags = 0
+  if (batch.indices && batch.indices.length > 0) flags |= F_LINE_INDICES
+  if (batch.linePattern) flags |= F_LINE_PATTERN
+  if (batch.lineDistances && batch.lineDistances.length > 0) {
+    flags |= F_LINE_DISTANCES
+  }
+  writer.writeU8(flags)
+
+  if (flags & F_LINE_INDICES) {
+    writer.writeUint32Array(batch.indices!)
+  }
+  if (flags & F_LINE_PATTERN) {
+    writer.writeJson(batch.linePattern!)
+  }
+  if (flags & F_LINE_DISTANCES) {
+    writer.writeFloat32Array(batch.lineDistances!)
+  }
+}
+
+function readLineBatch(reader: BinaryReader): AcExLineBatch {
+  const layer = reader.readString()
+  const color = reader.readU32()
+  const offset: [number, number, number] = [
+    reader.readF32(),
+    reader.readF32(),
+    reader.readF32()
+  ]
+  const positions = reader.readFloat32Array()
+  const flags = reader.readU8()
+
+  const batch: AcExLineBatch = { layer, color, offset, positions }
+  if (flags & F_LINE_INDICES) {
+    batch.indices = reader.readUint32Array()
+  }
+  if (flags & F_LINE_PATTERN) {
+    batch.linePattern =
+      reader.readJson<NonNullable<AcExLineBatch['linePattern']>>()
+  }
+  if (flags & F_LINE_DISTANCES) {
+    batch.lineDistances = reader.readFloat32Array()
+  }
+  return batch
+}
+
+function writeMeshBatch(writer: BinaryWriter, batch: AcExMeshBatch): void {
+  writer.writeString(batch.layer)
+  writer.writeU32(batch.color >>> 0)
+  writer.writeF32(batch.offset[0]!)
+  writer.writeF32(batch.offset[1]!)
+  writer.writeF32(batch.offset[2]!)
+  writer.writeFloat32Array(batch.positions)
+
+  let flags = 0
+  if (batch.indices && batch.indices.length > 0) flags |= F_MESH_INDICES
+  if (batch.hatchPattern) flags |= F_MESH_HATCH
+  if (batch.gradientFill) flags |= F_MESH_GRADIENT_FILL
+  if (batch.gradientPositions && batch.gradientPositions.length > 0) {
+    flags |= F_MESH_GRADIENT_POS
+  }
+  if (batch.side != null) flags |= F_MESH_SIDE
+  writer.writeU8(flags)
+
+  if (flags & F_MESH_INDICES) {
+    writer.writeUint32Array(batch.indices!)
+  }
+  if (flags & F_MESH_HATCH) {
+    writer.writeJson(batch.hatchPattern!)
+  }
+  if (flags & F_MESH_GRADIENT_FILL) {
+    writer.writeJson(batch.gradientFill!)
+  }
+  if (flags & F_MESH_GRADIENT_POS) {
+    writer.writeFloat32Array(batch.gradientPositions!)
+  }
+  if (flags & F_MESH_SIDE) {
+    writer.writeU8(batch.side!)
+  }
+}
+
+function readMeshBatch(reader: BinaryReader): AcExMeshBatch {
+  const layer = reader.readString()
+  const color = reader.readU32()
+  const offset: [number, number, number] = [
+    reader.readF32(),
+    reader.readF32(),
+    reader.readF32()
+  ]
+  const positions = reader.readFloat32Array()
+  const flags = reader.readU8()
+
+  const batch: AcExMeshBatch = { layer, color, offset, positions }
+  if (flags & F_MESH_INDICES) {
+    batch.indices = reader.readUint32Array()
+  }
+  if (flags & F_MESH_HATCH) {
+    batch.hatchPattern =
+      reader.readJson<NonNullable<AcExMeshBatch['hatchPattern']>>()
+  }
+  if (flags & F_MESH_GRADIENT_FILL) {
+    batch.gradientFill =
+      reader.readJson<NonNullable<AcExMeshBatch['gradientFill']>>()
+  }
+  if (flags & F_MESH_GRADIENT_POS) {
+    batch.gradientPositions = reader.readFloat32Array()
+  }
+  if (flags & F_MESH_SIDE) {
+    batch.side = reader.readU8()
+  }
+  return batch
+}
+
+class BinaryWriter {
+  private readonly chunks: Uint8Array[] = []
+  private length = 0
+
+  writeU8(value: number): void {
+    const chunk = new Uint8Array(1)
+    chunk[0] = value & 0xff
+    this.chunks.push(chunk)
+    this.length += 1
+  }
+
+  writeU32(value: number): void {
+    const chunk = new Uint8Array(4)
+    new DataView(chunk.buffer).setUint32(0, value >>> 0, true)
+    this.chunks.push(chunk)
+    this.length += 4
+  }
+
+  writeF32(value: number): void {
+    const chunk = new Uint8Array(4)
+    new DataView(chunk.buffer).setFloat32(0, value, true)
+    this.chunks.push(chunk)
+    this.length += 4
+  }
+
+  writeBytes(bytes: Uint8Array): void {
+    this.chunks.push(bytes)
+    this.length += bytes.length
+  }
+
+  writeString(value: string): void {
+    const bytes = strToU8(value)
+    this.writeU32(bytes.length)
+    this.writeBytes(bytes)
+  }
+
+  writeJson(value: unknown): void {
+    this.writeString(JSON.stringify(value))
+  }
+
+  writeFloat32Array(array: Float32Array): void {
+    const bytes = new Uint8Array(
+      array.buffer,
+      array.byteOffset,
+      array.byteLength
+    )
+    this.writeU32(bytes.length)
+    this.writeBytes(bytes)
+  }
+
+  writeUint32Array(array: Uint32Array): void {
+    const bytes = new Uint8Array(
+      array.buffer,
+      array.byteOffset,
+      array.byteLength
+    )
+    this.writeU32(bytes.length)
+    this.writeBytes(bytes)
+  }
+
+  toUint8Array(): Uint8Array {
+    const result = new Uint8Array(this.length)
+    let offset = 0
+    for (const chunk of this.chunks) {
+      result.set(chunk, offset)
+      offset += chunk.length
+    }
+    return result
+  }
+}
+
+class BinaryReader {
+  private offset = 0
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  readU8(): number {
+    return this.bytes[this.offset++]!
+  }
+
+  readU32(): number {
+    const view = new DataView(
+      this.bytes.buffer,
+      this.bytes.byteOffset + this.offset,
+      4
+    )
+    const value = view.getUint32(0, true)
+    this.offset += 4
+    return value
+  }
+
+  readF32(): number {
+    const view = new DataView(
+      this.bytes.buffer,
+      this.bytes.byteOffset + this.offset,
+      4
+    )
+    const value = view.getFloat32(0, true)
+    this.offset += 4
+    return value
+  }
+
+  readBytes(length: number): Uint8Array {
+    const slice = this.bytes.subarray(this.offset, this.offset + length)
+    this.offset += length
+    return slice
+  }
+
+  readString(): string {
+    const length = this.readU32()
+    if (length === 0) {
+      return ''
+    }
+    return strFromU8(this.readBytes(length))
+  }
+
+  readJson<T>(): T {
+    const text = this.readString()
+    if (text.length === 0) {
+      throw new Error('Expected JSON payload')
+    }
+    return JSON.parse(text) as T
+  }
+
+  readFloat32Array(): Float32Array {
+    const byteLength = this.readU32()
+    if (byteLength === 0) {
+      return new Float32Array(0)
+    }
+    const bytes = this.readBytes(byteLength)
+    const buffer = new ArrayBuffer(byteLength)
+    new Uint8Array(buffer).set(bytes)
+    return new Float32Array(buffer)
+  }
+
+  readUint32Array(): Uint32Array {
+    const byteLength = this.readU32()
+    if (byteLength === 0) {
+      return new Uint32Array(0)
+    }
+    const bytes = this.readBytes(byteLength)
+    const buffer = new ArrayBuffer(byteLength)
+    new Uint8Array(buffer).set(bytes)
+    return new Uint32Array(buffer)
+  }
+}

--- a/packages/cad-html-plugin/src/AcExSnapshotCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotCodec.ts
@@ -1,23 +1,27 @@
-import { gunzipSync, gzipSync, strFromU8, strToU8 } from 'fflate'
+import { gunzipSync, gzipSync } from 'fflate'
 
-import { ACEX_SNAPSHOT_VERSION, type AcExSnapshotV1 } from './AcExSnapshotTypes'
+import {
+  decodeSnapshotBinary,
+  encodeSnapshotBinary
+} from './AcExSnapshotBinaryCodec'
+import { ACEX_SNAPSHOT_VERSION, type AcExSnapshot } from './AcExSnapshotTypes'
 
-const SNAPSHOT_MIME = 'application/vnd.mlightcad.acex-snapshot+json'
+const SNAPSHOT_MIME = 'application/vnd.mlightcad.acex-snapshot+binary'
 
 /**
  * Serializes a snapshot to a gzip-compressed base64 string for HTML embedding.
  *
- * @param snapshot - Snapshot to encode; {@link AcExSnapshotV1.version} must match
+ * @param snapshot - Snapshot to encode; {@link AcExSnapshot.version} must match
  *   {@link ACEX_SNAPSHOT_VERSION}.
  * @returns Base64-encoded gzip payload (no data-URL prefix).
  * @throws When the snapshot version is unsupported.
  */
-export function encodeSnapshot(snapshot: AcExSnapshotV1): string {
+export function encodeSnapshot(snapshot: AcExSnapshot): string {
   if (snapshot.version !== ACEX_SNAPSHOT_VERSION) {
     throw new Error(`Unsupported snapshot version: ${snapshot.version}`)
   }
-  const json = JSON.stringify(snapshot)
-  const compressed = gzipSync(strToU8(json))
+  const binary = encodeSnapshotBinary(snapshot)
+  const compressed = gzipSync(binary)
   return uint8ToBase64(compressed)
 }
 
@@ -25,17 +29,13 @@ export function encodeSnapshot(snapshot: AcExSnapshotV1): string {
  * Parses a gzip-compressed base64 snapshot payload from an exported HTML file.
  *
  * @param payload - Base64 text from the snapshot `<script>` element body.
- * @returns Parsed {@link AcExSnapshotV1} object.
- * @throws When decompression, JSON parsing, or version validation fails.
+ * @returns Parsed {@link AcExSnapshot} object.
+ * @throws When decompression, parsing, or version validation fails.
  */
-export function decodeSnapshot(payload: string): AcExSnapshotV1 {
+export function decodeSnapshot(payload: string): AcExSnapshot {
   const bytes = base64ToUint8(payload.trim())
-  const json = strFromU8(gunzipSync(bytes))
-  const snapshot = JSON.parse(json) as AcExSnapshotV1
-  if (snapshot.version !== ACEX_SNAPSHOT_VERSION) {
-    throw new Error(`Unsupported snapshot version: ${snapshot.version}`)
-  }
-  return snapshot
+  const binary = gunzipSync(bytes)
+  return decodeSnapshotBinary(binary)
 }
 
 /**

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -2,9 +2,9 @@ import type { AcExOsnapCatalog } from './AcExOsnapPrimitiveTypes'
 
 /**
  * Current snapshot schema version.
- * Increment when breaking changes are introduced to {@link AcExSnapshotV1}.
+ * Increment when breaking changes are introduced to {@link AcExSnapshot}.
  */
-export const ACEX_SNAPSHOT_VERSION = 1 as const
+export const ACEX_SNAPSHOT_VERSION = 2 as const
 
 /**
  * Literal type of the supported snapshot schema version.
@@ -118,19 +118,19 @@ export interface AcExLineBatch {
    * Flat vertex buffer: `[x0, y0, z0, x1, y1, z1, …]` in local space
    * before {@link AcExLineBatch.offset} is applied.
    */
-  positions: number[]
+  positions: Float32Array
   /**
    * Optional index buffer referencing vertices in {@link AcExLineBatch.positions}.
    * When omitted, positions are consumed sequentially as segment pairs.
    */
-  indices?: number[]
+  indices?: Uint32Array
   /** Optional linetype pattern for dashed/dotted lines. */
   linePattern?: AcExLinePattern
   /**
    * Per-vertex cumulative distance along the polyline, required when
    * {@link AcExLineBatch.linePattern} is set.
    */
-  lineDistances?: number[]
+  lineDistances?: Float32Array
 }
 
 /**
@@ -164,12 +164,12 @@ export interface AcExMeshBatch {
    * Flat vertex buffer: `[x0, y0, z0, x1, y1, z1, …]` in local space
    * before {@link AcExMeshBatch.offset} is applied.
    */
-  positions: number[]
+  positions: Float32Array
   /**
    * Triangle index buffer into {@link AcExMeshBatch.positions}.
    * When omitted, a single triangle may be inferred from the first three vertices.
    */
-  indices?: number[]
+  indices?: Uint32Array
   /** Optional hatch pattern for non-solid fills. */
   hatchPattern?: AcExHatchPattern
   /** Optional gradient fill parameters for gradient hatches. */
@@ -178,7 +178,7 @@ export interface AcExMeshBatch {
    * Normalized gradient coordinates per vertex `[x0, y0, x1, y1, …]`.
    * Required when {@link AcExMeshBatch.gradientFill} is set.
    */
-  gradientPositions?: number[]
+  gradientPositions?: Float32Array
   /** Material side when a custom fill shader is used (`0` = front, `1` = back). */
   side?: number
 }
@@ -207,8 +207,7 @@ export interface AcExLayoutSnapshot {
    *
    * When {@link AcExOsnapCatalog.primitives} is non-empty, {@link AcExOsnapIndex}
    * uses these definitions exclusively and does **not** snap to discretized
-   * {@link AcExLineBatch} / {@link AcExMeshBatch} vertices. Older HTML files
-   * without this field continue to use batch-based snapping.
+   * {@link AcExLineBatch} / {@link AcExMeshBatch} vertices.
    */
   osnap?: AcExOsnapCatalog
 }
@@ -216,8 +215,12 @@ export interface AcExLayoutSnapshot {
 /**
  * Display-only snapshot embedded in exported HTML.
  * Does not contain DXF/DWG bytes, `AcDb` entity records, or editable drawing state.
+ *
+ * Geometry buffers ({@link AcExLineBatch.positions}, indices, distances, etc.)
+ * are stored as typed arrays in memory and serialized as raw binary in
+ * {@link encodeSnapshot} / {@link decodeSnapshot}.
  */
-export interface AcExSnapshotV1 {
+export interface AcExSnapshot {
   /** Schema version; must equal {@link ACEX_SNAPSHOT_VERSION}. */
   version: AcExSnapshotVersion
   /** Document-level metadata and viewer defaults. */

--- a/packages/cad-html-plugin/src/AcExViewerMetadata.ts
+++ b/packages/cad-html-plugin/src/AcExViewerMetadata.ts
@@ -24,7 +24,7 @@ export interface AcExViewerMetadata {
  *
  * @param database - Open `AcDbDatabase` to read sysvars and extents from.
  * @param options - Optional title override and background color (default `0x000000`).
- * @returns Metadata object suitable for {@link AcExSnapshotV1.meta}.
+ * @returns Metadata object suitable for {@link AcExSnapshot.meta}.
  */
 export function buildViewerMetadata(
   database: AcDbDatabase,

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -8,6 +8,11 @@
 export * from './AcExSnapshotTypes'
 /** Gzip/base64 encode and decode for embedded snapshot payloads. */
 export * from './AcExSnapshotCodec'
+/** Binary snapshot serialization used by {@link encodeSnapshot}. */
+export {
+  decodeSnapshotBinary,
+  encodeSnapshotBinary
+} from './AcExSnapshotBinaryCodec'
 /** THREE.js scene traversal helpers that produce export batches. */
 export * from './AcExSceneBatchCollector'
 /** Database metadata extraction for snapshot `meta` fields. */


### PR DESCRIPTION
## Summary

This PR upgrades the HTML export snapshot format from **v1 (JSON + gzip + base64)** to **v2 (custom binary + gzip + base64)** and stores geometry data in typed arrays instead of plain `number[]` arrays.

Key changes:

- Bump `ACEX_SNAPSHOT_VERSION` from `1` to `2` and rename `AcExSnapshotV1` to `AcExSnapshot`.
- Add `AcExSnapshotBinaryCodec` to serialize metadata as length-prefixed UTF-8 JSON and geometry buffers as raw `Float32Array` / `Uint32Array` bytes.
- Update `encodeSnapshot` / `decodeSnapshot` to use the binary codec; MIME type changes from `application/vnd.mlightcad.acex-snapshot+json` to `application/vnd.mlightcad.acex-snapshot+binary`.
- Refactor batch geometry handling to use typed arrays throughout the export pipeline (`AcExSceneBatchCollector`, `AcExPatternSnapshot`, `AcExLayerExtents`).
- Extract shared buffer helpers into `AcExBatchBuffers` (`applyOffsetToPositions`, `copyFloat32Range`, `copyUint32Range`) and reuse them in the offline viewer runtime.
- Update tests to cover typed-array geometry and binary round-trip encoding/decoding.

## Motivation

JSON serialization of large vertex/index arrays is slow and produces oversized HTML exports. A compact binary layout with typed arrays reduces payload size and improves export/decode performance while keeping the same in-memory snapshot structure.

## Breaking changes

- **Snapshot v1 HTML files are not compatible with this version.** Only snapshots produced with v2 can be decoded by the updated viewer runtime.
- Public type rename: `AcExSnapshotV1` → `AcExSnapshot`.

## Test plan

- [ ] Run `cad-html-plugin` unit tests (`AcExSnapshotCodec`, `AcExSceneBatchCollector`, `AcExPatternSnapshot`, `AcExLayerExtents`, `AcExOsnap`).
- [ ] Export a drawing to HTML and confirm the file opens correctly in the offline viewer.
- [ ] Verify line batches with linetype patterns, hatch fills, and gradient fills render as expected.
- [ ] Verify layer visibility toggling and layer extents/zoom still work.
- [ ] Compare exported HTML file size before/after on a medium-to-large drawing.
- [ ] Confirm object snap behavior is unchanged for drawings with osnap catalogs.