### PR TITLE
feat(html-plugin): add measure settings, ortho/polar tracking, and expanded OSNAP export

### DIFF
--- a/packages/cad-html-plugin/README.md
+++ b/packages/cad-html-plugin/README.md
@@ -13,7 +13,7 @@ The plugin path is designed for **lazy loading** so the export bundle is only do
 - **Display-only snapshot** — layers, layouts, line/mesh batches, extents, and drawing units (no editable DXF/DWG payload)
 - **Self-contained HTML** — gzip/base64 snapshot + inline viewer runtime; opens offline in any modern browser
 - **Offline viewer** — pan/zoom (OrbitControls), layer panel, layout switching, measurement, object snap (OSNAP)
-- **i18n** — embedded English / Chinese UI in the exported HTML (`en`, `zh`)
+- **i18n** — embedded English / Chinese UI; initial language follows the browser (`zh*` → Chinese, otherwise English), with manual switch persisted in `localStorage`
 - **Plugin API** — implements `AcApPlugin`; register once with `registerLazyHtmlPlugin`
 - **Composable API** — build snapshots from your own pipeline or call `packHtml` with a pre-built snapshot
 
@@ -155,7 +155,7 @@ import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.j
 | `collectBatchesFromObject3D` | THREE.js scene → line/mesh batches |
 | `buildViewerMetadata` | Database → viewer meta (units, extents, background, …) |
 | `buildOsnapCatalog`, OSNAP primitive helpers | Analytic snap geometry for the offline viewer |
-| `AcExHtmlI18n`, `detectAcExHtmlLocale`, `resolveAcExHtmlLocale` | Viewer UI strings and locale detection |
+| `AcExHtmlI18n`, `detectAcExHtmlLocale`, `detectBrowserAcExHtmlLocale`, `resolveAcExHtmlLocale` | Viewer UI strings and locale detection |
 
 ## Project layout
 

--- a/packages/cad-html-plugin/__tests__/AcExHtmlI18n.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlI18n.spec.ts
@@ -1,14 +1,80 @@
 import {
   AcExHtmlI18n,
+  ACEX_HTML_LOCALE_STORAGE_KEY,
+  detectAcExHtmlLocale,
+  detectBrowserAcExHtmlLocale,
   formatAcExHtmlMessage,
   resolveAcExHtmlLocale
 } from '../src/AcExHtmlI18n'
 
 describe('AcExHtmlI18n', () => {
+  const originalNavigator = globalThis.navigator
+  const originalLocalStorage = globalThis.localStorage
+  let storage: Record<string, string>
+
+  beforeEach(() => {
+    storage = {}
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage[key] ?? null,
+        setItem: (key: string, value: string) => {
+          storage[key] = value
+        },
+        removeItem: (key: string) => {
+          delete storage[key]
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator
+    })
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: originalLocalStorage
+    })
+  })
+
+  function mockNavigator(languages: string[], language?: string): void {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        languages,
+        language: language ?? languages[0] ?? 'en-US'
+      }
+    })
+  }
+
   it('resolves locale codes', () => {
     expect(resolveAcExHtmlLocale('zh-CN')).toBe('zh')
     expect(resolveAcExHtmlLocale('en-US')).toBe('en')
     expect(resolveAcExHtmlLocale('fr')).toBeNull()
+  })
+
+  it('detects browser locale from language preferences', () => {
+    mockNavigator(['zh-CN', 'en-US'])
+    expect(detectBrowserAcExHtmlLocale()).toBe('zh')
+
+    mockNavigator(['en-US', 'zh-CN'])
+    expect(detectBrowserAcExHtmlLocale()).toBe('en')
+
+    mockNavigator(['fr-FR'])
+    expect(detectBrowserAcExHtmlLocale()).toBe('en')
+  })
+
+  it('prefers stored locale over browser language', () => {
+    mockNavigator(['zh-CN'])
+    localStorage.setItem(ACEX_HTML_LOCALE_STORAGE_KEY, 'en')
+    expect(detectAcExHtmlLocale()).toBe('en')
+  })
+
+  it('falls back to browser locale when storage is empty', () => {
+    mockNavigator(['zh-CN'])
+    expect(detectAcExHtmlLocale()).toBe('zh')
   })
 
   it('translates messages with parameters', () => {

--- a/packages/cad-html-plugin/__tests__/AcExMeasureTracking.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMeasureTracking.spec.ts
@@ -1,0 +1,58 @@
+import { constrainToAcExTracking } from '../src/AcExMeasureTracking'
+
+describe('constrainToAcExTracking', () => {
+  const reference = { x: 0, y: 0 }
+
+  it('returns the point unchanged when tracking is disabled', () => {
+    const point = { x: 10, y: 3 }
+    expect(
+      constrainToAcExTracking(point, reference, {
+        ortho: false,
+        polar: false,
+        polarAng: 90,
+        angbase: 0,
+        angdir: 0
+      })
+    ).toEqual(point)
+  })
+
+  it('locks to horizontal when ortho is enabled', () => {
+    const point = { x: 10, y: 3 }
+    expect(
+      constrainToAcExTracking(point, reference, {
+        ortho: true,
+        polar: false,
+        polarAng: 90,
+        angbase: 0,
+        angdir: 0
+      })
+    ).toEqual({ x: 10, y: 0 })
+  })
+
+  it('locks to vertical when ortho prefers Y', () => {
+    const point = { x: 2, y: 10 }
+    expect(
+      constrainToAcExTracking(point, reference, {
+        ortho: true,
+        polar: false,
+        polarAng: 90,
+        angbase: 0,
+        angdir: 0
+      })
+    ).toEqual({ x: 0, y: 10 })
+  })
+
+  it('snaps to 45° when polar tracking is enabled', () => {
+    const point = { x: 10, y: 9 }
+    const result = constrainToAcExTracking(point, reference, {
+      ortho: false,
+      polar: true,
+      polarAng: 45,
+      angbase: 0,
+      angdir: 0
+    })
+    const angle = Math.atan2(result.y, result.x)
+    expect(Math.abs(angle - Math.PI / 4)).toBeLessThan(0.01)
+    expect(Math.hypot(result.x, result.y)).toBeCloseTo(Math.hypot(10, 9), 5)
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
@@ -4,14 +4,24 @@ import {
   AcDbBlockTableRecord,
   AcDbDatabase,
   AcDbDataGenerator,
+  AcDbHatch,
   AcDbLeader,
   AcDbLine,
+  AcDbMLeader,
+  AcDbMLeaderContentType,
+  AcDbMLine,
   AcDbPoint,
+  AcDbRasterImage,
   AcDbRay,
+  AcDbTable,
   AcDbText,
   AcDbTrace,
   AcDbXline,
+  AcGeLine2d,
+  AcGeLoop2d,
+  AcGePoint2d,
   AcGePoint3d,
+  AcGePolyline2d,
   AcGeVector3d,
   acdbHostApplicationServices
 } from '@mlightcad/data-model'
@@ -159,5 +169,208 @@ describe('buildOsnapCatalog', () => {
     expect(catalog.primitives.some(p => p.kind === 'point' && p.x === 70)).toBe(
       true
     )
+  })
+
+  it('exports snap primitives for MLINE reference path', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const mline = new AcDbMLine()
+    mline.startPosition = new AcGePoint3d(0, 0, 0)
+    mline.segments = [
+      {
+        position: new AcGePoint3d(10, 0, 0),
+        direction: new AcGeVector3d(1, 0, 0),
+        miterDirection: new AcGeVector3d(0, 1, 0),
+        elements: [
+          {
+            parameterCount: 1,
+            parameters: [0],
+            fillCount: 0,
+            fillParameters: []
+          }
+        ]
+      },
+      {
+        position: new AcGePoint3d(10, 10, 0),
+        direction: new AcGeVector3d(0, 1, 0),
+        miterDirection: new AcGeVector3d(-1, 0, 0),
+        elements: [
+          {
+            parameterCount: 1,
+            parameters: [0],
+            fillCount: 0,
+            fillParameters: []
+          }
+        ]
+      }
+    ]
+    modelSpace.appendEntity(mline)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const lines = catalog.primitives.filter(p => p.kind === 'line')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toMatchObject({
+      kind: 'line',
+      layer: '0',
+      x0: 0,
+      y0: 0,
+      x1: 10,
+      y1: 0
+    })
+    expect(lines[1]).toMatchObject({
+      kind: 'line',
+      x0: 10,
+      y0: 0,
+      x1: 10,
+      y1: 10
+    })
+  })
+
+  it('exports snap primitives for MLEADER leader lines and text anchor', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const mleader = new AcDbMLeader()
+    mleader.contentType = AcDbMLeaderContentType.MTextContent
+    mleader.mtextContent = {
+      text: 'Note',
+      anchorPoint: new AcGePoint3d(20, 20, 0)
+    }
+    const leaderIndex = mleader.addLeader()
+    mleader.addLeaderLine(leaderIndex, [
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 10, 0)
+    ])
+    modelSpace.appendEntity(mleader)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    expect(catalog.primitives.some(p => p.kind === 'line')).toBe(true)
+    expect(
+      catalog.primitives.some(
+        p => p.kind === 'point' && p.x === 20 && p.y === 20
+      )
+    ).toBe(true)
+
+    const index = new AcExOsnapIndex()
+    index.rebuild({
+      btrId: modelSpace.objectId,
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [],
+      meshBatches: [],
+      osnap: catalog
+    })
+    const snap = index.findSnap(0.1, 0.1, 5)
+    expect(snap?.mode).toBe('endpoint')
+    expect(snap?.x).toBeCloseTo(0, 5)
+    expect(snap?.y).toBeCloseTo(0, 5)
+  })
+
+  it('exports snap primitives for hatch boundary loops', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const hatch = new AcDbHatch()
+    hatch.add(
+      new AcGePolyline2d(
+        [
+          { x: 0, y: 0 },
+          { x: 20, y: 0 },
+          { x: 20, y: 10 },
+          { x: 0, y: 10 }
+        ],
+        true
+      )
+    )
+    modelSpace.appendEntity(hatch)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const lines = catalog.primitives.filter(p => p.kind === 'line')
+    expect(lines.length).toBeGreaterThanOrEqual(4)
+    expect(
+      lines.some(p => p.x0 === 0 && p.y0 === 0 && p.x1 === 20 && p.y1 === 0)
+    ).toBe(true)
+  })
+
+  it('exports snap primitives for hatch edge loops with arcs', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const hatch = new AcDbHatch()
+    const loop = new AcGeLoop2d()
+    loop.add(new AcGeLine2d(new AcGePoint2d(0, 0), new AcGePoint2d(10, 0)))
+    loop.add(new AcGeLine2d(new AcGePoint2d(10, 0), new AcGePoint2d(10, 5)))
+    loop.add(new AcGeLine2d(new AcGePoint2d(10, 5), new AcGePoint2d(0, 5)))
+    loop.add(new AcGeLine2d(new AcGePoint2d(0, 5), new AcGePoint2d(0, 0)))
+    hatch.add(loop)
+    modelSpace.appendEntity(hatch)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(4)
+  })
+
+  it('exports snap primitives for raster image frame boundary', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const image = new AcDbRasterImage()
+    image.position = new AcGePoint3d(5, 5, 0)
+    image.width = 20
+    image.height = 10
+    modelSpace.appendEntity(image)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const lines = catalog.primitives.filter(p => p.kind === 'line')
+    expect(lines.length).toBeGreaterThanOrEqual(4)
+    expect(
+      catalog.primitives.some(p => p.kind === 'point' && p.x === 5 && p.y === 5)
+    ).toBe(true)
+  })
+
+  it('exports snap primitives for procedural table grid lines', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const table = new AcDbTable('SNAP_TABLE', 2, 2)
+    table.position = new AcGePoint3d(10, 20, 0)
+    table.setUniformRowHeight(5)
+    table.setUniformColumnWidth(8)
+    modelSpace.appendEntity(table)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const lines = catalog.primitives.filter(p => p.kind === 'line')
+    expect(lines.length).toBeGreaterThanOrEqual(6)
+    expect(
+      catalog.primitives.some(
+        p => p.kind === 'point' && p.x === 10 && p.y === 20
+      )
+    ).toBe(true)
+  })
+
+  it('exports snap primitives for table anonymous blocks', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = '*T_SNAP_TABLE'
+    db.tables.blockTable.add(blockRecord)
+    blockRecord.appendEntity(
+      new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(12, 0, 0))
+    )
+
+    const table = new AcDbTable('*T_SNAP_TABLE', 1, 1)
+    table.position = new AcGePoint3d(0, 0, 0)
+    modelSpace.appendEntity(table)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const line = catalog.primitives.find(p => p.kind === 'line')
+    expect(line).toMatchObject({
+      kind: 'line',
+      x0: 0,
+      y0: 0,
+      x1: 12,
+      y1: 0
+    })
   })
 })

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -23,9 +23,17 @@ export type AcExHtmlMessageKey =
   | 'toolbar.measureArea'
   | 'toolbar.measureCoordinate'
   | 'toolbar.clearMeasurements'
