### PR TITLE
feat: improve missed-data replacement handling and emit UI refresh event

### DIFF
--- a/packages/cad-simple-viewer/src/editor/global/eventBus.ts
+++ b/packages/cad-simple-viewer/src/editor/global/eventBus.ts
@@ -20,6 +20,7 @@ export interface AcEdFontNotLoadedInfo {
  * - **File Operations**: `open-file`, `open-file-progress`, `failed-to-open-file`
  * - **Palette Control**: `close-layer-manager`
  * - **Font Management**: `fonts-not-loaded`, `failed-to-get-avaiable-fonts`, `font-not-found`
+ * - **Missing Resources**: `missed-data-changed`
  * - **User Messages**: `message`
  */
 export type AcEdEvents = {
@@ -61,6 +62,8 @@ export type AcEdEvents = {
     /** Number of entities that require this font */
     count: number
   }
+  /** Emitted after missing resource caches change and UI state should refresh */
+  'missed-data-changed': {}
 }
 
 /**

--- a/packages/cad-simple-viewer/src/util/AcApFontUtil.ts
+++ b/packages/cad-simple-viewer/src/util/AcApFontUtil.ts
@@ -36,6 +36,19 @@ export class AcApFontUtil {
   }
 
   /**
+   * Font name used at render time when the requested font is missing.
+   *
+   * Checks user {@link FontManager.setFontMapping | font mapping} first, then falls
+   * back to {@link FontManager.defaultFont}.
+   *
+   * @param fontName - Original font name referenced by the drawing.
+   * @returns The loaded font name if available; otherwise the mapped or default replacement.
+   */
+  static getReplacementFontName(fontName: string): string {
+    return FontManager.instance.findAndReplaceFont(fontName)
+  }
+
+  /**
    * Sorted SHX glyph indices present in the loaded font payload.
    *
    * @param fontName - Name as registered in the font manager after load.

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -83,6 +83,7 @@
  */
 import {
   AcApDocManager,
+  AcApFontUtil,
   AcApOpenDatabaseOptions,
   AcEdMTextEditor,
   AcEdOpenMode,
@@ -182,7 +183,35 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { t } = useI18n()
 const { effectiveLocale, elementPlusLocale } = useLocale(props.locale)
-const { info, warning, error, success } = useNotificationCenter()
+const {
+  info,
+  warning,
+  error,
+  success,
+  removeWhere,
+  removeResolvedFontMissedNotifications
+} = useNotificationCenter()
+
+const fontMissedNotificationOptions = (fontNames: string[]) => ({
+  source: 'font-missed' as const,
+  fontNames
+})
+
+const formatFontWithReplacement = (fontName: string) =>
+  t('main.message.fontMissedReplacement', {
+    font: fontName,
+    replacement: AcApFontUtil.getReplacementFontName(fontName)
+  })
+
+const formatFontsWithReplacement = (fontNames: string[]) =>
+  fontNames.map(formatFontWithReplacement).join(', ')
+
+const syncFontMissedNotifications = () => {
+  const missedFonts = Object.keys(
+    AcApDocManager.instance.curView.missedData.fonts
+  )
+  removeResolvedFontMissedNotifications(missedFonts)
+}
 
 // Canvas element reference
 const containerRef = ref<HTMLDivElement>()
@@ -512,17 +541,50 @@ eventBus.on('message', params => {
 
 // Handle failure that fonts can't be loaded from remote font repository
 eventBus.on('fonts-not-loaded', params => {
-  const fonts = params.fonts.map(font => font.fontName).join(', ')
-  const message = t('main.message.fontsNotLoaded', { fonts })
-  error(t('main.notification.title.fontNotFound'), message)
+  const fontNames = params.fonts.map(font => font.fontName)
+  const message = t('main.message.fontsNotLoaded', {
+    fonts: formatFontsWithReplacement(fontNames)
+  })
+  error(t('main.notification.title.fontNotFound'), message, {
+    ...fontMissedNotificationOptions(fontNames),
+    persistent: true
+  })
 })
 
 // Handle failure that fonts can't be found in remote font repository
 eventBus.on('fonts-not-found', params => {
   const message = t('main.message.fontsNotFound', {
-    fonts: params.fonts.join(', ')
+    fonts: formatFontsWithReplacement(params.fonts)
   })
-  warning(t('main.notification.title.fontNotFound'), message)
+  warning(t('main.notification.title.fontNotFound'), message, {
+    ...fontMissedNotificationOptions(params.fonts)
+  })
+})
+
+// Handle fonts required by the drawing that are not available during rendering
+eventBus.on('font-not-found', params => {
+  const fontName = params.fontName.trim()
+  if (!fontName) return
+
+  removeWhere(
+    notification =>
+      notification.source === 'font-missed' &&
+      notification.fontNames?.includes(fontName) === true
+  )
+
+  warning(
+    t('main.notification.title.fontNotFound'),
+    t('main.message.fontMissedInDrawing', {
+      font: fontName,
+      count: params.count,
+      replacementFont: AcApFontUtil.getReplacementFontName(fontName)
+    }),
+    fontMissedNotificationOptions([fontName])
+  )
+})
+
+eventBus.on('missed-data-changed', () => {
+  syncFontMissedNotifications()
 })
 
 // Handle failures when trying to get available fonts from the system

--- a/packages/cad-viewer/src/component/common/MlBaseDialog.vue
+++ b/packages/cad-viewer/src/component/common/MlBaseDialog.vue
@@ -119,6 +119,8 @@ function handleCancel() {
   position: relative;
   z-index: 1;
   --ml-dialog-font-size: 12px;
+  --ml-dialog-body-padding-x: 16px;
+  --ml-dialog-body-padding-y: 16px;
   --el-font-size-base: 12px;
   background: var(--el-bg-color);
   border: 1px solid var(--el-border-color);
@@ -184,9 +186,9 @@ function handleCancel() {
   justify-content: center;
 }
 
-/* Body */
+/* Body — horizontal/vertical content inset is shared by all dialogs */
 .ml-base-dialog-body {
-  padding: 16px;
+  padding: var(--ml-dialog-body-padding-y) var(--ml-dialog-body-padding-x);
   overflow-y: auto;
   flex: 1;
   font-size: var(--ml-dialog-font-size);

--- a/packages/cad-viewer/src/component/dialog/MlReplacementDlg.vue
+++ b/packages/cad-viewer/src/component/dialog/MlReplacementDlg.vue
@@ -98,7 +98,8 @@
 <script lang="ts" setup>
 import {
   AcApDocManager,
-  AcApSettingManager
+  AcApSettingManager,
+  eventBus
 } from '@mlightcad/cad-simple-viewer'
 import { AcDbRasterImage } from '@mlightcad/data-model'
 import {
@@ -135,8 +136,10 @@ const loadAvailableFonts = () => {
   availableFonts.value = fonts.map(f => f.name[0])
 }
 
-const handleConfirm = () => {
-  const db = AcApDocManager.instance.curDocument.database
+const handleConfirm = async () => {
+  const docManager = AcApDocManager.instance
+  const db = docManager.curDocument.database
+  let replacedImage = false
   imageTableData.forEach(item => {
     if (item.file) {
       item.ids.forEach(id => {
@@ -145,16 +148,43 @@ const handleConfirm = () => {
         ) as AcDbRasterImage
         image.image = item.file
         image.triggerModifiedEvent()
+        replacedImage = true
       })
     }
   })
 
   const settingManager = AcApSettingManager.instance
+  const nextFontMapping = { ...settingManager.fontMapping }
+  const fontsToLoad = new Set<string>()
+  let replacedFont = false
+
   fontMapping.forEach((mappedFont, missedFont) => {
-    if (missedFont && mappedFont) {
-      settingManager.setFontMapping(missedFont, mappedFont)
+    const originalFont = missedFont.trim()
+    const replacementFont = mappedFont.trim()
+
+    if (originalFont && replacementFont) {
+      nextFontMapping[originalFont] = replacementFont
+      fontsToLoad.add(replacementFont)
+      replacedFont = true
     }
   })
+
+  if (replacedFont) {
+    settingManager.fontMapping = nextFontMapping
+    docManager.curView.renderer.setFontMapping(nextFontMapping)
+
+    try {
+      await docManager.loadFonts([...fontsToLoad])
+    } catch {
+      // Font loader emits detailed failure notifications; still regenerate.
+    }
+
+    await docManager.regen()
+  }
+
+  if (replacedFont || replacedImage) {
+    eventBus.emit('missed-data-changed', {})
+  }
 }
 
 const handleSelectImage = (row: ImageMappingData) => {

--- a/packages/cad-viewer/src/component/dialog/MlReplacementDlg.vue
+++ b/packages/cad-viewer/src/component/dialog/MlReplacementDlg.vue
@@ -1,35 +1,119 @@
 <template>
   <ml-base-dialog
     :title="t('dialog.replacementDlg.title')"
+    :width="480"
     v-model="dialogVisible"
     name="ReplacementDlg"
     @ok="handleConfirm"
-    @open="loadAvailableFonts"
+    @open="handleOpen"
   >
-    <el-tabs size="small" v-model="activeName">
-      <el-tab-pane
-        v-if="fontMapping.size > 0"
-        :label="t('dialog.replacementDlg.fontTabName')"
-        name="font"
-      >
-        <div>
-          <el-row>
-            <el-col :span="12">
+    <div class="ml-replacement-dlg">
+      <el-tabs v-if="showTabs" v-model="activeTab" class="ml-replacement-dlg__tabs">
+        <el-tab-pane
+          v-if="fontMapping.size > 0"
+          :label="t('dialog.replacementDlg.fontTabName')"
+          name="font"
+        >
+          <div class="ml-replacement-dlg__font-panel">
+            <el-checkbox v-model="matchFontType" class="ml-replacement-dlg__option">
+              {{ t('dialog.replacementDlg.matchFontType') }}
+            </el-checkbox>
+            <div class="ml-replacement-dlg__font-grid">
+              <div
+                class="ml-replacement-dlg__font-row ml-replacement-dlg__font-row--header"
+              >
+                <span>{{ t('dialog.replacementDlg.missedFont') }}</span>
+                <span>{{ t('dialog.replacementDlg.replacedFont') }}</span>
+              </div>
+              <div
+                v-for="[missedFont, mappedFont] in fontMapping"
+                :key="missedFont"
+                class="ml-replacement-dlg__font-row"
+              >
+                <span
+                  class="ml-replacement-dlg__missed-font"
+                  :title="missedFont"
+                >
+                  {{ missedFont }}
+                </span>
+                <el-select
+                  :model-value="mappedFont"
+                  :placeholder="t('dialog.replacementDlg.selectFont')"
+                  @update:model-value="
+                    (value: string) => updateMappedFont(missedFont, value)
+                  "
+                  style="width: 100%"
+                >
+                  <el-option
+                    v-for="replacement in getReplacementFontsFor(missedFont)"
+                    :key="replacement"
+                    :label="replacement"
+                    :value="replacement"
+                  />
+                </el-select>
+              </div>
+            </div>
+          </div>
+        </el-tab-pane>
+        <el-tab-pane
+          v-if="imageTableData.size > 0"
+          :label="t('dialog.replacementDlg.imageTabName')"
+          name="image"
+        >
+          <div class="ml-replacement-dlg__image-panel">
+            <el-table
+              :data="Array.from(imageTableData.values())"
+              style="width: 100%"
+            >
+              <el-table-column
+                :label="t('dialog.replacementDlg.file')"
+                prop="fileName"
+                :min-width="0"
+              />
+              <el-table-column
+                :label="t('dialog.replacementDlg.replace')"
+                fixed="right"
+                width="60"
+              >
+                <template #default="{ row }">
+                  <el-button
+                    link
+                    type="primary"
+                    size="small"
+                    @click="handleSelectImage(row)"
+                  >
+                    ...
+                  </el-button>
+                </template>
+              </el-table-column>
+            </el-table>
+          </div>
+        </el-tab-pane>
+      </el-tabs>
+
+      <template v-else>
+        <div v-if="fontMapping.size > 0" class="ml-replacement-dlg__font-panel">
+          <el-checkbox v-model="matchFontType" class="ml-replacement-dlg__option">
+            {{ t('dialog.replacementDlg.matchFontType') }}
+          </el-checkbox>
+          <div class="ml-replacement-dlg__font-grid">
+            <div
+              class="ml-replacement-dlg__font-row ml-replacement-dlg__font-row--header"
+            >
               <span>{{ t('dialog.replacementDlg.missedFont') }}</span>
-            </el-col>
-            <el-col :span="12">
               <span>{{ t('dialog.replacementDlg.replacedFont') }}</span>
-            </el-col>
-          </el-row>
-          <el-row
-            v-for="[missedFont, mappedFont] in fontMapping"
-            :key="missedFont"
-            style="margin-top: 10px"
-          >
-            <el-col :span="12">
-              <span>{{ missedFont }}</span>
-            </el-col>
-            <el-col :span="12">
+            </div>
+            <div
+              v-for="[missedFont, mappedFont] in fontMapping"
+              :key="missedFont"
+              class="ml-replacement-dlg__font-row"
+            >
+              <span
+                class="ml-replacement-dlg__missed-font"
+                :title="missedFont"
+              >
+                {{ missedFont }}
+              </span>
               <el-select
                 :model-value="mappedFont"
                 :placeholder="t('dialog.replacementDlg.selectFont')"
@@ -39,81 +123,76 @@
                 style="width: 100%"
               >
                 <el-option
-                  v-for="(replacement, rIndex) in availableFonts"
-                  :key="rIndex"
+                  v-for="replacement in getReplacementFontsFor(missedFont)"
+                  :key="replacement"
                   :label="replacement"
                   :value="replacement"
                 />
               </el-select>
-            </el-col>
-          </el-row>
+            </div>
+          </div>
         </div>
-      </el-tab-pane>
-      <el-tab-pane
-        v-if="imageTableData.size > 0"
-        :label="t('dialog.replacementDlg.imageTabName')"
-        name="image"
-      >
-        <el-table
-          :data="Array.from(imageTableData.values())"
-          style="width: 100%"
-          :v-show="false"
-        >
-          <el-table-column
-            :label="t('dialog.replacementDlg.file')"
-            prop="fileName"
-            :min-width="0"
-            :flex="1"
-          />
-          <el-table-column
-            :label="t('dialog.replacementDlg.replace')"
-            fixed="right"
-            width="60"
+
+        <div v-else class="ml-replacement-dlg__image-panel">
+          <el-table
+            :data="Array.from(imageTableData.values())"
+            style="width: 100%"
           >
-            <template #default="{ row }">
-              <el-button
-                link
-                type="primary"
-                size="small"
-                @click="handleSelectImage(row)"
-              >
-                ...
-              </el-button>
-            </template>
-          </el-table-column>
-        </el-table>
-        <!-- File Input (hidden) -->
-        <input
-          type="file"
-          ref="fileInput"
-          accept=".png,.jpg,.jpeg"
-          @change="handleFileChange"
-          style="display: none"
-        />
-      </el-tab-pane>
-    </el-tabs>
+            <el-table-column
+              :label="t('dialog.replacementDlg.file')"
+              prop="fileName"
+              :min-width="0"
+            />
+            <el-table-column
+              :label="t('dialog.replacementDlg.replace')"
+              fixed="right"
+              width="60"
+            >
+              <template #default="{ row }">
+                <el-button
+                  link
+                  type="primary"
+                  size="small"
+                  @click="handleSelectImage(row)"
+                >
+                  ...
+                </el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+        </div>
+      </template>
+
+      <input
+        type="file"
+        ref="fileInput"
+        accept=".png,.jpg,.jpeg"
+        @change="handleFileChange"
+        style="display: none"
+      />
+    </div>
   </ml-base-dialog>
 </template>
 
 <script lang="ts" setup>
 import {
   AcApDocManager,
+  AcApFontUtil,
   AcApSettingManager,
   eventBus
 } from '@mlightcad/cad-simple-viewer'
-import { AcDbRasterImage } from '@mlightcad/data-model'
+import { AcDbFontInfo, AcDbRasterImage } from '@mlightcad/data-model'
 import {
   ElButton,
-  ElCol,
+  ElCheckbox,
   ElOption,
-  ElRow,
   ElSelect,
   ElTable,
   ElTableColumn,
   ElTabPane,
   ElTabs
 } from 'element-plus'
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { ImageMappingData, useMissedData } from '../../composable'
@@ -123,17 +202,62 @@ const { t } = useI18n()
 const { fonts: fontMapping, images: imageTableData } = useMissedData()
 const dialogVisible = ref(true)
 
-const activeName = computed(() => {
-  return fontMapping.size > 0 ? 'font' : 'image'
-})
+const showTabs = computed(
+  () => fontMapping.size > 0 && imageTableData.size > 0
+)
+const activeTab = ref('font')
 const fileInput = ref<HTMLInputElement | null>(null)
+const availableFontInfos = ref<AcDbFontInfo[]>([])
+const matchFontType = ref(true)
+const pendingImageRow = ref<ImageMappingData | null>(null)
 
-// Move availableFonts to a ref and populate it in onMounted
-const availableFonts = ref<string[]>([])
+watch(
+  showTabs,
+  hasTabs => {
+    if (!hasTabs) {
+      activeTab.value = fontMapping.size > 0 ? 'font' : 'image'
+    }
+  },
+  { immediate: true }
+)
 
-const loadAvailableFonts = () => {
-  const fonts = AcApDocManager.instance.avaiableFonts
-  availableFonts.value = fonts.map(f => f.name[0])
+watch(matchFontType, enabled => {
+  if (!enabled) return
+
+  fontMapping.forEach((mappedFont, missedFont) => {
+    if (!mappedFont) return
+    const options = getReplacementFontsFor(missedFont)
+    if (!options.includes(mappedFont)) {
+      fontMapping.set(missedFont, '')
+    }
+  })
+})
+
+const handleOpen = () => {
+  availableFontInfos.value = AcApDocManager.instance.avaiableFonts
+}
+
+const getMissedFontType = (missedFont: string): 'shx' | 'mesh' | undefined => {
+  return (
+    AcApFontUtil.getCatalogFontType(missedFont) ??
+    AcApFontUtil.getFontType(missedFont)
+  )
+}
+
+const getReplacementFontsFor = (missedFont: string): string[] => {
+  const fonts = availableFontInfos.value
+  if (!matchFontType.value) {
+    return fonts.map(font => font.name[0])
+  }
+
+  const targetType = getMissedFontType(missedFont)
+  if (!targetType) {
+    return fonts.map(font => font.name[0])
+  }
+
+  return fonts
+    .filter(font => font.type === targetType)
+    .map(font => font.name[0])
 }
 
 const handleConfirm = async () => {
@@ -179,7 +303,8 @@ const handleConfirm = async () => {
       // Font loader emits detailed failure notifications; still regenerate.
     }
 
-    await docManager.regen()
+    docManager.regen()
+    await nextTick()
   }
 
   if (replacedFont || replacedImage) {
@@ -188,18 +313,18 @@ const handleConfirm = async () => {
 }
 
 const handleSelectImage = (row: ImageMappingData) => {
-  if (fileInput.value) {
-    fileInput.value.click()
-    fileInput.value.onchange = () => {
-      handleFileChange(row)
-    }
-  }
+  pendingImageRow.value = row
+  fileInput.value?.click()
 }
 
-const handleFileChange = (row: ImageMappingData) => {
+const handleFileChange = () => {
   const file = fileInput.value?.files?.[0]
-  if (file) {
-    row.file = file
+  if (file && pendingImageRow.value) {
+    pendingImageRow.value.file = file
+  }
+  pendingImageRow.value = null
+  if (fileInput.value) {
+    fileInput.value.value = ''
   }
 }
 
@@ -207,3 +332,49 @@ const updateMappedFont = (missedFont: string, mappedFont: string) => {
   fontMapping.set(missedFont, mappedFont)
 }
 </script>
+
+<style scoped>
+.ml-replacement-dlg__tabs :deep(.el-tabs__header) {
+  margin: 0 0 8px;
+}
+
+.ml-replacement-dlg__tabs :deep(.el-tabs__nav-wrap::after) {
+  height: 1px;
+}
+
+.ml-replacement-dlg__tabs :deep(.el-tabs__item) {
+  height: 28px;
+  line-height: 28px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+
+.ml-replacement-dlg__option {
+  margin-bottom: 8px;
+}
+
+.ml-replacement-dlg__font-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ml-replacement-dlg__font-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.ml-replacement-dlg__font-row--header {
+  color: var(--el-text-color-secondary);
+  font-weight: 600;
+  padding-bottom: 2px;
+}
+
+.ml-replacement-dlg__missed-font {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/packages/cad-viewer/src/composable/useMissedData.ts
+++ b/packages/cad-viewer/src/composable/useMissedData.ts
@@ -6,47 +6,166 @@ import {
 import { AcDbObjectId } from '@mlightcad/data-model'
 import { reactive } from 'vue'
 
+/**
+ * Missed Data Composable
+ *
+ * Tracks fonts and raster images that the current drawing references but that are
+ * missing on disk or unavailable to the renderer. State is shared module-wide so
+ * every caller sees the same reactive maps (for example the status-bar warning
+ * button and the replacement dialog).
+ *
+ * Data is synchronized from {@link AcApDocManager.instance.curView.missedData}
+ * and persisted font substitutions from
+ * {@link AcApSettingManager.instance.fontMapping}. Consumers may mutate the
+ * returned maps (choose replacement fonts, attach image files) before applying
+ * changes through the replacement dialog.
+ *
+ * @example
+ * ```typescript
+ * import { useMissedData } from '@mlightcad/cad-viewer'
+ *
+ * const { fonts, images } = useMissedData()
+ *
+ * if (fonts.size > 0) {
+ *   console.log('Missing fonts:', [...fonts.keys()])
+ * }
+ *
+ * images.forEach((row, fileName) => {
+ *   console.log(fileName, 'affects', row.ids.size, 'entities')
+ * })
+ * ```
+ */
+
+/**
+ * One row in the missed-image replacement table.
+ *
+ * Multiple drawing entities can reference the same missing image file; they are
+ * grouped under a single row keyed by {@link fileName}.
+ */
 export interface ImageMappingData {
+  /** File name reported by the viewer for the missing image resource. */
   fileName: string
+  /**
+   * User-selected replacement file, set by the replacement dialog before confirm.
+   * Undefined until the user picks a file.
+   */
   file?: File
+  /** Entity object IDs whose raster image reference resolves to {@link fileName}. */
   ids: Set<AcDbObjectId>
 }
 
-export function useMissedData() {
-  const fontMapping = reactive(new Map<string, string>())
-  const imageData = reactive(new Map<string, ImageMappingData>())
+/**
+ * Reactive state returned by {@link useMissedData}.
+ */
+export interface UseMissedDataReturn {
+  /**
+   * Missed font name → replacement font name.
+   *
+   * Keys come from the active view's missed-font list. Values are initialized from
+   * application settings; an empty string means no replacement has been chosen yet.
+   */
+  fonts: Map<string, string>
+  /**
+   * Missed image file name → grouped mapping row.
+   *
+   * Keys are image resource names from the drawing. Values aggregate all entities
+   * that reference that resource.
+   */
+  images: Map<string, ImageMappingData>
+}
 
-  const reset = () => {
-    const missedData = AcApDocManager.instance.curView.missedData
-    const storedFontMapping = AcApSettingManager.instance.fontMapping
+/** Shared reactive font substitutions (missed name → replacement name). */
+const fontMapping = reactive(new Map<string, string>())
 
-    fontMapping.clear()
-    Object.keys(missedData.fonts).forEach(key => {
-      const mappedFont = storedFontMapping[key]
-      fontMapping.set(key, mappedFont || '')
-    })
+/** Shared reactive missed-image rows keyed by file name. */
+const imageData = reactive(new Map<string, ImageMappingData>())
 
-    imageData.clear()
-    missedData.images.forEach((value, key) => {
-      const item = imageData.get(value)
-      if (item) {
-        item.ids.add(key)
-      } else {
-        imageData.set(value, {
-          fileName: value,
-          ids: new Set([key])
-        })
-      }
-    })
+/** Whether document and event-bus listeners have been registered. */
+let initialized = false
+
+/**
+ * Builds image table rows from the view's missed-image map.
+ *
+ * @param missedImages - Map from entity object id to image file name (as reported by the renderer).
+ * @returns New map keyed by file name with entity ids grouped per file.
+ */
+function buildImageMapping(
+  missedImages: Map<AcDbObjectId, string>
+): Map<string, ImageMappingData> {
+  const next = new Map<string, ImageMappingData>()
+
+  for (const [objectId, fileName] of missedImages) {
+    const existing = next.get(fileName)
+    if (existing) {
+      existing.ids.add(objectId)
+    } else {
+      next.set(fileName, {
+        fileName,
+        ids: new Set([objectId])
+      })
+    }
   }
 
+  return next
+}
+
+/**
+ * Replaces module state with missed data from the active document view.
+ *
+ * Clears and repopulates {@link fontMapping} and {@link imageData}. Font values
+ * prefer entries in {@link AcApSettingManager.instance.fontMapping}; otherwise
+ * they default to an empty string.
+ */
+function syncFromCurrentView(): void {
+  const missedData = AcApDocManager.instance.curView.missedData
+  const storedFontMapping = AcApSettingManager.instance.fontMapping
+
+  fontMapping.clear()
+  for (const missedFont of Object.keys(missedData.fonts)) {
+    fontMapping.set(missedFont, storedFontMapping[missedFont] ?? '')
+  }
+
+  imageData.clear()
+  const grouped = buildImageMapping(missedData.images)
+  for (const [fileName, row] of grouped) {
+    imageData.set(fileName, row)
+  }
+}
+
+/**
+ * Registers one-time listeners and performs the initial sync.
+ *
+ * Listens for document activation, {@link eventBus} `font-not-found`, and
+ * `missed-data-changed` so UI stays aligned with the renderer and user replacements.
+ */
+function ensureInitialized(): void {
+  if (initialized) return
+  initialized = true
+
   AcApDocManager.instance.events.documentActivated.addEventListener(() => {
-    reset()
+    syncFromCurrentView()
   })
 
-  eventBus.on('font-not-found', _ => {
-    reset()
+  eventBus.on('font-not-found', () => {
+    syncFromCurrentView()
   })
+
+  eventBus.on('missed-data-changed', () => {
+    syncFromCurrentView()
+  })
+
+  syncFromCurrentView()
+}
+
+/**
+ * Access shared reactive state for missing fonts and images in the current drawing.
+ *
+ * Safe to call from multiple components; initialization and event wiring run once.
+ *
+ * @returns Reactive maps for the replacement dialog and warning affordances.
+ */
+export function useMissedData(): UseMissedDataReturn {
+  ensureInitialized()
 
   return {
     fonts: fontMapping,

--- a/packages/cad-viewer/src/composable/useNotificationCenter.ts
+++ b/packages/cad-viewer/src/composable/useNotificationCenter.ts
@@ -1,9 +1,280 @@
 import { computed, ref } from 'vue'
 
 /**
- * Notification Center Composable
+ * Identifies the subsystem or feature that produced a notification.
+ *
+ * Used to group related notifications and remove them selectively (for example,
+ * when the underlying issue is resolved) without clearing unrelated entries.
+ *
+ * @remarks
+ * Currently only `font-missed` is defined. Additional sources may be added as
+ * new notification producers are integrated.
+ */
+export type NotificationSource = 'font-missed'
+
+/**
+ * A single notification entry displayed in the notification center panel.
+ *
+ * Notifications are ordered by insertion time (newest first) and may include
+ * optional action buttons and auto-dismiss behavior.
+ */
+export interface Notification {
+  /** Unique identifier assigned automatically when the notification is created. */
+  id: string
+  /** Visual severity and icon category (`info`, `warning`, `error`, or `success`). */
+  type: 'info' | 'warning' | 'error' | 'success'
+  /** Short headline shown in the notification header. */
+  title: string
+  /** Optional longer description body; omitted for title-only toasts. */
+  message?: string
+  /** Time the notification was created. */
+  timestamp: Date
+  /** Optional buttons that invoke callbacks when clicked. */
+  actions?: NotificationAction[]
+  /**
+   * When `true`, the notification is not auto-dismissed and must be closed
+   * manually or via {@link NotificationCenter.remove}.
+   */
+  persistent?: boolean
+  /**
+   * Auto-dismiss delay in milliseconds.
+   * Ignored when {@link Notification.persistent | persistent} is `true`.
+   */
+  timeout?: number
+  /**
+   * Groups related notifications for selective removal
+   * (e.g. resolved missed-font alerts).
+   */
+  source?: NotificationSource
+  /**
+   * Font names referenced by this notification; used by
+   * {@link NotificationCenter.removeResolvedFontMissedNotifications} to clear
+   * entries when those fonts are no longer missing.
+   */
+  fontNames?: string[]
+}
+
+/**
+ * A clickable action rendered as a button on a notification.
+ */
+export interface NotificationAction {
+  /** Button label text displayed to the user. */
+  label: string
+  /** Callback invoked when the user clicks the button. */
+  action: () => void
+  /** When `true`, renders the button with primary (emphasized) styling. */
+  primary?: boolean
+}
+
+/**
+ * Singleton service that stores and manages the global notification list.
+ *
+ * All state is held in Vue refs so consumers bound through
+ * {@link useNotificationCenter} receive reactive updates when notifications
+ * are added or removed.
+ */
+class NotificationCenter {
+  /** Reactive backing store for all active notifications (newest first). */
+  private notifications = ref<Notification[]>([])
+  /** Monotonic counter used to generate unique notification IDs. */
+  private nextId = 1
+
+  /**
+   * Reactive computed list of all notifications, ordered newest first.
+   *
+   * @returns A Vue computed ref whose value is the current notification array.
+   */
+  get allNotifications() {
+    return computed(() => this.notifications.value)
+  }
+
+  /**
+   * Reactive count of active notifications.
+   *
+   * @returns A Vue computed ref whose value equals the number of notifications.
+   */
+  get unreadCount() {
+    return computed(() => this.notifications.value.length)
+  }
+
+  /**
+   * Reactive flag indicating whether any notifications are present.
+   *
+   * @returns A Vue computed ref that is `true` when at least one notification exists.
+   */
+  get hasNotifications() {
+    return computed(() => this.notifications.value.length > 0)
+  }
+
+  /**
+   * Creates and prepends a new notification to the list.
+   *
+   * @param notification - Notification fields excluding auto-assigned `id` and `timestamp`.
+   * @returns The generated notification ID, usable with {@link NotificationCenter.remove}.
+   */
+  add(notification: Omit<Notification, 'id' | 'timestamp'>) {
+    const newNotification: Notification = {
+      ...notification,
+      id: `notification-${this.nextId++}`,
+      timestamp: new Date()
+    }
+
+    this.notifications.value.unshift(newNotification)
+
+    return newNotification.id
+  }
+
+  /**
+   * Removes a single notification by its ID.
+   *
+   * No-op if no notification with the given ID exists.
+   *
+   * @param id - The notification ID returned by {@link NotificationCenter.add}.
+   */
+  remove(id: string) {
+    const index = this.notifications.value.findIndex(n => n.id === id)
+    if (index > -1) {
+      this.notifications.value.splice(index, 1)
+    }
+  }
+
+  /**
+   * Removes all notifications from the center.
+   */
+  clear() {
+    this.notifications.value = []
+  }
+
+  /**
+   * Alias for {@link NotificationCenter.clear}.
+   * Provided for API symmetry with other "clear all" patterns in the viewer.
+   */
+  clearAll() {
+    this.clear()
+  }
+
+  /**
+   * Removes every notification for which the predicate returns `true`.
+   *
+   * @param predicate - Called for each notification; return `true` to remove it.
+   */
+  removeWhere(predicate: (notification: Notification) => boolean) {
+    this.notifications.value = this.notifications.value.filter(
+      notification => !predicate(notification)
+    )
+  }
+
+  /**
+   * Removes all notifications tagged with the given {@link NotificationSource}.
+   *
+   * @param source - The source tag to match (e.g. `'font-missed'`).
+   */
+  removeBySource(source: NotificationSource) {
+    this.removeWhere(notification => notification.source === source)
+  }
+
+  /**
+   * Drops `font-missed` notifications whose fonts are no longer reported as missing.
+   *
+   * When the missed-font set is empty, removes all `font-missed` notifications.
+   * Otherwise, removes only entries whose {@link Notification.fontNames} no longer
+   * intersect the current missed set.
+   *
+   * @param missedFontNames - Iterable of font names still reported as missing.
+   */
+  removeResolvedFontMissedNotifications(missedFontNames: Iterable<string>) {
+    const missed = new Set(missedFontNames)
+    this.removeWhere(notification => {
+      if (notification.source !== 'font-missed') return false
+      if (missed.size === 0) return true
+      if (!notification.fontNames?.length) return false
+      return !notification.fontNames.some(fontName => missed.has(fontName))
+    })
+  }
+
+  /**
+   * Adds an informational notification.
+   *
+   * @param title - Notification headline.
+   * @param message - Optional body text.
+   * @param options - Additional fields (actions, timeout, source, etc.).
+   * @returns The generated notification ID.
+   */
+  info(title: string, message?: string, options?: Partial<Notification>) {
+    return this.add({
+      type: 'info',
+      title,
+      message,
+      ...options
+    })
+  }
+
+  /**
+   * Adds a warning notification.
+   *
+   * @param title - Notification headline.
+   * @param message - Optional body text.
+   * @param options - Additional fields (actions, timeout, source, etc.).
+   * @returns The generated notification ID.
+   */
+  warning(title: string, message?: string, options?: Partial<Notification>) {
+    return this.add({
+      type: 'warning',
+      title,
+      message,
+      ...options
+    })
+  }
+
+  /**
+   * Adds an error notification.
+   *
+   * Errors are {@link Notification.persistent | persistent} by default so they
+   * remain visible until the user dismisses them or takes an action.
+   *
+   * @param title - Notification headline.
+   * @param message - Optional body text.
+   * @param options - Additional fields; `persistent: false` overrides the default.
+   * @returns The generated notification ID.
+   */
+  error(title: string, message?: string, options?: Partial<Notification>) {
+    return this.add({
+      type: 'error',
+      title,
+      message,
+      persistent: true, // Errors are persistent by default
+      ...options
+    })
+  }
+
+  /**
+   * Adds a success notification.
+   *
+   * @param title - Notification headline.
+   * @param message - Optional body text.
+   * @param options - Additional fields (actions, timeout, source, etc.).
+   * @returns The generated notification ID.
+   */
+  success(title: string, message?: string, options?: Partial<Notification>) {
+    return this.add({
+      type: 'success',
+      title,
+      message,
+      ...options
+    })
+  }
+}
+
+/** Shared global {@link NotificationCenter} instance used by {@link useNotificationCenter}. */
+const notificationCenter = new NotificationCenter()
+
+/**
+ * Composable that exposes the global notification center.
  *
  * Provides a centralized notification system similar to Visual Studio Code.
+ * All returned state is reactive; multiple callers share the same underlying list.
+ *
+ * @returns Notification management functions and reactive state.
  *
  * @example
  * ```typescript
@@ -30,137 +301,38 @@ import { computed, ref } from 'vue'
  * console.log(`You have ${unreadCount.value} notifications`)
  * ```
  */
-
-export interface Notification {
-  id: string
-  type: 'info' | 'warning' | 'error' | 'success'
-  title: string
-  message?: string
-  timestamp: Date
-  actions?: NotificationAction[]
-  persistent?: boolean
-  timeout?: number
-}
-
-export interface NotificationAction {
-  label: string
-  action: () => void
-  primary?: boolean
-}
-
-class NotificationCenter {
-  private notifications = ref<Notification[]>([])
-  private nextId = 1
-
-  get allNotifications() {
-    return computed(() => this.notifications.value)
-  }
-
-  get unreadCount() {
-    return computed(() => this.notifications.value.length)
-  }
-
-  get hasNotifications() {
-    return computed(() => this.notifications.value.length > 0)
-  }
-
-  add(notification: Omit<Notification, 'id' | 'timestamp'>) {
-    const newNotification: Notification = {
-      ...notification,
-      id: `notification-${this.nextId++}`,
-      timestamp: new Date()
-    }
-
-    this.notifications.value.unshift(newNotification)
-
-    return newNotification.id
-  }
-
-  remove(id: string) {
-    const index = this.notifications.value.findIndex(n => n.id === id)
-    if (index > -1) {
-      this.notifications.value.splice(index, 1)
-    }
-  }
-
-  clear() {
-    this.notifications.value = []
-  }
-
-  clearAll() {
-    this.clear()
-  }
-
-  // Convenience methods for different notification types
-  info(title: string, message?: string, options?: Partial<Notification>) {
-    return this.add({
-      type: 'info',
-      title,
-      message,
-      ...options
-    })
-  }
-
-  warning(title: string, message?: string, options?: Partial<Notification>) {
-    return this.add({
-      type: 'warning',
-      title,
-      message,
-      ...options
-    })
-  }
-
-  error(title: string, message?: string, options?: Partial<Notification>) {
-    return this.add({
-      type: 'error',
-      title,
-      message,
-      persistent: true, // Errors are persistent by default
-      ...options
-    })
-  }
-
-  success(title: string, message?: string, options?: Partial<Notification>) {
-    return this.add({
-      type: 'success',
-      title,
-      message,
-      ...options
-    })
-  }
-}
-
-// Global notification center instance
-const notificationCenter = new NotificationCenter()
-
-/**
- * Hook to access the notification center functionality
- *
- * @returns Object containing notification management functions and reactive state
- */
 export function useNotificationCenter() {
   return {
-    /** Reactive list of all notifications */
+    /** Reactive list of all notifications, ordered newest first. */
     notifications: notificationCenter.allNotifications,
-    /** Reactive count of unread notifications */
+    /** Reactive count of active notifications. */
     unreadCount: notificationCenter.unreadCount,
-    /** Reactive boolean indicating if there are any notifications */
+    /** Reactive boolean; `true` when at least one notification exists. */
     hasNotifications: notificationCenter.hasNotifications,
-    /** Add a custom notification */
+    /** Creates and prepends a custom notification. Returns the new notification ID. */
     add: notificationCenter.add.bind(notificationCenter),
-    /** Remove a notification by ID */
+    /** Removes a notification by ID. No-op if the ID is not found. */
     remove: notificationCenter.remove.bind(notificationCenter),
-    /** Clear all notifications */
+    /** Removes all notifications from the center. */
     clear: notificationCenter.clear.bind(notificationCenter),
-    /** Clear all notifications (alias for clear) */
+    /** Alias for {@link NotificationCenter.clear}. */
     clearAll: notificationCenter.clearAll.bind(notificationCenter),
-    /** Add an info notification */
+    /** Removes notifications for which the predicate returns `true`. */
+    removeWhere: notificationCenter.removeWhere.bind(notificationCenter),
+    /** Removes all notifications tagged with the given {@link NotificationSource}. */
+    removeBySource: notificationCenter.removeBySource.bind(notificationCenter),
+    /** Removes resolved `font-missed` notifications based on the current missed-font set. */
+    removeResolvedFontMissedNotifications:
+      notificationCenter.removeResolvedFontMissedNotifications.bind(
+        notificationCenter
+      ),
+    /** Adds an informational notification. Returns the new notification ID. */
     info: notificationCenter.info.bind(notificationCenter),
-    /** Add a warning notification */
+    /** Adds a warning notification. Returns the new notification ID. */
     warning: notificationCenter.warning.bind(notificationCenter),
-    /** Add an error notification */
+    /** Adds an error notification (persistent by default). Returns the new notification ID. */
     error: notificationCenter.error.bind(notificationCenter),
-    /** Add a success notification */
+    /** Adds a success notification. Returns the new notification ID. */
     success: notificationCenter.success.bind(notificationCenter)
   }
 }

--- a/packages/cad-viewer/src/locale/en/dialog.ts
+++ b/packages/cad-viewer/src/locale/en/dialog.ts
@@ -11,7 +11,8 @@ export default {
     replace: 'Replace',
     missedFont: 'Missed Font',
     replacedFont: 'Replaced Font',
-    selectFont: 'Select font to replace'
+    selectFont: 'Select font to replace',
+    matchFontType: 'Use the same font type (SHX replaces SHX, mesh replaces mesh)'
   },
   pointStyleDlg: {
     title: 'Point Style',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -592,8 +592,11 @@ export default {
   message: {
     loadingFonts: 'Loading fonts ...',
     loadingDwgConverter: 'Loading DWG converter...',
-    fontsNotFound: 'Fonts "{fonts}" can not be found in font repository!',
-    fontsNotLoaded: 'Fonts "{fonts}" can not be loaded!',
+    fontsNotFound: 'Fonts {fonts} can not be found in font repository!',
+    fontsNotLoaded: 'Fonts {fonts} can not be loaded!',
+    fontMissedInDrawing:
+      'Font "{font}" is required by {count} text object(s) but is not available. Displaying with "{replacementFont}".',
+    fontMissedReplacement: '"{font}" (displaying with "{replacement}")',
     failedToGetAvaiableFonts: 'Failed to get avaiable fonts from "{url}"!',
     failedToOpenFile: 'Failed to open file "{fileName}"!',
     fetchingDrawingFile: 'Fetching file ...',

--- a/packages/cad-viewer/src/locale/zh/dialog.ts
+++ b/packages/cad-viewer/src/locale/zh/dialog.ts
@@ -11,7 +11,8 @@ export default {
     replace: '替换',
     missedFont: '缺失字体',
     replacedFont: '替换字体',
-    selectFont: '选择要替换的字体'
+    selectFont: '选择要替换的字体',
+    matchFontType: '使用相同类型的字体进行替换（SHX 替换 SHX，mesh 替换 mesh）'
   },
   pointStyleDlg: {
     title: '点样式',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -558,6 +558,9 @@ export default {
     loadingDwgConverter: '正在加载DWG转换器...',
     fontsNotFound: '在字体库中找不到字体：{fonts}。',
     fontsNotLoaded: '无法加载字体：{fonts}。',
+    fontMissedInDrawing:
+      '字体 "{font}" 被 {count} 个文字对象使用，但不可用，已使用 "{replacementFont}" 显示。',
+    fontMissedReplacement: '"{font}"（已用 "{replacement}" 显示）',
     failedToGetAvaiableFonts: '无法从"{url}"获取可用的字体信息！',
     failedToOpenFile: '无法打开文件"{fileName}"！',
     fetchingDrawingFile: '正在加载图纸文件...',


### PR DESCRIPTION
## Summary

This PR improves the end-to-end flow when a drawing references fonts or raster images that are missing or unavailable, so replacements persist correctly and the UI stays in sync with the renderer.

- Add a `missed-data-changed` event on the editor event bus and emit it from the replacement dialog after successful font/image substitutions, triggering document regeneration and UI refresh.
- Introduce `AcApFontUtil.getReplacementFontName()` so the viewer can show the same render-time fallback font name used by `FontManager` (mapping first, then default font).
- Extend the notification center with `source` / `fontNames` metadata, deduplication, and selective removal APIs so font-missed alerts do not stack and clear automatically when a font is resolved.
- Update `MlCadViewer` to surface replacement font names in `fonts-not-loaded` / `fonts-not-found` messages, handle per-entity `font-not-found` during rendering, and prune stale font-missed notifications on `missed-data-changed`.
- Redesign `MlReplacementDlg` with a compact grid layout, optional SHX/mesh font-type filtering, single-tab mode when only fonts or only images are missing, and safer image file-picker handling.
- Refactor `useMissedData` into shared reactive module state that syncs from the active view, settings, and event-bus updates (`documentActivated`, `font-not-found`, `missed-data-changed`).

## Test plan

- [ ] Open a DXF/DWG that references fonts not present in the remote font repository; confirm warning/error notifications show the mapped or default replacement font name.
- [ ] Open a drawing that triggers `font-not-found` during render; confirm a per-font warning appears with occurrence count and replacement name, without duplicate entries for the same font.
- [ ] Open **Replace Missing Fonts/Images**, assign replacement fonts (with and without **Match font type**), confirm only compatible fonts appear when the option is enabled, and confirm the drawing regenerates and notifications clear after OK.
- [ ] Replace a missing raster image via the dialog; confirm `missed-data-changed` refreshes the status-bar warning and notification list.
- [ ] Switch documents and verify missed-font/image state resets from the new view's `missedData`.
- [ ] Verify EN/ZH locale strings for new dialog labels and notification messages.
