### PR TITLE
perf(html-plugin): reduce offline viewer memory and avoid osnap index rebuilds on layer toggle

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
@@ -40,29 +40,43 @@ describe('AcExOsnapIndex', () => {
 
   it('snaps to the nearest endpoint within threshold', () => {
     const index = new AcExOsnapIndex(['endpoint'])
-    index.rebuild(layout, () => true)
+    index.rebuild(layout)
     const snap = index.findSnap(0.4, 0.2, 1)
     expect(snap).toEqual({ x: 0, y: 0, mode: 'endpoint' })
   })
 
   it('snaps to segment midpoint', () => {
     const index = new AcExOsnapIndex(['midpoint'])
-    index.rebuild(layout, () => true)
+    index.rebuild(layout)
     const snap = index.findSnap(5.1, 0.1, 1)
     expect(snap).toEqual({ x: 5, y: 0, mode: 'midpoint' })
   })
 
   it('prefers endpoint over nearest on the same segment', () => {
     const index = new AcExOsnapIndex(['endpoint', 'nearest'])
-    index.rebuild(layout, () => true)
+    index.rebuild(layout)
     const snap = index.findSnap(0.2, 0.1, 1)
     expect(snap?.mode).toBe('endpoint')
   })
 
   it('ignores geometry on hidden layers', () => {
     const index = new AcExOsnapIndex(['endpoint'])
-    index.rebuild(layout, name => name !== '0')
+    index.rebuild(layout)
+    index.setLayerHidden('0', true)
     expect(index.findSnap(0.1, 0.1, 1)).toBeUndefined()
+  })
+
+  it('toggles layer visibility without rebuilding the spatial index', () => {
+    const index = new AcExOsnapIndex(['endpoint'])
+    index.rebuild(layout)
+    index.hideAllLayers(['0'])
+    expect(index.findSnap(0.1, 0.1, 1)).toBeUndefined()
+    index.showAllLayers()
+    expect(index.findSnap(0.1, 0.1, 1)).toEqual({
+      x: 0,
+      y: 0,
+      mode: 'endpoint'
+    })
   })
 
   it('uses analytic primitives instead of tessellated segments', () => {
@@ -82,7 +96,7 @@ describe('AcExOsnapIndex', () => {
       }
     }
     const index = new AcExOsnapIndex(['center'])
-    index.rebuild(primitiveLayout, () => true)
+    index.rebuild(primitiveLayout)
     const snap = index.findSnap(50.2, 0.1, 2)
     expect(snap).toEqual({ x: 50, y: 0, mode: 'center' })
   })
@@ -104,7 +118,7 @@ describe('AcExOsnapIndex', () => {
       }
     }
     const index = new AcExOsnapIndex(['center', 'nearest'])
-    index.rebuild(primitiveLayout, () => true)
+    index.rebuild(primitiveLayout)
     const snap = index.findSnap(0.5, 0.5, 5)
     expect(snap?.mode).toBe('center')
   })
@@ -131,7 +145,7 @@ describe('AcExOsnapIndex', () => {
       lineBatches: [batch]
     }
     const index = new AcExOsnapIndex(['endpoint'])
-    index.rebuild(patternedLayout, () => true)
+    index.rebuild(patternedLayout)
     const snap = index.findSnap(9.8, 0.1, 1)
     expect(snap).toEqual({ x: 10, y: 0, mode: 'endpoint' })
   })
@@ -167,7 +181,7 @@ describe('AcExOsnapIndex', () => {
       }
     }
     const index = new AcExOsnapIndex(['endpoint'])
-    index.rebuild(hybridLayout, () => true)
+    index.rebuild(hybridLayout)
     const snap = index.findSnap(1.5, 0.2, 2)
     expect(snap).toEqual({ x: 0, y: 0, mode: 'endpoint' })
   })