+  | 'toolbar.settings'
   | 'toolbar.layers'
   | 'toolbar.language'
   | 'toolbar.languageSwitch'
+  | 'toolbar.collapse'
+  | 'toolbar.expand'
+  | 'settings.toolbar'
+  | 'settings.measureColor'
+  | 'settings.ortho'
+  | 'settings.polar'
+  | 'settings.polarAngles'
   | 'layers.title'
   | 'layers.close'
   | 'layers.showAll'
@@ -65,9 +73,19 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       measureArea: 'Measure area',
       measureCoordinate: 'Measure coordinates',
       clearMeasurements: 'Clear measurements',
+      settings: 'Measure settings',
       layers: 'Layers',
       language: 'Language',
-      languageSwitch: 'Switch to Chinese'
+      languageSwitch: 'Switch to Chinese',
+      collapse: 'Collapse toolbar',
+      expand: 'Expand toolbar'
+    },
+    settings: {
+      toolbar: 'Measure settings',
+      measureColor: 'Measure color',
+      ortho: 'Toggle orthogonal mode',
+      polar: 'Polar tracking angles',
+      polarAngles: 'Polar tracking angles'
     },
     layers: {
       title: 'Layers',
@@ -108,9 +126,19 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       measureArea: '测量面积',
       measureCoordinate: '测量坐标',
       clearMeasurements: '清除测量',
+      settings: '测量设置',
       layers: '图层',
       language: '语言',
-      languageSwitch: '切换到 English'
+      languageSwitch: '切换到 English',
+      collapse: '收起工具栏',
+      expand: '展开工具栏'
+    },
+    settings: {
+      toolbar: '测量设置',
+      measureColor: '测量颜色',
+      ortho: '切换正交模式',
+      polar: '极轴追踪角度',
+      polarAngles: '极轴追踪角度'
     },
     layers: {
       title: '图层',
@@ -165,15 +193,35 @@ export function resolveAcExHtmlLocale(
 }
 
 /**
- * Chooses the initial locale for the offline viewer using, in order:
- * `localStorage`, snapshot preference, `<html lang>`, and `navigator.language`.
+ * Detects locale from the browser's language preferences.
+ * Chinese (`zh*`) maps to `'zh'`; all other languages default to `'en'`.
  *
- * @param preferred - Optional locale from {@link AcExSnapshot.meta.locale}.
+ * @returns `'zh'` when a preferred browser language is Chinese, otherwise `'en'`.
+ */
+export function detectBrowserAcExHtmlLocale(): AcExHtmlLocale {
+  if (typeof navigator === 'undefined') return 'en'
+
+  const candidates = [
+    ...(navigator.languages ?? []),
+    navigator.language
+  ].filter(Boolean)
+
+  for (const candidate of candidates) {
+    const resolved = resolveAcExHtmlLocale(candidate)
+    if (resolved === 'zh') return 'zh'
+    if (resolved === 'en') return 'en'
+  }
+
+  return 'en'
+}
+
+/**
+ * Chooses the initial locale for the offline viewer using, in order:
+ * persisted user choice in `localStorage`, then {@link detectBrowserAcExHtmlLocale}.
+ *
  * @returns Resolved locale, defaulting to `'en'`.
  */
-export function detectAcExHtmlLocale(
-  preferred?: string | null
-): AcExHtmlLocale {
+export function detectAcExHtmlLocale(): AcExHtmlLocale {
   if (typeof localStorage !== 'undefined') {
     try {
       const stored = localStorage.getItem(ACEX_HTML_LOCALE_STORAGE_KEY)
@@ -184,20 +232,7 @@ export function detectAcExHtmlLocale(
     }
   }
 
-  const fromPreferred = resolveAcExHtmlLocale(preferred)
-  if (fromPreferred) return fromPreferred
-
-  if (typeof document !== 'undefined') {
-    const fromDocument = resolveAcExHtmlLocale(document.documentElement.lang)
-    if (fromDocument) return fromDocument
-  }
-
-  if (typeof navigator !== 'undefined') {
-    const fromNavigator = resolveAcExHtmlLocale(navigator.language)
-    if (fromNavigator) return fromNavigator
-  }
-
-  return 'en'
+  return detectBrowserAcExHtmlLocale()
 }
 
 function lookupMessage(tree: AcExMessageTree, key: string): string | undefined {
@@ -319,6 +354,7 @@ export class AcExHtmlI18n {
   applyToDocument(root?: ParentNode): void {
     if (typeof document === 'undefined') return
     const scope = root ?? document
+    document.documentElement.lang = this._locale
 
     // Only leaf text targets — never set textContent on containers or icon buttons.
     scope.querySelectorAll<HTMLElement>('[data-i18n-text]').forEach(el => {

--- a/packages/cad-html-plugin/src/AcExHtmlIcons.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlIcons.ts
@@ -36,6 +36,24 @@ const ICON_LAYER_OFF =
 const ICON_LANGUAGE =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="m18.5 10 4.4 11h-2.155l-1.201-3h-4.09l-1.199 3h-2.154L16.5 10h2zM10 2v2h6v2h-1.968a18.222 18.222 0 0 1-3.62 6.301 14.864 14.864 0 0 0 2.336 1.707l-.751 1.878A17.015 17.015 0 0 1 9 13.725 16.676 16.676 0 0 1 3.524 17.273l-.536-1.929a14.7 14.7 0 0 0 5.327-3.042A18.078 18.078 0 0 1 4.767 8h2.24A16.032 16.032 0 0 0 9 10.877 16.165 16.165 0 0 0 11.91 6.001L2 6V4h6V2h2zm7.5 10.885L16.253 16h2.492L17.5 12.885z"/></svg>'
 
+const ICON_SETTING =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" aria-hidden="true"><path fill="currentColor" d="M600.704 64a32 32 0 0 1 30.464 22.208l35.2 109.376c14.784 7.232 28.928 15.36 42.432 24.512l112.384-24.192a32 32 0 0 1 34.432 15.36L944.32 364.8a32 32 0 0 1-4.032 37.504l-77.12 85.12a357 357 0 0 1 0 49.024l77.12 85.248a32 32 0 0 1 4.032 37.504l-88.704 153.6a32 32 0 0 1-34.432 15.296L708.8 803.904c-13.44 9.088-27.648 17.28-42.368 24.512l-35.264 109.376A32 32 0 0 1 600.704 960H423.296a32 32 0 0 1-30.464-22.208L357.696 828.48a352 352 0 0 1-42.56-24.64l-112.32 24.256a32 32 0 0 1-34.432-15.36L79.68 659.2a32 32 0 0 1 4.032-37.504l77.12-85.248a357 357 0 0 1 0-48.896l-77.12-85.248A32 32 0 0 1 79.68 364.8l88.704-153.6a32 32 0 0 1 34.432-15.296l112.32 24.256c13.568-9.152 27.776-17.408 42.56-24.64l35.2-109.312A32 32 0 0 1 423.232 64H600.64zm-23.424 64H446.72l-36.352 113.088l-24.512 11.968a294 294 0 0 0-34.816 20.096l-22.656 15.36l-116.224-25.088l-65.28 113.152l79.68 88.192l-1.92 27.136a293 293 0 0 0 0 40.192l1.92 27.136l-79.808 88.192l65.344 113.152l116.224-25.024l22.656 15.296a294 294 0 0 0 34.816 20.096l24.512 11.968L446.72 896h130.688l36.48-113.152l24.448-11.904a288 288 0 0 0 34.752-20.096l22.592-15.296l116.288 25.024l65.28-113.152l-79.744-88.192l1.92-27.136a293 293 0 0 0 0-40.256l-1.92-27.136l79.808-88.128l-65.344-113.152l-116.288 24.96l-22.592-15.232a288 288 0 0 0-34.752-20.096l-24.448-11.904L577.344 128zM512 320a192 192 0 1 1 0 384a192 192 0 0 1 0-384m0 64a128 128 0 1 0 0 256a128 128 0 0 0 0-256"/></svg>'
+
+const ICON_ORTHO_MODE =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M3 2H2v16h16v-1H8v-5H3V2zm0 11v4h4v-4H3z"/></svg>'
+
+const ICON_POLAR_TRACKING =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M16.98 11L18.5 11L18.5 10L16.98 10C16.86 8.13 16.05 6.44 14.8 5.2L16.88 2.83L16.12 2.17L14.05 4.54C12.79 3.57 11.21 3 9.5 3C5.36 3 2 6.36 2 10.5C2 14.64 5.36 18 9.5 18C13.47 18 16.73 14.91 16.98 11ZM15.98 10C15.86 8.43 15.18 7.01 14.14 5.95L10.6 10L15.98 10ZM13.39 5.29L8.4 11L15.98 11C15.73 14.36 12.92 17 9.5 17C5.91 17 3 14.09 3 10.5C3 6.91 5.91 4 9.5 4C10.96 4 12.31 4.48 13.39 5.29Z"/></svg>'
+
+const ICON_COLOR =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="#e75958" d="M22 12H12l5 8.66A10 10 0 0 0 22 12Z"/><path fill="#814dff" d="M17 20.66 12 12 7 20.66A10 10 0 0 0 17 20.66Z"/><path fill="#13b0ce" d="M7 20.66 12 12H2A10 10 0 0 0 7 20.66Z"/><path fill="#4ecd83" d="M2 12H12L7 3.34A10 10 0 0 0 2 12Z"/><path fill="#ffc33f" d="M7 3.34 12 12l5-8.66A10 10 0 0 0 7 3.34Z"/><path fill="#ff9543" d="M17 3.34 12 12H22A10 10 0 0 0 17 3.34Z"/></svg>'
+
+const ICON_CHEVRON_UP =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M10 6.5 5.5 11h9L10 6.5Z"/></svg>'
+
+const ICON_CHEVRON_DOWN =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M10 13.5 14.5 9h-9L10 13.5Z"/></svg>'
+
 /**
  * Inline SVG markup keyed by toolbar / layer UI usage.
  * Each value is a complete `<svg>…</svg>` string using `currentColor`.
@@ -64,7 +82,19 @@ export const acExHtmlIcons = {
   /** “Hide all layers” action icon. */
   layerOff: ICON_LAYER_OFF,
   /** Language switch toolbar icon. */
-  language: ICON_LANGUAGE
+  language: ICON_LANGUAGE,
+  /** Measure settings toolbar icon. */
+  setting: ICON_SETTING,
+  /** Orthogonal mode toggle icon. */
+  orthoMode: ICON_ORTHO_MODE,
+  /** Polar tracking toggle icon. */
+  polarTracking: ICON_POLAR_TRACKING,
+  /** Measure color picker icon. */
+  color: ICON_COLOR,
+  /** Collapse toolbar (chevron up). */
+  chevronUp: ICON_CHEVRON_UP,
+  /** Expand toolbar (chevron down). */
+  chevronDown: ICON_CHEVRON_DOWN
 } as const
 
 /**

--- a/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
@@ -1,0 +1,387 @@
+import type { AcExHtmlI18n } from './AcExHtmlI18n'
+import { acExHtmlIcons, acExToolbarButton } from './AcExHtmlIcons'
+import type { AcExMeasureController } from './AcExMeasurement'
+import type { AcExTrackingOptions } from './AcExMeasureTracking'
+
+/** Default measurement accent color (`--mlcad-accent`). */
+export const ACEX_DEFAULT_MEASURE_COLOR = 0x08e8de
+
+/** `localStorage` key for persisted measure settings. */
+export const ACEX_MEASURE_SETTINGS_STORAGE_KEY = 'mlcad-html-measure-settings'
+
+/** Common polar angle increments for the offline HTML viewer. */
+export const ACEX_POLAR_ANGLE_INCREMENTS = [90, 45, 30, 23, 18, 10, 5] as const
+
+/** Polar increment equivalent to orthogonal mode. */
+export const ACEX_ORTHO_POLAR_ANGLE = 90
+
+/** Default polar increment when polar tracking is enabled. */
+export const ACEX_DEFAULT_POLAR_ANGLE = ACEX_ORTHO_POLAR_ANGLE
+
+/** Persisted measure settings for the offline HTML viewer. */
+export interface AcExMeasureSettingsState {
+  measureColor: number
+  ortho: boolean
+  polar: boolean
+  polarAng: number
+}
+
+interface AcExMeasureSettingsPersisted {
+  measureColor?: number
+  ortho?: boolean
+  polar?: boolean
+  polarAng?: number
+}
+
+/** Dependencies for {@link setupAcExHtmlMeasureSettings}. */
+export interface AcExHtmlMeasureSettingsContext {
+  i18n: AcExHtmlI18n
+  measure: AcExMeasureController
+  angbase: number
+  angdir: number
+}
+
+function hexToCss(hex: number): string {
+  return `#${hex.toString(16).padStart(6, '0')}`
+}
+
+function hexToRgba(hex: number, alpha: number): string {
+  const r = (hex >> 16) & 0xff
+  const g = (hex >> 8) & 0xff
+  const b = hex & 0xff
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+function applyMeasureColorCss(hex: number): void {
+  const css = hexToCss(hex)
+  const root = document.documentElement
+  root.style.setProperty('--mlcad-measure-accent', css)
+  root.style.setProperty('--mlcad-measure-accent-border', hexToRgba(hex, 0.45))
+  root.style.setProperty('--mlcad-measure-accent-fill', hexToRgba(hex, 0.2))
+}
+
+function isOrthoPolarAngle(angle: number): boolean {
+  return Math.abs(angle - ACEX_ORTHO_POLAR_ANGLE) < 0.001
+}
+
+function normalizeTrackingState(state: AcExMeasureSettingsState): void {
+  if (state.ortho) {
+    state.polar = false
+    state.polarAng = ACEX_ORTHO_POLAR_ANGLE
+    return
+  }
+  if (state.polar && isOrthoPolarAngle(state.polarAng)) {
+    state.ortho = true
+    state.polar = false
+  }
+}
+
+function loadPersistedSettings(): Partial<AcExMeasureSettingsState> {
+  if (typeof localStorage === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(ACEX_MEASURE_SETTINGS_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as AcExMeasureSettingsPersisted
+    const result: Partial<AcExMeasureSettingsState> = {}
+    if (
+      typeof parsed.measureColor === 'number' &&
+      Number.isFinite(parsed.measureColor)
+    ) {
+      result.measureColor = parsed.measureColor
+    }
+    if (typeof parsed.ortho === 'boolean') result.ortho = parsed.ortho
+    if (typeof parsed.polar === 'boolean') result.polar = parsed.polar
+    if (
+      typeof parsed.polarAng === 'number' &&
+      Number.isFinite(parsed.polarAng)
+    ) {
+      const match = ACEX_POLAR_ANGLE_INCREMENTS.find(
+        value => Math.abs(value - parsed.polarAng!) < 0.001
+      )
+      if (match != null) result.polarAng = match
+    }
+    if (
+      result.ortho != null ||
+      result.polar != null ||
+      result.polarAng != null
+    ) {
+      const normalized: AcExMeasureSettingsState = {
+        measureColor: ACEX_DEFAULT_MEASURE_COLOR,
+        ortho: result.ortho ?? false,
+        polar: result.polar ?? false,
+        polarAng: result.polarAng ?? ACEX_DEFAULT_POLAR_ANGLE
+      }
+      normalizeTrackingState(normalized)
+      result.ortho = normalized.ortho
+      result.polar = normalized.polar
+      result.polarAng = normalized.polarAng
+    }
+    return result
+  } catch {
+    return {}
+  }
+}
+
+function savePersistedSettings(state: AcExMeasureSettingsState): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(
+      ACEX_MEASURE_SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        measureColor: state.measureColor,
+        ortho: state.ortho,
+        polar: state.polar,
+        polarAng: state.polarAng
+      })
+    )
+  } catch {
+    /* private mode */
+  }
+}
+
+/**
+ * Builds the settings strip markup inserted beside the toolbar in {@link buildAcExHtmlShellBody}.
+ */
+export function buildAcExHtmlSettingsStrip(): string {
+  const polarAngleButtons = ACEX_POLAR_ANGLE_INCREMENTS.map(
+    angle =>
+      `<button type="button" class="mlcad-tool-btn mlcad-settings-option-btn mlcad-polar-angle-btn" data-polar-ang="${angle}" title="${angle}°" aria-label="${angle}°"><span class="mlcad-settings-option-indicator" aria-hidden="true"></span><span class="mlcad-settings-option-text">${angle}°</span></button>`
+  ).join('')
+
+  return `
+      <div id="mlcad-settings-wrap" hidden>
+        <div id="mlcad-settings-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="settings.toolbar" aria-label="Measure settings">
+          <button type="button" class="mlcad-tool-btn mlcad-color-btn" id="mlcad-measure-color-btn" data-i18n-key="settings.measureColor" data-i18n-attr="title aria-label" title="Measure color" aria-label="Measure color">
+            ${acExHtmlIcons.color}
+          </button>
+          <input type="color" id="mlcad-measure-color-input" class="mlcad-color-input" value="${hexToCss(ACEX_DEFAULT_MEASURE_COLOR)}" tabindex="-1" aria-hidden="true" />
+          ${acExToolbarButton(acExHtmlIcons.orthoMode, 'Orthogonal mode', {
+            id: 'mlcad-ortho-btn',
+            'data-toggle': 'ortho',
+            'data-i18n-key': 'settings.ortho',
+            'data-i18n-attr': 'title aria-label'
+          })}
+          ${acExToolbarButton(acExHtmlIcons.polarTracking, 'Polar tracking', {
+            id: 'mlcad-polar-btn',
+            'data-toggle': 'polar',
+            'data-i18n-key': 'settings.polar',
+            'data-i18n-attr': 'title aria-label'
+          })}
+          <button type="button" class="mlcad-tool-btn mlcad-lang-btn" id="mlcad-lang-btn" data-i18n-key="toolbar.languageSwitch" data-i18n-attr="title aria-label" title="Switch language" aria-label="Switch language">
+            ${acExHtmlIcons.language}
+            <span class="mlcad-lang-badge" id="mlcad-lang-badge">EN</span>
+          </button>
+        </div>
+        <div id="mlcad-polar-angles" role="group" data-i18n-attr="aria-label" data-i18n-key="settings.polarAngles" aria-label="Polar tracking angles" hidden>
+          ${polarAngleButtons}
+        </div>
+      </div>`
+}
+
+/** Live measure settings exposed to the measurement controller. */
+export interface AcExHtmlMeasureSettingsController {
+  /** Current settings snapshot. */
+  readonly state: AcExMeasureSettingsState
+  /** Tracking options derived from state and snapshot angle metadata. */
+  getTrackingOptions(): AcExTrackingOptions
+  /** Reapplies i18n labels after locale change. */
+  refreshLabels: () => void
+}
+
+/**
+ * Wires the measure settings strip: color picker, ortho, and polar tracking.
+ */
+export function setupAcExHtmlMeasureSettings(
+  ctx: AcExHtmlMeasureSettingsContext
+): AcExHtmlMeasureSettingsController {
+  const persisted = loadPersistedSettings()
+  const state: AcExMeasureSettingsState = {
+    measureColor: persisted.measureColor ?? ACEX_DEFAULT_MEASURE_COLOR,
+    ortho: persisted.ortho ?? false,
+    polar: persisted.polar ?? false,
+    polarAng: persisted.polarAng ?? ACEX_DEFAULT_POLAR_ANGLE
+  }
+  normalizeTrackingState(state)
+
+  const settingsBtn = document.getElementById('mlcad-settings-btn')
+  const settingsWrap = document.getElementById('mlcad-settings-wrap')
+  const polarPanel = document.getElementById('mlcad-polar-angles')
+  const orthoBtn = document.getElementById('mlcad-ortho-btn')
+  const polarBtn = document.getElementById('mlcad-polar-btn')
+  const colorBtn = document.getElementById('mlcad-measure-color-btn')
+  const colorInput = document.getElementById(
+    'mlcad-measure-color-input'
+  ) as HTMLInputElement | null
+
+  const persist = () => savePersistedSettings(state)
+
+  const syncMeasureColor = () => {
+    applyMeasureColorCss(state.measureColor)
+    ctx.measure.setMeasureColor(state.measureColor)
+  }
+
+  const syncTrackingButtons = () => {
+    orthoBtn?.classList.toggle('active', state.ortho)
+    const polarPanelOpen = polarPanel ? !polarPanel.hidden : false
+    polarBtn?.classList.toggle(
+      'active',
+      polarPanelOpen || (state.polar && !state.ortho)
+    )
+  }
+
+  const isPolarAngleSelected = (angle: number): boolean => {
+    if (isOrthoPolarAngle(angle)) return state.ortho
+    return (
+      state.polar && !state.ortho && Math.abs(state.polarAng - angle) < 0.001
+    )
+  }
+
+  const syncPolarAngleButtons = () => {
+    document
+      .querySelectorAll<HTMLButtonElement>(
+        '#mlcad-polar-angles [data-polar-ang]'
+      )
+      .forEach(btn => {
+        const ang = Number(btn.getAttribute('data-polar-ang'))
+        btn.classList.toggle('active', isPolarAngleSelected(ang))
+      })
+  }
+
+  const setSettingsOpen = (open: boolean) => {
+    if (settingsWrap) settingsWrap.hidden = !open
+    settingsBtn?.classList.toggle('active', open)
+    settingsBtn?.setAttribute('aria-expanded', String(open))
+    if (!open) setPolarPanelOpen(false)
+  }
+
+  const setPolarPanelOpen = (open: boolean) => {
+    if (!polarPanel) return
+    polarPanel.hidden = !open
+    polarBtn?.setAttribute('aria-expanded', String(open))
+    if (open) syncPolarAngleButtons()
+    syncTrackingButtons()
+  }
+
+  const disableTracking = () => {
+    state.ortho = false
+    state.polar = false
+    syncTrackingButtons()
+    syncPolarAngleButtons()
+    persist()
+  }
+
+  const enableOrtho = () => {
+    state.ortho = true
+    state.polar = false
+    state.polarAng = ACEX_ORTHO_POLAR_ANGLE
+    syncTrackingButtons()
+    syncPolarAngleButtons()
+    persist()
+  }
+
+  const disableOrtho = () => {
+    state.ortho = false
+    syncTrackingButtons()
+    syncPolarAngleButtons()
+    persist()
+  }
+
+  const enablePolar = (angle: number) => {
+    if (isOrthoPolarAngle(angle)) {
+      enableOrtho()
+      return
+    }
+    state.ortho = false
+    state.polar = true
+    state.polarAng = angle
+    syncTrackingButtons()
+    syncPolarAngleButtons()
+    persist()
+  }
+
+  syncMeasureColor()
+  syncTrackingButtons()
+  syncPolarAngleButtons()
+  if (colorInput) colorInput.value = hexToCss(state.measureColor)
+
+  settingsBtn?.addEventListener('click', event => {
+    event.stopPropagation()
+    const open = settingsWrap?.hidden !== false
+    setSettingsOpen(open)
+  })
+
+  colorBtn?.addEventListener('click', event => {
+    event.stopPropagation()
+    colorInput?.click()
+  })
+
+  colorInput?.addEventListener('input', () => {
+    const hex = Number.parseInt(colorInput.value.slice(1), 16)
+    if (!Number.isFinite(hex)) return
+    state.measureColor = hex
+    syncMeasureColor()
+    persist()
+  })
+
+  orthoBtn?.addEventListener('click', event => {
+    event.stopPropagation()
+    setPolarPanelOpen(false)
+    if (state.ortho) {
+      disableOrtho()
+    } else {
+      enableOrtho()
+    }
+  })
+
+  polarBtn?.addEventListener('click', event => {
+    event.stopPropagation()
+    setPolarPanelOpen(polarPanel?.hidden !== false)
+  })
+
+  document
+    .querySelectorAll<HTMLButtonElement>('#mlcad-polar-angles [data-polar-ang]')
+    .forEach(btn => {
+      btn.addEventListener('click', event => {
+        event.stopPropagation()
+        const ang = Number(btn.getAttribute('data-polar-ang'))
+        if (!Number.isFinite(ang)) return
+        if (isPolarAngleSelected(ang)) {
+          disableTracking()
+          return
+        }
+        enablePolar(ang)
+      })
+    })
+
+  document.addEventListener('click', event => {
+    if (settingsWrap?.hidden) return
+    const target = event.target
+    if (!(target instanceof Node)) return
+    const sidebar = document.getElementById('mlcad-sidebar')
+    if (sidebar?.contains(target)) return
+    setSettingsOpen(false)
+  })
+
+  const refreshLabels = () => {
+    ctx.i18n.applyToDocument(
+      document.getElementById('mlcad-settings-wrap') ?? undefined
+    )
+    syncPolarAngleButtons()
+  }
+
+  return {
+    get state() {
+      return state
+    },
+    getTrackingOptions(): AcExTrackingOptions {
+      return {
+        ortho: state.ortho,
+        polar: state.polar,
+        polarAng: state.ortho ? ACEX_ORTHO_POLAR_ANGLE : state.polarAng,
+        angbase: ctx.angbase,
+        angdir: ctx.angdir
+      }
+    },
+    refreshLabels
+  }
+}

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -1,4 +1,5 @@
 import { acExHtmlIcons, acExToolbarButton } from './AcExHtmlIcons'
+import { buildAcExHtmlSettingsStrip } from './AcExHtmlMeasureSettings'
 
 /**
  * Shared CSS for the offline HTML viewer chrome (toolbar, layer drawer, status bar).
@@ -13,6 +14,9 @@ export const ACEX_HTML_SHELL_CSS = `
     --mlcad-ui-muted: #9aa0a6;
     --mlcad-accent: #08e8de;
     --mlcad-accent-active: #1a8cff;
+    --mlcad-measure-accent: #08e8de;
+    --mlcad-measure-accent-border: rgba(8, 232, 222, 0.45);
+    --mlcad-measure-accent-fill: rgba(8, 232, 222, 0.2);
     --mlcad-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
     --mlcad-toolbar-width: 44px;
     --mlcad-drawer-width: 220px;
@@ -82,6 +86,20 @@ export const ACEX_HTML_SHELL_CSS = `
   }
   .mlcad-tool-btn svg {
     width: 20px; height: 20px; display: block; flex-shrink: 0;
+  }
+  #mlcad-toolbar-toggle {
+    height: calc(var(--mlcad-toolbar-width) / 2);
+    margin-top: -4px;
+    margin-bottom: -4px;
+    border-radius: 4px;
+  }
+  #mlcad-toolbar-toggle svg {
+    width: calc(var(--mlcad-toolbar-width) / 2);
+    height: calc(var(--mlcad-toolbar-width) / 2);
+  }
+  #mlcad-toolbar > .mlcad-tool-separator:last-of-type {
+    margin-top: 0;
+    margin-bottom: 0;
   }
   .mlcad-lang-btn { position: relative; }
   .mlcad-lang-badge {
@@ -196,6 +214,94 @@ export const ACEX_HTML_SHELL_CSS = `
     margin: 4px 8px;
     background: var(--mlcad-ui-border);
   }
+
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-settings-wrap,
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-layer-drawer {
+    display: none !important;
+  }
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-toolbar .mlcad-tool-btn:not(#mlcad-toolbar-toggle),
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-toolbar .mlcad-tool-separator {
+    display: none;
+  }
+
+  #mlcad-settings-wrap {
+    flex-shrink: 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: var(--mlcad-drawer-gap);
+  }
+  #mlcad-settings-wrap[hidden] { display: none; }
+
+  #mlcad-settings-strip {
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+    padding: 6px;
+    background: var(--mlcad-ui-bg);
+    border: 1px solid var(--mlcad-ui-border);
+    border-radius: 8px;
+    box-shadow: var(--mlcad-shadow);
+    backdrop-filter: blur(12px);
+  }
+
+  #mlcad-polar-angles {
+    flex-shrink: 0;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+    padding: 6px;
+    max-width: min(280px, calc(100vw - 2 * var(--mlcad-ui-inset) - 3 * var(--mlcad-toolbar-width) - 3 * var(--mlcad-drawer-gap)));
+    background: var(--mlcad-ui-bg);
+    border: 1px solid var(--mlcad-ui-border);
+    border-radius: 8px;
+    box-shadow: var(--mlcad-shadow);
+    backdrop-filter: blur(12px);
+  }
+  #mlcad-polar-angles[hidden] { display: none; }
+
+  .mlcad-color-input {
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .mlcad-settings-option-btn {
+    width: 100%;
+    box-sizing: border-box;
+    height: var(--mlcad-toolbar-width);
+    justify-content: flex-start;
+    gap: 8px;
+    padding: 0 10px;
+    font-size: 11px;
+    font-weight: 500;
+  }
+  .mlcad-settings-option-indicator {
+    flex-shrink: 0;
+    width: 10px;
+    height: 10px;
+    border: 1px solid var(--mlcad-ui-muted);
+    border-radius: 2px;
+    box-sizing: border-box;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  .mlcad-settings-option-btn.active .mlcad-settings-option-indicator {
+    background: var(--mlcad-accent);
+    border-color: var(--mlcad-accent);
+  }
+  .mlcad-settings-option-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    pointer-events: none;
+    line-height: 1.2;
+  }
+
   #mlcad-measure-overlays {
     position: absolute;
     inset: 0;
@@ -214,7 +320,7 @@ export const ACEX_HTML_SHELL_CSS = `
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background: var(--mlcad-accent);
+    background: var(--mlcad-measure-accent);
     border: 2px solid rgba(255, 255, 255, 0.9);
     box-sizing: border-box;
     transform: translate(-50%, -50%);
@@ -225,8 +331,8 @@ export const ACEX_HTML_SHELL_CSS = `
     padding: 3px 10px;
     border-radius: 14px;
     background: var(--mlcad-ui-bg-elevated);
-    border: 1px solid rgba(8, 232, 222, 0.45);
-    color: var(--mlcad-accent);
+    border: 1px solid var(--mlcad-measure-accent-border);
+    color: var(--mlcad-measure-accent);
     font-size: 12px;
     font-weight: 600;
     white-space: nowrap;
@@ -251,7 +357,7 @@ export const ACEX_HTML_SHELL_CSS = `
   .mlcad-measure-live-label {
     position: absolute;
     pointer-events: none;
-    color: var(--mlcad-accent);
+    color: var(--mlcad-measure-accent);
     font-size: 12px;
     font-weight: 600;
     text-shadow: 0 0 4px #000, 0 1px 3px #000;
@@ -379,11 +485,22 @@ export function buildAcExHtmlShellBody(loadingBg: string): string {
           'data-i18n-key': 'toolbar.layers',
           'data-i18n-attr': 'title aria-label'
         })}
-        <button type="button" class="mlcad-tool-btn mlcad-lang-btn" id="mlcad-lang-btn" data-i18n-key="toolbar.languageSwitch" data-i18n-attr="title aria-label" title="Switch language" aria-label="Switch language">
-          ${acExHtmlIcons.language}
-          <span class="mlcad-lang-badge" id="mlcad-lang-badge">EN</span>
-        </button>
+        ${acExToolbarButton(acExHtmlIcons.setting, 'Measure settings', {
+          id: 'mlcad-settings-btn',
+          'aria-haspopup': 'true',
+          'aria-expanded': 'false',
+          'data-i18n-key': 'toolbar.settings',
+          'data-i18n-attr': 'title aria-label'
+        })}
+        <div class="mlcad-tool-separator" aria-hidden="true"></div>
+        ${acExToolbarButton(acExHtmlIcons.chevronUp, 'Collapse toolbar', {
+          id: 'mlcad-toolbar-toggle',
+          'aria-expanded': 'true',
+          'data-i18n-key': 'toolbar.collapse',
+          'data-i18n-attr': 'title aria-label'
+        })}
       </nav>
+      ${buildAcExHtmlSettingsStrip()}
       <div id="mlcad-layer-drawer" role="dialog" data-i18n-attr="aria-label" data-i18n-key="layers.title" aria-label="Layers" hidden>
         <div class="mlcad-drawer-header">
           <span data-i18n-key="layers.title" data-i18n-text>Layers</span>

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 
 import { AcExHtmlI18n, detectAcExHtmlLocale } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
+import { setupAcExHtmlMeasureSettings } from './AcExHtmlMeasureSettings'
 import {
   computeLayerExtentsMap,
   resolveLayoutViewExtents
@@ -72,7 +73,7 @@ function startViewer(): void {
     return
   }
 
-  const i18n = new AcExHtmlI18n(detectAcExHtmlLocale(snapshot.meta.locale))
+  const i18n = new AcExHtmlI18n(detectAcExHtmlLocale())
   i18n.applyToDocument()
 
   const layout =
@@ -260,6 +261,10 @@ function startViewer(): void {
     renderer.render(scene, camera)
   }
 
+  const measureSettingsRef: {
+    current: ReturnType<typeof setupAcExHtmlMeasureSettings> | null
+  } = { current: null }
+
   const measure = new AcExMeasureController({
     root,
     scene,
@@ -273,6 +278,8 @@ function startViewer(): void {
         osnapMarker.hide()
       }
     },
+    getTrackingOptions: () =>
+      measureSettingsRef.current?.getTrackingOptions() ?? null,
     view: {
       screenToWcs,
       wcsToScreen,
@@ -282,6 +289,15 @@ function startViewer(): void {
       formatAngle
     }
   })
+
+  measureSettingsRef.current = setupAcExHtmlMeasureSettings({
+    i18n,
+    measure,
+    angbase: snapshot.meta.units.angbase,
+    angdir: snapshot.meta.units.angdir
+  })
+
+  const toolbarCollapse = setupToolbarCollapse(i18n)
 
   const layerPanel = setupLayerPanel({
     snapshot,
@@ -307,6 +323,8 @@ function startViewer(): void {
       statusEl.textContent = readyStatus
     }
     layerPanel?.refreshLayerLabels()
+    measureSettingsRef.current?.refreshLabels()
+    toolbarCollapse.refreshLabels()
   })
 
   document
@@ -382,6 +400,70 @@ interface AcExLayerRowRefs {
   name: string
   /** Per-layer zoom button whose `title` / `aria-label` are retranslated. */
   zoomBtn: HTMLButtonElement
+}
+
+/** Handles returned by {@link setupToolbarCollapse} for locale-driven UI updates. */
+interface AcExToolbarCollapseController {
+  refreshLabels: () => void
+}
+
+function setupToolbarCollapse(
+  i18n: AcExHtmlI18n
+): AcExToolbarCollapseController {
+  const sidebar = document.getElementById('mlcad-sidebar')
+  const toggleBtn = document.getElementById('mlcad-toolbar-toggle')
+  if (!sidebar || !toggleBtn) {
+    return { refreshLabels: () => {} }
+  }
+
+  let collapsed = false
+
+  const closeSidePanels = () => {
+    const layerDrawer = document.getElementById('mlcad-layer-drawer')
+    const layersBtn = document.getElementById('mlcad-layers-btn')
+    const settingsWrap = document.getElementById('mlcad-settings-wrap')
+    const settingsBtn = document.getElementById('mlcad-settings-btn')
+    const polarPanel = document.getElementById('mlcad-polar-angles')
+    const polarBtn = document.getElementById('mlcad-polar-btn')
+
+    if (layerDrawer) layerDrawer.hidden = true
+    layersBtn?.classList.remove('active')
+    layersBtn?.setAttribute('aria-expanded', 'false')
+
+    if (settingsWrap) settingsWrap.hidden = true
+    settingsBtn?.classList.remove('active')
+    settingsBtn?.setAttribute('aria-expanded', 'false')
+
+    if (polarPanel) polarPanel.hidden = true
+    polarBtn?.setAttribute('aria-expanded', 'false')
+  }
+
+  const syncToggle = () => {
+    sidebar.classList.toggle('mlcad-sidebar--collapsed', collapsed)
+    toggleBtn.innerHTML = collapsed
+      ? acExHtmlIcons.chevronDown
+      : acExHtmlIcons.chevronUp
+    toggleBtn.setAttribute('aria-expanded', String(!collapsed))
+    toggleBtn.dataset.i18nKey = collapsed
+      ? 'toolbar.expand'
+      : 'toolbar.collapse'
+    const label = i18n.t(collapsed ? 'toolbar.expand' : 'toolbar.collapse')
+    toggleBtn.setAttribute('title', label)
+    toggleBtn.setAttribute('aria-label', label)
+  }
+
+  toggleBtn.addEventListener('click', event => {
+    event.stopPropagation()
+    collapsed = !collapsed
+    if (collapsed) closeSidePanels()
+    syncToggle()
+  })
+
+  syncToggle()
+
+  return {
+    refreshLabels: () => syncToggle()
+  }
 }
 
 /** Dependencies passed into {@link setupLayerPanel}. */

--- a/packages/cad-html-plugin/src/AcExMeasureTracking.ts
+++ b/packages/cad-html-plugin/src/AcExMeasureTracking.ts
@@ -1,0 +1,147 @@
+/**
+ * Orthogonal and polar cursor tracking for offline HTML measurement tools.
+ *
+ * Lightweight port of {@link AcEdPolarTracking} / {@link AcEdOrthoMode} without
+ * an open {@link AcDbDatabase} — uses snapshot unit metadata instead.
+ *
+ * @packageDocumentation
+ */
+
+/** Options for {@link constrainToAcExTracking}. */
+export interface AcExTrackingOptions {
+  /** When true, locks movement to horizontal/vertical from the reference point. */
+  ortho: boolean
+  /** When true, snaps direction to {@link polarAng} increments (and ortho dirs if enabled). */
+  polar: boolean
+  /** Polar angle increment in degrees (AutoCAD **POLARANG**; default 90). */
+  polarAng: number
+  /** AutoCAD **ANGBASE** in radians. */
+  angbase: number
+  /** AutoCAD **ANGDIR** — `0` = CCW positive, `1` = CW positive. */
+  angdir: number
+}
+
+function normalizeAngle(angle: number): number {
+  const twoPi = Math.PI * 2
+  let a = angle % twoPi
+  if (a < 0) a += twoPi
+  return a
+}
+
+function constrainToOrtho(
+  point: { x: number; y: number },
+  reference: { x: number; y: number }
+): { x: number; y: number } {
+  const dx = point.x - reference.x
+  const dy = point.y - reference.y
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return { x: point.x, y: reference.y }
+  }
+  return { x: reference.x, y: point.y }
+}
+
+function toDisplayAngleRadians(
+  radians: number,
+  angbase: number,
+  angdir: number
+): number {
+  let angle = radians - angbase
+  if (angdir === 1) angle = -angle
+  return normalizeAngle(angle)
+}
+
+function fromDisplayAngleRadians(
+  displayRadians: number,
+  angbase: number,
+  angdir: number
+): number {
+  let angle = displayRadians
+  if (angdir === 1) angle = -angle
+  return normalizeAngle(angle + angbase)
+}
+
+function buildTrackingDisplayAnglesRadians(
+  options: AcExTrackingOptions
+): number[] {
+  const degreeSet = new Set<number>()
+  if (options.ortho) {
+    for (const degrees of [0, 90, 180, 270]) {
+      degreeSet.add(degrees)
+    }
+  }
+  if (options.polar) {
+    const increment = options.polarAng
+    if (increment > 0) {
+      const steps = Math.max(1, Math.round(360 / increment))
+      for (let i = 0; i < steps; i++) {
+        degreeSet.add((((i * increment) % 360) + 360) % 360)
+      }
+    }
+  }
+  return [...degreeSet].map(deg => (deg * Math.PI) / 180)
+}
+
+function smallestAngleDelta(a: number, b: number): number {
+  const diff = Math.abs(normalizeAngle(a - b))
+  return Math.min(diff, Math.PI * 2 - diff)
+}
+
+function nearestDisplayAngle(target: number, candidates: number[]): number {
+  let best = candidates[0]!
+  let bestDelta = smallestAngleDelta(target, best)
+  for (let i = 1; i < candidates.length; i++) {
+    const candidate = candidates[i]!
+    const delta = smallestAngleDelta(target, candidate)
+    if (delta < bestDelta) {
+      bestDelta = delta
+      best = candidate
+    }
+  }
+  return best
+}
+
+/**
+ * Constrains a WCS point to orthogonal and/or polar tracking relative to a reference.
+ *
+ * Matches AutoCAD behavior: OSNAP should be applied before calling this function.
+ *
+ * @param point - Cursor position after object snap (if any).
+ * @param reference - Tracking base (last picked point or angle vertex).
+ * @param options - Ortho/polar flags and drawing angle metadata.
+ */
+export function constrainToAcExTracking(
+  point: { x: number; y: number },
+  reference: { x: number; y: number },
+  options: AcExTrackingOptions
+): { x: number; y: number } {
+  if (!options.ortho && !options.polar) return point
+  if (options.ortho && !options.polar) {
+    return constrainToOrtho(point, reference)
+  }
+
+  const dx = point.x - reference.x
+  const dy = point.y - reference.y
+  const distance = Math.hypot(dx, dy)
+  if (distance < 1e-10) return point
+
+  const wcsAngle = Math.atan2(dy, dx)
+  const displayAngle = toDisplayAngleRadians(
+    wcsAngle,
+    options.angbase,
+    options.angdir
+  )
+  const candidates = buildTrackingDisplayAnglesRadians(options)
+  if (candidates.length === 0) return point
+
+  const lockedDisplay = nearestDisplayAngle(displayAngle, candidates)
+  const lockedWcs = fromDisplayAngleRadians(
+    lockedDisplay,
+    options.angbase,
+    options.angdir
+  )
+
+  return {
+    x: reference.x + distance * Math.cos(lockedWcs),
+    y: reference.y + distance * Math.sin(lockedWcs)
+  }
+}

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -8,6 +8,10 @@
 import * as THREE from 'three'
 
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
+import {
+  type AcExTrackingOptions,
+  constrainToAcExTracking
+} from './AcExMeasureTracking'
 import type { AcExOsnapPoint } from './AcExOsnap'
 
 /**
@@ -20,13 +24,20 @@ export const ACEX_MEASURE_COLOR = 0x08e8de
 export const ACEX_MEASURE_SELECT_COLOR = 0xffd54f
 
 /** CSS color string used by 2D canvas measurement overlays. */
-const MEASURE_CSS = '#08e8de'
+function measureColorToCss(hex: number): string {
+  return `#${hex.toString(16).padStart(6, '0')}`
+}
+
+/** Semi-transparent fill derived from a measure accent hex color. */
+function measureColorToFill(hex: number): string {
+  const r = (hex >> 16) & 0xff
+  const g = (hex >> 8) & 0xff
+  const b = hex & 0xff
+  return `rgba(${r}, ${g}, ${b}, 0.2)`
+}
 
 /** Screen-pixel tolerance for picking a committed measurement. */
 const MEASURE_HIT_THRESHOLD_PX = 10
-
-/** Semi-transparent fill for committed area measurements. */
-const MEASURE_FILL = 'rgba(8, 232, 222, 0.2)'
 
 /**
  * Active measurement tool selected from the toolbar.
@@ -134,6 +145,8 @@ export interface AcExMeasureControllerOptions {
     snap: AcExOsnapPoint | null,
     screen: { x: number; y: number } | null
   ) => void
+  /** Returns ortho/polar tracking options while measuring; omit to disable tracking. */
+  getTrackingOptions?: () => AcExTrackingOptions | null
 }
 
 /** Teardown callback registered when a measurement overlay is created. @internal */
@@ -635,6 +648,12 @@ export class AcExMeasureController {
   private readonly _getReadyStatus: () => string
   /** Snap marker callback for the runtime. */
   private readonly _onOsnapMarker: AcExMeasureControllerOptions['onOsnapMarker']
+  /** Ortho/polar tracking options from the settings panel. */
+  private readonly _getTrackingOptions:
+    | (() => AcExTrackingOptions | null)
+    | null
+  /** Accent color for lines, labels, and canvas overlays. */
+  private _measureColor = ACEX_MEASURE_COLOR
   /** Parent group for committed THREE line geometry. */
   private readonly _measureGroup: THREE.Group
   /** Host for canvas overlays, dots, badges, and the live label. */
@@ -651,8 +670,8 @@ export class AcExMeasureController {
   private _commitParts: AcExCommitParts | null = null
   /** Monotonic id source for {@link _committed}. */
   private _commitCounter = 0
-  /** Selected committed measurement id, if any. */
-  private _selectedId: string | null = null
+  /** Selected committed measurement ids. */
+  private readonly _selectedIds = new Set<string>()
 
   /** Active toolbar mode, or `null` when idle. */
   private _mode: AcExMeasureMode | null = null
@@ -677,6 +696,7 @@ export class AcExMeasureController {
     this._statusEl = options.statusEl
     this._getReadyStatus = options.getReadyStatus
     this._onOsnapMarker = options.onOsnapMarker
+    this._getTrackingOptions = options.getTrackingOptions ?? null
 
     this._measureGroup = new THREE.Group()
     this._measureGroup.name = 'measurements'
@@ -692,7 +712,7 @@ export class AcExMeasureController {
     this._overlayLayer.appendChild(this._liveLabel)
 
     const previewMaterial = new THREE.LineBasicMaterial({
-      color: ACEX_MEASURE_COLOR,
+      color: this._measureColor,
       depthTest: false
     })
     const previewGeometry = new THREE.BufferGeometry()
@@ -714,6 +734,41 @@ export class AcExMeasureController {
    */
   get mode(): AcExMeasureMode | null {
     return this._mode
+  }
+
+  /**
+   * Updates the accent color used for measurement overlays and redraws canvases.
+   *
+   * @param hex - 24-bit RGB color (for example `0x08e8de`).
+   */
+  setMeasureColor(hex: number): void {
+    if (!Number.isFinite(hex)) return
+    this._measureColor = hex
+    const material = this._previewLine.material
+    if (material instanceof THREE.LineBasicMaterial) {
+      material.color.setHex(hex)
+    }
+    for (const measure of this._committed) {
+      if (this._selectedIds.has(measure.id)) continue
+      for (const line of measure.parts.lines) {
+        const lineMaterial = line.material
+        if (lineMaterial instanceof THREE.LineBasicMaterial) {
+          lineMaterial.color.setHex(hex)
+        }
+      }
+    }
+    for (const fn of this._redrawListeners) fn()
+    this._view.render()
+  }
+
+  /** CSS stroke/fill color for canvas overlays. @internal */
+  private _measureCss(): string {
+    return measureColorToCss(this._measureColor)
+  }
+
+  /** Semi-transparent fill for area measurements. @internal */
+  private _measureFill(): string {
+    return measureColorToFill(this._measureColor)
   }
 
   /**
@@ -790,7 +845,7 @@ export class AcExMeasureController {
    * @returns `true` when the event was handled.
    */
   handlePointerDown(clientX: number, clientY: number): boolean {
-    if (this._trySelectCommittedAt(clientX, clientY, false)) {
+    if (this._trySelectCommittedAt(clientX, clientY)) {
       return true
     }
     if (!this._mode) return false
@@ -857,7 +912,7 @@ export class AcExMeasureController {
         this.cancelMode()
         return true
       }
-      if (this._selectedId) {
+      if (this._selectedIds.size > 0) {
         this._deselect()
         return true
       }
@@ -879,16 +934,16 @@ export class AcExMeasureController {
    */
   handleSelectionPointerDown(clientX: number, clientY: number): boolean {
     if (this._mode || this._committed.length === 0) return false
-    return this._trySelectCommittedAt(clientX, clientY, true)
+    return this._trySelectCommittedAt(clientX, clientY)
   }
 
   /**
-   * Deletes the selected committed measurement.
+   * Deletes all selected committed measurements.
    * Handles `Delete` and `Backspace` (Mac delete key).
    */
   handleSelectionKeyDown(key: string, event?: KeyboardEvent): boolean {
     if (key !== 'Delete' && key !== 'Backspace') return false
-    if (!this._selectedId) return false
+    if (this._selectedIds.size === 0) return false
 
     const target = event?.target
     if (target instanceof HTMLElement) {
@@ -898,8 +953,12 @@ export class AcExMeasureController {
       }
     }
 
-    this._removeCommitted(this._selectedId)
+    for (const id of [...this._selectedIds]) {
+      this._removeCommitted(id, false)
+    }
+    this._selectedIds.clear()
     this._statusEl.textContent = this._getReadyStatus()
+    this._view.render()
     return true
   }
 
@@ -954,9 +1013,24 @@ export class AcExMeasureController {
     clientX: number,
     clientY: number
   ): THREE.Vector2 {
-    const { point, snap } = this._view.resolvePoint(clientX, clientY)
+    const { point: rawPoint, snap } = this._view.resolvePoint(clientX, clientY)
+    let point = rawPoint
+    const tracking = this._getTrackingOptions?.()
+    const reference = this._trackingReference()
+    if (tracking && reference && (tracking.ortho || tracking.polar)) {
+      const constrained = constrainToAcExTracking(point, reference, tracking)
+      point = new THREE.Vector2(constrained.x, constrained.y)
+    }
     this._onOsnapMarker(snap, snap ? this._view.wcsToScreen(point) : null)
     return point
+  }
+
+  /** Reference point for ortho/polar tracking during the active tool. @internal */
+  private _trackingReference(): THREE.Vector2 | null {
+    if (!this._mode || this._points.length === 0) return null
+    if (this._mode === 'coordinate') return null
+    if (this._mode === 'angle') return this._points[0] ?? null
+    return this._points[this._points.length - 1] ?? null
   }
 
   /**
@@ -1488,7 +1562,7 @@ export class AcExMeasureController {
     const geometry = makeLineGeometry(points)
     if (!geometry) return
     const material = new THREE.LineBasicMaterial({
-      color: ACEX_MEASURE_COLOR,
+      color: this._measureColor,
       depthTest: false
     })
     const line = new THREE.Line(geometry, material)
@@ -1616,31 +1690,23 @@ export class AcExMeasureController {
   }
 
   /**
-   * Selects a committed measurement under the pointer, or deselects when idle.
-   * @param deselectOnMiss - When true and nothing was hit, clears the current selection.
+   * Selects a committed measurement under the pointer.
+   * Clicking empty space does not change the current selection.
    * @internal
    */
-  private _trySelectCommittedAt(
-    clientX: number,
-    clientY: number,
-    deselectOnMiss: boolean
-  ): boolean {
+  private _trySelectCommittedAt(clientX: number, clientY: number): boolean {
     const measure = this._pickCommittedMeasure(clientX, clientY)
     if (measure) {
-      const changed = measure.id !== this._selectedId
       this._select(measure.id)
-      return changed || measure.id === this._selectedId
+      return true
     }
-    if (!deselectOnMiss || !this._selectedId) return false
-    this._deselect()
-    return true
+    return false
   }
 
   /** @internal */
   private _select(id: string): void {
-    if (this._selectedId === id) return
-    this._deselect()
-    this._selectedId = id
+    if (this._selectedIds.has(id)) return
+    this._selectedIds.add(id)
     const measure = this._committed.find(m => m.id === id)
     if (measure) this._applyMeasureSelection(measure.parts, true)
     this._view.render()
@@ -1648,10 +1714,12 @@ export class AcExMeasureController {
 
   /** @internal */
   private _deselect(): void {
-    if (!this._selectedId) return
-    const measure = this._committed.find(m => m.id === this._selectedId)
-    if (measure) this._applyMeasureSelection(measure.parts, false)
-    this._selectedId = null
+    if (this._selectedIds.size === 0) return
+    for (const id of this._selectedIds) {
+      const measure = this._committed.find(m => m.id === id)
+      if (measure) this._applyMeasureSelection(measure.parts, false)
+    }
+    this._selectedIds.clear()
     this._view.render()
   }
 
@@ -1664,7 +1732,7 @@ export class AcExMeasureController {
       const material = line.material
       if (material instanceof THREE.LineBasicMaterial) {
         material.color.setHex(
-          selected ? ACEX_MEASURE_SELECT_COLOR : ACEX_MEASURE_COLOR
+          selected ? ACEX_MEASURE_SELECT_COLOR : this._measureColor
         )
       }
     }
@@ -1680,9 +1748,7 @@ export class AcExMeasureController {
   private _removeCommitted(id: string, render = true): void {
     const idx = this._committed.findIndex(m => m.id === id)
     if (idx < 0) return
-    if (this._selectedId === id) {
-      this._selectedId = null
-    }
+    this._selectedIds.delete(id)
     const [measure] = this._committed.splice(idx, 1)
     for (const fn of measure.parts.cleanups) fn()
     if (render) this._view.render()
@@ -1754,7 +1820,7 @@ export class AcExMeasureController {
 
     ctx.beginPath()
     ctx.arc(vx, vy, arc.r, arc.startAngle, arc.endAngle, arc.antiClockwise)
-    ctx.strokeStyle = MEASURE_CSS
+    ctx.strokeStyle = this._measureCss()
     ctx.lineWidth = 2
     ctx.stroke()
     ctx.restore()
@@ -1808,7 +1874,7 @@ export class AcExMeasureController {
 
     ctx.beginPath()
     ctx.arc(cx, cy, screenR, sa, ea, counterClockwise)
-    ctx.strokeStyle = MEASURE_CSS
+    ctx.strokeStyle = this._measureCss()
     ctx.lineWidth = 3
     ctx.stroke()
     ctx.restore()
@@ -1856,9 +1922,9 @@ export class AcExMeasureController {
       ctx.lineTo(spts[i]!.x, spts[i]!.y)
     }
     ctx.closePath()
-    ctx.fillStyle = MEASURE_FILL
+    ctx.fillStyle = this._measureFill()
     ctx.fill()
-    ctx.strokeStyle = MEASURE_CSS
+    ctx.strokeStyle = this._measureCss()
     ctx.lineWidth = 2
     ctx.stroke()
     ctx.restore()

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -35,8 +35,6 @@ function modePriority(mode: AcExOsnapMode): number {
     case 'center':
       return 0
     case 'quadrant':
-    case 'focus':
-    case 'control':
     case 'node':
       return 1
     case 'nearest':
@@ -659,7 +657,7 @@ export class AcExOsnapIndex {
    * tessellated {@link AcExLineBatch} / mesh segments.
    *
    * Uses AutoCAD-style mode priority: endpoint / midpoint / center beat
-   * quadrant / focus / control / node, which beat nearest. Within the same
+   * quadrant / node, which beat nearest. Within the same
    * priority tier, the closest candidate within `threshold` wins.
    *
    * @param px - Cursor X in drawing units (WCS).
@@ -825,11 +823,9 @@ export function acExOsnapModeToMarkerType(
     case 'center':
       return 'circle'
     case 'quadrant':
-    case 'focus':
       return 'diamond'
     case 'nearest':
       return 'x'
-    case 'control':
     case 'node':
     default:
       return 'rect'

--- a/packages/cad-html-plugin/src/AcExOsnapGeometry.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapGeometry.ts
@@ -129,11 +129,6 @@ export function collectPrimitiveSnapCandidates(
           pushPoint(out, p, 'quadrant')
         }
       }
-      if (modes.has('focus')) {
-        for (const p of ellipse.getFocusPoints()) {
-          pushPoint(out, p, 'focus')
-        }
-      }
       if (modes.has('nearest')) {
         pushPoint(out, ellipse.nearestPoint(pick), 'nearest')
       }
@@ -147,11 +142,6 @@ export function collectPrimitiveSnapCandidates(
       if (modes.has('endpoint')) {
         pushPoint(out, { x: startPt[0]!, y: startPt[1]! }, 'endpoint')
         pushPoint(out, { x: endPt[0]!, y: endPt[1]! }, 'endpoint')
-      }
-      if (modes.has('control')) {
-        for (const cp of spline.controlPoints()) {
-          pushPoint(out, cp, 'control')
-        }
       }
       if (modes.has('node') && prim.kind === 'spline') {
         const seen = new Set<number>()

--- a/packages/cad-html-plugin/src/AcExOsnapMarker.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapMarker.ts
@@ -5,10 +5,10 @@ import { acExOsnapModeToMarkerType } from './AcExOsnap'
  * Visual shape of an object-snap marker in the offline HTML viewer.
  *
  * Selected by {@link acExOsnapModeToMarkerType} from {@link AcExOsnapMode}:
- * - `rect` — endpoint, control, node
+ * - `rect` — endpoint, node
  * - `triangle` — midpoint
  * - `circle` — center
- * - `diamond` — quadrant, focus
+ * - `diamond` — quadrant
  * - `x` — nearest
  */
 export type AcExOsnapMarkerShape =
@@ -87,7 +87,7 @@ export class AcExOsnapMarker {
         z-index: 6;
         transform: translate(-50%, -50%);
         box-sizing: border-box;
-        color: var(--mlcad-accent, #08e8de);
+        color: var(--mlcad-measure-accent, #08e8de);
       }
       .mlcad-osnap-marker--hidden { display: none; }
       .mlcad-osnap-marker--rect {

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
@@ -13,6 +13,7 @@ import {
   AcDb2dPolyline,
   AcDb3dPolyline,
   AcDbArc,
+  AcDbBlockReference,
   type AcDbBlockTableRecord,
   AcDbCircle,
   type AcDbDatabase,
@@ -20,20 +21,32 @@ import {
   AcDbEllipse,
   AcDbEntity,
   AcDbFace,
+  AcDbHatch,
   AcDbLeader,
   AcDbLine,
+  AcDbMLeader,
+  type AcDbMLeaderLeader,
+  type AcDbMLeaderLine,
+  AcDbMLine,
   AcDbMText,
   type AcDbObjectId,
   AcDbPoint,
   AcDbPolyline,
+  AcDbRasterImage,
   AcDbRay,
   AcDbSpline,
+  AcDbTable,
   AcDbText,
   AcDbTrace,
   AcDbXline,
   AcGeCircArc2d,
+  AcGeEllipseArc2d,
+  AcGeLine2d,
+  AcGeLoop2d,
+  type AcGeLoop2dType,
   type AcGeMatrix3d,
   type AcGePoint3dLike,
+  AcGePolyline2d,
   AcGeTol,
   type AcGeVector3dLike,
   FLOAT_TOL,
@@ -282,6 +295,52 @@ function resolveDimensionBlock(
 }
 
 /**
+ * Resolves the anonymous block referenced by a table entity.
+ *
+ * Prefers {@link AcDbBlockReference.blockTableRecord}; falls back to
+ * {@link AcDbTable.owningBlockRecordId} from imported DXF/DWG files.
+ *
+ * @internal
+ */
+function resolveTableBlock(
+  entity: AcDbTable,
+  database: AcDbDatabase
+): AcDbBlockTableRecord | undefined {
+  const asBlockRef = entity as unknown as AcExBlockReferenceLike
+  const resolved = resolveBlockReferenceBlock(asBlockRef, database)
+  if (resolved) {
+    return resolved
+  }
+  const owningBlockId = entity.owningBlockRecordId
+  return owningBlockId
+    ? database.tables.blockTable.getAt(owningBlockId)
+    : undefined
+}
+
+/** Returns the full INSERT transform for block/table entities. @internal */
+function blockInsertTransform(entity: AcDbBlockReference): AcGeMatrix3d {
+  return (
+    entity as unknown as AcExBlockReferenceLike
+  ).getFullInsertionTransform()
+}
+
+/** Returns whether a block table record contains at least one entity. @internal */
+function blockHasEntities(block: AcDbBlockTableRecord): boolean {
+  for (const _entity of block.newIterator()) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Raster image shape used to read {@link AcDbRasterImage.boundaryPath}.
+ * @internal
+ */
+type AcExRasterImageLike = AcDbRasterImage & {
+  boundaryPath(): AcGePoint3dLike[]
+}
+
+/**
  * Detects block references across data-model versions (`AcDbBlockReference`,
  * `AcDbBlockReference2`, etc.) without relying on `instanceof`.
  *
@@ -366,6 +425,94 @@ function pushVertexPath(
       vertices[(i + 1) % vertices.length]!
     )
   }
+}
+
+/**
+ * Builds the MLINE reference path (`startPosition` + segment vertices).
+ *
+ * Matches {@link AcDbMLine.subGetOsnapPoints}, which snaps to the center path
+ * rather than offset style-element geometry.
+ *
+ * @internal
+ */
+function pushMLine(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbMLine
+) {
+  const path: AcGePoint3dLike[] = [entity.startPosition]
+  for (const segment of entity.segments) {
+    path.push(segment.position)
+  }
+  pushVertexPath(out, layer, matrix, path, entity.closed)
+}
+
+/**
+ * Resolves drawable leader-line vertices the same way as
+ * `AcDbMLeader.getLeaderLineDrawPoints`.
+ *
+ * @internal
+ */
+function resolveMLeaderLineDrawPoints(
+  entity: AcDbMLeader,
+  leader: AcDbMLeaderLeader,
+  line: AcDbMLeaderLine
+): AcGePoint3dLike[] {
+  if (line.vertices.length >= 2) {
+    return line.vertices
+  }
+  if (line.vertices.length === 0) {
+    return []
+  }
+  const start = line.vertices[0]!
+  const end =
+    leader.lastLeaderLinePoint ??
+    leader.landingPoint ??
+    entity.landingPoint ??
+    entity.contentBasePosition
+  if (!end) {
+    return line.vertices
+  }
+  const dx = start.x - end.x
+  const dy = start.y - end.y
+  const dz = (start.z ?? 0) - (end.z ?? 0)
+  if (Math.hypot(dx, dy, dz) <= FLOAT_TOL) {
+    return line.vertices
+  }
+  return [start, end]
+}
+
+/**
+ * Exports multileader leader segments and annotation anchor points.
+ *
+ * Leader geometry follows {@link AcDbMLeader.subGetOsnapPoints}; anchor points
+ * mirror insertion snaps on MText/block content.
+ *
+ * @internal
+ */
+function pushMLeader(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbMLeader
+) {
+  for (const leader of entity.leaders) {
+    for (const line of leader.leaderLines) {
+      const drawPoints = resolveMLeaderLineDrawPoints(entity, leader, line)
+      pushVertexPath(out, layer, matrix, drawPoints, false)
+    }
+  }
+
+  const pushAnchor = (point: AcGePoint3dLike | undefined) => {
+    if (!point) return
+    const p = transformPoint(matrix, point)
+    out.push({ kind: 'point', layer, x: p.x, y: p.y })
+  }
+
+  pushAnchor(entity.contentBasePosition)
+  pushAnchor(entity.mtextContent?.anchorPoint)
+  pushAnchor(entity.blockContent?.position)
 }
 
 /**
@@ -620,6 +767,314 @@ function pushPolyline(
   }
 }
 
+/** Appends a WCS arc from a 2D circular arc at a fixed elevation. @internal */
+function pushCircArc2dBoundary(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  arc: AcGeCircArc2d,
+  elevation: number
+) {
+  if (scaleIsUniform(matrix)) {
+    const center = transformPoint(matrix, {
+      x: arc.center.x,
+      y: arc.center.y,
+      z: elevation
+    })
+    const sx = new THREE.Vector3(
+      matrix.elements[0],
+      matrix.elements[1],
+      matrix.elements[2]
+    ).length()
+    out.push({
+      kind: 'arc',
+      layer,
+      cx: center.x,
+      cy: center.y,
+      r: arc.radius * sx,
+      startAngle: arc.startAngle,
+      endAngle: arc.endAngle,
+      normalSign: arc.clockwise ? -1 : 1
+    })
+    return
+  }
+
+  pushLine(
+    out,
+    layer,
+    matrix,
+    { x: arc.startPoint.x, y: arc.startPoint.y, z: elevation },
+    { x: arc.endPoint.x, y: arc.endPoint.y, z: elevation }
+  )
+}
+
+/** Appends a WCS ellipse arc from a 2D ellipse arc at a fixed elevation. @internal */
+function pushEllipseArc2dBoundary(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  arc: AcGeEllipseArc2d,
+  elevation: number
+) {
+  const center = transformPoint(matrix, {
+    x: arc.center.x,
+    y: arc.center.y,
+    z: elevation
+  })
+  const majorDir = transformVector(matrix, {
+    x: Math.cos(arc.rotation),
+    y: Math.sin(arc.rotation),
+    z: 0
+  })
+  const len = Math.hypot(majorDir.x, majorDir.y) || 1
+  const sx = new THREE.Vector3(
+    matrix.elements[0],
+    matrix.elements[1],
+    matrix.elements[2]
+  ).length()
+  const sy = new THREE.Vector3(
+    matrix.elements[4],
+    matrix.elements[5],
+    matrix.elements[6]
+  ).length()
+  out.push({
+    kind: 'ellipse',
+    layer,
+    cx: center.x,
+    cy: center.y,
+    majorX: majorDir.x / len,
+    majorY: majorDir.y / len,
+    majorR: arc.majorAxisRadius * sx,
+    minorR: arc.minorAxisRadius * sy,
+    startAngle: arc.startAngle,
+    endAngle: arc.endAngle,
+    closed: false,
+    normalSign: arc.clockwise ? -1 : 1
+  })
+}
+
+/**
+ * Exports one hatch boundary polyline loop (bulge-aware).
+ *
+ * Matches {@link AcDbHatch.subGetOsnapPoints} boundary traversal.
+ *
+ * @internal
+ */
+function pushHatchPolyline2d(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  polyline: AcGePolyline2d,
+  elevation: number
+) {
+  const vertexCount = polyline.numberOfVertices
+  if (vertexCount < 2) return
+
+  const segmentCount = polyline.closed ? vertexCount : vertexCount - 1
+  for (let index = 0; index < segmentCount; index++) {
+    const start = polyline.getPointAt(index)
+    const end = polyline.getPointAt((index + 1) % vertexCount)
+    const bulge = polyline.vertices[index]?.bulge ?? 0
+    const start3 = { x: start.x, y: start.y, z: elevation }
+    const end3 = { x: end.x, y: end.y, z: elevation }
+    if (AcGeTol.isPositive(Math.abs(bulge))) {
+      const startW = transformPoint(matrix, start3)
+      const endW = transformPoint(matrix, end3)
+      const arc2d = new AcGeCircArc2d(startW, endW, bulge)
+      const center = arc2d.center
+      out.push({
+        kind: 'arc',
+        layer,
+        cx: center.x,
+        cy: center.y,
+        r: arc2d.radius,
+        startAngle: arc2d.startAngle,
+        endAngle: arc2d.endAngle,
+        normalSign: arc2d.clockwise ? -1 : 1
+      })
+    } else {
+      pushLine(out, layer, matrix, start3, end3)
+    }
+  }
+}
+
+/** Exports one hatch boundary loop (polyline or edge loop). @internal */
+function pushHatchLoop(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  loop: AcGeLoop2dType,
+  elevation: number
+) {
+  if (loop instanceof AcGePolyline2d) {
+    pushHatchPolyline2d(out, layer, matrix, loop, elevation)
+    return
+  }
+
+  if (loop instanceof AcGeLoop2d) {
+    for (const curve of loop.curves) {
+      if (curve instanceof AcGeLine2d) {
+        pushLine(
+          out,
+          layer,
+          matrix,
+          {
+            x: curve.startPoint.x,
+            y: curve.startPoint.y,
+            z: elevation
+          },
+          {
+            x: curve.endPoint.x,
+            y: curve.endPoint.y,
+            z: elevation
+          }
+        )
+      } else if (curve instanceof AcGeCircArc2d) {
+        pushCircArc2dBoundary(out, layer, matrix, curve, elevation)
+      } else if (curve instanceof AcGeEllipseArc2d) {
+        pushEllipseArc2dBoundary(out, layer, matrix, curve, elevation)
+      }
+    }
+  }
+}
+
+/**
+ * Exports hatch boundary loops as line/arc/ellipse primitives.
+ *
+ * Reads internal `_geo.loops` from the data model, mirroring
+ * {@link AcDbHatch.subGetOsnapPoints}.
+ *
+ * @internal
+ */
+function pushHatch(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbHatch
+) {
+  const loops = (
+    entity as unknown as {
+      _geo?: { loops?: ReadonlyArray<AcGeLoop2dType> }
+    }
+  )._geo?.loops
+  if (!loops?.length) return
+
+  const elevation = entity.elevation
+  for (const loop of loops) {
+    pushHatchLoop(out, layer, matrix, loop, elevation)
+  }
+}
+
+/**
+ * Exports procedural table grid lines when no anonymous block geometry exists.
+ *
+ * Grid layout follows {@link AcDbTable.subWorldDraw} local coordinates.
+ *
+ * @internal
+ */
+function pushTableGrid(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbTable
+) {
+  const tableMatrix = composeTransforms(matrix, blockInsertTransform(entity))
+
+  const columnXs = [0]
+  for (let column = 0; column < entity.numColumns; column++) {
+    columnXs.push(columnXs[column]! + entity.columnWidth(column))
+  }
+
+  const rowYs = [0]
+  for (let row = 0; row < entity.numRows; row++) {
+    rowYs.push(rowYs[row]! - entity.rowHeight(row))
+  }
+
+  const totalWidth = columnXs[columnXs.length - 1]!
+  const totalHeight = rowYs[rowYs.length - 1]!
+
+  for (const y of rowYs) {
+    pushLine(
+      out,
+      layer,
+      tableMatrix,
+      { x: 0, y, z: 0 },
+      { x: totalWidth, y, z: 0 }
+    )
+  }
+
+  for (const x of columnXs) {
+    pushLine(
+      out,
+      layer,
+      tableMatrix,
+      { x, y: 0, z: 0 },
+      { x, y: totalHeight, z: 0 }
+    )
+  }
+}
+
+/**
+ * Visits a table entity: anonymous block content when present, else grid lines.
+ *
+ * @internal
+ */
+function visitTableEntity(
+  entity: AcDbTable,
+  matrix: THREE.Matrix4,
+  insertLayer: string,
+  out: AcExOsnapPrimitive[],
+  blockStack: Set<AcDbObjectId>,
+  database: AcDbDatabase
+) {
+  const layer = effectiveLayer(entity.layer, insertLayer)
+  const block = resolveTableBlock(entity, database)
+  if (block && !blockStack.has(block.objectId) && blockHasEntities(block)) {
+    blockStack.add(block.objectId)
+    const nested = composeTransforms(matrix, blockInsertTransform(entity))
+    visitBlock(block, nested, layer, out, blockStack, database)
+    blockStack.delete(block.objectId)
+    return
+  }
+
+  pushTableGrid(out, layer, matrix, entity)
+  const insertion = transformPoint(matrix, entity.position)
+  out.push({ kind: 'point', layer, x: insertion.x, y: insertion.y })
+}
+
+/**
+ * Exports raster image clip/frame boundary and insertion point.
+ *
+ * Uses {@link AcDbRasterImage.boundaryPath} to match live-viewer osnap behavior.
+ *
+ * @internal
+ */
+function pushRasterImage(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbRasterImage
+) {
+  let boundary = (entity as AcExRasterImageLike).boundaryPath()
+  if (boundary.length > 1) {
+    const first = boundary[0]!
+    const last = boundary[boundary.length - 1]!
+    if (
+      first.x === last.x &&
+      first.y === last.y &&
+      (first.z ?? 0) === (last.z ?? 0)
+    ) {
+      boundary = boundary.slice(0, -1)
+    }
+  }
+  if (boundary.length >= 2) {
+    pushVertexPath(out, layer, matrix, boundary, true)
+  }
+
+  const insertion = transformPoint(matrix, entity.position)
+  out.push({ kind: 'point', layer, x: insertion.x, y: insertion.y })
+}
+
 /**
  * Resolves AutoCAD layer-0 inheritance inside blocks.
  *
@@ -651,6 +1106,11 @@ function visitEntity(
   if (!entity.visibility) return
 
   const layer = effectiveLayer(entity.layer, insertLayer)
+
+  if (entity instanceof AcDbTable) {
+    visitTableEntity(entity, matrix, insertLayer, out, blockStack, database)
+    return
+  }
 
   if (isBlockReferenceEntity(entity)) {
     const block = resolveBlockReferenceBlock(entity, database)
@@ -736,6 +1196,11 @@ function visitEntity(
     return
   }
 
+  if (entity instanceof AcDbHatch) {
+    pushHatch(out, layer, matrix, entity)
+    return
+  }
+
   if (entity instanceof AcDbRay) {
     pushDirectedLine(
       out,
@@ -780,6 +1245,16 @@ function visitEntity(
     return
   }
 
+  if (entity instanceof AcDbMLine) {
+    pushMLine(out, layer, matrix, entity)
+    return
+  }
+
+  if (entity instanceof AcDbMLeader) {
+    pushMLeader(out, layer, matrix, entity)
+    return
+  }
+
   if (entity instanceof AcDbText) {
     const p = transformPoint(matrix, entity.position)
     out.push({ kind: 'point', layer, x: p.x, y: p.y })
@@ -789,6 +1264,11 @@ function visitEntity(
   if (entity instanceof AcDbMText) {
     const p = transformPoint(matrix, entity.location)
     out.push({ kind: 'point', layer, x: p.x, y: p.y })
+    return
+  }
+
+  if (entity instanceof AcDbRasterImage) {
+    pushRasterImage(out, layer, matrix, entity)
     return
   }
 
@@ -846,9 +1326,10 @@ function ellipseFromArc(entity: AcDbArc): AcDbEllipse {
  * inside blocks inherit the INSERT layer per AutoCAD rules.
  *
  * Supported entity types: `AcDbLine`, `AcDbCircle`, `AcDbArc`, `AcDbEllipse`,
- * `AcDbSpline`, `AcDbPolyline`, `AcDb2dPolyline`, `AcDb3dPolyline`, `AcDbRay`,
- * `AcDbXline`, `AcDbTrace`, `AcDbFace`, `AcDbLeader`, `AcDbText`, `AcDbMText`,
- * `AcDbPoint`, INSERT, and dimension entities (`AcDbDimension` and subclasses
+ * `AcDbSpline`, `AcDbPolyline`, `AcDb2dPolyline`, `AcDb3dPolyline`, `AcDbHatch`,
+ * `AcDbRay`, `AcDbXline`, `AcDbTrace`, `AcDbFace`, `AcDbLeader`, `AcDbMLine`,
+ * `AcDbMLeader`, `AcDbText`, `AcDbMText`, `AcDbPoint`, `AcDbRasterImage`,
+ * `AcDbTable`, INSERT, and dimension entities (`AcDbDimension` and subclasses
  * via anonymous dim blocks).
  *
  * @param database - Open drawing database (same instance used for HTML export).

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
@@ -16,7 +16,7 @@
  *
  * Names align with common AutoCAD OSNAP modes. Priority when multiple candidates
  * are within the aperture is handled by {@link AcExOsnapIndex} (endpoint / midpoint /
- * center beat quadrant / focus / control / node, which beat nearest).
+ * center beat quadrant / node, which beat nearest).
  *
  * - `endpoint` — Line, arc, ellipse arc, and spline start/end vertices.
  * - `midpoint` — Segment midpoint, arc midpoint, or open ellipse arc parameter midpoint.
@@ -24,8 +24,6 @@
  * - `quadrant` — 0° / 90° / 180° / 270° on circles; arc-limited on arcs; axis crossings on closed ellipses.
  * - `nearest` — Closest point on the curve or segment to the pick point (not tessellated).
  * - `node` — Spline knot locations; also used for `AcDbPoint` entities.
- * - `focus` — Ellipse focal points (when major ≠ minor axis).
- * - `control` — B-spline control vertices (CV).
  *
  * Tangent snap is not implemented in the offline viewer.
  */
@@ -36,8 +34,6 @@ export type AcExOsnapMode =
   | 'quadrant'
   | 'nearest'
   | 'node'
-  | 'focus'
-  | 'control'
 
 /**
  * A single object snap candidate returned to the measurement UI.
@@ -58,7 +54,7 @@ export interface AcExOsnapPoint {
  *
  * Matches the subset commonly used for measure workflows in the main CAD viewer
  * (endpoint, midpoint, center, quadrant, nearest). Additional modes such as
- * `node`, `focus`, and `control` can be passed explicitly to {@link AcExOsnapIndex}.
+ * `node` can be passed explicitly to {@link AcExOsnapIndex}.
  */
 export const ACEX_DEFAULT_OSNAP_MODES: readonly AcExOsnapMode[] = [
   'endpoint',

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -248,7 +248,7 @@ export interface AcExSnapshot {
     units: AcExViewerUnits
     /** Canvas background color as 24-bit RGB hex. */
     background: number
-    /** Preferred UI locale when the HTML is first opened (`en` | `zh`). */
+    /** Export-time UI locale from the CAD app (informational; runtime uses browser language). */
     locale?: string
   }
   /** Layer table used by the layer drawer (visibility toggles, swatches). */

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -41,6 +41,7 @@ export {
   type AcExHtmlLocale,
   type AcExHtmlMessageKey,
   detectAcExHtmlLocale,
+  detectBrowserAcExHtmlLocale,
   resolveAcExHtmlLocale
 } from './AcExHtmlI18n'
 


### PR DESCRIPTION
## Summary

Enhances the offline HTML viewer with a measure settings panel (color, ortho, polar tracking), browser-driven i18n, toolbar collapse, and broader object-snap geometry export for complex entities.

## Changes

### Measure settings & tracking
- Add a **Measure settings** toolbar entry with a side panel for:
  - Custom **measure accent color** (CSS variables + THREE/canvas overlays), persisted in `localStorage`
  - **Orthogonal mode** and **polar tracking** with common angle increments (90°, 45°, 30°, 23°, 18°, 10°, 5°)
- Introduce `AcExMeasureTracking` / `constrainToAcExTracking` — a lightweight ortho/polar port that respects snapshot `angbase` / `angdir`
- Wire tracking into `AcExMeasureController` during distance, area, angle, and coordinate tools (OSNAP applied first, then tracking)
- Persist measure settings under `mlcad-html-measure-settings`

### Measurement UX
- Support **multi-select** of committed measurements and **bulk delete** (Delete / Backspace)
- Clicking empty space no longer clears the current selection
- Dynamic measure color updates preview lines, committed geometry, and canvas overlays

### Viewer chrome & i18n
- Add **toolbar collapse/expand** to reduce sidebar clutter on small screens
- Move the **language switch** into the measure settings strip
- Detect initial locale from **browser language preferences** (`zh*` → Chinese, otherwise English), with manual choice persisted in `localStorage`
- Export `detectBrowserAcExHtmlLocale`; snapshot `meta.locale` is now informational only
- Set `document.documentElement.lang` when applying translations

### OSNAP improvements
- Export snap primitives for additional entity types:
  - **MLINE** — center reference path
  - **MLEADER** — leader lines and MText anchor
  - **HATCH** — polyline and edge-loop boundaries (lines and arcs)
  - **Raster image** — frame boundary and insertion point
  - **TABLE** — procedural grid lines and anonymous block contents
- Drop unused **focus** and **control** snap modes from default collection and marker mapping
- Align OSNAP marker accent color with `--mlcad-measure-accent`

## Test plan

- [ ] Export a drawing to HTML and open it offline
- [ ] Open **Measure settings** — verify color picker, ortho toggle, polar panel, and language switch
- [ ] With ortho enabled, measure distance/area/angle — cursor should lock to horizontal/vertical from the last picked point
- [ ] With polar tracking enabled (e.g. 45°), verify direction snapping while preserving distance
- [ ] Confirm settings and locale persist after reload (`localStorage`)
- [ ] Collapse/expand the toolbar; verify side panels close when collapsed
- [ ] On drawings with MLINE, MLEADER, HATCH, raster images, and TABLE entities, verify endpoint/midpoint/nearest snaps
- [ ] Multi-select measurements, delete with Backspace/Delete, and confirm empty clicks do not clear selection
- [ ] Run unit tests:
  ```bash
  pnpm --filter @mlightcad/cad-html-plugin test