### PR TITLE
fix(html-plugin): preserve large-coordinate precision with rebased geometry and float64 batch origins

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
@@ -171,4 +171,36 @@ describe('AcExOsnapIndex', () => {
     const snap = index.findSnap(1.5, 0.2, 2)
     expect(snap).toEqual({ x: 0, y: 0, mode: 'endpoint' })
   })
+
+  it('rebuilds large tessellated layouts without blowing the call stack', () => {
+    const positions = new Float32Array(200_000 * 6)
+    for (let i = 0; i < 200_000; i++) {
+      const base = i * 6
+      positions[base] = i
+      positions[base + 1] = 0
+      positions[base + 3] = i + 1
+      positions[base + 4] = 0
+    }
+    const largeLayout = {
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0] as [number, number, number],
+          positions
+        }
+      ],
+      meshBatches: []
+    }
+    const index = new AcExOsnapIndex(['endpoint'])
+    expect(() => index.rebuild(largeLayout, () => true)).not.toThrow()
+    expect(index.findSnap(0.2, 0.1, 1)).toEqual({
+      x: 0,
+      y: 0,
+      mode: 'endpoint'
+    })
+  })
 })

--- a/packages/cad-html-plugin/__tests__/AcExRebase.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExRebase.spec.ts
@@ -1,0 +1,63 @@
+import { toWcsCoord } from '../src/AcExBatchBuffers'
+import { AcExOsnapIndex } from '../src/AcExOsnap'
+
+describe('rebase and measurement precision', () => {
+  it('combines float32 local vertices with double origins in WCS', () => {
+    const origin = 1_000_000_000.5
+    const local = 0.125
+    expect(toWcsCoord(local, origin)).toBe(1_000_000_000.625)
+  })
+
+  it('snaps using analytic osnap primitives stored as number', () => {
+    const origin = 5_000_000
+    const layout = {
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [],
+      meshBatches: [],
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: origin + 0.25,
+            y0: origin + 0.5,
+            x1: origin + 10.25,
+            y1: origin + 0.5
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['endpoint'])
+    index.rebuild(layout, () => true)
+    const snap = index.findSnap(origin + 0.26, origin + 0.51, 1)
+    expect(snap).toEqual({
+      x: origin + 0.25,
+      y: origin + 0.5,
+      mode: 'endpoint'
+    })
+  })
+
+  it('derives WCS from rebased batch geometry without baking the origin', () => {
+    const origin = 2_000_000_000
+    const layout = {
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [origin, origin, 0] as [number, number, number],
+          positions: Float32Array.from([0, 0, 0, 100, 0, 0])
+        }
+      ],
+      meshBatches: []
+    }
+    const index = new AcExOsnapIndex(['endpoint'])
+    index.rebuild(layout, () => true)
+    const snap = index.findSnap(origin + 0.1, origin + 0.1, 1)
+    expect(snap).toEqual({ x: origin, y: origin, mode: 'endpoint' })
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
@@ -104,4 +104,60 @@ describe('AcExSnapshotCodec', () => {
     expect(Array.from(mesh.indices!)).toEqual([0, 1, 2])
     expect(Array.from(mesh.gradientPositions!)).toEqual([0, 0, 1, 0, 0, 1])
   })
+
+  it('preserves large rebase origins as float64', () => {
+    const largeOrigin = 1_234_567_890.125
+    const snapshot = {
+      version: ACEX_SNAPSHOT_VERSION,
+      meta: {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        extents: {
+          minX: largeOrigin,
+          minY: largeOrigin,
+          maxX: largeOrigin + 10,
+          maxY: largeOrigin + 10
+        },
+        units: {
+          insunits: 4,
+          lunits: 2,
+          luprec: 4,
+          aunits: 0,
+          auprec: 0,
+          measurement: 1,
+          ltscale: 1,
+          angbase: 0,
+          angdir: 0
+        },
+        background: 0
+      },
+      layers: [{ name: '0', color: 0xffffff, visible: true }],
+      layouts: [
+        {
+          btrId: 'ms',
+          name: '*Model_Space',
+          isModelSpace: true,
+          lineBatches: [
+            {
+              layer: '0',
+              color: 0xff0000,
+              offset: [largeOrigin, largeOrigin + 100, 0] as [
+                number,
+                number,
+                number
+              ],
+              positions: f32([0.5, 1.25, 0, 10.5, 2.75, 0])
+            }
+          ],
+          meshBatches: []
+        }
+      ],
+      activeLayoutBtrId: 'ms'
+    }
+
+    const line = decodeSnapshot(encodeSnapshot(snapshot)).layouts[0]!
+      .lineBatches[0]!
+    expect(line.offset[0]).toBe(largeOrigin)
+    expect(line.offset[1]).toBe(largeOrigin + 100)
+    expect(Array.from(line.positions)).toEqual([0.5, 1.25, 0, 10.5, 2.75, 0])
+  })
 })

