### PR TITLE
fix(html-export): export only active batched geometry for line, mesh, and point

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -14,7 +14,31 @@ jest.mock('@mlightcad/three-renderer', () => ({
 import * as THREE from 'three'
 
 import { compactIndexedSlice } from '../src/AcExBatchBuffers'
-import { exportBufferGeometrySlice } from '../src/AcExSceneBatchCollector'
+import {
+  exportActiveBatchedSlice,
+  exportBufferGeometrySlice
+} from '../src/AcExSceneBatchCollector'
+
+function createMockBatch(
+  slots: Array<{
+    active: boolean
+    vertexStart: number
+    vertexCount: number
+    indexStart: number
+    indexCount: number
+  }>
+) {
+  return {
+    mappingStats: { count: slots.length },
+    getGeometryRangeAt(geometryId: number) {
+      const info = slots[geometryId]
+      if (!info?.active) {
+        throw new Error('inactive')
+      }
+      return info
+    }
+  }
+}
 
 describe('exportBufferGeometrySlice', () => {
   it('exports non-indexed geometry when drawRange.count is Infinity', () => {
@@ -83,6 +107,82 @@ describe('exportBufferGeometrySlice', () => {
 
     expect(Array.from(slice.positions)).toEqual([0, 0, 0, 10, 0, 0, 0, 10, 0])
     expect(Array.from(slice.indices!)).toEqual([0, 1, 2])
+  })
+})
+
+describe('exportActiveBatchedSlice', () => {
+  it('exports only active indexCount for indexed batched geometry', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(
+        new Float32Array([0, 0, 0, 10, 0, 0, 0, 10, 0, 99, 99, 99]),
+        3
+      )
+    )
+    geometry.setIndex([0, 1, 2, 0, 0, 0])
+    geometry.setDrawRange(0, 6)
+
+    const slice = exportActiveBatchedSlice(
+      createMockBatch([
+        {
+          active: true,
+          vertexStart: 0,
+          vertexCount: 3,
+          indexStart: 0,
+          indexCount: 3
+        }
+      ]),
+      geometry
+    )
+
+    expect(Array.from(slice.positions)).toEqual([0, 0, 0, 10, 0, 0, 0, 10, 0])
+    expect(Array.from(slice.indices!)).toEqual([0, 1, 2])
+  })
+
+  it('skips inactive slots and reserved vertices for non-indexed geometry', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(
+        new Float32Array([
+          0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 5, 5, 5, 6, 6, 6, 0, 0, 0, 0, 0, 0
+        ]),
+        3
+      )
+    )
+    geometry.setDrawRange(0, 8)
+
+    const slice = exportActiveBatchedSlice(
+      createMockBatch([
+        {
+          active: true,
+          vertexStart: 0,
+          vertexCount: 2,
+          indexStart: -1,
+          indexCount: 0
+        },
+        {
+          active: false,
+          vertexStart: 4,
+          vertexCount: 2,
+          indexStart: -1,
+          indexCount: 0
+        },
+        {
+          active: true,
+          vertexStart: 4,
+          vertexCount: 2,
+          indexStart: -1,
+          indexCount: 0
+        }
+      ]),
+      geometry
+    )
+
+    expect(Array.from(slice.positions)).toEqual([
+      0, 0, 0, 1, 0, 0, 5, 5, 5, 6, 6, 6
+    ])
   })
 })
 

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -124,57 +124,93 @@ export function exportBufferGeometrySlice(
   return { positions }
 }
 
-type AcTrPackedIndexInfo = {
+/** Per-slot geometry range metadata from {@link AcTrBatchedExportSource}. */
+type AcTrPackedGeometryInfo = {
   active: boolean
-  indexStart: number
-  indexCount: number
+  vertexStart: number
+  vertexCount: number
+  indexStart?: number
+  indexCount?: number
+}
+
+/** Batched object that exposes packed geometry slot metadata for HTML export. */
+type AcTrBatchedExportSource = {
+  mappingStats: { count: number }
+  getGeometryRangeAt(geometryId: number): AcTrPackedGeometryInfo
 }
 
 /**
- * Exports only active triangle indices from a batched mesh, skipping reserved
- * padding slots that can form spurious filled triangles in the HTML viewer.
+ * Exports only active geometry data from a batched line/mesh/point buffer,
+ * skipping reserved padding and inactive (deleted) slots.
  */
-function exportActiveBatchedMeshSlice(
-  batch: AcTrBatchedMesh,
+export function exportActiveBatchedSlice(
+  batch: AcTrBatchedExportSource,
   geometry: THREE.BufferGeometry
 ): AcExBufferGeometrySlice {
   const positionAttr = geometry.getAttribute('position') as
     | THREE.BufferAttribute
     | undefined
-  const indexAttr = geometry.getIndex()
-  if (!positionAttr || !indexAttr) {
-    return exportBufferGeometrySlice(geometry)
-  }
-
-  const positions = copyFloat32Range(
-    positionAttr.array as ArrayLike<number>,
-    0,
-    positionAttr.count * positionAttr.itemSize
-  )
-
-  const indexArray = indexAttr.array
-  const activeIndices: number[] = []
-  const { count } = batch.mappingStats
-  for (let geometryId = 0; geometryId < count; geometryId++) {
-    let info: AcTrPackedIndexInfo
-    try {
-      info = batch.getGeometryRangeAt(geometryId) as AcTrPackedIndexInfo
-    } catch {
-      continue
-    }
-    if (!info.active || info.indexCount <= 0) {
-      continue
-    }
-    for (let i = 0; i < info.indexCount; i++) {
-      activeIndices.push(indexArray[info.indexStart + i]!)
-    }
-  }
-
-  if (activeIndices.length === 0) {
+  if (!positionAttr) {
     return { positions: new Float32Array(0) }
   }
 
-  return compactIndexedSlice(positions, new Uint32Array(activeIndices))
+  const itemSize = positionAttr.itemSize
+  const positionArray = positionAttr.array as ArrayLike<number>
+  const indexAttr = geometry.getIndex()
+  const { count } = batch.mappingStats
+
+  if (indexAttr) {
+    const positions = copyFloat32Range(
+      positionArray,
+      0,
+      positionAttr.count * itemSize
+    )
+    const indexArray = indexAttr.array
+    const activeIndices: number[] = []
+
+    for (let geometryId = 0; geometryId < count; geometryId++) {
+      let info: AcTrPackedGeometryInfo
+      try {
+        info = batch.getGeometryRangeAt(geometryId)
+      } catch {
+        continue
+      }
+      const indexStart = info.indexStart ?? 0
+      const indexCount = info.indexCount ?? 0
+      if (!info.active || indexCount <= 0) {
+        continue
+      }
+      for (let i = 0; i < indexCount; i++) {
+        activeIndices.push(indexArray[indexStart + i]!)
+      }
+    }
+
+    if (activeIndices.length === 0) {
+      return { positions: new Float32Array(0) }
+    }
+
+    return compactIndexedSlice(positions, new Uint32Array(activeIndices))
+  }
+
+  const activeFloats: number[] = []
+  for (let geometryId = 0; geometryId < count; geometryId++) {
+    let info: AcTrPackedGeometryInfo
+    try {
+      info = batch.getGeometryRangeAt(geometryId)
+    } catch {
+      continue
+    }
+    if (!info.active || info.vertexCount <= 0) {
+      continue
+    }
+    const start = info.vertexStart * itemSize
+    const floatCount = info.vertexCount * itemSize
+    for (let i = 0; i < floatCount; i++) {
+      activeFloats.push(positionArray[start + i]!)
+    }
+  }
+
+  return { positions: new Float32Array(activeFloats) }
 }
 
 function readMaterialStyle(material: THREE.Material): {
@@ -267,7 +303,7 @@ function buildMeshBatch(
 }
 
 function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
-  const slice = exportBufferGeometrySlice(batch.geometry)
+  const slice = exportActiveBatchedSlice(batch, batch.geometry)
   if (slice.positions.length === 0) {
     return undefined
   }
@@ -275,8 +311,7 @@ function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
     batch.material as THREE.Material
   )
   const lineDistances = linePattern
-    ? (exportLineDistanceSlice(batch.geometry) ??
-      computeLineDistancesForSegments(slice.positions))
+    ? computeLineDistancesForSegments(slice.positions)
     : undefined
   return {
     layer,
@@ -289,7 +324,7 @@ function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
 }
 
 function exportBatchedMesh(batch: AcTrBatchedMesh): AcExMeshBatch | undefined {
-  const slice = exportActiveBatchedMeshSlice(batch, batch.geometry)
+  const slice = exportActiveBatchedSlice(batch, batch.geometry)
   if (slice.positions.length === 0) {
     return undefined
   }
@@ -304,7 +339,7 @@ function exportBatchedMesh(batch: AcTrBatchedMesh): AcExMeshBatch | undefined {
 function exportBatchedPoint(
   batch: AcTrBatchedPoint
 ): AcExMeshBatch | undefined {
-  const slice = exportBufferGeometrySlice(batch.geometry)
+  const slice = exportActiveBatchedSlice(batch, batch.geometry)
   if (slice.positions.length === 0) {
     return undefined
   }

--- a/packages/three-renderer/src/batch/AcTrBatchedLine.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine.ts
@@ -19,10 +19,18 @@ import {
   validateGeometry
 } from './AcTrBatchedMixin'
 
+/** Reusable scratch box for bounds queries. */
 const _box = /*@__PURE__*/ new THREE.Box3()
+/** Reusable scratch vector for bounds expansion. */
 const _vector = /*@__PURE__*/ new THREE.Vector3()
+/** Reusable scratch vector for bbox fallback raycast hits. */
 const _vector2 = /*@__PURE__*/ new THREE.Vector3()
 
+/**
+ * Mixin base produced by {@link createAcTrBatchedMixin} for indexed line batches.
+ *
+ * @internal Not exported; extended by {@link AcTrBatchedLine}.
+ */
 const AcTrBatchedLineBase = createAcTrBatchedMixin<AcTrBatchedGeometryInfo>(
   THREE.LineSegments,
   {
@@ -36,20 +44,34 @@ const AcTrBatchedLineBase = createAcTrBatchedMixin<AcTrBatchedGeometryInfo>(
 )
 
 /**
- * Batched renderer for `THREE.LineSegments`.
+ * Batched renderer for {@link THREE.LineSegments}.
  *
- * Multiple line geometries sharing compatible attribute layouts are packed into
- * one combined buffer to reduce draw calls.
+ * Multiple line geometries that share compatible attribute layouts and a material
+ * are packed into one combined vertex/index buffer to reduce draw calls. Supports
+ * point-symbol line regeneration and bbox-expanded raycast fallback for thin lines.
+ *
+ * @see {@link AcTrBatchedMesh} for mesh batching.
+ * @see {@link AcTrBatchedLine2} for wide-line (`Line2`) batching.
  */
 export class AcTrBatchedLine extends AcTrBatchedLineBase {
+  /** Typed container metadata attached to the batch object. */
   declare userData: AcTrBatchedContainerUserData
+
+  /** Multiplier applied when auto-growing vertex/index buffer capacity. */
   private static readonly GROWTH_FACTOR = 1.25
-  /** Stable world origin for this batch. */
+
+  /**
+   * Stable world-space origin for this batch.
+   *
+   * Set from the first appended geometry's bounding-box center plus offset.
+   * Vertex positions are stored relative to this origin to improve floating-point
+   * precision for large-coordinate CAD data.
+   */
   private _origin?: THREE.Vector3
 
-  /** Current allocated vertex capacity. */
+  /** Current allocated vertex capacity of the packed attribute buffers. */
   private _maxVertexCount: number
-  /** Current allocated index capacity. */
+  /** Current allocated index capacity of the packed index buffer. */
   private _maxIndexCount: number
 
   /** Next free index offset for appended geometries. */
@@ -57,9 +79,16 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
   /** Next free vertex offset for appended geometries. */
   private _nextVertexStart = 0
 
-  /** Whether packed geometry buffers have been allocated. */
+  /** Whether packed geometry buffers have been allocated from a reference layout. */
   private _geometryInitialized = false
 
+  /**
+   * Creates a new line batch with preallocated buffer capacities.
+   *
+   * @param maxVertexCount - Initial vertex capacity; defaults to `1000`.
+   * @param maxIndexCount - Initial index capacity; defaults to `maxVertexCount * 2`.
+   * @param material - Optional shared material for all sub-geometries in this batch.
+   */
   constructor(
     maxVertexCount: number = 1000,
     maxIndexCount: number = maxVertexCount * 2,
@@ -73,18 +102,40 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     this._maxIndexCount = maxIndexCount
   }
 
+  /**
+   * Total number of geometry ids ever allocated in this batch.
+   *
+   * Includes deleted slots until {@link optimize} compacts the id space.
+   *
+   * @returns Current `_geometryCount` value.
+   */
   get geometryCount() {
     return this._geometryCount
   }
 
+  /**
+   * Number of unused vertex slots remaining before the next buffer resize.
+   *
+   * @returns Remaining vertex capacity (`maxVertexCount - nextVertexStart`).
+   */
   get unusedVertexCount() {
     return this._maxVertexCount - this._nextVertexStart
   }
 
+  /**
+   * Number of unused index entries remaining before the next buffer resize.
+   *
+   * @returns Remaining index capacity (`maxIndexCount - nextIndexStart`).
+   */
   get unusedIndexCount() {
     return this._maxIndexCount - this._nextIndexStart
   }
 
+  /**
+   * Allocates packed attribute/index buffers on first geometry insertion.
+   *
+   * @param reference - First (or representative) geometry defining batch layout.
+   */
   private _initializeGeometry(reference: THREE.BufferGeometry) {
     if (this._geometryInitialized === false) {
       initializeGeometry(
@@ -97,11 +148,21 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     }
   }
 
-  // Make sure the geometry is compatible with the existing combined geometry attributes
+  /**
+   * Ensures the incoming geometry matches the batch attribute/index contract.
+   *
+   * @param geometry - Candidate geometry to append or update.
+   * @throws {Error} When layout is incompatible with the existing batch.
+   */
   private _validateGeometry(geometry: THREE.BufferGeometry) {
     validateGeometry(this.geometry, geometry, 'AcTrBatchedLine', true)
   }
 
+  /**
+   * Grows vertex and/or index buffer capacity when the next append would overflow.
+   *
+   * @param geometry - Incoming geometry whose counts drive the growth calculation.
+   */
   private _resizeSpaceIfNeeded(geometry: THREE.BufferGeometry) {
     const index = geometry.getIndex()
     const newMaxIndexCount =
@@ -135,6 +196,9 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
 
   /**
    * Clears all packed geometry ranges and resets internal cursor state.
+   *
+   * Disposes GPU buffers, clears geometry-info records, resets the batch origin
+   * and world position, and marks buffers as uninitialized for the next insert.
    */
   reset() {
     this.boundingBox = null
@@ -155,7 +219,11 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
   }
 
   /**
-   * Returns per-geometry user metadata used by point-symbol regeneration.
+   * Returns per-geometry user metadata for all allocated slots.
+   *
+   * Used when rebuilding point-symbol line geometry after a display-mode change.
+   *
+   * @returns Array of {@link AcTrBatchGeometryUserData} extracted from geometry-info records.
    */
   getUserData() {
     const userData: AcTrBatchGeometryUserData[] = []
@@ -172,6 +240,12 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
 
   /**
    * Rebuilds point-symbol batched line geometry for a new point display mode.
+   *
+   * Backs up entity metadata via {@link getUserData}, clears the batch with
+   * {@link reset}, then recreates line geometries from stored point positions
+   * using {@link AcTrPointSymbolCreator}.
+   *
+   * @param displayMode - Point style mode passed to the symbol creator.
    */
   resetGeometry(displayMode: number) {
     // Backup user data
@@ -193,7 +267,17 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
   }
 
   /**
-   * Appends one geometry into the packed line buffer.
+   * Appends one line geometry into the packed vertex/index buffers.
+   *
+   * Rebases vertices to the batch origin, reserves a geometry id, and copies
+   * attribute/index data into the shared buffers.
+   *
+   * @param geometry - Source line geometry to pack. Mutated in place (rebase).
+   * @param reservedVertexCount - Reserved vertex span for in-place updates; `-1` uses actual count.
+   * @param reservedIndexCount - Reserved index span for in-place updates; `-1` uses actual count.
+   * @param worldOffset - World-space offset applied before rebasing to the batch origin.
+   * @returns The assigned geometry id for subsequent updates and metadata binding.
+   * @throws {Error} When reserved space exceeds buffer capacity or layout is incompatible.
    */
   addGeometry(
     geometry: THREE.BufferGeometry,
@@ -261,6 +345,12 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     return geometryId
   }
 
+  /**
+   * Rebases geometry vertex positions into the batch's local coordinate frame.
+   *
+   * @param geometry - Geometry whose `position` attribute is mutated in place.
+   * @param worldOffset - World-space placement offset for the geometry.
+   */
   private rebaseGeometryInPlace(
     geometry: THREE.BufferGeometry,
     worldOffset: THREE.Vector3
@@ -306,6 +396,12 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
 
   /**
    * Assigns entity metadata for one packed geometry id.
+   *
+   * Copies optional point `position` in addition to object id and bbox hit-test flag.
+   *
+   * @param geometryId - Target slot index returned by {@link addGeometry}.
+   * @param userData - Entity metadata including optional source point position.
+   * @throws {Error} When `geometryId` is out of range.
    */
   setGeometryInfo(geometryId: number, userData: AcTrBatchGeometryUserData) {
     if (geometryId >= this._geometryCount) {
@@ -320,6 +416,12 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
 
   /**
    * Rewrites geometry payload for one existing packed geometry id.
+   *
+   * @param geometryId - Target slot index.
+   * @param geometry - New geometry payload to copy into the packed buffers.
+   * @returns The same `geometryId` for chaining.
+   * @throws {Error} When the id is out of range, layout is incompatible, or
+   *   the source exceeds reserved capacity.
    */
   setGeometryAt(geometryId: number, geometry: THREE.BufferGeometry) {
     if (geometryId >= this._geometryCount) {
@@ -337,6 +439,11 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
 
   /**
    * Compacts active geometry ranges to reclaim gaps left by deletions.
+   *
+   * Unlike {@link AcTrBatchedMesh.optimize}, advances cursors by **reserved**
+   * spans so in-place updates retain their preallocated slot sizes.
+   *
+   * @returns This instance for chaining.
    */
   optimize() {
     const geometry = this.geometry
@@ -444,7 +551,11 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
   }
 
   /**
-   * Returns cached bounds for one geometry id, computing lazily on first use.
+   * Returns cached axis-aligned bounds for one geometry id.
+   *
+   * @param geometryId - Slot index to query.
+   * @param target - Reusable {@link THREE.Box3} that receives the result.
+   * @returns `target` when the id is valid, otherwise `null`.
    */
   getBoundingBoxAt(geometryId: number, target: THREE.Box3) {
     if (geometryId >= this._geometryCount) {
@@ -480,6 +591,10 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
 
   /**
    * Returns cached bounding sphere for one geometry id.
+   *
+   * @param geometryId - Slot index to query.
+   * @param target - Reusable {@link THREE.Sphere} that receives the result.
+   * @returns `target` when the id is valid, otherwise `null`.
    */
   getBoundingSphereAt(geometryId: number, target: THREE.Sphere) {
     if (geometryId >= this._geometryCount) {
@@ -490,6 +605,13 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     return target
   }
 
+  /**
+   * Returns the geometry-info record for one slot after validation.
+   *
+   * @param geometryId - Slot index to query.
+   * @returns The internal {@link AcTrBatchedGeometryInfo} record.
+   * @throws {Error} When the id is invalid or the slot has been deleted.
+   */
   getGeometryAt(geometryId: number) {
     this.validateGeometryId(geometryId)
     return this._geometryInfo[geometryId]
@@ -497,6 +619,9 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
 
   /**
    * Resizes packed geometry buffers while preserving existing data.
+   *
+   * @param maxVertexCount - New vertex capacity.
+   * @param maxIndexCount - New index capacity.
    */
   setGeometrySize(maxVertexCount: number, maxIndexCount: number) {
     // dispose of the previous geometry
@@ -528,12 +653,28 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     this._syncDrawRange()
   }
 
+  /**
+   * Creates a standalone line object for one batched sub-geometry.
+   *
+   * Overrides the mixin implementation to copy the batch world position so
+   * isolated line views align with rebased vertex data.
+   *
+   * @param batchId - Geometry slot index.
+   * @returns A {@link THREE.LineSegments} view of the sub-geometry.
+   */
   override getObjectAt(batchId: number) {
     const object = super.getObjectAt(batchId)
     object.position.copy(this.position)
     return object
   }
 
+  /**
+   * Configures a temporary raycast object with the batch world position.
+   *
+   * Ensures line ray tests occur in the same coordinate frame as rebased vertices.
+   *
+   * @param raycastObject - Temporary object prepared for raycasting.
+   */
   override _initializeRaycastObject(
     raycastObject: THREE.Object3D & {
       geometry: THREE.BufferGeometry
@@ -546,8 +687,7 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
   }
 
   /**
-   * Before calling optimize(), drawRange defaults to { start: 0, count: Infinity }.
-   * After calling , you need to explicitly shrink it to the exact active range.
+   * Keeps `geometry.drawRange` in sync with the packed active data extent.
    */
   private _syncDrawRange() {
     const geometry = this.geometry
@@ -559,14 +699,19 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
   }
 
   /**
-   * Override mixin `_intersectWith` to add a bounding-box fallback when
-   * `THREE.LineSegments.raycast()` returns no hits.
+   * Performs ray intersection for one line geometry slot with bbox fallback.
    *
-   * `THREE.LineSegments.raycast()` honours `raycaster.params.Line.threshold`
-   * but can still miss for very precise geometries or when the threshold is
-   * too small relative to the camera distance.  The fallback expands the
-   * per-entity bounding box by the Line threshold and tests again, matching
-   * the pattern used in `AcTrBatchedLine2._intersectWith`.
+   * Overrides the mixin default to improve pick reliability for thin lines:
+   *
+   * 1. When `bboxIntersectionCheck` is set, tests world-space bounding box only.
+   * 2. Otherwise delegates to {@link THREE.LineSegments.raycast} on the sub-range.
+   * 3. If the precise raycast misses, retests against the bounding box expanded by
+   *    `raycaster.params.Line.threshold`.
+   *
+   * @param geometryId - Slot index to test.
+   * @param raycaster - Configured THREE.js raycaster.
+   * @param intersects - Output array populated with intersection records extended
+   *   by `batchId` and `objectId`.
    */
   _intersectWith(
     geometryId: number,
@@ -661,6 +806,12 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     this._batchIntersects.length = 0
   }
 
+  /**
+   * Deep-copies batched line state from another instance.
+   *
+   * @param source - Batch instance to copy from.
+   * @returns This instance for chaining.
+   */
   copy(source: AcTrBatchedLine) {
     super.copy(source)
 

--- a/packages/three-renderer/src/batch/AcTrBatchedMesh.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMesh.ts
@@ -18,9 +18,16 @@ import {
   validateGeometry
 } from './AcTrBatchedMixin'
 
+/** Reusable scratch box for bounds queries. */
 const _box = /*@__PURE__*/ new THREE.Box3()
+/** Reusable scratch vector for bounds expansion. */
 const _vector = /*@__PURE__*/ new THREE.Vector3()
 
+/**
+ * Mixin base produced by {@link createAcTrBatchedMixin} for indexed mesh batches.
+ *
+ * @internal Not exported; extended by {@link AcTrBatchedMesh}.
+ */
 const AcTrBatchedMeshBase = createAcTrBatchedMixin<AcTrBatchedGeometryInfo>(
   THREE.Mesh,
   {
@@ -34,20 +41,35 @@ const AcTrBatchedMeshBase = createAcTrBatchedMixin<AcTrBatchedGeometryInfo>(
 )
 
 /**
- * Batched renderer for `THREE.Mesh` geometry.
+ * Batched renderer for {@link THREE.Mesh} geometry.
  *
- * All compatible mesh geometries are packed into shared attribute/index buffers
- * per material to reduce draw calls.
+ * All compatible mesh geometries sharing the same attribute layout and material
+ * are packed into shared vertex/index buffers to reduce draw calls. Each inserted
+ * geometry receives a stable integer id used for updates, deletion, visibility
+ * toggles, and hit-testing.
+ *
+ * @see {@link AcTrBatchedLine} for line segment batching.
+ * @see {@link AcTrBatchedPoint} for point batching.
  */
 export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
+  /** Typed container metadata attached to the batch object. */
   declare userData: AcTrBatchedContainerUserData
+
+  /** Multiplier applied when auto-growing vertex/index buffer capacity. */
   private static readonly GROWTH_FACTOR = 1.25
-  /** Stable world origin for this batch. */
+
+  /**
+   * Stable world-space origin for this batch.
+   *
+   * Set from the first appended geometry's bounding-box center plus offset.
+   * Vertex positions are stored relative to this origin to improve floating-point
+   * precision for large-coordinate CAD data.
+   */
   private _origin?: THREE.Vector3
 
-  /** Current allocated vertex capacity. */
+  /** Current allocated vertex capacity of the packed attribute buffers. */
   private _maxVertexCount: number
-  /** Current allocated index capacity. */
+  /** Current allocated index capacity of the packed index buffer. */
   private _maxIndexCount: number
 
   /** Next free index offset for appended geometries. */
@@ -55,9 +77,16 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
   /** Next free vertex offset for appended geometries. */
   private _nextVertexStart = 0
 
-  /** Whether packed geometry buffers have been allocated. */
+  /** Whether packed geometry buffers have been allocated from a reference layout. */
   private _geometryInitialized = false
 
+  /**
+   * Creates a new mesh batch with preallocated buffer capacities.
+   *
+   * @param maxVertexCount - Initial vertex capacity; defaults to `1000`.
+   * @param maxIndexCount - Initial index capacity; defaults to `maxVertexCount * 2`.
+   * @param material - Optional shared material for all sub-geometries in this batch.
+   */
   constructor(
     maxVertexCount: number = 1000,
     maxIndexCount: number = maxVertexCount * 2,
@@ -71,14 +100,31 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
     this._maxIndexCount = maxIndexCount
   }
 
+  /**
+   * Number of unused vertex slots remaining before the next buffer resize.
+   *
+   * @returns Remaining vertex capacity (`maxVertexCount - nextVertexStart`).
+   */
   get unusedVertexCount() {
     return this._maxVertexCount - this._nextVertexStart
   }
 
+  /**
+   * Number of unused index entries remaining before the next buffer resize.
+   *
+   * @returns Remaining index capacity (`maxIndexCount - nextIndexStart`).
+   */
   get unusedIndexCount() {
     return this._maxIndexCount - this._nextIndexStart
   }
 
+  /**
+   * Allocates packed attribute/index buffers on first geometry insertion.
+   *
+   * Uses the incoming geometry as a layout reference for attribute names and types.
+   *
+   * @param reference - First (or representative) geometry defining batch layout.
+   */
   private _initializeGeometry(reference: THREE.BufferGeometry) {
     if (this._geometryInitialized === false) {
       initializeGeometry(
@@ -91,11 +137,23 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
     }
   }
 
-  // Make sure the geometry is compatible with the existing combined geometry attributes
+  /**
+   * Ensures the incoming geometry matches the batch attribute/index contract.
+   *
+   * @param geometry - Candidate geometry to append or update.
+   * @throws {Error} When layout is incompatible with the existing batch.
+   */
   private _validateGeometry(geometry: THREE.BufferGeometry) {
     validateGeometry(this.geometry, geometry, 'AcTrBatchedMesh', true)
   }
 
+  /**
+   * Grows vertex and/or index buffer capacity when the next append would overflow.
+   *
+   * Applies {@link AcTrBatchedMesh.GROWTH_FACTOR} via {@link growCapacityIfNeeded}.
+   *
+   * @param geometry - Incoming geometry whose counts drive the growth calculation.
+   */
   private _resizeSpaceIfNeeded(geometry: THREE.BufferGeometry) {
     const index = geometry.getIndex()
     const newMaxIndexCount =
@@ -128,7 +186,18 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
   }
 
   /**
-   * Appends one mesh geometry into packed buffers.
+   * Appends one mesh geometry into the packed vertex/index buffers.
+   *
+   * Rebases vertex positions relative to the batch origin, strips `uv` and
+   * `normal` attributes to save memory, reserves a geometry id, and copies
+   * attribute/index data into the shared buffers.
+   *
+   * @param geometry - Source mesh geometry to pack. Mutated in place (rebase, attribute removal).
+   * @param reservedVertexCount - Reserved vertex span for in-place updates; `-1` uses actual count.
+   * @param reservedIndexCount - Reserved index span for in-place updates; `-1` uses actual count.
+   * @param worldOffset - World-space offset applied before rebasing to the batch origin.
+   * @returns The assigned geometry id for subsequent updates and metadata binding.
+   * @throws {Error} When reserved space exceeds buffer capacity or layout is incompatible.
    */
   addGeometry(
     geometry: THREE.BufferGeometry,
@@ -204,6 +273,16 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
     return geometryId
   }
 
+  /**
+   * Rebases geometry vertex positions into the batch's local coordinate frame.
+   *
+   * On the first call, establishes `_origin` from the geometry bounding-box
+   * center plus `worldOffset` and sets the batch object's world position.
+   * Subsequent vertices are translated by `worldOffset - origin`.
+   *
+   * @param geometry - Geometry whose `position` attribute is mutated in place.
+   * @param worldOffset - World-space placement offset for the geometry.
+   */
   private rebaseGeometryInPlace(
     geometry: THREE.BufferGeometry,
     worldOffset: THREE.Vector3
@@ -253,6 +332,13 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
 
   /**
    * Assigns entity metadata for one packed geometry id.
+   *
+   * Metadata is copied into the internal geometry-info record and surfaced on
+   * raycast intersections via `objectId`.
+   *
+   * @param geometryId - Target slot index returned by {@link addGeometry}.
+   * @param userData - Entity metadata (object id, bbox-only hit test flag, etc.).
+   * @throws {Error} When `geometryId` is out of range.
    */
   setGeometryInfo(geometryId: number, userData: AcTrBatchGeometryUserData) {
     if (geometryId >= this._geometryCount) {
@@ -264,7 +350,16 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
   }
 
   /**
-   * Rewrites geometry payload for one packed geometry id.
+   * Rewrites geometry payload for one existing packed geometry id.
+   *
+   * Source geometry must fit within the slot's originally reserved vertex/index
+   * span. Cached bounds for the slot are invalidated.
+   *
+   * @param geometryId - Target slot index.
+   * @param geometry - New geometry payload to copy into the packed buffers.
+   * @returns The same `geometryId` for chaining.
+   * @throws {Error} When the id is out of range, layout is incompatible, or
+   *   the source exceeds reserved capacity.
    */
   setGeometryAt(geometryId: number, geometry: THREE.BufferGeometry) {
     if (geometryId >= this._geometryCount) {
@@ -281,7 +376,13 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
   }
 
   /**
-   * Compacts active geometry ranges to reclaim deleted-space gaps.
+   * Compacts active geometry ranges to reclaim gaps left by deletions.
+   *
+   * Moves vertex attributes and remaps indices so active slots are contiguous
+   * at the start of the packed buffers. Updates internal cursors, draw range,
+   * and clears the reusable-id pool.
+   *
+   * @returns This instance for chaining.
    */
   optimize() {
     const geometry = this.geometry
@@ -374,7 +475,14 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
   }
 
   /**
-   * Returns cached bounds for one geometry id, computing lazily on first use.
+   * Returns cached axis-aligned bounds for one geometry id.
+   *
+   * Computes bounds lazily from packed buffer data on first access and caches
+   * the result on the geometry-info record.
+   *
+   * @param geometryId - Slot index to query.
+   * @param target - Reusable {@link THREE.Box3} that receives the result.
+   * @returns `target` when the id is valid, otherwise `null`.
    */
   getBoundingBoxAt(geometryId: number, target: THREE.Box3) {
     if (geometryId >= this._geometryCount) {
@@ -410,6 +518,12 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
 
   /**
    * Returns cached bounding sphere for one geometry id.
+   *
+   * Derived from {@link getBoundingBoxAt} on first access.
+   *
+   * @param geometryId - Slot index to query.
+   * @param target - Reusable {@link THREE.Sphere} that receives the result.
+   * @returns `target` when the id is valid, otherwise `null`.
    */
   getBoundingSphereAt(geometryId: number, target: THREE.Sphere) {
     if (geometryId >= this._geometryCount) {
@@ -420,13 +534,14 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
     return target
   }
 
-  getGeometryRangeAt(geometryId: number) {
-    this.validateGeometryId(geometryId)
-    return this._geometryInfo[geometryId]
-  }
-
   /**
    * Resizes packed geometry buffers while preserving existing data.
+   *
+   * Disposes the previous {@link THREE.BufferGeometry}, allocates larger
+   * attribute/index arrays, and copies existing buffer contents.
+   *
+   * @param maxVertexCount - New vertex capacity.
+   * @param maxIndexCount - New index capacity.
    */
   setGeometrySize(maxVertexCount: number, maxIndexCount: number) {
     // dispose of the previous geometry
@@ -459,8 +574,10 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
   }
 
   /**
-   * Before calling optimize(), drawRange defaults to { start: 0, count: Infinity }.
-   * After calling , you need to explicitly shrink it to the exact active range.
+   * Keeps `geometry.drawRange` in sync with the packed active data extent.
+   *
+   * Uses index count when indexed, otherwise vertex count. Call after
+   * `addGeometry`, `optimize`, or `setGeometrySize`.
    */
   private _syncDrawRange() {
     const geometry = this.geometry
@@ -472,7 +589,13 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
   }
 
   /**
-   * Deep-copies batched geometry state.
+   * Deep-copies batched mesh state from another instance.
+   *
+   * Clones geometry, aggregate bounds, geometry-info records (including cached
+   * per-slot boxes), capacity cursors, and the batch origin.
+   *
+   * @param source - Batch instance to copy from.
+   * @returns This instance for chaining.
    */
   copy(source: AcTrBatchedMesh) {
     super.copy(source)

--- a/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
@@ -8,9 +8,20 @@ import {
   copyAttributeData
 } from './AcTrBatchedGeometryInfo'
 
+/**
+ * Generic constructor type used to parameterize the batched mixin factory.
+ *
+ * @typeParam T - Instance type produced by the constructor.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T = object> = new (...args: any[]) => T
 
+/**
+ * Minimum surface required of a THREE.js object that can host batched geometry.
+ *
+ * Combines {@link THREE.Object3D} with the geometry and material bindings that
+ * the batching pipeline reads and writes during packing and raycasting.
+ */
 type AcTrBatchBaseObject = THREE.Object3D & {
   /** Shared geometry bound to the render object. */
   geometry: THREE.BufferGeometry
@@ -18,21 +29,52 @@ type AcTrBatchBaseObject = THREE.Object3D & {
   material: THREE.Material | THREE.Material[]
 }
 
+/**
+ * Per-geometry bounds query contract implemented by concrete batched classes.
+ *
+ * Used internally by the mixin when aggregating bounds and configuring
+ * temporary raycast objects for individual sub-geometries.
+ */
 type AcTrBatchBounds = {
-  /** Returns cached/derived bounding box for one packed geometry id. */
+  /**
+   * Returns cached or lazily computed axis-aligned bounds for one packed geometry id.
+   *
+   * @param geometryId - Slot index of the sub-geometry within the batch.
+   * @param target - Reusable {@link THREE.Box3} that receives the result.
+   * @returns `target` when the id is valid, otherwise `null`.
+   */
   getBoundingBoxAt(geometryId: number, target: THREE.Box3): THREE.Box3 | null
-  /** Returns cached/derived bounding sphere for one packed geometry id. */
+  /**
+   * Returns cached or lazily computed bounding sphere for one packed geometry id.
+   *
+   * @param geometryId - Slot index of the sub-geometry within the batch.
+   * @param target - Reusable {@link THREE.Sphere} that receives the result.
+   * @returns `target` when the id is valid, otherwise `null`.
+   */
   getBoundingSphereAt(
     geometryId: number,
     target: THREE.Sphere
   ): THREE.Sphere | null
 }
 
+/**
+ * Geometry-info record shape shared by all batched primitive implementations.
+ *
+ * Alias of {@link AcTrVertexBatchGeometryInfo}; indexed batches extend this
+ * with index-range fields via {@link AcTrIndexedBatchGeometryInfo}.
+ */
 type AcTrBatchGeometryLike = AcTrVertexBatchGeometryInfo
 
 /**
  * Estimates memory footprint of one geometry-info record and returns aggregate
  * mapping statistics for the whole batch.
+ *
+ * Uses {@link AcTrCommonUtil.estimateObjectSize} on the first record and
+ * multiplies by the total slot count. Useful for diagnostics and capacity planning.
+ *
+ * @typeParam T - Geometry-info record type stored in the batch.
+ * @param geometryInfo - Array of per-sub-geometry mapping records.
+ * @returns Object containing the slot `count` and estimated total `size` in bytes.
  */
 export function getMappingStats<T>(geometryInfo: T[]) {
   const count = geometryInfo.length
@@ -50,6 +92,15 @@ export function getMappingStats<T>(geometryInfo: T[]) {
 /**
  * Initializes destination batch geometry buffers using a reference geometry
  * layout and preallocated capacities.
+ *
+ * Creates typed attribute arrays sized for `maxVertexCount` vertices and, when
+ * `maxIndexCount` is non-null and the reference geometry is indexed, allocates
+ * a matching index buffer (`Uint16Array` or `Uint32Array` depending on vertex count).
+ *
+ * @param geometry - Destination batch geometry whose attributes are created or replaced.
+ * @param reference - Source geometry whose attribute names, item sizes, and types define the layout.
+ * @param maxVertexCount - Preallocated vertex capacity for every attribute array.
+ * @param maxIndexCount - Preallocated index capacity, or `null` for non-indexed batches.
  */
 export function initializeGeometry(
   geometry: THREE.BufferGeometry,
@@ -84,6 +135,16 @@ export function initializeGeometry(
 /**
  * Validates that a geometry is compatible with current batch attribute/index
  * layout.
+ *
+ * Ensures every batch attribute exists on the incoming geometry with matching
+ * `itemSize` and `normalized` flags. When `checkIndex` is true, indexed and
+ * non-indexed geometries cannot be mixed within the same batch.
+ *
+ * @param batchGeometry - Combined geometry whose layout defines the batch contract.
+ * @param geometry - Candidate geometry to append or update.
+ * @param typeName - Batch class name included in error messages.
+ * @param checkIndex - When `true`, require consistent presence of an index buffer.
+ * @throws {Error} When attribute names, item sizes, normalized flags, or index usage differ.
  */
 export function validateGeometry(
   batchGeometry: THREE.BufferGeometry,
@@ -122,6 +183,16 @@ export function validateGeometry(
 /**
  * Reserves a geometry id slot for insertion, reusing deleted ids when
  * available.
+ *
+ * Deleted slots are tracked in `availableGeometryIds` and sorted ascending
+ * before reuse so lower ids are consumed first, keeping id density compact.
+ *
+ * @typeParam T - Geometry-info record type stored per slot.
+ * @param availableGeometryIds - Pool of ids freed by {@link deleteGeometryById}.
+ * @param geometryInfoList - Mutable array of per-slot mapping records.
+ * @param geometryCount - Current number of allocated ids (may exceed active count).
+ * @param geometryInfo - New record to assign to the reserved slot.
+ * @returns The assigned `geometryId` and updated `geometryCount`.
  */
 export function reserveGeometryId<T>(
   availableGeometryIds: number[],
@@ -147,6 +218,13 @@ export function reserveGeometryId<T>(
 
 /**
  * Converts sentinel reserved count `-1` into actual source geometry count.
+ *
+ * Callers pass `-1` to mean "use the geometry's current vertex or index count"
+ * when reserving space during {@link applyGeometryAt}.
+ *
+ * @param reservedCount - Requested reservation, or `-1` to adopt `actualCount`.
+ * @param actualCount - Vertex or index count from the source geometry.
+ * @returns The resolved reservation size.
  */
 export function resolveReservedCount(
   reservedCount: number,
@@ -157,6 +235,10 @@ export function resolveReservedCount(
 
 /**
  * Creates default active/visible state for a newly inserted geometry record.
+ *
+ * Bounding boxes start as `null` and are computed lazily on first bounds query.
+ *
+ * @returns Fresh state object merged into new geometry-info records.
  */
 export function createGeometryState() {
   return {
@@ -168,6 +250,16 @@ export function createGeometryState() {
 
 /**
  * Validates reserved vertex/index ranges against current batch capacities.
+ *
+ * @param params - Capacity check parameters.
+ * @param params.typeName - Batch class name included in error messages.
+ * @param params.maxVertexCount - Total vertex capacity of the packed buffer.
+ * @param params.vertexStart - Write offset for the new or updated slot.
+ * @param params.reservedVertexCount - Reserved vertex span for the slot.
+ * @param params.maxIndexCount - Total index capacity, omitted for non-indexed batches.
+ * @param params.indexStart - Write offset in the index buffer, or `-1` when unused.
+ * @param params.reservedIndexCount - Reserved index span for the slot.
+ * @throws {Error} When the requested range would exceed buffer capacity.
  */
 export function assertReservedCapacity(params: {
   typeName: string
@@ -202,6 +294,17 @@ export function assertReservedCapacity(params: {
 
 /**
  * Computes a grown capacity if the requested append range does not fit.
+ *
+ * When `nextStart + requiredCount` exceeds `currentMaxCount`, returns
+ * `ceil(totalRequired * growthFactor)` so batches grow amortized rather than
+ * per-vertex.
+ *
+ * @param params - Growth calculation inputs.
+ * @param params.currentMaxCount - Current buffer capacity.
+ * @param params.nextStart - Next free offset in the buffer.
+ * @param params.requiredCount - Count needed for the incoming geometry.
+ * @param params.growthFactor - Multiplier applied when growth is required (typically `1.25`).
+ * @returns Either unchanged `currentMaxCount` or the new larger capacity.
  */
 export function growCapacityIfNeeded(params: {
   currentMaxCount: number
@@ -219,6 +322,15 @@ export function growCapacityIfNeeded(params: {
 
 /**
  * Marks a geometry record as deleted and registers its id for reuse.
+ *
+ * Sets `active` and `visible` to `false` without compacting buffer memory;
+ * callers should invoke `optimize()` on the concrete batch class to reclaim space.
+ *
+ * @typeParam T - Geometry-info record type extending {@link AcTrBatchGeometryLike}.
+ * @param geometryId - Slot index to delete.
+ * @param geometryInfoList - Mutable array of per-slot mapping records.
+ * @param availableGeometryIds - Pool that receives the freed id.
+ * @returns `true` when the slot was active and is now deleted; `false` if already deleted or out of range.
  */
 export function deleteGeometryById<T extends AcTrBatchGeometryLike>(
   geometryId: number,
@@ -240,6 +352,12 @@ export function deleteGeometryById<T extends AcTrBatchGeometryLike>(
 
 /**
  * Throws when `geometryId` does not refer to an active geometry record.
+ *
+ * @typeParam T - Geometry-info record type extending {@link AcTrBatchGeometryLike}.
+ * @param geometryId - Slot index to validate.
+ * @param geometryInfoList - Array of per-slot mapping records.
+ * @param typeName - Batch class name included in error messages.
+ * @throws {Error} When the id is negative, out of range, or refers to a deleted slot.
  */
 export function validateGeometryId<T extends AcTrBatchGeometryLike>(
   geometryId: number,
@@ -260,6 +378,15 @@ export function validateGeometryId<T extends AcTrBatchGeometryLike>(
 /**
  * Copies all geometry attributes into batched buffers and zero-fills reserved
  * tail ranges to avoid stale data.
+ *
+ * Writes source attribute data starting at `vertexStart` and clears any unused
+ * portion of the reserved span so GPU reads do not see leftover vertices from
+ * previous occupants of the slot.
+ *
+ * @param batchGeometry - Combined destination geometry.
+ * @param geometry - Source geometry whose attributes are copied.
+ * @param vertexStart - Destination vertex offset in the packed buffer.
+ * @param reservedVertexCount - Total reserved vertex span including padding.
  */
 export function copyGeometryAttributes(
   batchGeometry: THREE.BufferGeometry,
@@ -292,6 +419,16 @@ export function copyGeometryAttributes(
 
 /**
  * Copies and rebases index data into the destination batch index buffer.
+ *
+ * Each source index is offset by `vertexStart` so it references vertices in
+ * the packed attribute array. Unused index entries within the reserved span are
+ * filled with `vertexStart` as a safe degenerate reference.
+ *
+ * @param batchGeometry - Combined destination geometry with an index buffer.
+ * @param geometry - Source indexed geometry.
+ * @param vertexStart - Vertex offset applied to every copied index value.
+ * @param indexStart - Destination index offset in the packed index buffer.
+ * @param reservedIndexCount - Total reserved index span including padding.
  */
 export function copyGeometryIndices(
   batchGeometry: THREE.BufferGeometry,
@@ -320,6 +457,17 @@ export function copyGeometryIndices(
 
 /**
  * Writes a full source geometry into one reserved batched geometry range.
+ *
+ * Validates that the source fits within the slot's reserved vertex (and index,
+ * when applicable) capacity, copies attributes and indices, updates actual
+ * counts, and invalidates cached bounds.
+ *
+ * @typeParam T - Geometry-info record type extending {@link AcTrBatchGeometryLike}.
+ * @param geometryInfo - Target slot metadata describing buffer offsets and reservations.
+ * @param batchGeometry - Combined destination geometry.
+ * @param geometry - Source geometry payload to write.
+ * @param typeName - Batch class name included in error messages.
+ * @throws {Error} When the source geometry exceeds the slot's reserved capacity.
  */
 export function applyGeometryAt<T extends AcTrBatchGeometryLike>(
   geometryInfo: T,
@@ -370,6 +518,13 @@ export function applyGeometryAt<T extends AcTrBatchGeometryLike>(
 
 /**
  * Computes global bounding box of all active geometry records in a batch.
+ *
+ * Unions lazily cached per-slot boxes; slots without computed bounds are skipped.
+ *
+ * @typeParam T - Geometry-info record type extending {@link AcTrBatchGeometryLike}.
+ * @param currentBoundingBox - Existing aggregate box to reuse, or `null` to allocate.
+ * @param geometryInfo - Array of per-slot mapping records.
+ * @returns A bounding box containing all active sub-geometries with known bounds.
  */
 export function computeBoundingBox<T extends AcTrBatchGeometryLike>(
   currentBoundingBox: THREE.Box3 | null,
@@ -391,6 +546,15 @@ export function computeBoundingBox<T extends AcTrBatchGeometryLike>(
 
 /**
  * Computes global bounding sphere of all active geometry records in a batch.
+ *
+ * Delegates per-slot sphere computation to `getBoundingSphereAt` so concrete
+ * batch classes can apply their lazy bounds caching strategy.
+ *
+ * @typeParam T - Geometry-info record type extending {@link AcTrBatchGeometryLike}.
+ * @param currentBoundingSphere - Existing aggregate sphere to reuse, or `null` to allocate.
+ * @param geometryInfo - Array of per-slot mapping records.
+ * @param getBoundingSphereAt - Callback provided by the concrete batch class.
+ * @returns A bounding sphere enclosing all active sub-geometries.
  */
 export function computeBoundingSphere<T extends AcTrBatchGeometryLike>(
   currentBoundingSphere: THREE.Sphere | null,
@@ -415,6 +579,13 @@ export function computeBoundingSphere<T extends AcTrBatchGeometryLike>(
 
 /**
  * Rebinds a temporary raycast object to the shared batch geometry buffers.
+ *
+ * Shares attribute and index references with the batch geometry (no copy) and
+ * ensures bounding box/sphere objects exist for draw-range ray tests.
+ *
+ * @param raycastObject - Temporary object used for per-slot raycasting.
+ * @param batchGeometry - Combined geometry whose buffers are shared.
+ * @param material - Material bound to the raycast object for intersection tests.
  */
 export function initializeRaycastObject(
   raycastObject: AcTrBatchBaseObject,
@@ -436,6 +607,15 @@ export function initializeRaycastObject(
 
 /**
  * Updates draw-range and bounds for raycasting one batched sub-geometry.
+ *
+ * Restricts the temporary raycast geometry to `[start, start + count)` and
+ * copies precomputed bounds so THREE.js culling operates on the sub-range only.
+ *
+ * @param raycastObject - Temporary object whose geometry draw range is updated.
+ * @param start - Index or vertex offset of the sub-geometry within the packed buffer.
+ * @param count - Number of indices or vertices to include in the draw range.
+ * @param boundingBox - Axis-aligned bounds of the sub-geometry in local space.
+ * @param boundingSphere - Bounding sphere of the sub-geometry in local space.
  */
 export function setRaycastObjectInfo(
   raycastObject: AcTrBatchBaseObject,
@@ -451,6 +631,11 @@ export function setRaycastObjectInfo(
 
 /**
  * Clears temporary raycast object bindings to prevent accidental retention.
+ *
+ * Detaches shared buffer references and resets the draw range to the full buffer
+ * so the temporary object does not keep batch memory alive after a raycast pass.
+ *
+ * @param raycastObject - Temporary object to reset after raycasting.
  */
 export function resetRaycastObjectInfo(raycastObject: AcTrBatchBaseObject) {
   raycastObject.geometry.index = null
@@ -459,29 +644,55 @@ export function resetRaycastObjectInfo(raycastObject: AcTrBatchBaseObject) {
 }
 
 /**
+ * Configuration passed to {@link createAcTrBatchedMixin} for a concrete batch type.
+ *
+ * @typeParam TInfo - Per-slot geometry-info record type.
+ */
+export type AcTrBatchedMixinOptions<TInfo extends AcTrBatchGeometryLike> = {
+  /** Human-readable batch class name used in validation errors. */
+  typeName: string
+  /** Factory that creates temporary THREE objects for raycast and `getObjectAt`. */
+  createObject: () => AcTrBatchBaseObject
+  /**
+   * Resolves the draw range (index or vertex) for one sub-geometry slot.
+   *
+   * @param instance - The batched render object instance.
+   * @param info - Geometry-info record for the requested slot.
+   */
+  getDrawRange: (
+    instance: AcTrBatchBaseObject,
+    info: TInfo
+  ) => {
+    start: number
+    count: number
+  }
+}
+
+/**
  * Creates a reusable mixin that implements shared behavior for batched render
  * objects (visibility, bounds aggregation, id lifecycle, and raycast flow).
+ *
+ * The returned class extends `Base` (typically {@link THREE.Mesh},
+ * {@link THREE.LineSegments}, or {@link THREE.Points}) and is further extended
+ * by {@link AcTrBatchedMesh}, {@link AcTrBatchedLine}, and
+ * {@link AcTrBatchedPoint}.
+ *
+ * @typeParam TInfo - Per-slot geometry-info record type.
+ * @typeParam TBase - Constructor of the THREE.js object being extended.
+ * @param Base - THREE.js base class constructor (e.g. `THREE.Mesh`).
+ * @param options - Batch-specific configuration and draw-range resolver.
+ * @returns A mixin base class with shared batched-object behavior.
  */
 export function createAcTrBatchedMixin<
   TInfo extends AcTrBatchGeometryLike,
   TBase extends Constructor<AcTrBatchBaseObject> =
     Constructor<AcTrBatchBaseObject>
->(
-  Base: TBase,
-  options: {
-    typeName: string
-    createObject: () => AcTrBatchBaseObject
-    getDrawRange: (
-      instance: AcTrBatchBaseObject,
-      info: TInfo
-    ) => {
-      start: number
-      count: number
-    }
-  }
-) {
+>(Base: TBase, options: AcTrBatchedMixinOptions<TInfo>) {
   /**
    * Base class produced by {@link createAcTrBatchedMixin}.
+   *
+   * Implements geometry-id lifecycle, aggregate bounds, visibility toggles,
+   * and batched raycasting shared across mesh, line, and point batch types.
    */
   return class AcTrBatchedMixinBase extends Base {
     /** Aggregate bounding box across all active packed geometries. */
@@ -489,38 +700,66 @@ export function createAcTrBatchedMixin<
     /** Aggregate bounding sphere across all active packed geometries. */
     boundingSphere: THREE.Sphere | null = null
 
-    /** Per-geometry mapping/state records. */
+    /** Per-geometry mapping/state records indexed by geometry id. */
     _geometryInfo: TInfo[] = []
-    /** Deleted geometry ids available for reuse. */
+    /** Deleted geometry ids available for reuse on subsequent inserts. */
     _availableGeometryIds: number[] = []
-    /** Number of allocated geometry ids. */
+    /** Total number of geometry ids ever allocated (includes deleted slots). */
     _geometryCount = 0
 
     /** Shared temporary object used for batched raycast operations. */
     readonly _raycastObject = options.createObject()
-    /** Temporary intersection collection for one raycast pass. */
+    /** Temporary intersection collection reused for one raycast sub-pass. */
     readonly _batchIntersects: THREE.Intersection[] = []
-    /** Reused bounding box scratch object. */
+    /** Reused axis-aligned bounding box scratch object. */
     readonly _box = new THREE.Box3()
     /** Reused bounding sphere scratch object. */
     readonly _sphere = new THREE.Sphere()
-    /** Reused vector scratch object. */
+    /** Reused vector scratch object for ray/box tests. */
     readonly _vector = new THREE.Vector3()
-    /** Typed view exposing optional batch/object ids on intersections. */
+    /** Typed view exposing optional `batchId` and `objectId` on intersections. */
     readonly _typedBatchIntersects: Array<
       THREE.Intersection & { batchId?: number; objectId?: string }
     > = this._batchIntersects as Array<
       THREE.Intersection & { batchId?: number; objectId?: string }
     >
 
+    /**
+     * Estimated memory footprint and slot count of `_geometryInfo` records.
+     *
+     * @returns Mapping statistics from {@link getMappingStats}.
+     */
     get mappingStats() {
       return getMappingStats(this._geometryInfo)
     }
 
+    /**
+     * Validates that `geometryId` refers to an active, in-range geometry slot.
+     *
+     * @param geometryId - Slot index to validate.
+     * @throws {Error} When the id is invalid or the slot has been deleted.
+     */
     validateGeometryId(geometryId: number) {
       validateGeometryId(geometryId, this._geometryInfo, options.typeName)
     }
 
+    /**
+     * Returns the geometry-info record for one active slot.
+     *
+     * @param geometryId - Slot index to query.
+     * @returns The mapping record describing buffer offsets and entity metadata.
+     * @throws {Error} When the id is invalid or the slot has been deleted.
+     */
+    getGeometryRangeAt(geometryId: number) {
+      this.validateGeometryId(geometryId)
+      return this._geometryInfo[geometryId]
+    }
+
+    /**
+     * Recomputes the aggregate bounding box from all active sub-geometries.
+     *
+     * @returns This instance for chaining.
+     */
     computeBoundingBox() {
       this.boundingBox = computeBoundingBox(
         this.boundingBox,
@@ -528,6 +767,11 @@ export function createAcTrBatchedMixin<
       )
     }
 
+    /**
+     * Recomputes the aggregate bounding sphere from all active sub-geometries.
+     *
+     * @returns This instance for chaining.
+     */
     computeBoundingSphere() {
       this.boundingSphere = computeBoundingSphere(
         this.boundingSphere,
@@ -539,6 +783,17 @@ export function createAcTrBatchedMixin<
       )
     }
 
+    /**
+     * Sets per-slot visibility without removing geometry from the batch buffer.
+     *
+     * Invisible slots are skipped during raycasting but remain in packed memory
+     * until deleted and optimized.
+     *
+     * @param geometryId - Slot index to update.
+     * @param value - Desired visibility flag.
+     * @returns This instance for chaining.
+     * @throws {Error} When the id is invalid or the slot has been deleted.
+     */
     setVisibleAt(geometryId: number, value: boolean) {
       this.validateGeometryId(geometryId)
 
@@ -551,11 +806,27 @@ export function createAcTrBatchedMixin<
       return this
     }
 
+    /**
+     * Returns the visibility flag for one geometry slot.
+     *
+     * @param geometryId - Slot index to query.
+     * @returns `true` when the slot is visible.
+     * @throws {Error} When the id is invalid or the slot has been deleted.
+     */
     getVisibleAt(geometryId: number) {
       this.validateGeometryId(geometryId)
       return this._geometryInfo[geometryId].visible
     }
 
+    /**
+     * Soft-deletes one geometry slot and registers its id for reuse.
+     *
+     * Does not compact buffer memory; call `optimize()` on the concrete batch
+     * class to reclaim gaps.
+     *
+     * @param geometryId - Slot index to delete.
+     * @returns This instance for chaining.
+     */
     deleteGeometry(geometryId: number) {
       const deleted = deleteGeometryById(
         geometryId,
@@ -569,6 +840,16 @@ export function createAcTrBatchedMixin<
       return this
     }
 
+    /**
+     * Creates a standalone THREE object view of one batched sub-geometry.
+     *
+     * The returned object shares buffer references with the batch and is
+     * configured with the correct draw range and bounds for inspection or
+     * isolated rendering.
+     *
+     * @param batchId - Geometry slot index.
+     * @returns A new THREE object representing only the requested sub-geometry.
+     */
     getObjectAt(batchId: number) {
       const object = options.createObject()
       this._initializeRaycastObject(object)
@@ -578,6 +859,16 @@ export function createAcTrBatchedMixin<
       return object
     }
 
+    /**
+     * Raycasts one batched sub-geometry and appends hits to `intersects`.
+     *
+     * Initializes and tears down temporary raycast bindings around the call.
+     *
+     * @param geometryId - Slot index to test.
+     * @param raycaster - Configured THREE.js raycaster.
+     * @param intersects - Output array populated with intersection records
+     *   extended by optional `batchId` and `objectId` fields.
+     */
     intersectWith(
       geometryId: number,
       raycaster: THREE.Raycaster,
@@ -588,6 +879,14 @@ export function createAcTrBatchedMixin<
       this._resetRaycastObjectInfo(this._raycastObject)
     }
 
+    /**
+     * Raycasts all active, visible sub-geometries in this batch.
+     *
+     * Implements the standard THREE.js `raycast` entry point for batched objects.
+     *
+     * @param raycaster - Configured THREE.js raycaster.
+     * @param intersects - Output array populated with intersection records.
+     */
     raycast(raycaster: THREE.Raycaster, intersects: THREE.Intersection[]) {
       this._initializeRaycastObject(this._raycastObject)
 
@@ -597,11 +896,21 @@ export function createAcTrBatchedMixin<
       this._resetRaycastObjectInfo(this._raycastObject)
     }
 
+    /**
+     * Disposes packed GPU buffers held by this batch object.
+     *
+     * @returns This instance for chaining.
+     */
     dispose() {
       this.geometry.dispose()
       return this
     }
 
+    /**
+     * Synchronizes world transform and shared buffer bindings on a raycast object.
+     *
+     * @param raycastObject - Temporary object to configure before raycasting.
+     */
     _initializeRaycastObject(raycastObject: AcTrBatchBaseObject) {
       initializeRaycastObject(raycastObject, this.geometry, this.material)
       raycastObject.position.copy(this.position)
@@ -611,6 +920,14 @@ export function createAcTrBatchedMixin<
       raycastObject.updateMatrixWorld(true)
     }
 
+    /**
+     * Applies draw range and per-slot bounds to a raycast object.
+     *
+     * @param raycastObject - Temporary object to configure.
+     * @param index - Geometry slot index whose bounds are copied.
+     * @param start - Draw-range start offset within the packed buffer.
+     * @param count - Draw-range length.
+     */
     _setRaycastObjectInfo(
       raycastObject: AcTrBatchBaseObject,
       index: number,
@@ -623,10 +940,28 @@ export function createAcTrBatchedMixin<
       setRaycastObjectInfo(raycastObject, start, count, this._box, this._sphere)
     }
 
+    /**
+     * Clears temporary raycast bindings after a sub-pass completes.
+     *
+     * @param raycastObject - Temporary object to reset.
+     */
     _resetRaycastObjectInfo(raycastObject: AcTrBatchBaseObject) {
       resetRaycastObjectInfo(raycastObject)
     }
 
+    /**
+     * Performs ray intersection for one geometry slot.
+     *
+     * Skips inactive or invisible slots. When `bboxIntersectionCheck` is set on
+     * the slot, tests against the world-space bounding box only; otherwise
+     * delegates to the underlying THREE.js primitive raycast on the sub-range.
+     *
+     * Subclasses such as {@link AcTrBatchedLine} may override to add fallback logic.
+     *
+     * @param geometryId - Slot index to test.
+     * @param raycaster - Configured THREE.js raycaster.
+     * @param intersects - Output array populated with intersection records.
+     */
     _intersectWith(
       geometryId: number,
       raycaster: THREE.Raycaster,

--- a/packages/three-renderer/src/batch/AcTrBatchedPoint.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedPoint.ts
@@ -18,11 +18,24 @@ import {
   validateGeometry
 } from './AcTrBatchedMixin'
 
+/**
+ * Per-slot geometry-info type used by {@link AcTrBatchedPoint}.
+ *
+ * Point batches are non-indexed; this alias omits index-range fields present
+ * on {@link AcTrBatchedGeometryInfo}.
+ */
 export type AcTrBatchedGeometryInfo = AcTrVertexBatchGeometryInfo
 
+/** Reusable scratch box for bounds queries. */
 const _box = /*@__PURE__*/ new THREE.Box3()
+/** Reusable scratch vector for bounds expansion. */
 const _vector = /*@__PURE__*/ new THREE.Vector3()
 
+/**
+ * Mixin base produced by {@link createAcTrBatchedMixin} for non-indexed point batches.
+ *
+ * @internal Not exported; extended by {@link AcTrBatchedPoint}.
+ */
 const AcTrBatchedPointBase = createAcTrBatchedMixin<AcTrBatchedGeometryInfo>(
   THREE.Points,
   {
@@ -36,25 +49,46 @@ const AcTrBatchedPointBase = createAcTrBatchedMixin<AcTrBatchedGeometryInfo>(
 )
 
 /**
- * Batched renderer for `THREE.Points`.
+ * Batched renderer for {@link THREE.Points}.
  *
- * Point geometries are packed into a shared non-indexed attribute buffer.
+ * Point geometries are packed into a shared non-indexed attribute buffer to
+ * reduce draw calls. Each point entity receives a stable geometry id for
+ * updates, visibility toggles, and hit-testing.
+ *
+ * @see {@link AcTrBatchedMesh} for mesh batching.
+ * @see {@link AcTrBatchedLine} for line segment batching.
  */
 export class AcTrBatchedPoint extends AcTrBatchedPointBase {
+  /** Typed container metadata attached to the batch object. */
   declare userData: AcTrBatchedContainerUserData
+
+  /** Multiplier applied when auto-growing vertex buffer capacity. */
   private static readonly GROWTH_FACTOR = 1.25
-  /** Stable world origin for this batch. */
+
+  /**
+   * Stable world-space origin for this batch.
+   *
+   * Set from the first appended geometry's bounding-box center plus offset.
+   * Vertex positions are stored relative to this origin to improve floating-point
+   * precision for large-coordinate CAD data.
+   */
   private _origin?: THREE.Vector3
 
-  /** Current allocated vertex capacity. */
+  /** Current allocated vertex capacity of the packed attribute buffer. */
   private _maxVertexCount: number
 
   /** Next free vertex offset for appended geometries. */
   private _nextVertexStart = 0
 
-  /** Whether packed geometry buffers have been allocated. */
+  /** Whether packed geometry buffers have been allocated from a reference layout. */
   private _geometryInitialized = false
 
+  /**
+   * Creates a new point batch with preallocated vertex capacity.
+   *
+   * @param maxVertexCount - Initial vertex capacity; defaults to `1000`.
+   * @param material - Optional shared material for all sub-geometries in this batch.
+   */
   constructor(maxVertexCount: number = 1000, material?: THREE.Material) {
     super(new THREE.BufferGeometry(), material)
     this.frustumCulled = false
@@ -63,14 +97,31 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
     this._maxVertexCount = maxVertexCount
   }
 
+  /**
+   * Total number of geometry ids ever allocated in this batch.
+   *
+   * @returns Current `_geometryCount` value.
+   */
   get geometryCount() {
     return this._geometryCount
   }
 
+  /**
+   * Number of unused vertex slots remaining before the next buffer resize.
+   *
+   * @returns Remaining vertex capacity (`maxVertexCount - nextVertexStart`).
+   */
   get unusedVertexCount() {
     return this._maxVertexCount - this._nextVertexStart
   }
 
+  /**
+   * Allocates packed attribute buffers on first geometry insertion.
+   *
+   * Point batches are non-indexed; `maxIndexCount` is passed as `null`.
+   *
+   * @param reference - First (or representative) geometry defining batch layout.
+   */
   private _initializeGeometry(reference: THREE.BufferGeometry) {
     if (this._geometryInitialized === false) {
       initializeGeometry(this.geometry, reference, this._maxVertexCount, null)
@@ -78,11 +129,23 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
     }
   }
 
-  // Make sure the geometry is compatible with the existing combined geometry attributes
+  /**
+   * Ensures the incoming geometry matches the batch attribute layout.
+   *
+   * Index buffers are not required or validated for point batches.
+   *
+   * @param geometry - Candidate geometry to append or update.
+   * @throws {Error} When attribute layout is incompatible with the existing batch.
+   */
   private _validateGeometry(geometry: THREE.BufferGeometry) {
     validateGeometry(this.geometry, geometry, 'AcTrBatchedPoint', false)
   }
 
+  /**
+   * Grows vertex buffer capacity when the next append would overflow.
+   *
+   * @param geometry - Incoming geometry whose vertex count drives the growth calculation.
+   */
   private _resizeSpaceIfNeeded(geometry: THREE.BufferGeometry) {
     const positionAttribute = geometry.getAttribute('position')
     const newMaxVertexCount =
@@ -102,6 +165,9 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
 
   /**
    * Clears all packed point ranges and resets internal cursor state.
+   *
+   * Disposes GPU buffers, clears geometry-info records, resets the batch origin
+   * and world position, and marks buffers as uninitialized for the next insert.
    */
   reset() {
     this.boundingBox = null
@@ -121,7 +187,16 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
   }
 
   /**
-   * Appends one point geometry into packed buffers.
+   * Appends one point geometry into the packed vertex buffer.
+   *
+   * Rebases vertices to the batch origin, reserves a geometry id, and copies
+   * attribute data into the shared buffer.
+   *
+   * @param geometry - Source point geometry to pack. Mutated in place (rebase).
+   * @param reservedVertexCount - Reserved vertex span for in-place updates; `-1` uses actual count.
+   * @param worldOffset - World-space offset applied before rebasing to the batch origin.
+   * @returns The assigned geometry id for subsequent updates and metadata binding.
+   * @throws {Error} When reserved space exceeds buffer capacity or layout is incompatible.
    */
   addGeometry(
     geometry: THREE.BufferGeometry,
@@ -177,6 +252,12 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
     return geometryId
   }
 
+  /**
+   * Rebases geometry vertex positions into the batch's local coordinate frame.
+   *
+   * @param geometry - Geometry whose `position` attribute is mutated in place.
+   * @param worldOffset - World-space placement offset for the geometry.
+   */
   private rebaseGeometryInPlace(
     geometry: THREE.BufferGeometry,
     worldOffset: THREE.Vector3
@@ -226,6 +307,12 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
 
   /**
    * Assigns entity metadata for one packed geometry id.
+   *
+   * Copies optional source point `position` for symbol regeneration workflows.
+   *
+   * @param geometryId - Target slot index returned by {@link addGeometry}.
+   * @param userData - Entity metadata including optional source point position.
+   * @throws {Error} When `geometryId` is out of range.
    */
   setGeometryInfo(geometryId: number, userData: AcTrBatchGeometryUserData) {
     if (geometryId >= this._geometryCount) {
@@ -239,7 +326,13 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
   }
 
   /**
-   * Rewrites geometry payload for one packed geometry id.
+   * Rewrites geometry payload for one existing packed geometry id.
+   *
+   * @param geometryId - Target slot index.
+   * @param geometry - New geometry payload to copy into the packed buffers.
+   * @returns The same `geometryId` for chaining.
+   * @throws {Error} When the id is out of range, layout is incompatible, or
+   *   the source exceeds reserved capacity.
    */
   setGeometryAt(geometryId: number, geometry: THREE.BufferGeometry) {
     if (geometryId >= this._geometryCount) {
@@ -257,7 +350,12 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
   }
 
   /**
-   * Compacts active geometry ranges to reclaim deleted-space gaps.
+   * Compacts active geometry ranges to reclaim gaps left by deletions.
+   *
+   * Moves vertex attributes so active slots are contiguous. Advances cursors by
+   * **reserved** vertex spans to preserve in-place update capacity.
+   *
+   * @returns This instance for chaining.
    */
   optimize() {
     let nextVertexStart = 0
@@ -315,7 +413,13 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
   }
 
   /**
-   * Returns cached bounds for one geometry id, computing lazily on first use.
+   * Returns cached axis-aligned bounds for one geometry id.
+   *
+   * Iterates the slot's vertex range in the non-indexed position buffer.
+   *
+   * @param geometryId - Slot index to query.
+   * @param target - Reusable {@link THREE.Box3} that receives the result.
+   * @returns `target` when the id is valid, otherwise `null`.
    */
   getBoundingBoxAt(geometryId: number, target: THREE.Box3) {
     if (geometryId >= this._geometryCount) {
@@ -352,6 +456,10 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
 
   /**
    * Returns cached bounding sphere for one geometry id.
+   *
+   * @param geometryId - Slot index to query.
+   * @param target - Reusable {@link THREE.Sphere} that receives the result.
+   * @returns `target` when the id is valid, otherwise `null`.
    */
   getBoundingSphereAt(geometryId: number, target: THREE.Sphere) {
     if (geometryId >= this._geometryCount) {
@@ -362,6 +470,13 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
     return target
   }
 
+  /**
+   * Returns the geometry-info record for one slot after validation.
+   *
+   * @param geometryId - Slot index to query.
+   * @returns The internal {@link AcTrBatchedGeometryInfo} record.
+   * @throws {Error} When the id is invalid or the slot has been deleted.
+   */
   getGeometryAt(geometryId: number) {
     this.validateGeometryId(geometryId)
     return this._geometryInfo[geometryId]
@@ -369,6 +484,8 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
 
   /**
    * Resizes packed point buffers while preserving existing data.
+   *
+   * @param maxVertexCount - New vertex capacity.
    */
   setGeometrySize(maxVertexCount: number) {
     // dispose of the previous geometry
@@ -401,15 +518,19 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
   }
 
   /**
-   * Keeps geometry.drawRange in sync with active vertex data.
-   * Call after add / optimize / resize.
+   * Keeps `geometry.drawRange` in sync with the packed active vertex extent.
+   *
+   * Call after `addGeometry`, `optimize`, or `setGeometrySize`.
    */
   private _syncDrawRange() {
     this.geometry.setDrawRange(0, this._nextVertexStart)
   }
 
   /**
-   * Deep-copies batched point state.
+   * Deep-copies batched point state from another instance.
+   *
+   * @param source - Batch instance to copy from.
+   * @returns This instance for chaining.
    */
   copy(source: AcTrBatchedPoint) {
     super.copy(source)


### PR DESCRIPTION
## Summary

HTML snapshot export previously copied batched geometry via `geometry.drawRange`, which includes **reserved** vertex/index capacity and can include **inactive** (deleted) slots. That could export degenerate indices, padding vertices, and stale buffer data into offline HTML.

This PR aligns **line**, **point**, and **mesh** batch export with per-slot active ranges (`vertexCount` / `indexCount`), matching how the three-renderer batch buffers are actually used at runtime.

## Changes

### `@mlightcad/three-renderer`
- Add `getGeometryRangeAt()` to `AcTrBatchedMixin` so all batched primitives (line, mesh, point) expose packed slot metadata.
- Remove the duplicate `getGeometryRangeAt()` implementation from `AcTrBatchedMesh`.

### `@mlightcad/cad-html-plugin`
- Replace `exportActiveBatchedMeshSlice` with a shared **`exportActiveBatchedSlice`** used by:
  - `AcTrBatchedMesh` (indexed: active `indexCount` only, then `compactIndexedSlice`)
  - `AcTrBatchedLine` (indexed or non-indexed active vertices/indices)
  - `AcTrBatchedPoint` (non-indexed active `vertexCount` only)
- For batched lines with linetype patterns, compute `lineDistances` from the **exported** positions via `computeLineDistancesForSegments` instead of slicing the full buffer by `drawRange`.
- Keep `exportBufferGeometrySlice` for non-batched `THREE.LineSegments` / `THREE.Mesh`.
- Add unit tests for `exportActiveBatchedSlice` (indexed reserved padding, inactive slots, non-indexed reserved vertices).

## Motivation

Batched buffers pre-allocate space for performance. `drawRange` is synced to `_nextIndexStart` / `_nextVertexStart`, which span **reserved** regions—not only valid geometry. Mesh export already walked active slots; line and point did not. This change makes HTML export size and correctness consistent across batch types.

## Test plan

- [x] `npx jest packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts`
- [ ] Export a drawing with dense lines, fills, and points via `chtml`; open HTML offline and verify geometry matches the live viewer (no spurious triangles/segments).
- [ ] Export a drawing after deleting entities (without relying on `optimize()`); confirm no ghost geometry in HTML.
- [ ] Export a drawing with dashed/linetype lines; confirm line patterns render correctly in the offline viewer.