@@ -196,7 +210,7 @@ describe('AcExOsnapIndex', () => {
       meshBatches: []
     }
     const index = new AcExOsnapIndex(['endpoint'])
-    expect(() => index.rebuild(largeLayout, () => true)).not.toThrow()
+    expect(() => index.rebuild(largeLayout)).not.toThrow()
     expect(index.findSnap(0.2, 0.1, 1)).toEqual({
       x: 0,
       y: 0,

--- a/packages/cad-html-plugin/__tests__/AcExRebase.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExRebase.spec.ts
@@ -30,7 +30,7 @@ describe('rebase and measurement precision', () => {
       }
     }
     const index = new AcExOsnapIndex(['endpoint'])
-    index.rebuild(layout, () => true)
+    index.rebuild(layout)
     const snap = index.findSnap(origin + 0.26, origin + 0.51, 1)
     expect(snap).toEqual({
       x: origin + 0.25,
@@ -56,7 +56,7 @@ describe('rebase and measurement precision', () => {
       meshBatches: []
     }
     const index = new AcExOsnapIndex(['endpoint'])
-    index.rebuild(layout, () => true)
+    index.rebuild(layout)
     const snap = index.findSnap(origin + 0.1, origin + 0.1, 1)
     expect(snap).toEqual({ x: origin, y: origin, mode: 'endpoint' })
   })

--- a/packages/cad-html-plugin/__tests__/AcExViewerMemory.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExViewerMemory.spec.ts
@@ -1,0 +1,158 @@
+import * as THREE from 'three'
+
+import {
+  canReleaseActiveLayoutBatches,
+  copyFloat32Buffer,
+  releaseLayerGroupsGeometryCpuArrays,
+  releaseSnapshotBatchBuffers
+} from '../src/AcExViewerMemory'
+import { ACEX_SNAPSHOT_VERSION } from '../src/AcExSnapshotTypes'
+
+function f32(values: number[]): Float32Array {
+  return Float32Array.from(values)
+}
+
+function makeSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    version: ACEX_SNAPSHOT_VERSION,
+    meta: {
+      createdAt: '',
+      extents: { minX: 0, minY: 0, maxX: 1, maxY: 1 },
+      units: {
+        insunits: 0,
+        lunits: 2,
+        luprec: 2,
+        aunits: 0,
+        auprec: 0,
+        measurement: 1,
+        ltscale: 1,
+        angbase: 0,
+        angdir: 0
+      },
+      background: 0
+    },
+    layers: [],
+    layouts: [
+      {
+        btrId: 'ms',
+        name: 'Model',
+        isModelSpace: true,
+        lineBatches: [
+          {
+            layer: '0',
+            color: 0xffffff,
+            offset: [0, 0, 0] as [number, number, number],
+            positions: f32([0, 0, 0, 1, 0, 0])
+          }
+        ],
+        meshBatches: [],
+        osnap: {
+          primitives: [
+            {
+              kind: 'line' as const,
+              layer: '0',
+              x0: 0,
+              y0: 0,
+              x1: 1,
+              y1: 0
+            }
+          ]
+        }
+      },
+      {
+        btrId: 'ps',
+        name: 'Layout1',
+        isModelSpace: false,
+        lineBatches: [
+          {
+            layer: '0',
+            color: 0xffffff,
+            offset: [0, 0, 0] as [number, number, number],
+            positions: f32([2, 0, 0, 3, 0, 0])
+          }
+        ],
+        meshBatches: []
+      }
+    ],
+    activeLayoutBtrId: 'ms',
+    ...overrides
+  }
+}
+
+describe('AcExViewerMemory', () => {
+  it('copyFloat32Buffer creates an independent array', () => {
+    const source = f32([1, 2, 3])
+    const copy = copyFloat32Buffer(source)
+    source[0] = 99
+    expect(copy[0]).toBe(1)
+  })
+
+  it('canReleaseActiveLayoutBatches requires analytic osnap catalog', () => {
+    const withOsnap = makeSnapshot().layouts[0]!
+    expect(canReleaseActiveLayoutBatches(withOsnap)).toBe(true)
+
+    const withoutOsnap = makeSnapshot({
+      layouts: [
+        {
+          btrId: 'ms',
+          name: 'Model',
+          isModelSpace: true,
+          lineBatches: [],
+          meshBatches: []
+        }
+      ]
+    }).layouts[0]!
+    expect(canReleaseActiveLayoutBatches(withoutOsnap)).toBe(false)
+  })
+
+  it('releaseSnapshotBatchBuffers clears inactive layouts always', () => {
+    const snapshot = makeSnapshot()
+
+    releaseSnapshotBatchBuffers(snapshot, 'ms')
+
+    expect(snapshot.layouts[0]!.lineBatches).toHaveLength(0)
+    expect(snapshot.layouts[1]!.lineBatches).toHaveLength(0)
+  })
+
+  it('releaseSnapshotBatchBuffers keeps active layout batches without osnap catalog', () => {
+    const snapshot = makeSnapshot({
+      layouts: [
+        {
+          btrId: 'ms',
+          name: 'Model',
+          isModelSpace: true,
+          lineBatches: [
+            {
+              layer: '0',
+              color: 0xffffff,
+              offset: [0, 0, 0] as [number, number, number],
+              positions: f32([0, 0, 0, 1, 0, 0])
+            }
+          ],
+          meshBatches: []
+        }
+      ],
+      activeLayoutBtrId: 'ms'
+    })
+
+    releaseSnapshotBatchBuffers(snapshot, 'ms')
+
+    expect(snapshot.layouts[0]!.lineBatches).toHaveLength(1)
+    expect(snapshot.layouts[0]!.lineBatches[0]!.positions).toHaveLength(6)
+  })
+
+  it('releaseLayerGroupsGeometryCpuArrays empties geometry attribute arrays', () => {
+    const group = new THREE.Group()
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(f32([0, 0, 0, 1, 0, 0]), 3)
+    )
+    group.add(new THREE.LineSegments(geometry, new THREE.LineBasicMaterial()))
+
+    releaseLayerGroupsGeometryCpuArrays(new Map([['0', group]]))
+
+    const position = geometry.getAttribute('position') as THREE.BufferAttribute
+    expect(position.array).toHaveLength(0)
+  })
+})

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -18,6 +18,8 @@ export const ACEX_HTML_SHELL_CSS = `
     --mlcad-drawer-width: 220px;
     --mlcad-drawer-gap: 8px;
     --mlcad-ui-inset: 12px;
+    --mlcad-z-chrome: 7;
+    --mlcad-z-measure: 5;
   }
   html, body {
     margin: 0; height: 100%; overflow: hidden;
@@ -37,7 +39,7 @@ export const ACEX_HTML_SHELL_CSS = `
     position: absolute;
     left: var(--mlcad-ui-inset);
     top: 50%;
-    z-index: 4;
+    z-index: var(--mlcad-z-chrome);
     transform: translateY(-50%);
     display: flex;
     align-items: flex-start;
@@ -178,7 +180,7 @@ export const ACEX_HTML_SHELL_CSS = `
   .mlcad-layer-zoom:disabled { opacity: 0.35; cursor: not-allowed; }
 
   #mlcad-status-bar {
-    position: absolute; left: 12px; right: 12px; bottom: 10px; z-index: 3;
+    position: absolute; left: 12px; right: 12px; bottom: 10px; z-index: var(--mlcad-z-chrome);
     display: flex; align-items: center; min-height: 28px; padding: 0 12px;
     border: 1px solid var(--mlcad-ui-border);
     border-radius: 6px;
@@ -198,7 +200,7 @@ export const ACEX_HTML_SHELL_CSS = `
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 5;
+    z-index: var(--mlcad-z-measure);
     overflow: hidden;
   }
   .mlcad-measure-canvas {

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -20,6 +20,13 @@ import type {
   AcExMeshBatch,
   AcExSnapshot
 } from './AcExSnapshotTypes'
+import {
+  copyFloat32Buffer,
+  copyUint32Buffer,
+  releaseLayerGroupsGeometryCpuArrays,
+  releaseSnapshotBatchBuffers,
+  removeSnapshotElement
+} from './AcExViewerMemory'
 
 /** Matches {@link AcTrBaseView} orthographic half-height in world units. */
 const ACEX_CAMERA_FRUSTUM = 400
@@ -134,11 +141,15 @@ function startViewer(): void {
 
   const osnapIndex = new AcExOsnapIndex()
   const osnapMarker = new AcExOsnapMarker(root)
-  const isLayerVisible = (name: string) => layerVisible.get(name) !== false
-  const rebuildOsnapIndex = () => {
-    osnapIndex.rebuild(layout, isLayerVisible)
+  osnapIndex.rebuild(layout)
+  for (const layer of snapshot.layers) {
+    if (!layer.visible) {
+      osnapIndex.setLayerHidden(layer.name, true)
+    }
   }
-  rebuildOsnapIndex()
+
+  releaseSnapshotBatchBuffers(snapshot, snapshot.activeLayoutBtrId)
+  removeSnapshotElement(snapshotEl)
 
   const updateCameraFrustum = (width?: number, height?: number) => {
     const size = getCanvasSize()
@@ -270,7 +281,13 @@ function startViewer(): void {
     i18n,
     render,
     zoomToExtents,
-    rebuildOsnapIndex
+    osnapIndex,
+    sortedLayerNames: [
+      ...new Set([
+        ...snapshot.layers.map(layer => layer.name),
+        ...layerGroups.keys()
+      ])
+    ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
   })
 
   i18n.setOnChange(() => {
@@ -340,6 +357,7 @@ function startViewer(): void {
 
   resize()
   fit()
+  releaseLayerGroupsGeometryCpuArrays(layerGroups)
   statusEl.textContent = readyStatus
   hideLoading()
 }
@@ -370,8 +388,10 @@ interface AcExLayerPanelContext {
   render: () => void
   /** Fits the camera to the given extents and redraws. */
   zoomToExtents: (extents: AcExExtents) => void
-  /** Rebuilds the object-snap index after layer visibility changes. */
-  rebuildOsnapIndex: () => void
+  /** Object-snap index updated when layer visibility changes. */
+  osnapIndex: AcExOsnapIndex
+  /** Sorted layer names for bulk show/hide actions. */
+  sortedLayerNames: string[]
 }
 
 /** Handles returned by {@link setupLayerPanel} for locale-driven UI updates. */
@@ -392,7 +412,8 @@ function setupLayerPanel(
     i18n,
     render,
     zoomToExtents,
-    rebuildOsnapIndex
+    osnapIndex,
+    sortedLayerNames
   } = ctx
 
   const layersBtn = document.getElementById('mlcad-layers-btn')
@@ -405,14 +426,7 @@ function setupLayerPanel(
 
   const layerRows: AcExLayerRowRefs[] = []
 
-  const layerNames = new Set(snapshot.layers.map(layer => layer.name))
-  for (const name of layerGroups.keys()) {
-    layerNames.add(name)
-  }
-
-  const sortedLayers = [...layerNames].sort((a, b) =>
-    a.localeCompare(b, undefined, { numeric: true })
-  )
+  const sortedLayers = sortedLayerNames
 
   const layerMeta = new Map(snapshot.layers.map(layer => [layer.name, layer]))
 
@@ -422,12 +436,19 @@ function setupLayerPanel(
     layerVisible.set(name, visible)
     const group = layerGroups.get(name)
     if (group) group.visible = visible
-    rebuildOsnapIndex()
+    osnapIndex.setLayerHidden(name, !visible)
   }
 
   const setAllLayersVisible = (visible: boolean) => {
     for (const name of sortedLayers) {
-      setLayerVisible(name, visible)
+      layerVisible.set(name, visible)
+      const group = layerGroups.get(name)
+      if (group) group.visible = visible
+    }
+    if (visible) {
+      osnapIndex.showAllLayers()
+    } else {
+      osnapIndex.hideAllLayers(sortedLayers)
     }
     for (const checkbox of checkboxes) {
       checkbox.checked = visible
@@ -527,10 +548,12 @@ function createLineObject(batch: AcExLineBatch): THREE.LineSegments | null {
   const geometry = new THREE.BufferGeometry()
   geometry.setAttribute(
     'position',
-    new THREE.BufferAttribute(batch.positions, 3)
+    new THREE.BufferAttribute(copyFloat32Buffer(batch.positions), 3)
   )
   if (batch.indices && batch.indices.length > 0) {
-    geometry.setIndex(new THREE.BufferAttribute(batch.indices, 1))
+    geometry.setIndex(
+      new THREE.BufferAttribute(copyUint32Buffer(batch.indices), 1)
+    )
   }
   if (
     batch.linePattern &&
@@ -539,7 +562,10 @@ function createLineObject(batch: AcExLineBatch): THREE.LineSegments | null {
   ) {
     geometry.setAttribute(
       'lineDistance',
-      new THREE.Float32BufferAttribute(batch.lineDistances, 1)
+      new THREE.Float32BufferAttribute(
+        copyFloat32Buffer(batch.lineDistances),
+        1
+      )
     )
   }
   const material = createViewerLineMaterial(batch)
@@ -608,10 +634,12 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
   const geometry = new THREE.BufferGeometry()
   geometry.setAttribute(
     'position',
-    new THREE.BufferAttribute(batch.positions, 3)
+    new THREE.BufferAttribute(copyFloat32Buffer(batch.positions), 3)
   )
   if (batch.indices && batch.indices.length > 0) {
-    geometry.setIndex(new THREE.BufferAttribute(batch.indices, 1))
+    geometry.setIndex(
+      new THREE.BufferAttribute(copyUint32Buffer(batch.indices), 1)
+    )
   } else if (batch.positions.length >= 9) {
     geometry.setIndex([0, 1, 2])
   }
@@ -622,7 +650,10 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
   ) {
     geometry.setAttribute(
       'gradientPosition',
-      new THREE.Float32BufferAttribute(batch.gradientPositions, 2)
+      new THREE.Float32BufferAttribute(
+        copyFloat32Buffer(batch.gradientPositions),
+        2
+      )
     )
   }
   const material = createViewerMeshMaterial(batch)

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -378,33 +378,38 @@ export function extractLineBatchSnapSegments(
 /**
  * Collects all tessellated snap segments from a layout snapshot.
  *
- * Iterates visible {@link AcExLayoutSnapshot.lineBatches} through
+ * Iterates {@link AcExLayoutSnapshot.lineBatches} through
  * {@link extractLineBatchSnapSegments} and appends mesh outline edges from
  * {@link AcExLayoutSnapshot.meshBatches}. The result supplements (or replaces,
  * when no catalog is present) analytic {@link AcExLayoutSnapshot.osnap} primitives
  * inside {@link AcExOsnapIndex}.
  *
  * @param layout - Active layout snapshot.
- * @param isLayerVisible - Layer visibility predicate from the offline viewer.
- * @returns Flat list of WCS segments indexed by {@link AcExOsnapIndex.rebuild}.
+ * @returns Flat list of WCS segments and parallel layer names for spatial indexing.
  * @internal
  */
-function collectBatchSegments(
-  layout: AcExLayoutSnapshot,
-  isLayerVisible: (layerName: string) => boolean
-): AcExOsnapSegment[] {
+function collectBatchSegments(layout: AcExLayoutSnapshot): {
+  segments: AcExOsnapSegment[]
+  segmentLayers: string[]
+} {
   const segments: AcExOsnapSegment[] = []
-  for (const batch of layout.lineBatches) {
-    if (!isLayerVisible(batch.layer)) continue
-    appendSegments(segments, extractLineBatchSnapSegments(batch))
+  const segmentLayers: string[] = []
+  const pushSegment = (seg: AcExOsnapSegment, layer: string) => {
+    segments.push(seg)
+    segmentLayers.push(layer)
   }
-  for (const batch of layout.meshBatches) {
-    if (!isLayerVisible(batch.layer)) continue
-    for (const seg of iterMeshEdges(batch)) {
-      segments.push(seg)
+
+  for (const batch of layout.lineBatches) {
+    for (const seg of extractLineBatchSnapSegments(batch)) {
+      pushSegment(seg, batch.layer)
     }
   }
-  return segments
+  for (const batch of layout.meshBatches) {
+    for (const seg of iterMeshEdges(batch)) {
+      pushSegment(seg, batch.layer)
+    }
+  }
+  return { segments, segmentLayers }
 }
 
 function* iterMeshEdges(batch: AcExMeshBatch): Generator<AcExOsnapSegment> {
@@ -509,13 +514,20 @@ type AcExOsnapIndexKind = 'primitive' | 'segment'
 
 export class AcExOsnapIndex {
   private segments: AcExOsnapSegment[] = []
+  private segmentLayers: string[] = []
   private primitives: AcExOsnapPrimitive[] = []
   private indexedItems: Array<
-    { kind: 'primitive'; index: number } | { kind: 'segment'; index: number }
+    | { kind: 'primitive'; index: number; layer: string }
+    | {
+        kind: 'segment'
+        index: number
+        layer: string
+      }
   > = []
   private grid = new Map<string, number[]>()
   private cellSize = 1
   private modes: Set<AcExOsnapMode>
+  private hiddenLayers = new Set<string>()
 
   /**
    * @param modes - Enabled snap modes; defaults to {@link ACEX_DEFAULT_OSNAP_MODES}.
@@ -525,37 +537,74 @@ export class AcExOsnapIndex {
   }
 
   /**
-   * Rebuilds the snap index from the active layout snapshot.
+   * Marks one layer hidden or visible for object snap without rebuilding the index.
    *
-   * Analytic {@link AcExLayoutSnapshot.osnap} primitives are preferred at query
-   * time. Tessellated batches supplement or replace them when the catalog is
-   * absent or does not cover the picked geometry.
+   * @param layerName - Layer to update.
+   * @param hidden - When `true`, snap skips geometry on this layer.
+   */
+  setLayerHidden(layerName: string, hidden: boolean): void {
+    if (hidden) {
+      this.hiddenLayers.add(layerName)
+    } else {
+      this.hiddenLayers.delete(layerName)
+    }
+  }
+
+  /** Makes every indexed layer eligible for object snap. */
+  showAllLayers(): void {
+    this.hiddenLayers.clear()
+  }
+
+  /**
+   * Excludes every listed layer from object snap.
+   *
+   * @param layerNames - Layers to hide from snap queries.
+   */
+  hideAllLayers(layerNames: Iterable<string>): void {
+    this.hiddenLayers.clear()
+    for (const name of layerNames) {
+      this.hiddenLayers.add(name)
+    }
+  }
+
+  /**
+   * Builds the snap index from the active layout snapshot.
+   *
+   * Indexes all analytic and tessellated geometry once. Layer visibility is
+   * applied at query time via {@link setLayerHidden}, {@link showAllLayers}, and
+   * {@link hideAllLayers} so toggling many layers stays O(1).
    *
    * @param layout - Active layout snapshot (batches + optional {@link AcExLayoutSnapshot.osnap}).
-   * @param isLayerVisible - When `false`, primitives/batches on that layer are excluded.
    */
-  rebuild(
-    layout: AcExLayoutSnapshot,
-    isLayerVisible: (layerName: string) => boolean
-  ): void {
+  rebuild(layout: AcExLayoutSnapshot): void {
     const catalog = layout.osnap
-    this.primitives =
-      catalog?.primitives.filter(p => isLayerVisible(p.layer)) ?? []
-    // Tessellated batches can contain millions of edges; skip them when analytic
-    // osnap data is available (avoids stack overflow and unnecessary work).
-    this.segments =
-      this.primitives.length > 0
-        ? []
-        : collectBatchSegments(layout, isLayerVisible)
+    this.primitives = catalog?.primitives ?? []
+    if (this.primitives.length > 0) {
+      this.segments = []
+      this.segmentLayers = []
+    } else {
+      const collected = collectBatchSegments(layout)
+      this.segments = collected.segments
+      this.segmentLayers = collected.segmentLayers
+    }
 
     this.indexedItems = []
     for (let i = 0; i < this.primitives.length; i++) {
-      this.indexedItems.push({ kind: 'primitive', index: i })
+      this.indexedItems.push({
+        kind: 'primitive',
+        index: i,
+        layer: this.primitives[i]!.layer
+      })
     }
     for (let i = 0; i < this.segments.length; i++) {
-      this.indexedItems.push({ kind: 'segment', index: i })
+      this.indexedItems.push({
+        kind: 'segment',
+        index: i,
+        layer: this.segmentLayers[i]!
+      })
     }
 
+    this.hiddenLayers.clear()
     this.grid.clear()
     if (this.indexedItems.length === 0) return
 
@@ -697,6 +746,7 @@ export class AcExOsnapIndex {
           seen.add(index)
           const item = this.indexedItems[index]!
           if (!include(item)) continue
+          if (this.hiddenLayers.has(item.layer)) continue
 
           if (item.kind === 'primitive') {
             const prim = this.primitives[item.index]!

--- a/packages/cad-html-plugin/src/AcExViewerMemory.ts
+++ b/packages/cad-html-plugin/src/AcExViewerMemory.ts
@@ -1,0 +1,110 @@
+import * as THREE from 'three'
+
+import type { AcExLayoutSnapshot, AcExSnapshot } from './AcExSnapshotTypes'
+
+/** Returns a shallow copy of a float vertex buffer. */
+export function copyFloat32Buffer(source: Float32Array): Float32Array {
+  return new Float32Array(source)
+}
+
+/** Returns a shallow copy of an index buffer. */
+export function copyUint32Buffer(source: Uint32Array): Uint32Array {
+  return new Uint32Array(source)
+}
+
+/**
+ * Whether tessellated batch buffers on the active layout can be dropped after
+ * the THREE scene is built.
+ *
+ * When an analytic OSNAP catalog exists, layer visibility toggles filter
+ * primitives only and never re-read {@link AcExLayoutSnapshot.lineBatches}.
+ */
+export function canReleaseActiveLayoutBatches(
+  layout: AcExLayoutSnapshot
+): boolean {
+  return (layout.osnap?.primitives.length ?? 0) > 0
+}
+
+/**
+ * Clears tessellated batch typed arrays on snapshot layouts to reclaim CPU memory.
+ *
+ * Inactive layouts are always cleared. The active layout is cleared only when
+ * {@link canReleaseActiveLayoutBatches} is true so OSNAP can still fall back to
+ * tessellated segments when no analytic catalog was exported.
+ */
+export function releaseSnapshotBatchBuffers(
+  snapshot: AcExSnapshot,
+  activeLayoutBtrId: string
+): void {
+  for (const layout of snapshot.layouts) {
+    const isActive = layout.btrId === activeLayoutBtrId
+    if (!isActive || canReleaseActiveLayoutBatches(layout)) {
+      clearLayoutBatchBuffers(layout)
+    }
+  }
+}
+
+/**
+ * Removes the embedded snapshot script from the DOM after decode.
+ *
+ * The gzip/base64 payload is often the largest resident string in memory.
+ */
+export function removeSnapshotElement(element: HTMLElement): void {
+  element.textContent = ''
+  element.remove()
+}
+
+/**
+ * Drops CPU-side typed arrays for static CAD geometry after the first GPU upload.
+ *
+ * Only traverses layer groups (not measurement overlays). WebGL buffer objects
+ * retain the uploaded data; static display geometry never updates CPU buffers again.
+ */
+export function releaseLayerGroupsGeometryCpuArrays(
+  layerGroups: Map<string, THREE.Group>
+): void {
+  for (const group of layerGroups.values()) {
+    group.traverse(object => {
+      if (
+        object instanceof THREE.Mesh ||
+        object instanceof THREE.LineSegments ||
+        object instanceof THREE.Line ||
+        object instanceof THREE.Points
+      ) {
+        releaseBufferGeometryCpuArrays(object.geometry)
+      }
+    })
+  }
+}
+
+function clearLayoutBatchBuffers(layout: AcExLayoutSnapshot): void {
+  for (const batch of layout.lineBatches) {
+    batch.positions = new Float32Array(0)
+    if (batch.indices) batch.indices = new Uint32Array(0)
+    if (batch.lineDistances) batch.lineDistances = new Float32Array(0)
+  }
+  layout.lineBatches.length = 0
+
+  for (const batch of layout.meshBatches) {
+    batch.positions = new Float32Array(0)
+    if (batch.indices) batch.indices = new Uint32Array(0)
+    if (batch.gradientPositions) batch.gradientPositions = new Float32Array(0)
+  }
+  layout.meshBatches.length = 0
+}
+
+function releaseBufferGeometryCpuArrays(geometry: THREE.BufferGeometry): void {
+  for (const key in geometry.attributes) {
+    const attr = geometry.attributes[key] as THREE.BufferAttribute
+    attr.array = new Float32Array(0)
+    attr.clearUpdateRanges()
+    attr.needsUpdate = false
+  }
+
+  const index = geometry.getIndex()
+  if (index) {
+    index.array = new Uint32Array(0)
+    index.clearUpdateRanges()
+    index.needsUpdate = false
+  }
+}


### PR DESCRIPTION
## Summary

This PR improves memory usage and layer-toggle performance in the offline HTML viewer (`cad-html-plugin`).

- **Memory reclamation after load** — Introduces `AcExViewerMemory` to release CPU-side resources once the THREE.js scene is built:
  - Copy snapshot typed arrays into THREE geometries, then clear layout batch buffers
  - Remove the embedded snapshot `<script>` element from the DOM (often the largest resident string)
  - Drop CPU-side geometry attribute arrays after the first GPU upload
  - Active layout batches are only cleared when an analytic OSNAP catalog exists, so tessellated fallback remains available when no catalog was exported
- **Faster layer visibility toggles** — Refactors `AcExOsnapIndex` to index all geometry once and apply layer visibility at query time via `setLayerHidden` / `showAllLayers` / `hideAllLayers`, instead of rebuilding the spatial index on every toggle
- **UI stacking fix** — Centralizes z-index values for chrome and measurement overlays using CSS variables (`--mlcad-z-chrome`, `--mlcad-z-measure`)

## Changes

| Area | What changed |
|------|--------------|
| `AcExViewerMemory.ts` | New module with buffer copy helpers and memory release utilities |
| `AcExHtmlViewerRuntime.ts` | Integrates memory release pipeline; bulk layer show/hide uses osnap layer filters |
| `AcExOsnap.ts` | Query-time layer filtering; `rebuild()` no longer accepts a visibility predicate |
| `AcExHtmlShell.ts` | CSS z-index variables for toolbar, status bar, and measure overlay |
| Tests | Updated osnap/rebase specs; added `AcExViewerMemory.spec.ts` |

## Test plan

- [ ] Open an exported HTML viewer with a large drawing and confirm geometry renders correctly after load
- [ ] Toggle individual layer visibility and verify geometry and object snap respect hidden layers
- [ ] Use "Show all" / "Hide all" layer actions and confirm snap points update without noticeable lag
- [ ] Verify object snap still works for drawings exported without an analytic OSNAP catalog (tessellated fallback)
- [ ] Confirm measurement overlay renders above the canvas but below toolbar/status bar
- [ ] Run unit tests: `nx test cad-html-plugin`