--- a/packages/cad-html-plugin/src/AcExBatchBuffers.ts
+++ b/packages/cad-html-plugin/src/AcExBatchBuffers.ts
@@ -1,25 +1,4 @@
 /**
- * Applies a world-space offset to a flat XYZ {@link Float32Array} position buffer.
- *
- * @param positions - Local-space vertex buffer (`itemSize` 3).
- * @param offset - Translation added to every vertex.
- * @returns A new buffer with the offset baked in.
- */
-export function applyOffsetToPositions(
-  positions: Float32Array,
-  offset: [number, number, number]
-): Float32Array {
-  const result = new Float32Array(positions.length)
-  const [ox, oy, oz] = offset
-  for (let i = 0; i < positions.length; i += 3) {
-    result[i] = positions[i]! + ox
-    result[i + 1] = positions[i + 1]! + oy
-    result[i + 2] = positions[i + 2]! + oz
-  }
-  return result
-}
-
-/**
  * Copies a contiguous span from an array-like source into a {@link Float32Array}.
  *
  * @internal
@@ -57,4 +36,14 @@ export function copyUint32Range(
     result[i] = array[start + i]!
   }
   return result
+}
+
+/**
+ * Converts one rebased local coordinate plus batch origin to WCS using double precision.
+ *
+ * Used by extent and legacy batch-based OSNAP paths so large origins are not
+ * baked into {@link Float32Array} vertex buffers.
+ */
+export function toWcsCoord(local: number, origin: number): number {
+  return local + origin
 }

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -2,7 +2,6 @@ import { FLOAT_TOL } from '@mlightcad/data-model'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 
-import { applyOffsetToPositions } from './AcExBatchBuffers'
 import { AcExHtmlI18n, detectAcExHtmlLocale } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import { computeLayerExtentsMap } from './AcExLayerExtents'
@@ -526,8 +525,10 @@ function setupLayerPanel(
 function createLineObject(batch: AcExLineBatch): THREE.LineSegments | null {
   if (batch.positions.length < 6) return null
   const geometry = new THREE.BufferGeometry()
-  const positions = applyOffsetToPositions(batch.positions, batch.offset)
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geometry.setAttribute(
+    'position',
+    new THREE.BufferAttribute(batch.positions, 3)
+  )
   if (batch.indices && batch.indices.length > 0) {
     geometry.setIndex(new THREE.BufferAttribute(batch.indices, 1))
   }
@@ -542,7 +543,9 @@ function createLineObject(batch: AcExLineBatch): THREE.LineSegments | null {
     )
   }
   const material = createViewerLineMaterial(batch)
-  return new THREE.LineSegments(geometry, material)
+  const object = new THREE.LineSegments(geometry, material)
+  object.position.set(batch.offset[0], batch.offset[1], batch.offset[2])
+  return object
 }
 
 /** Same defaults as {@link AcTrBaseView#createCameraControls}. */
