### PR TITLE
feat(html-plugin): show aggregated measurement totals in idle status bar

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExMeasureTotals.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMeasureTotals.spec.ts
@@ -1,0 +1,20 @@
+import {
+  sumMeasureQuantities,
+  type AcExMeasureQuantityEntry
+} from '../src/AcExMeasureTotals'
+
+describe('sumMeasureQuantities', () => {
+  it('sums length and area entries separately', () => {
+    const entries: AcExMeasureQuantityEntry[] = [
+      { quantity: 'length', value: 10 },
+      { quantity: 'length', value: 2.5 },
+      { quantity: 'area', value: 100 },
+      { quantity: 'area', value: 50 }
+    ]
+    expect(sumMeasureQuantities(entries)).toEqual({ length: 12.5, area: 150 })
+  })
+
+  it('returns zero totals for an empty list', () => {
+    expect(sumMeasureQuantities([])).toEqual({ length: 0, area: 0 })
+  })
+})

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -50,6 +50,8 @@ export type AcExHtmlMessageKey =
   | 'status.angle'
   | 'status.arcLength'
   | 'status.area'
+  | 'status.lengthTotal'
+  | 'status.areaTotal'
   | 'status.zoomLayer'
   | 'status.loadFailed'
   | 'status.noLayout'
@@ -111,6 +113,8 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       angle: 'Angle: {value}',
       arcLength: 'Arc length: {value}',
       area: 'Area: {value}',
+      lengthTotal: 'Length total: {value}',
+      areaTotal: 'Area total: {value}',
       zoomLayer: 'Zoom: {name}',
       loadFailed: 'Failed to load drawing: {error}',
       noLayout: 'No layout data in snapshot.'
@@ -159,6 +163,8 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       angle: '角度：{value}',
       arcLength: '弧长：{value}',
       area: '面积：{value}',
