### PR TITLE
fix(html-plugin): eliminate spurious solid fills in exported HTML viewer

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -1,12 +1,19 @@
 jest.mock('@mlightcad/three-renderer', () => ({
-  AcTrBatchedLine: class AcTrBatchedLine {},
-  AcTrBatchedMesh: class AcTrBatchedMesh {},
-  AcTrBatchedPoint: class AcTrBatchedPoint {},
+  AcTrBatchedLine: class AcTrBatchedLine {
+    optimize() {}
+  },
+  AcTrBatchedMesh: class AcTrBatchedMesh {
+    optimize() {}
+  },
+  AcTrBatchedPoint: class AcTrBatchedPoint {
+    optimize() {}
+  },
   getMaterialMetadata: () => ({ layer: '0' })
 }))
 
 import * as THREE from 'three'
 
+import { compactIndexedSlice } from '../src/AcExBatchBuffers'
 import { exportBufferGeometrySlice } from '../src/AcExSceneBatchCollector'
 
 describe('exportBufferGeometrySlice', () => {
@@ -56,5 +63,37 @@ describe('exportBufferGeometrySlice', () => {
     const slice = exportBufferGeometrySlice(geometry)
 
     expect(Array.from(slice.positions)).toEqual([1, 0, 0, 2, 0, 0])
+  })
+
+  it('trims unused position tail for indexed geometry exports', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(
+        new Float32Array([
+          0, 0, 0, 10, 0, 0, 0, 10, 0, 999, 999, 999, 999, 999, 999
+        ]),
+        3
+      )
+    )
+    geometry.setIndex([0, 1, 2])
+    geometry.setDrawRange(0, 3)
+
+    const slice = exportBufferGeometrySlice(geometry)
+
+    expect(Array.from(slice.positions)).toEqual([0, 0, 0, 10, 0, 0, 0, 10, 0])
+    expect(Array.from(slice.indices!)).toEqual([0, 1, 2])
+  })
+})
+
+describe('compactIndexedSlice', () => {
+  it('keeps positions referenced by the index buffer', () => {
+    const positions = new Float32Array([0, 0, 0, 1, 0, 0, 2, 0, 0, 99, 99, 99])
+    const indices = new Uint32Array([0, 1, 2])
+
+    const compact = compactIndexedSlice(positions, indices)
+
+    expect(Array.from(compact.positions)).toEqual([0, 0, 0, 1, 0, 0, 2, 0, 0])
+    expect(Array.from(compact.indices)).toEqual([0, 1, 2])
   })
 })

--- a/packages/cad-html-plugin/src/AcExBatchBuffers.ts
+++ b/packages/cad-html-plugin/src/AcExBatchBuffers.ts
@@ -39,6 +39,40 @@ export function copyUint32Range(
 }
 
 /**
+ * Trims an indexed geometry slice to the vertex span referenced by {@link indices}.
+ *
+ * Batched mesh buffers pre-allocate capacity; export copies the full position
+ * buffer but only a subset of indices. Unused tail vertices must not participate
+ * in fallback triangulation when indices are missing during HTML playback.
+ */
+export function compactIndexedSlice(
+  positions: Float32Array,
+  indices: Uint32Array
+): { positions: Float32Array; indices: Uint32Array } {
+  if (indices.length === 0) {
+    return { positions, indices }
+  }
+
+  let maxIndex = 0
+  for (let i = 0; i < indices.length; i++) {
+    const index = indices[i]!
+    if (index > maxIndex) {
+      maxIndex = index
+    }
+  }
+
+  const vertexFloatCount = (maxIndex + 1) * 3
+  if (vertexFloatCount >= positions.length) {
+    return { positions, indices }
+  }
+
+  return {
+    positions: copyFloat32Range(positions, 0, vertexFloatCount),
+    indices
+  }
+}
+
+/**
  * Converts one rebased local coordinate plus batch origin to WCS using double precision.
  *
  * Used by extent and legacy batch-based OSNAP paths so large origins are not

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -14,7 +14,8 @@ import { AcExOsnapMarker } from './AcExOsnapMarker'
 import {
   acexCameraZoomUniform,
   createViewerLineMaterial,
-  createViewerMeshMaterial
+  createViewerMeshMaterial,
+  createViewerPointsMaterial
 } from './AcExPatternSnapshot'
 import { decodeSnapshot } from './AcExSnapshotCodec'
 import type {
@@ -133,7 +134,9 @@ function startViewer(): void {
     if (object) getLayerGroup(batch.layer).add(object)
   }
   for (const batch of layout.meshBatches) {
-    const object = createMeshObject(batch)
+    const object = batch.points
+      ? createPointObject(batch)
+      : createMeshObject(batch)
     if (object) getLayerGroup(batch.layer).add(object)
   }
 
@@ -636,11 +639,21 @@ function setupMeasurePointerInput(
   })
 }
 
+function createPointObject(batch: AcExMeshBatch): THREE.Points | null {
+  if (batch.positions.length < 3) return null
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.BufferAttribute(copyFloat32Buffer(batch.positions), 3)
+  )
+  const material = createViewerPointsMaterial(batch)
+  const object = new THREE.Points(geometry, material)
+  object.position.set(batch.offset[0], batch.offset[1], batch.offset[2])
+  return object
+}
+
 function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
-  if (
-    batch.positions.length < 9 &&
-    (!batch.indices || batch.indices.length < 3)
-  ) {
+  if (!batch.indices || batch.indices.length < 3) {
     return null
   }
   const geometry = new THREE.BufferGeometry()
@@ -648,13 +661,9 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
     'position',
     new THREE.BufferAttribute(copyFloat32Buffer(batch.positions), 3)
   )
-  if (batch.indices && batch.indices.length > 0) {
-    geometry.setIndex(
-      new THREE.BufferAttribute(copyUint32Buffer(batch.indices), 1)
-    )
-  } else if (batch.positions.length >= 9) {
-    geometry.setIndex([0, 1, 2])
-  }
+  geometry.setIndex(
+    new THREE.BufferAttribute(copyUint32Buffer(batch.indices), 1)
+  )
   if (
     batch.gradientFill &&
     batch.gradientPositions &&

--- a/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
+++ b/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
@@ -271,6 +271,19 @@ export function createViewerLineMaterial(batch: AcExLineBatch): THREE.Material {
 }
 
 /**
+ * Creates a viewer material for one exported point batch.
+ */
+export function createViewerPointsMaterial(
+  batch: AcExMeshBatch
+): THREE.PointsMaterial {
+  return new THREE.PointsMaterial({
+    color: batch.color,
+    size: 1,
+    sizeAttenuation: false
+  })
+}
+
+/**
  * Re-aligns hatch pattern coordinates after unbatched geometry was baked
  * into world space during batch-group cloning.
  */

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -6,7 +6,11 @@ import {
 } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 
