### PR TITLE
fix(html-plugin): improve hatch export, batch-derived zoom extents, and measurement hit testing

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
@@ -1,0 +1,139 @@
+import { AcTrStyleManager } from '../../three-renderer/src/style/AcTrStyleManager'
+import { getSceneDrawableUserData } from '../../three-renderer/src/util/AcTrObjectUserData'
+import { AcTrSubEntityTraitsUtil } from '../../three-renderer/src/util/AcTrEntityTraitsUtil'
+import * as THREE from 'three'
+
+import {
+  createViewerMeshMaterial,
+  extractHatchPattern
+} from '../src/AcExPatternSnapshot'
+import { collectBatchesFromObject3D } from '../src/AcExSceneBatchCollector'
+import { decodeSnapshot, encodeSnapshot } from '../src/AcExSnapshotCodec'
+import { ACEX_SNAPSHOT_VERSION } from '../src/AcExSnapshotTypes'
+
+function createPatternedHatchMaterial(
+  styleManager: AcTrStyleManager
+): THREE.ShaderMaterial {
+  const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+  traits.layer = 'A-HATCH'
+  traits.rgbColor = 0x00ff00
+  traits.drawOrder = -1
+  traits.fillType = {
+    solidFill: false,
+    patternAngle: 0,
+    definitionLines: [
+      {
+        angle: Math.PI / 4,
+        base: { x: 10, y: 20 },
+        offset: { x: 0, y: 3.175 },
+        dashLengths: [1, -1]
+      }
+    ]
+  }
+  return styleManager.getFillMaterial(traits) as THREE.ShaderMaterial
+}
+
+function cloneUnbatchedHatchMesh(source: THREE.Mesh): THREE.Mesh {
+  const cloned = source.clone() as THREE.Mesh
+  const clonedGeometry = source.geometry.clone()
+  clonedGeometry.applyMatrix4(source.matrixWorld)
+  cloned.geometry = clonedGeometry
+  cloned.material = source.material
+  getSceneDrawableUserData(cloned).bakedWorldMatrix =
+    source.matrixWorld.toArray()
+  cloned.position.set(0, 0, 0)
+  cloned.rotation.set(0, 0, 0)
+  cloned.scale.set(1, 1, 1)
+  cloned.updateMatrix()
+  return cloned
+}
+
+describe('patterned hatch HTML export', () => {
+  it('collects hatch pattern data from unbatched world-baked meshes', () => {
+    const styleManager = new AcTrStyleManager()
+    const material = createPatternedHatchMaterial(styleManager)
+    expect(extractHatchPattern(material)).toBeDefined()
+
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(
+        new Float32Array([0, 0, 0, 10, 0, 0, 0, 10, 0]),
+        3
+      )
+    )
+
+    const source = new THREE.Mesh(geometry, material)
+    source.position.set(100, 200, 0)
+    source.updateMatrixWorld(true)
+
+    const root = new THREE.Group()
+    root.add(cloneUnbatchedHatchMesh(source))
+
+    const { meshBatches } = collectBatchesFromObject3D(root)
+    expect(meshBatches).toHaveLength(1)
+    expect(meshBatches[0]?.hatchPattern?.patternLines.length).toBeGreaterThan(0)
+
+    const viewerMaterial = createViewerMeshMaterial(meshBatches[0]!)
+    expect(viewerMaterial).toBeInstanceOf(THREE.ShaderMaterial)
+    expect(viewerMaterial.type).toBe('ShaderMaterial')
+  })
+
+  it('round-trips hatch patterns through the snapshot codec', () => {
+    const styleManager = new AcTrStyleManager()
+    const material = createPatternedHatchMaterial(styleManager)
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(
+        new Float32Array([0, 0, 0, 10, 0, 0, 0, 10, 0]),
+        3
+      )
+    )
+    const source = new THREE.Mesh(geometry, material)
+    source.updateMatrixWorld(true)
+
+    const root = new THREE.Group()
+    root.add(cloneUnbatchedHatchMesh(source))
+    const { meshBatches } = collectBatchesFromObject3D(root)
+    const batch = meshBatches[0]!
+
+    const snapshot = {
+      version: ACEX_SNAPSHOT_VERSION,
+      meta: {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        extents: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        units: {
+          insunits: 4,
+          lunits: 2,
+          luprec: 4,
+          aunits: 0,
+          auprec: 0,
+          measurement: 1,
+          ltscale: 1,
+          angbase: 0,
+          angdir: 0
+        },
+        background: 0
+      },
+      layers: [{ name: 'A-HATCH', color: 0xffffff, visible: true }],
+      layouts: [
+        {
+          btrId: 'ms',
+          name: '*Model_Space',
+          isModelSpace: true,
+          lineBatches: [],
+          meshBatches: [batch]
+        }
+      ],
+      activeLayoutBtrId: 'ms'
+    }
+
+    const decoded = decodeSnapshot(encodeSnapshot(snapshot))
+    const decodedBatch = decoded.layouts[0]!.meshBatches[0]!
+    expect(decodedBatch.hatchPattern).toEqual(batch.hatchPattern)
+
+    const viewerMaterial = createViewerMeshMaterial(decodedBatch)
+    expect(viewerMaterial).toBeInstanceOf(THREE.ShaderMaterial)
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExLayerExtents.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExLayerExtents.spec.ts
@@ -1,4 +1,8 @@
-import { computeLayerExtentsMap } from '../src/AcExLayerExtents'
+import {
+  computeLayerExtentsMap,
+  computeLayoutExtents,
+  resolveLayoutViewExtents
+} from '../src/AcExLayerExtents'
 
 function f32(values: number[]): Float32Array {
   return Float32Array.from(values)
@@ -35,6 +39,58 @@ describe('AcExLayerExtents', () => {
       minY: 2,
       maxX: 3,
       maxY: 4
+    })
+  })
+
+  it('unions all batches into one layout extent', () => {
+    expect(
+      computeLayoutExtents(
+        [
+          {
+            layer: 'A',
+            color: 0,
+            offset: [0, 0, 0],
+            positions: f32([0, 0, 0, 10, 5, 0])
+          }
+        ],
+        [
+          {
+            layer: 'B',
+            color: 0,
+            offset: [1, 2, 0],
+            positions: f32([0, 0, 0, 2, 2, 0])
+          }
+        ]
+      )
+    ).toEqual({
+      minX: 0,
+      minY: 0,
+      maxX: 10,
+      maxY: 5
+    })
+  })
+
+  it('prefers batch extents over persisted viewExtents fallback', () => {
+    expect(
+      resolveLayoutViewExtents(
+        {
+          lineBatches: [
+            {
+              layer: '0',
+              color: 0,
+              offset: [0, 0, 0],
+              positions: f32([0, 0, 0, 5, 5, 0])
+            }
+          ],
+          meshBatches: []
+        },
+        { minX: 0, minY: 0, maxX: 1000, maxY: 1000 }
+      )
+    ).toEqual({
+      minX: 0,
+      minY: 0,
+      maxX: 5,
+      maxY: 5
     })
   })
 })

