### PR TITLE
[codex] Fix dev startup dependency setup

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,6 +6,14 @@
         "^build"
       ],
       "cache": true
+    },
+    "dev": {
+      "dependsOn": [
+        {
+          "target": "build",
+          "dependencies": true
+        }
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,29 +40,6 @@
     "node": ">=24",
     "pnpm": ">=10"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "core-js",
-      "esbuild",
-      "nx",
-      "unrs-resolver",
-      "vue-demi"
-    ],
-    "overrides": {
-      "@mlightcad/data-model": "^1.8.1",
-      "@mlightcad/libredwg-converter": "^3.6.1",
-      "@mlightcad/mtext-input-box": "^0.2.13",
-      "@mlightcad/mtext-renderer": "^0.10.16",
-      "@mlightcad/ribbon": "^0.1.10",
-      "element-plus": "^2.12.0",
-      "glob": "^13.0.6",
-      "lodash-es": "4.17.21",
-      "three": "^0.172.0",
-      "vue": "^3.4.21",
-      "vue-i18n": "^11.4.4"
-    }
-  },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
     "@eslint/js": "^9.9.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,20 @@ packages:
   - 'packages/*'
 allowBuilds:
   '@parcel/watcher': true
+  core-js: true
   esbuild: true
   nx: true
   unrs-resolver: true
   vue-demi: true
+overrides:
+  '@mlightcad/data-model': ^1.8.1
+  '@mlightcad/libredwg-converter': ^3.6.1
+  '@mlightcad/mtext-input-box': ^0.2.13
+  '@mlightcad/mtext-renderer': ^0.10.16
+  '@mlightcad/ribbon': ^0.1.10
+  element-plus: ^2.12.0
+  glob: ^13.0.6
+  lodash-es: 4.17.21
+  three: ^0.172.0
+  vue: ^3.4.21
+  vue-i18n: ^11.4.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,14 +8,14 @@ allowBuilds:
   unrs-resolver: true
   vue-demi: true
 overrides:
-  '@mlightcad/data-model': ^1.8.1
-  '@mlightcad/libredwg-converter': ^3.6.1
-  '@mlightcad/mtext-input-box': ^0.2.13
-  '@mlightcad/mtext-renderer': ^0.10.16
-  '@mlightcad/ribbon': ^0.1.10
-  element-plus: ^2.12.0
-  glob: ^13.0.6
-  lodash-es: 4.17.21
-  three: ^0.172.0
-  vue: ^3.4.21
-  vue-i18n: ^11.4.4
+  '@mlightcad/data-model': '^1.8.1'
+  '@mlightcad/libredwg-converter': '^3.6.1'
+  '@mlightcad/mtext-input-box': '^0.2.13'
+  '@mlightcad/mtext-renderer': '^0.10.16'
+  '@mlightcad/ribbon': '^0.1.10'
+  element-plus: '^2.12.0'
+  glob: '^13.0.6'
+  lodash-es: '4.17.21'
+  three: '^0.172.0'
+  vue: '^3.4.21'
+  vue-i18n: '^11.4.4'

--- a/tools/sync-versions.mjs
+++ b/tools/sync-versions.mjs
@@ -7,17 +7,72 @@ const toolsDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(toolsDir, '..');
 const packagesDir = path.join(rootDir, 'packages');
 const rootPackageJsonPath = path.join(rootDir, 'package.json');
+const pnpmWorkspaceYamlPath = path.join(rootDir, 'pnpm-workspace.yaml');
 
 function isWorkspaceVersion(value) {
   return typeof value === 'string' && value.startsWith('workspace:');
 }
 
-function buildRootVersionMap(rootPkg) {
+function parseOverridesFromWorkspaceYaml(content) {
+  const overrides = {};
+  const lines = content.split(/\r?\n/);
+  let inOverrides = false;
+
+  for (const line of lines) {
+    if (!inOverrides) {
+      if (/^overrides:\s*$/.test(line)) {
+        inOverrides = true;
+      }
+      continue;
+    }
+
+    if (/^[^\s#]/.test(line)) {
+      break;
+    }
+
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const entryMatch = trimmed.match(
+      /^(?:'([^']+)'|"([^"]+)"|([^:\s]+))\s*:\s*(.+)$/
+    );
+    if (!entryMatch) continue;
+
+    const key = entryMatch[1] ?? entryMatch[2] ?? entryMatch[3];
+    let value = entryMatch[4].trim();
+    if (
+      (value.startsWith("'") && value.endsWith("'")) ||
+      (value.startsWith('"') && value.endsWith('"'))
+    ) {
+      value = value.slice(1, -1);
+    }
+    overrides[key] = value;
+  }
+
+  return overrides;
+}
+
+async function readPnpmOverrides() {
+  try {
+    const content = await readFile(pnpmWorkspaceYamlPath, { encoding: 'utf8' });
+    const fromYaml = parseOverridesFromWorkspaceYaml(content);
+    if (Object.keys(fromYaml).length > 0) {
+      return fromYaml;
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+
+  const rootPkg = await readJson(rootPackageJsonPath);
+  return rootPkg.pnpm?.overrides ?? {};
+}
+
+function buildRootVersionMap(rootPkg, overrides) {
   return {
     ...(rootPkg.dependencies ?? {}),
     ...(rootPkg.devDependencies ?? {}),
     ...(rootPkg.peerDependencies ?? {}),
-    ...(rootPkg.pnpm?.overrides ?? {}),
+    ...overrides,
   };
 }
 
@@ -84,7 +139,7 @@ async function syncPackage(packageFilePath, rootVersionMap, workspacePackageName
         }
         newVersion = rootVersion;
       }
-      // Priority 2: check versions in pnpm.overrides
+      // Priority 2: check versions in pnpm-workspace.yaml overrides
       else if (overrides[name] && value !== overrides[name]) {
         newVersion = overrides[name];
       }
@@ -106,8 +161,8 @@ async function syncPackage(packageFilePath, rootVersionMap, workspacePackageName
 (async () => {
   try {
     const rootPkg = await readJson(rootPackageJsonPath);
-    const rootVersionMap = buildRootVersionMap(rootPkg);
-    const overrides = rootPkg.pnpm?.overrides ?? {};
+    const overrides = await readPnpmOverrides();
+    const rootVersionMap = buildRootVersionMap(rootPkg, overrides);
     const workspacePackageNames = await findWorkspacePackageNames(rootPkg);
 
     const packageDirs = await readdir(packagesDir, { withFileTypes: true });


### PR DESCRIPTION
## Summary
- Build workspace dependencies before example dev targets so `pnpm dev` prepares `viewer-runtime.iife.js` before Vite loads config.
- Move pnpm settings from the ignored `package.json#pnpm` block into `pnpm-workspace.yaml`.

## Verification
- Ran `pnpm dev`; Vite started at `http://localhost:5173/`.
- Loaded the app in the in-app browser, verified the `DWG/DXF Viewer` screen, toggled the Review mode, and saw no console errors.