### PR TITLE
fix(cad-html-plugin): export OSNAP primitives for block and dimension entities in HTML snapshots

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
@@ -1,0 +1,111 @@
+import {
+  AcDbAlignedDimension,
+  AcDbBlockReference,
+  AcDbBlockTableRecord,
+  AcDbDatabase,
+  AcDbDataGenerator,
+  AcDbLine,
+  AcGePoint3d,
+  acdbHostApplicationServices
+} from '@mlightcad/data-model'
+
+import { buildOsnapCatalog } from '../src/AcExOsnapPrimitiveBuilder'
+import { AcExOsnapIndex } from '../src/AcExOsnap'
+
+describe('buildOsnapCatalog', () => {
+  it('exports snap primitives for geometry inside block references', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'SNAP_TEST_BLOCK'
+    db.tables.blockTable.add(blockRecord)
+    blockRecord.appendEntity(
+      new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(10, 0, 0))
+    )
+
+    const insert = new AcDbBlockReference('SNAP_TEST_BLOCK')
+    insert.position = new AcGePoint3d(100, 50, 0)
+    modelSpace.appendEntity(insert)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const line = catalog.primitives.find(p => p.kind === 'line')
+    expect(line).toEqual({
+      kind: 'line',
+      layer: '0',
+      x0: 100,
+      y0: 50,
+      x1: 110,
+      y1: 50
+    })
+  })
+
+  it('exports snap primitives for rotated block references', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'SNAP_ROT_BLOCK'
+    db.tables.blockTable.add(blockRecord)
+    blockRecord.appendEntity(
+      new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(10, 0, 0))
+    )
+
+    const insert = new AcDbBlockReference('SNAP_ROT_BLOCK')
+    insert.position = new AcGePoint3d(0, 0, 0)
+    insert.rotation = Math.PI / 2
+    modelSpace.appendEntity(insert)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const line = catalog.primitives.find(p => p.kind === 'line')
+    expect(line?.x0).toBeCloseTo(0, 5)
+    expect(line?.y0).toBeCloseTo(0, 5)
+    expect(line?.x1).toBeCloseTo(0, 5)
+    expect(line?.y1).toBeCloseTo(10, 5)
+  })
+
+  it('exports snap primitives for dimension anonymous blocks', () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    const modelSpace = db.tables.blockTable.modelSpace
+    const generator = new AcDbDataGenerator(db)
+    generator.createArrowBlock()
+
+    const dimension = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0),
+      new AcGePoint3d(5, 2, 0)
+    )
+    const blockName = '*DIM_TEST'
+    db.tables.blockTable.add(dimension.createDimBlock(blockName))
+    dimension.dimBlockId = blockName
+    modelSpace.appendEntity(dimension)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    expect(catalog.primitives.length).toBeGreaterThan(0)
+
+    const extensionLine = catalog.primitives.find(
+      (p): p is Extract<typeof p, { kind: 'line' }> =>
+        p.kind === 'line' &&
+        Math.abs(p.x0) < 1e-10 &&
+        Math.abs(p.x1) < 1e-10 &&
+        p.y0 < p.y1
+    )
+    expect(extensionLine).toBeDefined()
+
+    const index = new AcExOsnapIndex(['endpoint'])
+    index.rebuild({
+      btrId: modelSpace.objectId,
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [],
+      meshBatches: [],
+      osnap: catalog
+    })
+
+    const endpointSnap = index.findSnap(0.1, extensionLine!.y0 + 0.05, 1)
+    expect(endpointSnap?.mode).toBe('endpoint')
+    expect(endpointSnap?.x).toBeCloseTo(0, 5)
+    expect(endpointSnap?.y).toBeCloseTo(extensionLine!.y0, 5)
+  })
+})

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
@@ -14,6 +14,7 @@ import {
   type AcDbBlockTableRecord,
   AcDbCircle,
   type AcDbDatabase,
+  AcDbDimension,
   AcDbEllipse,
   AcDbEntity,
   AcDbLine,
@@ -22,6 +23,7 @@ import {
   AcDbPolyline,
   AcDbSpline,
   AcGeCircArc2d,
+  type AcGeMatrix3d,
   type AcGePoint3dLike,
   AcGeTol,
   type AcGeVector3dLike,
@@ -52,6 +54,46 @@ function transformPoint(
 ): { x: number; y: number } {
   const v = new THREE.Vector3(p.x, p.y, p.z ?? 0).applyMatrix4(matrix)
   return { x: v.x, y: v.y }
+}
+
+/**
+ * Converts an {@link AcGeMatrix3d} (or compatible matrix) to `THREE.Matrix4`.
+ *
+ * Block and dimension transforms from `@mlightcad/data-model` are `AcGeMatrix3d`
+ * instances. They share column-major `elements` with Three.js but are not
+ * `THREE.Matrix4` subclasses, so they must be copied before use with Three APIs
+ * that rely on matrix type checks.
+ *
+ * @internal
+ */
+function acGeMatrix3dToThree(matrix: AcGeMatrix3d): THREE.Matrix4 {
+  const e = matrix.elements
+  return new THREE.Matrix4(
+    e[0],
+    e[4],
+    e[8],
+    e[12],
+    e[1],
+    e[5],
+    e[9],
+    e[13],
+    e[2],
+    e[6],
+    e[10],
+    e[14],
+    e[3],
+    e[7],
+    e[11],
+    e[15]
+  )
+}
+
+/** Composes parent and child layout / INSERT / dimension-block transforms. @internal */
+function composeTransforms(
+  parent: THREE.Matrix4,
+  child: AcGeMatrix3d
+): THREE.Matrix4 {
+  return new THREE.Matrix4().multiplyMatrices(parent, acGeMatrix3dToThree(child))
 }
 
 /** Applies a 4×4 matrix to a direction vector (no translation); returns normalized XY. @internal */
@@ -182,7 +224,46 @@ function pushLineEntity(
 /** Block reference shape used for recursive osnap traversal. @internal */
 type AcExBlockReferenceLike = AcDbEntity & {
   blockTableRecord: AcDbBlockTableRecord | undefined
-  getFullInsertionTransform(): THREE.Matrix4
+  blockName?: string
+  getFullInsertionTransform(): AcGeMatrix3d
+}
+
+/** Dimension entity shape whose geometry lives in an anonymous block. @internal */
+type AcExDimensionLike = AcDbDimension & {
+  getFullDimBlockTransform(): AcGeMatrix3d
+}
+
+/**
+ * Resolves the block table record referenced by an INSERT entity.
+ *
+ * Prefer {@link AcExBlockReferenceLike.blockTableRecord} when the entity is
+ * database-backed; fall back to `blockName` on the export database.
+ *
+ * @internal
+ */
+function resolveBlockReferenceBlock(
+  entity: AcExBlockReferenceLike,
+  database: AcDbDatabase
+): AcDbBlockTableRecord | undefined {
+  return (
+    entity.blockTableRecord ??
+    (entity.blockName
+      ? database.tables.blockTable.getAt(entity.blockName)
+      : undefined)
+  )
+}
+
+/**
+ * Resolves the anonymous block referenced by a dimension entity.
+ *
+ * @internal
+ */
+function resolveDimensionBlock(
+  entity: AcExDimensionLike,
+  database: AcDbDatabase
+): AcDbBlockTableRecord | undefined {
+  const dimBlockId = entity.dimBlockId
+  return dimBlockId ? database.tables.blockTable.getAt(dimBlockId) : undefined
 }
 
 /**
@@ -455,20 +536,34 @@ function visitEntity(
   matrix: THREE.Matrix4,
   insertLayer: string,
   out: AcExOsnapPrimitive[],
-  blockStack: Set<AcDbObjectId>
+  blockStack: Set<AcDbObjectId>,
+  database: AcDbDatabase
 ) {
   if (!entity.visibility) return
 
   const layer = effectiveLayer(entity.layer, insertLayer)
 
   if (isBlockReferenceEntity(entity)) {
-    const block = entity.blockTableRecord
+    const block = resolveBlockReferenceBlock(entity, database)
     if (!block || blockStack.has(block.objectId)) return
     blockStack.add(block.objectId)
-    const insertMatrix = entity.getFullInsertionTransform()
-    const nested = new THREE.Matrix4().multiplyMatrices(matrix, insertMatrix)
+    const nested = composeTransforms(matrix, entity.getFullInsertionTransform())
     const blockInsertLayer = effectiveLayer(entity.layer, insertLayer)
-    visitBlock(block, nested, blockInsertLayer, out, blockStack)
+    visitBlock(block, nested, blockInsertLayer, out, blockStack, database)
+    blockStack.delete(block.objectId)
+    return
+  }
+
+  if (entity instanceof AcDbDimension) {
+    const dimension = entity as AcExDimensionLike
+    const block = resolveDimensionBlock(dimension, database)
+    if (!block || blockStack.has(block.objectId)) return
+    blockStack.add(block.objectId)
+    const nested = composeTransforms(
+      matrix,
+      dimension.getFullDimBlockTransform()
+    )
+    visitBlock(block, nested, layer, out, blockStack, database)
     blockStack.delete(block.objectId)
     return
   }
@@ -530,10 +625,11 @@ function visitBlock(
   matrix: THREE.Matrix4,
   insertLayer: string,
   out: AcExOsnapPrimitive[],
-  blockStack: Set<AcDbObjectId>
+  blockStack: Set<AcDbObjectId>,
+  database: AcDbDatabase
 ) {
   for (const entity of block.newIterator()) {
-    visitEntity(entity, matrix, insertLayer, out, blockStack)
+    visitEntity(entity, matrix, insertLayer, out, blockStack, database)
   }
 }
 
@@ -571,7 +667,8 @@ function ellipseFromArc(entity: AcDbArc): AcDbEllipse {
  * inside blocks inherit the INSERT layer per AutoCAD rules.
  *
  * Supported entity types: `AcDbLine`, `AcDbCircle`, `AcDbArc`, `AcDbEllipse`,
- * `AcDbSpline`, `AcDbPolyline` (lines + bulge arcs), `AcDbPoint`, and INSERT.
+ * `AcDbSpline`, `AcDbPolyline` (lines + bulge arcs), `AcDbPoint`, INSERT, and
+ * dimension entities (`AcDbDimension` and subclasses via anonymous dim blocks).
  *
  * @param database - Open drawing database (same instance used for HTML export).
  * @param layoutBtrId - Object id of the layout's owning block table record
@@ -596,6 +693,6 @@ export function buildOsnapCatalog(
 
   const primitives: AcExOsnapPrimitive[] = []
   const identity = new THREE.Matrix4()
-  visitBlock(block, identity, '0', primitives, new Set())
+  visitBlock(block, identity, '0', primitives, new Set(), database)
   return { primitives }
 }


### PR DESCRIPTION
## Summary

Fixes object snap (OSNAP) in exported HTML viewer snapshots for geometry that lives inside block definitions — especially dimension entities, whose visual geometry is stored in anonymous blocks rather than as direct model-space entities.

Previously, `buildOsnapCatalog` only emitted analytic snap primitives for top-level entities and recursively expanded `AcDbBlockReference` (INSERT) entities. Dimension entities (`AcDbDimension` and subclasses) were skipped entirely, so extension lines, dimension lines, and other geometry inside their anonymous `dimBlockId` blocks never appeared in `layout.osnap.primitives`. As a result, endpoint/midpoint snapping did not work on exported annotations even though they rendered correctly.

This PR extends the OSNAP catalog builder to traverse dimension anonymous blocks and hardens block-reference handling during export.

## Changes

- **`AcExOsnapPrimitiveBuilder.ts`**
  - Recursively visit anonymous blocks referenced by `AcDbDimension` entities via `dimBlockId`, applying `getFullDimBlockTransform()` to map block-local geometry into WCS.
  - Resolve INSERT block definitions through `blockTableRecord`, with a fallback lookup by `blockName` on the export database.
  - Convert `AcGeMatrix3d` transforms to `THREE.Matrix4` before composing nested layout / INSERT / dimension-block transforms.
  - Thread the `AcDbDatabase` instance through `visitBlock` / `visitEntity` so block resolution is consistent during recursive traversal.

- **`AcExOsnapPrimitiveBuilder.spec.ts`** (new)
  - Block references with translation and rotation produce correct WCS line primitives.
  - Aligned dimensions export non-empty OSNAP catalogs, and `AcExOsnapIndex` can snap to extension-line endpoints.

## Test plan

- [x] `npx jest packages/cad-html-plugin/__tests__`
- [ ] Export a drawing containing dimensions and nested block references to HTML
- [ ] Open the exported HTML in a browser and verify endpoint/midpoint OSNAP works on dimension extension lines and block-contained geometry during measurement