-import { copyFloat32Range, copyUint32Range } from './AcExBatchBuffers'
+import {
+  compactIndexedSlice,
+  copyFloat32Range,
+  copyUint32Range
+} from './AcExBatchBuffers'
 import {
   computeLineDistancesForSegments,
   exportLineDistanceSlice,
@@ -103,7 +107,7 @@ export function exportBufferGeometrySlice(
       indexStart
     )
     const indices = copyUint32Range(indexArray, indexStart, indexCount)
-    return { positions, indices }
+    return compactIndexedSlice(positions, indices)
   }
 
   const vertexStart = clampRangeStart(drawRange.start, positionAttr.count)
@@ -118,6 +122,59 @@ export function exportBufferGeometrySlice(
     vertexCount * itemSize
   )
   return { positions }
+}
+
+type AcTrPackedIndexInfo = {
+  active: boolean
+  indexStart: number
+  indexCount: number
+}
+
+/**
+ * Exports only active triangle indices from a batched mesh, skipping reserved
+ * padding slots that can form spurious filled triangles in the HTML viewer.
+ */
+function exportActiveBatchedMeshSlice(
+  batch: AcTrBatchedMesh,
+  geometry: THREE.BufferGeometry
+): AcExBufferGeometrySlice {
+  const positionAttr = geometry.getAttribute('position') as
+    | THREE.BufferAttribute
+    | undefined
+  const indexAttr = geometry.getIndex()
+  if (!positionAttr || !indexAttr) {
+    return exportBufferGeometrySlice(geometry)
+  }
+
+  const positions = copyFloat32Range(
+    positionAttr.array as ArrayLike<number>,
+    0,
+    positionAttr.count * positionAttr.itemSize
+  )
+
+  const indexArray = indexAttr.array
+  const activeIndices: number[] = []
+  const { count } = batch.mappingStats
+  for (let geometryId = 0; geometryId < count; geometryId++) {
+    let info: AcTrPackedIndexInfo
+    try {
+      info = batch.getGeometryRangeAt(geometryId) as AcTrPackedIndexInfo
+    } catch {
+      continue
+    }
+    if (!info.active || info.indexCount <= 0) {
+      continue
+    }
+    for (let i = 0; i < info.indexCount; i++) {
+      activeIndices.push(indexArray[info.indexStart + i]!)
+    }
+  }
+
+  if (activeIndices.length === 0) {
+    return { positions: new Float32Array(0) }
+  }
+
+  return compactIndexedSlice(positions, new Uint32Array(activeIndices))
 }
 
 function readMaterialStyle(material: THREE.Material): {
@@ -232,7 +289,7 @@ function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
 }
 
 function exportBatchedMesh(batch: AcTrBatchedMesh): AcExMeshBatch | undefined {
-  const slice = exportBufferGeometrySlice(batch.geometry)
+  const slice = exportActiveBatchedMeshSlice(batch, batch.geometry)
   if (slice.positions.length === 0) {
     return undefined
   }
@@ -251,12 +308,15 @@ function exportBatchedPoint(
   if (slice.positions.length === 0) {
     return undefined
   }
-  return buildMeshBatch(
-    batch.geometry,
-    batch.material as THREE.Material,
-    batch,
-    slice
-  )
+  return {
+    points: true,
+    ...buildMeshBatch(
+      batch.geometry,
+      batch.material as THREE.Material,
+      batch,
+      slice
+    )
+  }
 }
 
 /**

--- a/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
@@ -19,6 +19,7 @@ const F_MESH_HATCH = 2
 const F_MESH_GRADIENT_FILL = 4
 const F_MESH_GRADIENT_POS = 8
 const F_MESH_SIDE = 16
+const F_MESH_POINTS = 32
 
 /**
  * Serializes a snapshot to a compact binary byte array.
@@ -196,6 +197,7 @@ function writeMeshBatch(writer: BinaryWriter, batch: AcExMeshBatch): void {
     flags |= F_MESH_GRADIENT_POS
   }
   if (batch.side != null) flags |= F_MESH_SIDE
+  if (batch.points) flags |= F_MESH_POINTS
   writer.writeU8(flags)
 
   if (flags & F_MESH_INDICES) {
@@ -243,6 +245,9 @@ function readMeshBatch(reader: BinaryReader): AcExMeshBatch {
   }
   if (flags & F_MESH_SIDE) {
     batch.side = reader.readU8()
+  }
+  if (flags & F_MESH_POINTS) {
+    batch.points = true
   }
   return batch
 }

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -150,8 +150,8 @@ export interface AcExGradientFill {
 }
 
 /**
- * One packed mesh batch (filled regions, MText quads, point glyphs, etc.)
- * rendered as `THREE.Mesh` in the offline viewer.
+ * One packed mesh or point batch (filled regions, MText quads, point glyphs, etc.)
+ * rendered in the offline viewer.
  */
 export interface AcExMeshBatch {
   /** Layer name used for grouping and visibility in the viewer. */
@@ -166,8 +166,13 @@ export interface AcExMeshBatch {
    */
   positions: Float32Array
   /**
+   * When `true`, {@link AcExMeshBatch.positions} is rendered with `THREE.Points`
+   * instead of a filled `THREE.Mesh`.
+   */
+  points?: boolean
+  /**
    * Triangle index buffer into {@link AcExMeshBatch.positions}.
-   * When omitted, a single triangle may be inferred from the first three vertices.
+   * Required for filled mesh batches; omitted for {@link AcExMeshBatch.points}.
    */
   indices?: Uint32Array
   /** Optional hatch pattern for non-solid fills. */


### PR DESCRIPTION
## Summary

Fixes incorrect solid white filled regions appearing in exported HTML drawings that are not present in the live CAD viewer. The artifacts typically show up as large triangles spanning dimension lines, view boundaries, or unrelated geometry.

Two root causes were identified and addressed:

- **Point batches rendered as filled meshes** — `AcTrBatchedPoint` geometry was exported into `meshBatches` but replayed with `THREE.Mesh`. Without an index buffer, Three.js treats every group of three consecutive vertices as a filled triangle, producing many spurious solid regions across the drawing.
- **Batched mesh padding indices exported** — `AcTrBatchedMesh` draw ranges include reserved index slots beyond the active `indexCount`. Exporting those padding indices caused invalid triangles to be filled during HTML playback.

## Changes

### Export (`AcExSceneBatchCollector`)
- Add `exportActiveBatchedMeshSlice()` to export only active triangle indices from batched meshes, skipping reserved padding slots.
- Mark point batches with `points: true` when exporting `AcTrBatchedPoint`.
- Compact indexed geometry slices via `compactIndexedSlice()` to trim unused tail vertices from pre-allocated batch buffers.

### Offline viewer (`AcExHtmlViewerRuntime`)
- Render point batches with `THREE.Points` via new `createPointObject()`.
- Require a valid triangle index buffer for filled mesh batches; remove the unsafe `[0, 1, 2]` fallback that could connect unrelated vertices into a solid triangle.
- Add `createViewerPointsMaterial()` for point batch playback.

### Snapshot schema
- Extend `AcExMeshBatch` with optional `points?: boolean`.
- Add `F_MESH_POINTS` flag to the v2 binary snapshot codec.

### Tests
- Cover indexed slice compaction and unused position tail trimming in `AcExSceneBatchCollector.spec.ts`.

## Test plan

- [ ] Rebuild `@mlightcad/cad-html-plugin` (`pnpm --filter @mlightcad/cad-html-plugin build`)
- [ ] Export HTML from a drawing with dimensions, hatches, and multiple views (front / left / top)
- [ ] Confirm the offline HTML viewer matches the live viewer — no extra solid white triangles or filled regions
- [ ] Verify point entities still render correctly in exported HTML
- [ ] Verify hatch / solid fill regions still render correctly
- [ ] Run unit tests: `npx jest packages/cad-html-plugin/__tests__`