--- a/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
@@ -5,6 +5,7 @@ import {
 } from '@mlightcad/cad-simple-viewer'
 import type { AcDbDatabase } from '@mlightcad/data-model'
 
+import { computeLayoutExtents } from './AcExLayerExtents'
 import { buildOsnapCatalog } from './AcExOsnapPrimitiveBuilder'
 import { collectBatchesFromObject3D } from './AcExSceneBatchCollector'
 import {
@@ -119,7 +120,12 @@ export class AcApHtmlSnapshotBuilder {
 
     return {
       version: ACEX_SNAPSHOT_VERSION,
-      meta: buildSnapshotMeta(meta, options),
+      meta: buildSnapshotMeta(
+        meta,
+        options,
+        layouts,
+        scene.activeLayoutBtrId || scene.modelSpaceBtrId
+      ),
       layers,
       layouts,
       activeLayoutBtrId: scene.activeLayoutBtrId || scene.modelSpaceBtrId
@@ -170,7 +176,12 @@ export class AcApHtmlSnapshotBuilder {
 
     return {
       version: ACEX_SNAPSHOT_VERSION,
-      meta: buildSnapshotMeta(meta, options),
+      meta: buildSnapshotMeta(
+        meta,
+        options,
+        layouts,
+        scene.activeLayoutBtrId || scene.modelSpaceBtrId
+      ),
       layers,
       layouts,
       activeLayoutBtrId: scene.activeLayoutBtrId || scene.modelSpaceBtrId
@@ -183,16 +194,27 @@ export class AcApHtmlSnapshotBuilder {
  *
  * @param meta - Extents, units, and background from {@link buildViewerMetadata}.
  * @param options - User overrides (title is taken from `meta`; locale from options).
+ * @param layouts - Exported layouts used to derive {@link AcExSnapshot.meta.viewExtents}.
+ * @param activeLayoutBtrId - Layout shown when the HTML file is first opened.
  * @returns The `meta` block stored on {@link AcExSnapshot}.
  */
 function buildSnapshotMeta(
   meta: ReturnType<typeof buildViewerMetadata>,
-  options: AcApHtmlSnapshotBuilderOptions
+  options: AcApHtmlSnapshotBuilderOptions,
+  layouts: AcExLayoutSnapshot[],
+  activeLayoutBtrId: string
 ) {
+  const activeLayout =
+    layouts.find(layout => layout.btrId === activeLayoutBtrId) ?? layouts[0]
+  const viewExtents = activeLayout
+    ? computeLayoutExtents(activeLayout.lineBatches, activeLayout.meshBatches)
+    : null
+
   return {
     title: meta.title,
     createdAt: new Date().toISOString(),
     extents: meta.extents,
+    viewExtents: viewExtents ?? undefined,
     units: meta.units,
     background: meta.background,
     locale: options.locale ?? AcApI18n.currentLocale

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -4,7 +4,10 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 
 import { AcExHtmlI18n, detectAcExHtmlLocale } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
-import { computeLayerExtentsMap } from './AcExLayerExtents'
+import {
+  computeLayerExtentsMap,
+  resolveLayoutViewExtents
+} from './AcExLayerExtents'
 import { AcExMeasureController, type AcExMeasureMode } from './AcExMeasurement'
 import { AcExOsnapIndex } from './AcExOsnap'
 import { AcExOsnapMarker } from './AcExOsnapMarker'
@@ -138,6 +141,10 @@ function startViewer(): void {
     layout.lineBatches,
     layout.meshBatches
   )
+  const layoutExtents = resolveLayoutViewExtents(
+    layout,
+    snapshot.meta.viewExtents ?? snapshot.meta.extents
+  )
 
   const osnapIndex = new AcExOsnapIndex()
   const osnapMarker = new AcExOsnapMarker(root)
@@ -195,7 +202,8 @@ function startViewer(): void {
   }
 
   const fit = () => {
-    zoomToExtents(snapshot.meta.extents)
+    // Initial open and toolbar "Zoom extents" both use batch-derived layout bounds.
+    zoomToExtents(layoutExtents)
   }
 
   let readyStatus = snapshot.meta.title ?? i18n.t('status.ready')
@@ -305,7 +313,10 @@ function startViewer(): void {
       i18n.toggleLocale()
     })
 
-  controls.addEventListener('change', () => render())
+  controls.addEventListener('change', () => {
+    acexCameraZoomUniform.value = camera.zoom
+    render()
+  })
 
   setupMeasurePointerInput(renderer.domElement, () => measure, render)
 
@@ -608,8 +619,9 @@ function setupMeasurePointerInput(
     if (event.button !== 0) return
     const measure = getMeasure()
     if (measure.isActive) {
-      measure.handlePointerDown(event.clientX, event.clientY)
-      render()
+      if (measure.handlePointerDown(event.clientX, event.clientY)) {
+        render()
+      }
       return
     }
     if (measure.handleSelectionPointerDown(event.clientX, event.clientY)) {

--- a/packages/cad-html-plugin/src/AcExLayerExtents.ts
+++ b/packages/cad-html-plugin/src/AcExLayerExtents.ts
@@ -1,6 +1,7 @@
 import { toWcsCoord } from './AcExBatchBuffers'
 import type {
   AcExExtents,
+  AcExLayoutSnapshot,
   AcExLineBatch,
   AcExMeshBatch
 } from './AcExSnapshotTypes'
@@ -94,6 +95,48 @@ export function toExtents(extents: AcExMutableExtents): AcExExtents | null {
     maxX: extents.maxX,
     maxY: extents.maxY
   }
+}
+
+/**
+ * Unions XY extents from every line and mesh batch in one layout.
+ *
+ * Used for initial zoom-to-fit in the offline viewer so hatch pattern shaders
+ * receive a realistic {@link acexCameraZoomUniform} instead of zooming to the
+ * often much larger database `EXTMIN`/`EXTMAX` header.
+ */
+export function computeLayoutExtents(
+  lineBatches: AcExLineBatch[],
+  meshBatches: AcExMeshBatch[]
+): AcExExtents | null {
+  const bucket = createEmptyExtents()
+  for (const batch of lineBatches) {
+    expandExtentsFromBatch(bucket, batch)
+  }
+  for (const batch of meshBatches) {
+    expandExtentsFromBatch(bucket, batch)
+  }
+  return toExtents(bucket)
+}
+
+/**
+ * Resolves zoom-to-fit extents for one layout snapshot.
+ *
+ * Prefers live batch geometry, then persisted {@link AcExSnapshot.meta.viewExtents},
+ * and only then the database header extents as a last resort.
+ */
+export function resolveLayoutViewExtents(
+  layout: Pick<AcExLayoutSnapshot, 'lineBatches' | 'meshBatches'>,
+  fallbackExtents?: AcExExtents
+): AcExExtents {
+  return (
+    computeLayoutExtents(layout.lineBatches, layout.meshBatches) ??
+    fallbackExtents ?? {
+      minX: 0,
+      minY: 0,
+      maxX: 1,
+      maxY: 1
+    }
+  )
 }
 
 /**

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -293,6 +293,31 @@ function interiorAngleArcScreenMetrics(
 }
 
 /**
+ * Hit test committed DOM overlays (badges/dots) using their rendered bounds.
+ * Accounts for CSS transforms such as the coordinate badge vertical offset.
+ * @internal
+ */
+function hitTestMeasureDom(
+  parts: AcExCommitParts,
+  clientX: number,
+  clientY: number,
+  paddingPx = 2
+): boolean {
+  for (const el of parts.dom) {
+    const rect = el.getBoundingClientRect()
+    if (
+      clientX >= rect.left - paddingPx &&
+      clientX <= rect.right + paddingPx &&
+      clientY >= rect.top - paddingPx &&
+      clientY <= rect.bottom + paddingPx
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Hit test for a committed angle measurement (arms, arc, badge, endpoint dots).
  * @internal
  */
@@ -765,6 +790,9 @@ export class AcExMeasureController {
    * @returns `true` when the event was handled.
    */
   handlePointerDown(clientX: number, clientY: number): boolean {
+    if (this._trySelectCommittedAt(clientX, clientY, false)) {
+      return true
+    }
     if (!this._mode) return false
     this._lastPointer = { x: clientX, y: clientY }
     const point = this._resolvePointerWithOsnap(clientX, clientY)
@@ -851,19 +879,7 @@ export class AcExMeasureController {
    */
   handleSelectionPointerDown(clientX: number, clientY: number): boolean {
     if (this._mode || this._committed.length === 0) return false
-
-    for (let i = this._committed.length - 1; i >= 0; i--) {
-      const measure = this._committed[i]!
-      if (measure.hitTest(clientX, clientY, MEASURE_HIT_THRESHOLD_PX)) {
-        const changed = measure.id !== this._selectedId
-        this._select(measure.id)
-        return changed
-      }
-    }
-
-    if (!this._selectedId) return false
-    this._deselect()
-    return true
+    return this._trySelectCommittedAt(clientX, clientY, true)
   }
 
   /**
@@ -1571,6 +1587,53 @@ export class AcExMeasureController {
       const s = this._view.wcsToScreen(p)
       return { x: s.x, y: s.y }
     })
+  }
+
+  /** @internal */
+  private _measureHitAt(
+    measure: AcExCommittedMeasure,
+    clientX: number,
+    clientY: number
+  ): boolean {
+    if (hitTestMeasureDom(measure.parts, clientX, clientY)) {
+      return true
+    }
+    return measure.hitTest(clientX, clientY, MEASURE_HIT_THRESHOLD_PX)
+  }
+
+  /** @internal */
+  private _pickCommittedMeasure(
+    clientX: number,
+    clientY: number
+  ): AcExCommittedMeasure | null {
+    for (let i = this._committed.length - 1; i >= 0; i--) {
+      const measure = this._committed[i]!
+      if (this._measureHitAt(measure, clientX, clientY)) {
+        return measure
+      }
+    }
+    return null
+  }
+
+  /**
+   * Selects a committed measurement under the pointer, or deselects when idle.
+   * @param deselectOnMiss - When true and nothing was hit, clears the current selection.
+   * @internal
+   */
+  private _trySelectCommittedAt(
+    clientX: number,
+    clientY: number,
+    deselectOnMiss: boolean
+  ): boolean {
+    const measure = this._pickCommittedMeasure(clientX, clientY)
+    if (measure) {
+      const changed = measure.id !== this._selectedId
+      this._select(measure.id)
+      return changed || measure.id === this._selectedId
+    }
+    if (!deselectOnMiss || !this._selectedId) return false
+    this._deselect()
+    return true
   }
 
   /** @internal */

--- a/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
+++ b/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
@@ -19,17 +19,31 @@ import type {
 /** Shared camera zoom uniform updated by the offline HTML viewer. */
 export const acexCameraZoomUniform = { value: 1.0 }
 
+function asShaderMaterial(
+  material: THREE.Material
+): THREE.ShaderMaterial | undefined {
+  const candidate = material as THREE.ShaderMaterial
+  if (
+    candidate.isShaderMaterial === true ||
+    material.type === 'ShaderMaterial'
+  ) {
+    return candidate
+  }
+  return undefined
+}
+
 /**
  * Reads a serialized linetype from a live export-time shader material.
  */
 export function extractLinePattern(
   material: THREE.Material
 ): AcExLinePattern | undefined {
-  if (!(material instanceof THREE.ShaderMaterial)) {
+  const shaderMaterial = asShaderMaterial(material)
+  if (!shaderMaterial) {
     return undefined
   }
-  const patternUniform = material.uniforms.pattern
-  const patternLengthUniform = material.uniforms.patternLength
+  const patternUniform = shaderMaterial.uniforms.pattern
+  const patternLengthUniform = shaderMaterial.uniforms.patternLength
   if (!patternUniform || !patternLengthUniform) {
     return undefined
   }
@@ -40,7 +54,7 @@ export function extractLinePattern(
   return {
     pattern: [...pattern],
     patternLength: Number(patternLengthUniform.value),
-    viewportScale: Number(material.uniforms.u_viewportScale?.value ?? 1)
+    viewportScale: Number(shaderMaterial.uniforms.u_viewportScale?.value ?? 1)
   }
 }
 
@@ -50,10 +64,11 @@ export function extractLinePattern(
 export function extractHatchPattern(
   material: THREE.Material
 ): AcExHatchPattern | undefined {
-  if (!(material instanceof THREE.ShaderMaterial)) {
+  const shaderMaterial = asShaderMaterial(material)
+  if (!shaderMaterial) {
     return undefined
   }
-  const patternLinesUniform = material.uniforms.u_patternLines
+  const patternLinesUniform = shaderMaterial.uniforms.u_patternLines
   if (!patternLinesUniform) {
     return undefined
   }
@@ -70,7 +85,7 @@ export function extractHatchPattern(
     return undefined
   }
   return {
-    patternAngle: Number(material.uniforms.u_patternAngle?.value ?? 0),
+    patternAngle: Number(shaderMaterial.uniforms.u_patternAngle?.value ?? 0),
     patternLines: patternLines.map(serializeHatchPatternLine)
   }
 }
@@ -81,27 +96,28 @@ export function extractHatchPattern(
 export function extractGradientFill(
   material: THREE.Material
 ): AcExGradientFill | undefined {
-  if (!(material instanceof THREE.ShaderMaterial)) {
+  const shaderMaterial = asShaderMaterial(material)
+  if (!shaderMaterial) {
     return undefined
   }
-  if (material.uniforms.u_patternLines) {
+  if (shaderMaterial.uniforms.u_patternLines) {
     return undefined
   }
-  const startColor = material.uniforms.u_startColor?.value as
+  const startColor = shaderMaterial.uniforms.u_startColor?.value as
     | THREE.Color
     | undefined
-  const endColor = material.uniforms.u_endColor?.value as
+  const endColor = shaderMaterial.uniforms.u_endColor?.value as
     | THREE.Color
     | undefined
-  const gradientTypeUniform = material.uniforms.u_gradientType
+  const gradientTypeUniform = shaderMaterial.uniforms.u_gradientType
   if (!startColor?.getHex || gradientTypeUniform == null) {
     return undefined
   }
   return {
     startColor: startColor.getHex(),
     endColor: endColor?.getHex?.() ?? startColor.getHex(),
-    angle: Number(material.uniforms.u_angle?.value ?? 0),
-    shift: Number(material.uniforms.u_shift?.value ?? 0),
+    angle: Number(shaderMaterial.uniforms.u_angle?.value ?? 0),
+    shift: Number(shaderMaterial.uniforms.u_shift?.value ?? 0),
     gradientType: Number(gradientTypeUniform.value)
   }
 }

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -140,8 +140,12 @@ function readMaterialStyle(material: THREE.Material): {
   const linePattern = extractLinePattern(material)
   const hatchPattern = extractHatchPattern(material)
   const gradientFill = extractGradientFill(material)
-  if (material instanceof THREE.ShaderMaterial) {
-    const shaderColor = material.uniforms.u_color?.value as
+  if (
+    material instanceof THREE.ShaderMaterial ||
+    material.type === 'ShaderMaterial'
+  ) {
+    const shaderMaterial = material as THREE.ShaderMaterial
+    const shaderColor = shaderMaterial.uniforms.u_color?.value as
       | THREE.Color
       | undefined
     if (shaderColor?.getHex) {

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -232,8 +232,13 @@ export interface AcExSnapshot {
     title?: string
     /** ISO-8601 timestamp when the snapshot was created. */
     createdAt: string
-    /** Overall drawing extents for initial zoom-to-extents. */
+    /** Database header extents (`EXTMIN` / `EXTMAX`); not used for zoom-to-fit. */
     extents: AcExExtents
+    /**
+     * Batch-derived extents for the initially active layout, used by the
+     * offline viewer for zoom-to-fit instead of {@link AcExSnapshot.meta.extents}.
+     */
+    viewExtents?: AcExExtents
     /** Unit and formatting sysvars for measurement display. */
     units: AcExViewerUnits
     /** Canvas background color as 24-bit RGB hex. */


### PR DESCRIPTION
## Summary

This PR improves the offline HTML export viewer in `cad-html-plugin` across three areas: hatch/pattern material extraction, initial zoom-to-fit behavior, and measurement interaction.

- **Hatch & pattern export:** Relax shader material detection so patterned hatch fills are collected from unbatched, world-baked meshes (not only `instanceof THREE.ShaderMaterial`). Adds regression tests for hatch batch collection and snapshot codec round-trip.
- **Zoom-to-fit extents:** Introduce `meta.viewExtents` — batch-derived bounds for the active layout — and use them for initial open and toolbar “Zoom extents” instead of database `EXTMIN`/`EXTMAX` header extents, which are often much larger than visible geometry.
- **Camera zoom for hatch shaders:** Update `acexCameraZoomUniform` on OrbitControls `change` so hatch pattern scaling stays correct while panning/zooming.
- **Measurement hit testing:** Hit-test committed measurement DOM overlays (badges, dots) via `getBoundingClientRect()`, accounting for CSS transforms. Refactor selection into shared helpers and allow selecting committed measurements while a measure tool is active.

## Changes

| Area | Files |
|------|--------|
| Snapshot meta & export | `AcApHtmlSnapshotBuilder.ts`, `AcExSnapshotTypes.ts` |
| Layout extents | `AcExLayerExtents.ts` |
| Viewer runtime | `AcExHtmlViewerRuntime.ts` |
| Pattern extraction | `AcExPatternSnapshot.ts`, `AcExSceneBatchCollector.ts` |
| Measurements | `AcExMeasurement.ts` |
| Tests | `AcExHatchExport.spec.ts` (new), `AcExLayerExtents.spec.ts` |

## Motivation

- Patterned hatches were missing from HTML export when meshes were cloned/baked outside the standard batched pipeline, because strict `instanceof` checks failed on deserialized or cloned materials.
- Zoom-to-extents used database header bounds, causing the viewer to open zoomed out and leaving hatch shaders with an unrealistic camera zoom uniform.
- Measurement badges were hard to click because hit testing only covered canvas geometry, not the positioned DOM label elements.

## Test plan

- [ ] Export a drawing with patterned (non-solid) hatches and confirm patterns render correctly in the offline HTML viewer.
- [ ] Open exported HTML for a drawing whose `EXTMIN`/`EXTMAX` is much larger than visible geometry; verify initial view and “Zoom extents” frame the actual content.
- [ ] Pan/zoom and confirm hatch patterns scale consistently (no sudden pattern density jumps).
- [ ] Create distance/angle/area measurements; click badges and endpoint dots to select/deselect; confirm selection works while a measure tool is active.
- [ ] Run unit tests:
  ```bash
  npx nx test cad-html-plugin --testPathPattern="AcExHatchExport|AcExLayerExtents"