@@ -603,11 +606,13 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
     return null
   }
   const geometry = new THREE.BufferGeometry()
-  const positions = applyOffsetToPositions(batch.positions, batch.offset)
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geometry.setAttribute(
+    'position',
+    new THREE.BufferAttribute(batch.positions, 3)
+  )
   if (batch.indices && batch.indices.length > 0) {
     geometry.setIndex(new THREE.BufferAttribute(batch.indices, 1))
-  } else if (positions.length >= 9) {
+  } else if (batch.positions.length >= 9) {
     geometry.setIndex([0, 1, 2])
   }
   if (
@@ -621,7 +626,9 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
     )
   }
   const material = createViewerMeshMaterial(batch)
-  return new THREE.Mesh(geometry, material)
+  const object = new THREE.Mesh(geometry, material)
+  object.position.set(batch.offset[0], batch.offset[1], batch.offset[2])
+  return object
 }
 
 bootstrap()

--- a/packages/cad-html-plugin/src/AcExLayerExtents.ts
+++ b/packages/cad-html-plugin/src/AcExLayerExtents.ts
@@ -1,3 +1,4 @@
+import { toWcsCoord } from './AcExBatchBuffers'
 import type {
   AcExExtents,
   AcExLineBatch,
@@ -50,8 +51,8 @@ export function expandExtentsFromPositions(
   const ox = offset[0]
   const oy = offset[1]
   for (let i = 0; i + 2 < positions.length; i += 3) {
-    const x = positions[i]! + ox
-    const y = positions[i + 1]! + oy
+    const x = toWcsCoord(positions[i]!, ox)
+    const y = toWcsCoord(positions[i + 1]!, oy)
     if (!extents.valid) {
       extents.minX = extents.maxX = x
       extents.minY = extents.maxY = y

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -1,5 +1,6 @@
 import { FLOAT_TOL } from '@mlightcad/data-model'
 
+import { toWcsCoord } from './AcExBatchBuffers'
 import { collectPrimitiveSnapCandidates, distSq } from './AcExOsnapGeometry'
 import type {
   AcExOsnapMode,
@@ -67,6 +68,23 @@ function closestPointOnSegment(
   return { x, y, distSq: distSq(px, py, x, y) }
 }
 
+function appendSegments(
+  target: AcExOsnapSegment[],
+  source: Iterable<AcExOsnapSegment>
+): void {
+  for (const seg of source) {
+    target.push(seg)
+  }
+}
+
+function segmentsFromIterable(
+  source: Iterable<AcExOsnapSegment>
+): AcExOsnapSegment[] {
+  const result: AcExOsnapSegment[] = []
+  appendSegments(result, source)
+  return result
+}
+
 function* iterLineSegments(batch: AcExLineBatch): Generator<AcExOsnapSegment> {
   const [ox, oy] = batch.offset
   const p = batch.positions
@@ -75,20 +93,20 @@ function* iterLineSegments(batch: AcExLineBatch): Generator<AcExOsnapSegment> {
       const i0 = batch.indices[i]! * 3
       const i1 = batch.indices[i + 1]! * 3
       yield {
-        x0: p[i0]! + ox,
-        y0: p[i0 + 1]! + oy,
-        x1: p[i1]! + ox,
-        y1: p[i1 + 1]! + oy
+        x0: toWcsCoord(p[i0]!, ox),
+        y0: toWcsCoord(p[i0 + 1]!, oy),
+        x1: toWcsCoord(p[i1]!, ox),
+        y1: toWcsCoord(p[i1 + 1]!, oy)
       }
     }
     return
   }
   for (let i = 0; i + 5 < p.length; i += 6) {
     yield {
-      x0: p[i]! + ox,
-      y0: p[i + 1]! + oy,
-      x1: p[i + 3]! + ox,
-      y1: p[i + 4]! + oy
+      x0: toWcsCoord(p[i]!, ox),
+      y0: toWcsCoord(p[i + 1]!, oy),
+      x1: toWcsCoord(p[i + 3]!, ox),
+      y1: toWcsCoord(p[i + 4]!, oy)
     }
   }
 }
@@ -215,8 +233,8 @@ function readBatchVertex(
   const [ox, oy] = batch.offset
   const base = vertexIndex * 3
   return {
-    x: batch.positions[base]! + ox,
-    y: batch.positions[base + 1]! + oy
+    x: toWcsCoord(batch.positions[base]!, ox),
+    y: toWcsCoord(batch.positions[base + 1]!, oy)
   }
 }
 
@@ -245,7 +263,7 @@ function extractPatternLineSnapSegments(
   batch: AcExLineBatch
 ): AcExOsnapSegment[] {
   if (!batch.indices || batch.indices.length < 2) {
-    return mergeConnectedSegments([...iterLineSegments(batch)])
+    return mergeConnectedSegments(segmentsFromIterable(iterLineSegments(batch)))
   }
 
   const edges: Array<{ a: number; b: number }> = []
@@ -326,7 +344,9 @@ function extractPatternLineSnapSegments(
     })
   }
 
-  return logical.length > 0 ? logical : [...iterLineSegments(batch)]
+  return logical.length > 0
+    ? logical
+    : segmentsFromIterable(iterLineSegments(batch))
 }
 
 /**
@@ -352,7 +372,7 @@ export function extractLineBatchSnapSegments(
   if (batch.linePattern) {
     return extractPatternLineSnapSegments(batch)
   }
-  return [...iterLineSegments(batch)]
+  return segmentsFromIterable(iterLineSegments(batch))
 }
 
 /**
@@ -376,7 +396,7 @@ function collectBatchSegments(
   const segments: AcExOsnapSegment[] = []
   for (const batch of layout.lineBatches) {
     if (!isLayerVisible(batch.layer)) continue
-    segments.push(...extractLineBatchSnapSegments(batch))
+    appendSegments(segments, extractLineBatchSnapSegments(batch))
   }
   for (const batch of layout.meshBatches) {
     if (!isLayerVisible(batch.layer)) continue
@@ -391,8 +411,8 @@ function* iterMeshEdges(batch: AcExMeshBatch): Generator<AcExOsnapSegment> {
   const [ox, oy] = batch.offset
   const p = batch.positions
   const read = (vi: number): { x: number; y: number } => ({
-    x: p[vi * 3]! + ox,
-    y: p[vi * 3 + 1]! + oy
+    x: toWcsCoord(p[vi * 3]!, ox),
+    y: toWcsCoord(p[vi * 3 + 1]!, oy)
   })
 
   function* triangleEdges(
@@ -521,7 +541,12 @@ export class AcExOsnapIndex {
     const catalog = layout.osnap
     this.primitives =
       catalog?.primitives.filter(p => isLayerVisible(p.layer)) ?? []
-    this.segments = collectBatchSegments(layout, isLayerVisible)
+    // Tessellated batches can contain millions of edges; skip them when analytic
+    // osnap data is available (avoids stack overflow and unnecessary work).
+    this.segments =
+      this.primitives.length > 0
+        ? []
+        : collectBatchSegments(layout, isLayerVisible)
 
     this.indexedItems = []
     for (let i = 0; i < this.primitives.length; i++) {

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
@@ -2,6 +2,8 @@
  * Object snap (OSNAP) types for the offline HTML viewer.
  *
  * These definitions describe **analytic** geometry in world coordinates (WCS, XY plane).
+ * All coordinate fields use IEEE-754 `number` (double precision) for measurement-grade
+ * accuracy on large-coordinate drawings.
  * They are serialized per layout in {@link AcExLayoutSnapshot.osnap} at export time
  * (see {@link buildOsnapCatalog}) and consumed at runtime by {@link AcExOsnapIndex}
  * instead of tessellated render batches.

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -177,6 +177,7 @@ function resolveExportedHatchPattern(
 }
 
 function readWorldOffset(object: THREE.Object3D): [number, number, number] {
+  // Batched geometry is rebased: vertices are local and object.position is the origin.
   const p = object.position
   return [p.x, p.y, p.z]
 }

--- a/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
@@ -131,9 +131,9 @@ function readLayout(reader: BinaryReader): AcExLayoutSnapshot {
 function writeLineBatch(writer: BinaryWriter, batch: AcExLineBatch): void {
   writer.writeString(batch.layer)
   writer.writeU32(batch.color >>> 0)
-  writer.writeF32(batch.offset[0]!)
-  writer.writeF32(batch.offset[1]!)
-  writer.writeF32(batch.offset[2]!)
+  writer.writeF64(batch.offset[0]!)
+  writer.writeF64(batch.offset[1]!)
+  writer.writeF64(batch.offset[2]!)
   writer.writeFloat32Array(batch.positions)
 
   let flags = 0
@@ -159,9 +159,9 @@ function readLineBatch(reader: BinaryReader): AcExLineBatch {
   const layer = reader.readString()
   const color = reader.readU32()
   const offset: [number, number, number] = [
-    reader.readF32(),
-    reader.readF32(),
-    reader.readF32()
+    reader.readF64(),
+    reader.readF64(),
+    reader.readF64()
   ]
   const positions = reader.readFloat32Array()
   const flags = reader.readU8()
@@ -183,9 +183,9 @@ function readLineBatch(reader: BinaryReader): AcExLineBatch {
 function writeMeshBatch(writer: BinaryWriter, batch: AcExMeshBatch): void {
   writer.writeString(batch.layer)
   writer.writeU32(batch.color >>> 0)
-  writer.writeF32(batch.offset[0]!)
-  writer.writeF32(batch.offset[1]!)
-  writer.writeF32(batch.offset[2]!)
+  writer.writeF64(batch.offset[0]!)
+  writer.writeF64(batch.offset[1]!)
+  writer.writeF64(batch.offset[2]!)
   writer.writeFloat32Array(batch.positions)
 
   let flags = 0
@@ -219,9 +219,9 @@ function readMeshBatch(reader: BinaryReader): AcExMeshBatch {
   const layer = reader.readString()
   const color = reader.readU32()
   const offset: [number, number, number] = [
-    reader.readF32(),
-    reader.readF32(),
-    reader.readF32()
+    reader.readF64(),
+    reader.readF64(),
+    reader.readF64()
   ]
   const positions = reader.readFloat32Array()
   const flags = reader.readU8()
@@ -270,6 +270,13 @@ class BinaryWriter {
     new DataView(chunk.buffer).setFloat32(0, value, true)
     this.chunks.push(chunk)
     this.length += 4
+  }
+
+  writeF64(value: number): void {
+    const chunk = new Uint8Array(8)
+    new DataView(chunk.buffer).setFloat64(0, value, true)
+    this.chunks.push(chunk)
+    this.length += 8
   }
 
   writeBytes(bytes: Uint8Array): void {
@@ -346,6 +353,17 @@ class BinaryReader {
     )
     const value = view.getFloat32(0, true)
     this.offset += 4
+    return value
+  }
+
+  readF64(): number {
+    const view = new DataView(
+      this.bytes.buffer,
+      this.bytes.byteOffset + this.offset,
+      8
+    )
+    const value = view.getFloat64(0, true)
+    this.offset += 8
     return value
   }
 

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -112,11 +112,11 @@ export interface AcExLineBatch {
   layer: string
   /** Line color as 24-bit RGB hex. */
   color: number
-  /** World-space translation applied to every vertex after unpacking. */
+  /** Rebase origin (world translation) stored in double precision; not baked into {@link AcExLineBatch.positions}. */
   offset: [number, number, number]
   /**
-   * Flat vertex buffer: `[x0, y0, z0, x1, y1, z1, …]` in local space
-   * before {@link AcExLineBatch.offset} is applied.
+   * Rebased local vertex buffer: `[x0, y0, z0, x1, y1, z1, …]`.
+   * World position = local + {@link AcExLineBatch.offset} (applied via object transform at render time).
    */
   positions: Float32Array
   /**
@@ -158,11 +158,11 @@ export interface AcExMeshBatch {
   layer: string
   /** Fill color as 24-bit RGB hex. */
   color: number
-  /** World-space translation applied to every vertex after unpacking. */
+  /** Rebase origin (world translation) stored in double precision; not baked into {@link AcExMeshBatch.positions}. */
   offset: [number, number, number]
   /**
-   * Flat vertex buffer: `[x0, y0, z0, x1, y1, z1, …]` in local space
-   * before {@link AcExMeshBatch.offset} is applied.
+   * Rebased local vertex buffer: `[x0, y0, z0, x1, y1, z1, …]`.
+   * World position = local + {@link AcExMeshBatch.offset} (applied via object transform at render time).
    */
   positions: Float32Array
   /**
@@ -204,6 +204,9 @@ export interface AcExLayoutSnapshot {
    * Populated at export time by {@link buildOsnapCatalog} from the drawing database
    * (not from tessellated THREE batches). Includes lines, arcs, circles, ellipses,
    * splines, and points in WCS, including entities inside block references.
+   *
+   * Coordinates are stored as IEEE-754 `number` (double) in JSON for measurement-grade
+   * precision; they are not converted to {@link Float32Array}.
    *
    * When {@link AcExOsnapCatalog.primitives} is non-empty, {@link AcExOsnapIndex}
    * uses these definitions exclusively and does **not** snap to discretized


### PR DESCRIPTION
## Summary

This PR improves large-coordinate handling in the HTML viewer by keeping batch geometry **rebased** instead of baking world-space offsets into `Float32Array` vertex buffers. Rebase origins are stored and serialized in **double precision**, while local vertices remain in `Float32Array` for rendering efficiency.

Key changes:

- **Rebased rendering pipeline** — Line and mesh batches now keep local `Float32Array` positions and apply the batch `offset` via `THREE.Object3D.position` at render time, rather than pre-merging offset into vertex data (`applyOffsetToPositions` removed).
- **Float64 batch origins in snapshot codec** — Line/mesh batch `offset` fields are encoded/decoded as `float64` in the binary snapshot format to preserve measurement-grade precision for large WCS coordinates.
- **WCS coordinate helper** — Introduces `toWcsCoord(local, origin)` for combining float32 local coordinates with double-precision origins in layer extents, OSNAP, and legacy batch-based snap paths.
- **OSNAP robustness** — Replaces spread-based segment collection (which could overflow the call stack on large tessellated layouts) with iterative `appendSegments` / `segmentsFromIterable`. When analytic OSNAP primitives are present, tessellated batch segments are skipped entirely.
- **Documentation & types** — Updates snapshot and OSNAP type docs to clarify the rebase model and double-precision coordinate semantics.

## Motivation

Drawings with large world coordinates (e.g. survey/GIS data) lose precision when offsets are stored as `float32` or baked into vertex buffers. Separating a double-precision origin from local float32 vertices matches the relative-to-eye rendering approach and keeps snapping, extents, and serialization accurate at scale.

## Test plan

- [x] `AcExRebase.spec.ts` — WCS conversion, analytic OSNAP with large origins, and rebased batch geometry
- [x] `AcExOsnap.spec.ts` — rebuild with 200k tessellated segments does not throw (stack overflow regression)
- [x] `AcExSnapshotCodec.spec.ts` — large rebase origins round-trip as float64 through encode/decode
- [ ] Manual: open an HTML export of a large-coordinate drawing and verify geometry renders correctly
- [ ] Manual: verify object snap (endpoint, midpoint, etc.) remains accurate near large coordinate values
- [ ] Manual: confirm zoom-to-extents and layer extents behave correctly after rebase changes