+      lengthTotal: '长度合计：{value}',
+      areaTotal: '面积合计：{value}',
       zoomLayer: '缩放：{name}',
       loadFailed: '无法加载图纸：{error}',
       noLayout: '快照中没有布局数据。'

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -320,7 +320,7 @@ function startViewer(): void {
   i18n.setOnChange(() => {
     readyStatus = snapshot.meta.title ?? i18n.t('status.ready')
     if (!measure.isActive) {
-      statusEl.textContent = readyStatus
+      measure.refreshIdleStatus()
     }
     layerPanel?.refreshLayerLabels()
     measureSettingsRef.current?.refreshLabels()
@@ -360,7 +360,6 @@ function startViewer(): void {
           fit()
         } else if (action === 'clear-measurements') {
           measure.clearAll()
-          statusEl.textContent = readyStatus
         } else if (action === 'measure') {
           const mode = button.getAttribute(
             'data-measure-mode'
@@ -390,7 +389,7 @@ function startViewer(): void {
   resize()
   fit()
   releaseLayerGroupsGeometryCpuArrays(layerGroups)
-  statusEl.textContent = readyStatus
+  measure.refreshIdleStatus()
   hideLoading()
 }
 

--- a/packages/cad-html-plugin/src/AcExMeasureTotals.ts
+++ b/packages/cad-html-plugin/src/AcExMeasureTotals.ts
@@ -1,0 +1,29 @@
+/** Measurable quantity category aggregated in the idle status bar. */
+export type AcExMeasureQuantity = 'length' | 'area'
+
+/** One committed measurement value included in idle totals. */
+export interface AcExMeasureQuantityEntry {
+  quantity: AcExMeasureQuantity
+  value: number
+}
+
+/** Aggregated length and area totals in drawing units. */
+export interface AcExMeasureTotals {
+  length: number
+  area: number
+}
+
+/**
+ * Sums length and area values from the given measurement entries.
+ */
+export function sumMeasureQuantities(
+  entries: readonly AcExMeasureQuantityEntry[]
+): AcExMeasureTotals {
+  let length = 0
+  let area = 0
+  for (const entry of entries) {
+    if (entry.quantity === 'length') length += entry.value
+    else area += entry.value
+  }
+  return { length, area }
+}

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -9,6 +9,10 @@ import * as THREE from 'three'
 
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import {
+  type AcExMeasureQuantity,
+  type AcExMeasureQuantityEntry,
+  sumMeasureQuantities} from './AcExMeasureTotals'
+import {
   type AcExTrackingOptions,
   constrainToAcExTracking
 } from './AcExMeasureTracking'
@@ -165,6 +169,8 @@ interface AcExCommitParts {
 interface AcExCommittedMeasure {
   id: string
   parts: AcExCommitParts
+  quantity: AcExMeasureQuantity | null
+  value: number
   hitTest: (clientX: number, clientY: number, thresholdPx: number) => boolean
 }
 
@@ -787,7 +793,7 @@ export class AcExMeasureController {
       return
     }
     this.cancelMode()
-    this._deselect()
+    this._deselect(false)
     if (mode === null) return
     this._mode = mode
     this._points = []
@@ -806,8 +812,15 @@ export class AcExMeasureController {
     this._hidePreview()
     this._onOsnapMarker(null, null)
     this._updateToolbarActive()
-    this._statusEl.textContent = this._getReadyStatus()
+    this._updateIdleStatus()
     this._view.render()
+  }
+
+  /**
+   * Refreshes the idle status bar (totals or ready text) when no tool is active.
+   */
+  refreshIdleStatus(): void {
+    this._updateIdleStatus()
   }
 
   /**
@@ -816,10 +829,11 @@ export class AcExMeasureController {
    */
   clearAll(): void {
     this.cancelMode()
-    this._deselect()
+    this._deselect(false)
     for (const measure of [...this._committed]) {
       this._removeCommitted(measure.id, false)
     }
+    this._updateIdleStatus()
     this._view.render()
   }
 
@@ -957,9 +971,53 @@ export class AcExMeasureController {
       this._removeCommitted(id, false)
     }
     this._selectedIds.clear()
-    this._statusEl.textContent = this._getReadyStatus()
+    this._updateIdleStatus()
     this._view.render()
     return true
+  }
+
+  /** Updates the status bar with measurement totals when idle. @internal */
+  private _updateIdleStatus(): void {
+    if (this._mode) return
+    this._statusEl.textContent = this._idleStatusText()
+  }
+
+  /** Idle status: ready text, or aggregated length/area totals. @internal */
+  private _idleStatusText(): string {
+    const entries = this._quantityEntriesForIdleStatus()
+    if (entries.length === 0) return this._getReadyStatus()
+
+    const { length, area } = sumMeasureQuantities(entries)
+    const parts: string[] = []
+    if (entries.some(entry => entry.quantity === 'length')) {
+      parts.push(
+        this._i18n.t('status.lengthTotal', {
+          value: this._view.formatLength(length)
+        })
+      )
+    }
+    if (entries.some(entry => entry.quantity === 'area')) {
+      parts.push(
+        this._i18n.t('status.areaTotal', {
+          value: `${this._view.formatLength(area)}²`
+        })
+      )
+    }
+    return parts.length > 0 ? parts.join('  ') : this._getReadyStatus()
+  }
+
+  /** Committed measurements included in idle totals. @internal */
+  private _quantityEntriesForIdleStatus(): AcExMeasureQuantityEntry[] {
+    const measures =
+      this._selectedIds.size > 0
+        ? this._committed.filter(measure => this._selectedIds.has(measure.id))
+        : this._committed
+    const entries: AcExMeasureQuantityEntry[] = []
+    for (const measure of measures) {
+      if (measure.quantity == null) continue
+      entries.push({ quantity: measure.quantity, value: measure.value })
+    }
+    return entries
   }
 
   /** Localized status-bar hint for the given tool. @internal */
@@ -1148,7 +1206,7 @@ export class AcExMeasureController {
     this._finishCommit((clientX, clientY, threshold) => {
       const s = this._view.wcsToScreen(point)
       return Math.hypot(clientX - s.x, clientY - s.y) <= threshold
-    })
+    }, null)
     this._statusEl.textContent = this._i18n.t('status.coordinates', {
       x: this._view.formatLength(point.x),
       y: this._view.formatLength(point.y)
@@ -1206,14 +1264,18 @@ export class AcExMeasureController {
     this._addDot(b)
     const mid = new THREE.Vector2((a.x + b.x) / 2, (a.y + b.y) / 2)
     this._addBadge(mid, this._view.formatLength(dist))
-    this._finishCommit((clientX, clientY, threshold) => {
-      const sa = this._view.wcsToScreen(a)
-      const sb = this._view.wcsToScreen(b)
-      return (
-        distPointToSegmentPx(clientX, clientY, sa.x, sa.y, sb.x, sb.y) <=
-        threshold
-      )
-    })
+    this._finishCommit(
+      (clientX, clientY, threshold) => {
+        const sa = this._view.wcsToScreen(a)
+        const sb = this._view.wcsToScreen(b)
+        return (
+          distPointToSegmentPx(clientX, clientY, sa.x, sa.y, sb.x, sb.y) <=
+          threshold
+        )
+      },
+      'length',
+      dist
+    )
     this._statusEl.textContent = this._i18n.t('status.distance', {
       value: this._view.formatLength(dist)
     })
@@ -1318,17 +1380,19 @@ export class AcExMeasureController {
       vertex.y + by * offset
     )
     this._addBadge(badgePos, this._view.formatAngle(deg))
-    this._finishCommit((clientX, clientY, threshold) =>
-      hitTestAngleMeasure(
-        clientX,
-        clientY,
-        threshold,
-        vertex,
-        arm1,
-        arm2,
-        badgePos,
-        wcs => this._view.wcsToScreen(wcs)
-      )
+    this._finishCommit(
+      (clientX, clientY, threshold) =>
+        hitTestAngleMeasure(
+          clientX,
+          clientY,
+          threshold,
+          vertex,
+          arm1,
+          arm2,
+          badgePos,
+          wcs => this._view.wcsToScreen(wcs)
+        ),
+      null
     )
     this._statusEl.textContent = this._i18n.t('status.angle', {
       value: this._view.formatAngle(deg)
@@ -1422,34 +1486,38 @@ export class AcExMeasureController {
     this._addDot(through)
     this._addDot(end)
     this._addBadge(mid, this._view.formatLength(len))
-    this._finishCommit((clientX, clientY, threshold) => {
-      const sc = this._view.wcsToScreen(new THREE.Vector2(geom.cx, geom.cy))
-      const ss = this._view.wcsToScreen(start)
-      const se = this._view.wcsToScreen(end)
-      const cx = sc.x
-      const cy = sc.y
-      const screenR = Math.hypot(ss.x - cx, ss.y - cy)
-      const sa = Math.atan2(ss.y - cy, ss.x - cx)
-      const ea = Math.atan2(se.y - cy, se.x - cx)
-      const { counterClockwise } = arcSweepThroughMiddle(
-        start,
-        through,
-        end,
-        geom
-      )
-      return (
-        distPointToArcPx(
-          clientX,
-          clientY,
-          cx,
-          cy,
-          screenR,
-          sa,
-          ea,
-          counterClockwise
-        ) <= threshold
-      )
-    })
+    this._finishCommit(
+      (clientX, clientY, threshold) => {
+        const sc = this._view.wcsToScreen(new THREE.Vector2(geom.cx, geom.cy))
+        const ss = this._view.wcsToScreen(start)
+        const se = this._view.wcsToScreen(end)
+        const cx = sc.x
+        const cy = sc.y
+        const screenR = Math.hypot(ss.x - cx, ss.y - cy)
+        const sa = Math.atan2(ss.y - cy, ss.x - cx)
+        const ea = Math.atan2(se.y - cy, se.x - cx)
+        const { counterClockwise } = arcSweepThroughMiddle(
+          start,
+          through,
+          end,
+          geom
+        )
+        return (
+          distPointToArcPx(
+            clientX,
+            clientY,
+            cx,
+            cy,
+            screenR,
+            sa,
+            ea,
+            counterClockwise
+          ) <= threshold
+        )
+      },
+      'length',
+      len
+    )
     this._statusEl.textContent = this._i18n.t('status.arcLength', {
       value: this._view.formatLength(len)
     })
@@ -1546,12 +1614,16 @@ export class AcExMeasureController {
 
     for (const p of points) this._addDot(p)
     this._addBadge(centroid(points), `${this._view.formatLength(area)}²`)
-    this._finishCommit((clientX, clientY, threshold) => {
-      const poly = this._screenPolyline(points)
-      if (pointInPolygonPx(clientX, clientY, poly)) return true
-      const closedPoly = [...poly, poly[0]!]
-      return distPointToPolylinePx(clientX, clientY, closedPoly) <= threshold
-    })
+    this._finishCommit(
+      (clientX, clientY, threshold) => {
+        const poly = this._screenPolyline(points)
+        if (pointInPolygonPx(clientX, clientY, poly)) return true
+        const closedPoly = [...poly, poly[0]!]
+        return distPointToPolylinePx(clientX, clientY, closedPoly) <= threshold
+      },
+      'area',
+      area
+    )
     this._statusEl.textContent = this._i18n.t('status.area', {
       value: `${this._view.formatLength(area)}²`
     })
@@ -1632,11 +1704,13 @@ export class AcExMeasureController {
 
   /** @internal */
   private _finishCommit(
-    hitTest: (clientX: number, clientY: number, thresholdPx: number) => boolean
+    hitTest: (clientX: number, clientY: number, thresholdPx: number) => boolean,
+    quantity: AcExMeasureQuantity | null,
+    value = 0
   ): void {
     const parts = this._commitParts
     if (!parts) return
-    this._committed.push({ id: parts.id, parts, hitTest })
+    this._committed.push({ id: parts.id, parts, hitTest, quantity, value })
     this._commitParts = null
   }
 
@@ -1709,17 +1783,19 @@ export class AcExMeasureController {
     this._selectedIds.add(id)
     const measure = this._committed.find(m => m.id === id)
     if (measure) this._applyMeasureSelection(measure.parts, true)
+    if (!this._mode) this._updateIdleStatus()
     this._view.render()
   }
 
   /** @internal */
-  private _deselect(): void {
+  private _deselect(updateStatus = true): void {
     if (this._selectedIds.size === 0) return
     for (const id of this._selectedIds) {
       const measure = this._committed.find(m => m.id === id)
       if (measure) this._applyMeasureSelection(measure.parts, false)
     }
     this._selectedIds.clear()
+    if (updateStatus && !this._mode) this._updateIdleStatus()
     this._view.render()
   }
 
@@ -1751,6 +1827,7 @@ export class AcExMeasureController {
     this._selectedIds.delete(id)
     const [measure] = this._committed.splice(idx, 1)
     for (const fn of measure.parts.cleanups) fn()
+    if (render && !this._mode) this._updateIdleStatus()
     if (render) this._view.render()
   }
 


### PR DESCRIPTION
## Summary

When no measurement tool is active in the exported HTML viewer, the status bar now shows aggregated length and area totals instead of only the drawing title / ready message.

- **No tool, no selection** — displays the sum of all distance and arc-length measurements, plus the sum of all area measurements on the canvas.
- **No tool, with selection** — displays totals for the currently selected measurement(s) only (supports multi-select).
- **Tool active** — unchanged; the status bar continues to show the active tool's hint text.
- **No length/area measurements** — falls back to the existing ready/title status text (angle and coordinate measurements are excluded from totals).

## Implementation

- Store `quantity` (`length` | `area`) and numeric `value` on each committed measurement in `AcExMeasureController`.
- Add `AcExMeasureTotals` helper module with `sumMeasureQuantities()` for aggregation logic.
- Introduce `refreshIdleStatus()` and wire it into cancel/clear, selection changes, deletion, locale changes, and viewer initialization.
- Add i18n strings: `status.lengthTotal` / `status.areaTotal` (EN + ZH).

## Test plan

- [ ] Export a drawing to HTML and create several distance, arc-length, and area measurements.
- [ ] Deactivate all measurement tools and confirm the status bar shows combined length and area totals.
- [ ] Select one or more measurements and confirm totals update to reflect only the selection.
- [ ] Deselect (Escape) and confirm totals revert to canvas-wide sums.
- [ ] Activate a measurement tool and confirm tool hints still appear in the status bar.
- [ ] Clear all measurements and confirm the status bar returns to the ready/title message.
- [ ] Switch locale (EN ↔ ZH) while idle and confirm total labels update correctly.
- [ ] Run unit tests: `pnpm --filter @mlightcad/cad-html-plugin test -- AcExMeasureTotals.spec.ts`
