### PR TITLE
feat: modern font fallback chain, jsDelivr CDN, and mtext sync

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
@@ -20,6 +20,7 @@ class MockAcApFontLoader {
 
 const mockInitialize = jest.fn()
 const mockSetRenderMode = jest.fn()
+const mockSetDefaultFonts = jest.fn(() => Promise.resolve())
 
 jest.mock('../src/app/AcApFontLoader', () => ({
   AcApFontLoader: MockAcApFontLoader
@@ -29,7 +30,8 @@ jest.mock('@mlightcad/three-renderer', () => ({
   AcTrMTextRenderer: {
     getInstance: jest.fn(() => ({
       initialize: mockInitialize,
-      setRenderMode: mockSetRenderMode
+      setRenderMode: mockSetRenderMode,
+      setDefaultFonts: mockSetDefaultFonts
     }))
   }
 }))
@@ -221,6 +223,7 @@ describe('AcApDocManager font URL configuration', () => {
     mockFontLoaderInstances.length = 0
     mockInitialize.mockClear()
     mockSetRenderMode.mockClear()
+    mockSetDefaultFonts.mockClear()
   })
 
   it('configures the font loader to download fonts from the custom base URL', async () => {
@@ -235,5 +238,14 @@ describe('AcApDocManager font URL configuration', () => {
 
     expect(mockFontLoaderInstances[0].baseUrl).toBe(`${baseUrl}fonts/`)
     expect(mockFontLoaderInstances[0].load).toHaveBeenCalledWith(['simkai'])
+  })
+
+  it('syncs the default fonts preset to the mtext renderer after worker init', () => {
+    AcApDocManager.createInstance({
+      notLoadDefaultFonts: true
+    })
+
+    expect(mockInitialize).toHaveBeenCalled()
+    expect(mockSetDefaultFonts).toHaveBeenCalledWith('modern')
   })
 })

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -659,15 +659,15 @@ export class AcApDocManager {
    * Loads default fonts for CAD text rendering.
    *
    * This method loads either the specified fonts or the configured default font
-   * fallback chain ({@link DEFAULT_FONTS_PRESET}, currently `modern`:
-   * `hztxt` → `simsun` → `gdt`) if no fonts are provided. The loaded fonts are
-   * used for rendering CAD text entities like MText and Text in the viewer.
+   * fallback chains ({@link DEFAULT_FONTS_PRESET}, currently `modern`: text
+   * `hztxt` → `simsun`, symbol `amgdt`) if no fonts are provided. The loaded
+   * fonts are used for rendering CAD text entities like MText and Text in the viewer.
    *
    * It is better to load default fonts when viewer is initialized so that the viewer can
    * render text correctly if fonts used in the document are not available.
    *
    * @param fonts - Optional array of font names to load. If not provided or null,
-   *               loads the active {@link FontManager.defaultFonts} chain
+   *               loads the active {@link FontManager.getFontsToLoad} chains
    * @returns Promise that resolves when all specified fonts are loaded
    *
    * @example
@@ -687,7 +687,7 @@ export class AcApDocManager {
    */
   async loadDefaultFonts(fonts?: string[]) {
     if (fonts == null) {
-      await this._fontLoader.load([...FontManager.instance.defaultFonts])
+      await this._fontLoader.load([...FontManager.instance.getFontsToLoad()])
     } else {
       await this._fontLoader.load(fonts)
     }
@@ -1379,11 +1379,13 @@ export class AcApDocManager {
    */
   private registerWorkers(webworkerFileUrls?: AcApWebworkerFiles) {
     this.registerConverters(webworkerFileUrls)
-    AcTrMTextRenderer.getInstance().initialize(
+    const mtextRenderer = AcTrMTextRenderer.getInstance()
+    mtextRenderer.initialize(
       webworkerFileUrls && webworkerFileUrls.mtextRender
         ? webworkerFileUrls.mtextRender
         : './assets/mtext-renderer-worker.js'
     )
+    void mtextRenderer.setDefaultFonts(DEFAULT_FONTS_PRESET)
   }
 
   /**

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -11,6 +11,7 @@ import {
   log
 } from '@mlightcad/data-model'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
+import { FontManager } from '@mlightcad/mtext-renderer'
 import { AcTrMTextRenderer } from '@mlightcad/three-renderer'
 
 import {
@@ -86,7 +87,7 @@ import { AcApProgress } from './AcApProgress'
 import { AcApOpenDatabaseOptions } from './AcDbOpenDatabaseOptions'
 import { isOpenFileProgressComplete } from './openFileProgress'
 
-const DEFAULT_BASE_URL = 'https://mlightcad.gitlab.io/cad-data/'
+const DEFAULT_BASE_URL = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data'
 /**
  * Built-in command alias table used when users do not provide explicit alias overrides.
  *
@@ -174,6 +175,9 @@ export interface AcApWebworkerFiles {
    */
   mtextRender?: string | URL
 }
+
+/** AutoCAD-era default font fallback chain used when glyphs are missing. */
+const DEFAULT_FONTS_PRESET = 'modern' as const
 
 /**
  * Options for creating AcApDocManager instance
@@ -378,6 +382,7 @@ export class AcApDocManager {
     } else {
       AcTrMTextRenderer.getInstance().setRenderMode('worker')
     }
+    FontManager.instance.setDefaultFonts(DEFAULT_FONTS_PRESET)
 
     this.events.documentToBeOpened.addEventListener(() => {
       this.resetOpenFileProgress()
@@ -653,20 +658,21 @@ export class AcApDocManager {
   /**
    * Loads default fonts for CAD text rendering.
    *
-   * This method loads either the specified fonts or falls back to default Chinese fonts
-   * (specifically 'simkai') if no fonts are provided. The loaded fonts are used for
-   * rendering CAD text entities like MText and Text in the viewer.
+   * This method loads either the specified fonts or the configured default font
+   * fallback chain ({@link DEFAULT_FONTS_PRESET}, currently `modern`:
+   * `hztxt` → `simsun` → `gdt`) if no fonts are provided. The loaded fonts are
+   * used for rendering CAD text entities like MText and Text in the viewer.
    *
    * It is better to load default fonts when viewer is initialized so that the viewer can
    * render text correctly if fonts used in the document are not available.
    *
    * @param fonts - Optional array of font names to load. If not provided or null,
-   *               defaults to ['simkai'] for Chinese text support
+   *               loads the active {@link FontManager.defaultFonts} chain
    * @returns Promise that resolves when all specified fonts are loaded
    *
    * @example
    * ```typescript
-   * // Load default fonts (simkai)
+   * // Load the modern default font chain
    * await docManager.loadDefaultFonts();
    *
    * // Load specific fonts
@@ -681,7 +687,7 @@ export class AcApDocManager {
    */
   async loadDefaultFonts(fonts?: string[]) {
     if (fonts == null) {
-      await this._fontLoader.load(['simkai'])
+      await this._fontLoader.load([...FontManager.instance.defaultFonts])
     } else {
       await this._fontLoader.load(fonts)
     }

--- a/packages/cad-simple-viewer/src/util/AcApFontUtil.ts
+++ b/packages/cad-simple-viewer/src/util/AcApFontUtil.ts
@@ -39,7 +39,7 @@ export class AcApFontUtil {
    * Font name used at render time when the requested font is missing.
    *
    * Checks user {@link FontManager.setFontMapping | font mapping} first, then falls
-   * back to {@link FontManager.defaultFont}.
+   * back to {@link FontManager.defaultFonts}.
    *
    * @param fontName - Original font name referenced by the drawing.
    * @returns The loaded font name if available; otherwise the mapped or default replacement.

--- a/packages/cad-viewer/README.md
+++ b/packages/cad-viewer/README.md
@@ -259,7 +259,7 @@ The `baseUrl` property allows you to customize where the CAD viewer loads fonts,
 - **Custom branding**: Use your own templates and fonts
 
 #### Default Behavior
-If no `baseUrl` is provided, the viewer uses the default URL: `https://mlightcad.gitlab.io/cad-data/`
+If no `baseUrl` is provided, the viewer uses the default URL: `https://cdn.jsdelivr.net/gh/mlightcad/cad-data`
 
 #### Resource Structure
 When using a custom `baseUrl`, ensure your server has the following structure:

--- a/packages/three-renderer/__tests__/AcTrFontLoader.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrFontLoader.spec.ts
@@ -2,7 +2,7 @@ const mockSetFontUrl = jest.fn()
 
 jest.mock('@mlightcad/mtext-renderer', () => {
   class MockDefaultFontLoader {
-    private _baseUrl = 'https://mlightcad.gitlab.io/cad-data/fonts/'
+    private _baseUrl = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/'
 
     get baseUrl() {
       return this._baseUrl

--- a/packages/three-renderer/__tests__/AcTrMTextRenderer.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMTextRenderer.spec.ts
@@ -1,6 +1,7 @@
 const mockRendererInstances: Array<{
   setFontUrl: jest.Mock
   setDefaultMode: jest.Mock
+  setDefaultFonts: jest.Mock
   setStyleManager: jest.Mock
   destroy: jest.Mock
 }> = []
@@ -9,6 +10,7 @@ const mockUnifiedRenderer = jest.fn().mockImplementation(() => {
   const renderer = {
     setFontUrl: jest.fn(),
     setDefaultMode: jest.fn(),
+    setDefaultFonts: jest.fn(() => Promise.resolve()),
     setStyleManager: jest.fn(),
     destroy: jest.fn()
   }
@@ -81,5 +83,23 @@ describe('AcTrMTextRenderer', () => {
 
     expect(mockRendererInstances[0].setDefaultMode).toHaveBeenCalledWith('main')
     expect(mockRendererInstances[0].setFontUrl).toHaveBeenCalledWith(fontUrl)
+  })
+
+  it('applies a pending default fonts preset when initialized later', async () => {
+    const renderer = AcTrMTextRenderer.getInstance()
+
+    await renderer.setDefaultFonts('modern')
+    renderer.initialize('./assets/mtext-renderer-worker.js')
+
+    expect(mockRendererInstances[0].setDefaultFonts).toHaveBeenCalledWith('modern')
+  })
+
+  it('forwards default fonts preset to an initialized renderer immediately', async () => {
+    const renderer = AcTrMTextRenderer.getInstance()
+
+    renderer.initialize('./assets/mtext-renderer-worker.js')
+    await renderer.setDefaultFonts('r12r14')
+
+    expect(mockRendererInstances[0].setDefaultFonts).toHaveBeenCalledWith('r12r14')
   })
 })

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -6,7 +6,7 @@ import { AcTrPointSymbolCreator } from '../geometry/AcTrPointSymbolCreator'
 import { AcTrEntity } from '../object'
 import { getMaterialMetadata } from '../style/AcTrMaterialMetadata'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
-import { AcTrMaterialUtil } from '../util'
+import { AcTrBufferGeometryUtil,AcTrMaterialUtil } from '../util'
 import {
   copyHighlightObjectFlags,
   getHighlightUserData,
@@ -993,7 +993,7 @@ export class AcTrBatchedGroup extends THREE.Group {
         source.getAttribute('instanceColorEnd').clone()
       )
     }
-    geometry.computeBoundingBox()
+    AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
     geometry.computeBoundingSphere()
     return geometry
   }

--- a/packages/three-renderer/src/batch/AcTrBatchedLine.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 
 import { AcTrPointSymbolCreator } from '../geometry/AcTrPointSymbolCreator'
+import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
 import type { AcTrBatchedContainerUserData } from '../util/AcTrObjectUserData'
 import {
   AcTrBatchedGeometryInfo,
@@ -361,7 +362,7 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     if (!position) return
 
     if (!this._origin) {
-      geometry.computeBoundingBox()
+      AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
       const center = geometry.boundingBox
         ? geometry.boundingBox.getCenter(new THREE.Vector3())
         : new THREE.Vector3()

--- a/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
@@ -3,6 +3,7 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
+import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
 import type { AcTrBatchedContainerUserData } from '../util/AcTrObjectUserData'
 import {
   AcTrBatchGeometryUserData,
@@ -213,7 +214,7 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     }
 
     if (!this._origin) {
-      geometry.computeBoundingBox()
+      AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
       const center = geometry.boundingBox
         ? geometry.boundingBox.getCenter(new THREE.Vector3())
         : new THREE.Vector3()

--- a/packages/three-renderer/src/batch/AcTrBatchedMesh.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMesh.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 
+import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
 import type { AcTrBatchedContainerUserData } from '../util/AcTrObjectUserData'
 import {
   AcTrBatchedGeometryInfo,
@@ -295,7 +296,7 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
     }
 
     if (!this._origin) {
-      geometry.computeBoundingBox()
+      AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
       const center = geometry.boundingBox
         ? geometry.boundingBox.getCenter(new THREE.Vector3())
         : new THREE.Vector3()

--- a/packages/three-renderer/src/batch/AcTrBatchedPoint.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedPoint.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 
+import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
 import type { AcTrBatchedContainerUserData } from '../util/AcTrObjectUserData'
 import {
   AcTrBatchGeometryUserData,
@@ -270,7 +271,7 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
     }
 
     if (!this._origin) {
-      geometry.computeBoundingBox()
+      AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
       const center = geometry.boundingBox
         ? geometry.boundingBox.getCenter(new THREE.Vector3())
         : new THREE.Vector3()

--- a/packages/three-renderer/src/object/AcTrLine.ts
+++ b/packages/three-renderer/src/object/AcTrLine.ts
@@ -88,8 +88,11 @@ export class AcTrLine extends AcTrEntity {
     geometry: THREE.BufferGeometry,
     localOrigin: THREE.Vector3
   ) {
-    geometry.computeBoundingBox()
-    const worldBox = geometry.boundingBox!.clone()
+    const boundingBox = AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+    if (!boundingBox) {
+      return
+    }
+    const worldBox = boundingBox.clone()
     worldBox.translate(localOrigin)
     this.box = worldBox
   }

--- a/packages/three-renderer/src/object/AcTrLineSegments.ts
+++ b/packages/three-renderer/src/object/AcTrLineSegments.ts
@@ -60,8 +60,10 @@ export class AcTrLineSegments extends AcTrEntity {
       new THREE.BufferAttribute(array, itemSize)
     )
     geometry.setIndex(new THREE.BufferAttribute(indices, 1))
-    geometry.computeBoundingBox()
-    this.box = geometry.boundingBox!
+    const boundingBox = AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+    if (boundingBox) {
+      this.box = boundingBox
+    }
 
     const line = new THREE.LineSegments(geometry, material)
     AcTrBufferGeometryUtil.computeLineDistances(line)

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -14,6 +14,7 @@ import * as THREE from 'three'
 import { AcTrMTextRenderer } from '../renderer'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
 import { AcTrMTextColorUtil } from '../util'
+import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
 import { getSceneDrawableUserData } from '../util/AcTrObjectUserData'
 import { AcTrEntity } from './AcTrEntity'
 
@@ -153,6 +154,7 @@ export class AcTrMText extends AcTrEntity {
   private attachMText(mtext: MTextObject) {
     this.add(mtext)
     this.flatten()
+    this.removeInvalidGeometryLeaves()
     this.traverse(object => {
       // Text picking should behave like CAD object picking: the visible glyph
       // area should be selectable even when the pointer lands inside a hollow
@@ -213,20 +215,41 @@ export class AcTrMText extends AcTrEntity {
       const geometry = object.geometry
       // Some renderer outputs already have bounds; compute lazily for those
       // that do not so custom/generated geometries still contribute.
-      if (geometry.boundingBox == null) {
-        geometry.computeBoundingBox()
-      }
-      if (geometry.boundingBox == null) return
+      const boundingBox = AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+      if (boundingBox == null) return
 
       object.updateMatrixWorld(true)
       // Move the child's local geometry box into the entity's current coordinate
       // frame before unioning.  This preserves translation/rotation/scale left on
       // the child by flattening.
-      childBox.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld)
+      childBox.copy(boundingBox).applyMatrix4(object.matrixWorld)
       box.union(childBox)
     })
 
     return box
+  }
+
+  /**
+   * Drops render leaves whose buffer positions contain NaN/Infinity.
+   *
+   * PCCAD tolerance MTEXT can occasionally emit degenerate glyph meshes; keeping
+   * them would poison bounding-box aggregation and flood the console with THREE.js
+   * warnings during batching.
+   */
+  private removeInvalidGeometryLeaves() {
+    const invalidObjects: THREE.Object3D[] = []
+    this.traverse(object => {
+      if (!this.hasGeometry(object)) return
+      if (AcTrBufferGeometryUtil.hasFinitePositions(object.geometry)) return
+      invalidObjects.push(object)
+    })
+
+    for (const object of invalidObjects) {
+      object.parent?.remove(object)
+      if (this.hasGeometry(object)) {
+        object.geometry.dispose()
+      }
+    }
   }
 
   /**

--- a/packages/three-renderer/src/object/AcTrPoint.ts
+++ b/packages/three-renderer/src/object/AcTrPoint.ts
@@ -7,6 +7,7 @@ import * as THREE from 'three'
 
 import { AcTrPointSymbolCreator } from '../geometry/AcTrPointSymbolCreator'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
 import { getSceneDrawableUserData } from '../util/AcTrObjectUserData'
 import { AcTrEntity } from './AcTrEntity'
 
@@ -36,7 +37,7 @@ export class AcTrPoint extends AcTrEntity {
     const geometry =
       pointSymbol.point ??
       new THREE.BufferGeometry().setFromPoints([_vector3.copy(point)])
-    geometry.computeBoundingBox()
+    AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
     if (geometry.boundingBox) this.box.union(geometry.boundingBox)
     const material = this.styleManager.getPointsMaterial(traits)
     const pointObj = new THREE.Points(geometry, material)
@@ -47,7 +48,7 @@ export class AcTrPoint extends AcTrEntity {
 
     if (pointSymbol.line) {
       const geometry = pointSymbol.line
-      geometry.computeBoundingBox()
+      AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
       if (geometry.boundingBox) this.box.union(geometry.boundingBox)
       const material = this.styleManager.getLineMaterial(traits, true)
       const lineSegmentsObj = new THREE.LineSegments(geometry, material)

--- a/packages/three-renderer/src/object/AcTrPolygon.ts
+++ b/packages/three-renderer/src/object/AcTrPolygon.ts
@@ -12,11 +12,16 @@ import * as THREE from 'three'
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
 
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
 import { getSceneDrawableUserData } from '../util/AcTrObjectUserData'
 import { AcTrEntity } from './AcTrEntity'
 
 function toVector2(points: AcGePoint2dLike[]): THREE.Vector2[] {
-  return points.map(point => new THREE.Vector2(point.x, point.y))
+  return points
+    .filter(
+      point => Number.isFinite(point.x) && Number.isFinite(point.y)
+    )
+    .map(point => new THREE.Vector2(point.x, point.y))
 }
 
 function hasFillVertices(geometry: THREE.BufferGeometry | undefined): boolean {
@@ -52,8 +57,13 @@ export class AcTrPolygon extends AcTrEntity {
     }
 
     if (geometry && hasFillVertices(geometry)) {
-      geometry.computeBoundingBox()
-      this.box = geometry.boundingBox!
+      const boundingBox = AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+      if (!boundingBox) {
+        log.warn('Skipped hatch fill with invalid geometry coordinates')
+        geometry.dispose()
+        return
+      }
+      this.box = boundingBox
 
       this.addGradientPositionAttribute(geometry, traits)
 
@@ -138,6 +148,10 @@ export class AcTrPolygon extends AcTrEntity {
     const createGeometry = (shape: THREE.Shape) => {
       try {
         const geom = new THREE.ShapeGeometry(shape)
+        if (!AcTrBufferGeometryUtil.hasFinitePositions(geom)) {
+          geom.dispose()
+          return
+        }
         if (geom.hasAttribute('uv')) {
           geom.deleteAttribute('uv')
         }

--- a/packages/three-renderer/src/renderer/AcTrMTextRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrMTextRenderer.ts
@@ -1,6 +1,7 @@
 import {
   ColorSettings,
   createDefaultColorSettings,
+  DefaultFontsPreset,
   MTextData,
   MTextObject,
   RenderMode,
@@ -45,6 +46,7 @@ export class AcTrMTextRenderer {
   private _fontUrl?: string
   private _renderMode?: RenderMode
   private _styleManager?: AcTrStyleManager
+  private _defaultFonts?: DefaultFontsPreset | string | readonly string[]
 
   private constructor() {
     // Do nothing for now
@@ -88,6 +90,19 @@ export class AcTrMTextRenderer {
       this._renderer.setDefaultMode(mode)
       this.applyFontUrl()
     }
+  }
+
+  /**
+   * Sets the default text and symbol font fallback chains on the active renderer
+   * and syncs them to Web Workers.
+   *
+   * @param fonts - A preset name, a single font name, or an ordered list of font names
+   */
+  async setDefaultFonts(
+    fonts: DefaultFontsPreset | string | readonly string[]
+  ): Promise<void> {
+    this._defaultFonts = fonts
+    await this.applyDefaultFonts()
   }
 
   /**
@@ -140,6 +155,7 @@ export class AcTrMTextRenderer {
       this._renderer.setDefaultMode(this._renderMode)
     }
     this.applyFontUrl()
+    void this.applyDefaultFonts()
     if (this._styleManager) {
       const styleManager = new AcTrMTextStyleManager(this._styleManager)
       this._renderer.setStyleManager(styleManager)
@@ -166,6 +182,12 @@ export class AcTrMTextRenderer {
   private applyFontUrl() {
     if (this._renderer && this._fontUrl) {
       this._renderer.setFontUrl(this._fontUrl)
+    }
+  }
+
+  private async applyDefaultFonts() {
+    if (this._renderer && this._defaultFonts !== undefined) {
+      await this._renderer.setDefaultFonts(this._defaultFonts)
     }
   }
 }

--- a/packages/three-renderer/src/util/AcTrBufferGeometryUtil.ts
+++ b/packages/three-renderer/src/util/AcTrBufferGeometryUtil.ts
@@ -283,4 +283,61 @@ export class AcTrBufferGeometryUtil {
 
     return geometry
   }
+
+  /**
+   * Returns true when every value in the geometry position attribute is finite.
+   */
+  static hasFinitePositions(
+    geometry: THREE.BufferGeometry | null | undefined
+  ): boolean {
+    const position = geometry?.getAttribute('position')
+    if (!position || position.count === 0) {
+      return true
+    }
+
+    const array = position.array as ArrayLike<number>
+    for (let index = 0; index < array.length; index++) {
+      if (!Number.isFinite(array[index])) {
+        return false
+      }
+    }
+    return true
+  }
+
+  /**
+   * Computes a bounding box only when position data is finite.
+   *
+   * Returns null for invalid geometry instead of letting THREE.js warn on NaN
+   * inputs during CAD file conversion.
+   */
+  static safeComputeBoundingBox(
+    geometry: THREE.BufferGeometry,
+    target?: THREE.Box3
+  ): THREE.Box3 | null {
+    if (!AcTrBufferGeometryUtil.hasFinitePositions(geometry)) {
+      geometry.boundingBox = null
+      return null
+    }
+
+    if (target) {
+      geometry.boundingBox = target
+    }
+    geometry.computeBoundingBox()
+
+    const box = geometry.boundingBox
+    if (
+      !box ||
+      !Number.isFinite(box.min.x) ||
+      !Number.isFinite(box.min.y) ||
+      !Number.isFinite(box.min.z) ||
+      !Number.isFinite(box.max.x) ||
+      !Number.isFinite(box.max.y) ||
+      !Number.isFinite(box.max.z)
+    ) {
+      geometry.boundingBox = null
+      return null
+    }
+
+    return box
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 overrides:
   '@mlightcad/data-model': ^1.8.1
   '@mlightcad/libredwg-converter': ^3.6.1
-  '@mlightcad/mtext-input-box': ^0.2.13
-  '@mlightcad/mtext-renderer': ../../../mtext-renderer/packages/mtext-renderer
+  '@mlightcad/mtext-input-box': ^0.2.14
+  '@mlightcad/mtext-renderer': ^0.11.0
   '@mlightcad/ribbon': ^0.1.10
   element-plus: ^2.12.0
   glob: ^13.0.6
@@ -121,8 +121,8 @@ importers:
         specifier: ^3.6.1
         version: 3.6.1(@mlightcad/data-model@1.8.1)
       '@mlightcad/mtext-renderer':
-        specifier: ../../../mtext-renderer/packages/mtext-renderer
-        version: link:../../../mtext-renderer/packages/mtext-renderer
+        specifier: ^0.11.0
+        version: 0.11.0(three@0.172.0)
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -197,11 +197,11 @@ importers:
         specifier: ^3.6.1
         version: 3.6.1(@mlightcad/data-model@1.8.1)
       '@mlightcad/mtext-input-box':
-        specifier: ^0.2.13
-        version: 0.2.13(@mlightcad/mtext-renderer@mtext-renderer+packages+mtext-renderer)(three@0.172.0)
+        specifier: ^0.2.14
+        version: 0.2.14(@mlightcad/mtext-renderer@0.11.0(three@0.172.0))(three@0.172.0)
       '@mlightcad/mtext-renderer':
-        specifier: ../../../mtext-renderer/packages/mtext-renderer
-        version: link:../../../mtext-renderer/packages/mtext-renderer
+        specifier: ^0.11.0
+        version: 0.11.0(three@0.172.0)
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -416,9 +416,6 @@ importers:
 
   packages/three-renderer:
     dependencies:
-      '@mlightcad/mtext-renderer':
-        specifier: ../../../mtext-renderer/packages/mtext-renderer
-        version: link:../../../mtext-renderer/packages/mtext-renderer
       '@velipso/polybool':
         specifier: ^1.1.1
         version: 1.1.1
@@ -426,6 +423,9 @@ importers:
       '@mlightcad/data-model':
         specifier: ^1.8.1
         version: 1.8.1
+      '@mlightcad/mtext-renderer':
+        specifier: ^0.11.0
+        version: 0.11.0(three@0.172.0)
       '@types/three':
         specifier: ^0.172.0
         version: 0.172.0
@@ -1547,14 +1547,19 @@ packages:
   '@mlightcad/libredwg-web@0.7.1':
     resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
-  '@mlightcad/mtext-input-box@0.2.13':
-    resolution: {integrity: sha512-uIZj6b9rTTLkdJT/CkgJeqIIxZOOcRsNMG/rqB7VkLpCfi600g1jeAtw+e4hWpU6m7KEke0pdnpL9RWHEzK73g==}
+  '@mlightcad/mtext-input-box@0.2.14':
+    resolution: {integrity: sha512-4VxTPBqLAq5HesW4yige6NlgFzh5Ojo8TRvwwVBbkla1LtZz2dR3SfmdFZW5OjQTGj8upyM15BXdg4ECPA/IFA==}
     peerDependencies:
-      '@mlightcad/mtext-renderer': ^0.10.16
+      '@mlightcad/mtext-renderer': ^0.11.0
       three: ^0.172.0
 
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
+
+  '@mlightcad/mtext-renderer@0.11.0':
+    resolution: {integrity: sha512-93jECtXH+J4F56Ifl3cTZUvL+AdZGVVuSi5c5hvpdWkRBFjIkonznyIVq5974Gx5uthxpM7MnILz1ZWSNrdjig==}
+    peerDependencies:
+      three: ^0.172.0
 
   '@mlightcad/ribbon@0.1.10':
     resolution: {integrity: sha512-bAAatX3zIqpyrRphbEqe5mVgxX63jJJ9vHu4FYbIJnsWzrPAg07lGZS9xs/2eZOtYWj11uQB5WOuGbh113BthQ==}
@@ -1562,6 +1567,9 @@ packages:
       '@element-plus/icons-vue': ^2.3.2
       element-plus: ^2.12.0
       vue: ^3.4.21
+
+  '@mlightcad/shx-parser@1.3.4':
+    resolution: {integrity: sha512-y0clXQIBslAOwTMFtUnQqzZqhtD5lxUCiJA7lYTYvzO2dzBtsd2LVhUYdyA6R6DwjygOzjegXcP/4oCIsDiZhg==}
 
   '@mlightcad/text-box-cursor@0.1.1':
     resolution: {integrity: sha512-Q3uLz+FXG6mLInq/Q1jUNdyjGFdMWZduWA2WO6d+jUqFbWeh4xsn5M/HY+vy1Rs0bvLWZvdRgJeEFVe6nhIihQ==}
@@ -3537,6 +3545,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  idb@8.0.3:
+    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -4213,6 +4224,10 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  opentype.js@2.0.0:
+    resolution: {integrity: sha512-kCyjv6xdDY1W/jLWZ/L3QhhTlKUqDZMQ5+Jdlw12b3dXkKNpYBqqlMMj0YDQPShWFTMwgZI1hG14kN3XUDSg/A==}
+    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -6635,19 +6650,30 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.1': {}
 
-  '@mlightcad/mtext-input-box@0.2.13(@mlightcad/mtext-renderer@mtext-renderer+packages+mtext-renderer)(three@0.172.0)':
+  '@mlightcad/mtext-input-box@0.2.14(@mlightcad/mtext-renderer@0.11.0(three@0.172.0))(three@0.172.0)':
     dependencies:
-      '@mlightcad/mtext-renderer': link:../mtext-renderer/packages/mtext-renderer
+      '@mlightcad/mtext-renderer': 0.11.0(three@0.172.0)
       '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
       three: 0.172.0
 
   '@mlightcad/mtext-parser@1.4.1': {}
+
+  '@mlightcad/mtext-renderer@0.11.0(three@0.172.0)':
+    dependencies:
+      '@mlightcad/mtext-parser': 1.4.1
+      '@mlightcad/shx-parser': 1.3.4
+      iconv-lite: 0.7.2
+      idb: 8.0.3
+      opentype.js: 2.0.0
+      three: 0.172.0
 
   '@mlightcad/ribbon@0.1.10(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@element-plus/icons-vue': 2.3.2(vue@3.5.31(typescript@5.9.3))
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
+
+  '@mlightcad/shx-parser@1.3.4': {}
 
   '@mlightcad/text-box-cursor@0.1.1(three@0.172.0)':
     dependencies:
@@ -8622,6 +8648,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb@8.0.3: {}
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -9483,6 +9511,8 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  opentype.js@2.0.0: {}
 
   optionator@0.9.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,14 +8,14 @@ overrides:
   '@mlightcad/data-model': ^1.8.1
   '@mlightcad/libredwg-converter': ^3.6.1
   '@mlightcad/mtext-input-box': ^0.2.13
-  '@mlightcad/mtext-renderer': ^0.10.16
+  '@mlightcad/mtext-renderer': ../../../mtext-renderer/packages/mtext-renderer
   '@mlightcad/ribbon': ^0.1.10
   element-plus: ^2.12.0
+  glob: ^13.0.6
+  lodash-es: 4.17.21
   three: ^0.172.0
   vue: ^3.4.21
   vue-i18n: ^11.4.4
-  glob: ^13.0.6
-  lodash-es: 4.17.21
 
 importers:
 
@@ -121,8 +121,8 @@ importers:
         specifier: ^3.6.1
         version: 3.6.1(@mlightcad/data-model@1.8.1)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.10.16
-        version: 0.10.16(three@0.172.0)
+        specifier: ../../../mtext-renderer/packages/mtext-renderer
+        version: link:../../../mtext-renderer/packages/mtext-renderer
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -198,10 +198,10 @@ importers:
         version: 3.6.1(@mlightcad/data-model@1.8.1)
       '@mlightcad/mtext-input-box':
         specifier: ^0.2.13
-        version: 0.2.13(@mlightcad/mtext-renderer@0.10.16(three@0.172.0))(three@0.172.0)
+        version: 0.2.13(@mlightcad/mtext-renderer@mtext-renderer+packages+mtext-renderer)(three@0.172.0)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.10.16
-        version: 0.10.16(three@0.172.0)
+        specifier: ../../../mtext-renderer/packages/mtext-renderer
+        version: link:../../../mtext-renderer/packages/mtext-renderer
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -416,6 +416,9 @@ importers:
 
   packages/three-renderer:
     dependencies:
+      '@mlightcad/mtext-renderer':
+        specifier: ../../../mtext-renderer/packages/mtext-renderer
+        version: link:../../../mtext-renderer/packages/mtext-renderer
       '@velipso/polybool':
         specifier: ^1.1.1
         version: 1.1.1
@@ -423,9 +426,6 @@ importers:
       '@mlightcad/data-model':
         specifier: ^1.8.1
         version: 1.8.1
-      '@mlightcad/mtext-renderer':
-        specifier: ^0.10.16
-        version: 0.10.16(three@0.172.0)
       '@types/three':
         specifier: ^0.172.0
         version: 0.172.0
@@ -1556,20 +1556,12 @@ packages:
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
-  '@mlightcad/mtext-renderer@0.10.16':
-    resolution: {integrity: sha512-mCDvR6fvIvK4ZxkK+P8WbEwmsJMVh3Z+AiONbPB44pE5x7ZZGFDIGr/8zLCNPZFZbFqwCkNmCeWc99r3bR6GKw==}
-    peerDependencies:
-      three: ^0.172.0
-
   '@mlightcad/ribbon@0.1.10':
     resolution: {integrity: sha512-bAAatX3zIqpyrRphbEqe5mVgxX63jJJ9vHu4FYbIJnsWzrPAg07lGZS9xs/2eZOtYWj11uQB5WOuGbh113BthQ==}
     peerDependencies:
       '@element-plus/icons-vue': ^2.3.2
       element-plus: ^2.12.0
       vue: ^3.4.21
-
-  '@mlightcad/shx-parser@1.3.2':
-    resolution: {integrity: sha512-j84hqbWOVMDuepLEjVsYvxeiCXOVxHyJhl4gM4HtgXZ6ChgTLsuSnqs2bNOt2SwriTvFOsv3QLsOu2iJh857JA==}
 
   '@mlightcad/text-box-cursor@0.1.1':
     resolution: {integrity: sha512-Q3uLz+FXG6mLInq/Q1jUNdyjGFdMWZduWA2WO6d+jUqFbWeh4xsn5M/HY+vy1Rs0bvLWZvdRgJeEFVe6nhIihQ==}
@@ -3545,9 +3537,6 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  idb@8.0.3:
-    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -4225,11 +4214,6 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  opentype.js@1.3.4:
-    resolution: {integrity: sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==}
-    engines: {node: '>= 8.0.0'}
-    hasBin: true
-
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4700,9 +4684,6 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
-  string.prototype.codepointat@0.2.1:
-    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
-
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -4792,9 +4773,6 @@ packages:
 
   three@0.172.0:
     resolution: {integrity: sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==}
-
-  tiny-inflate@1.0.3:
-    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -6657,30 +6635,19 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.1': {}
 
-  '@mlightcad/mtext-input-box@0.2.13(@mlightcad/mtext-renderer@0.10.16(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/mtext-input-box@0.2.13(@mlightcad/mtext-renderer@mtext-renderer+packages+mtext-renderer)(three@0.172.0)':
     dependencies:
-      '@mlightcad/mtext-renderer': 0.10.16(three@0.172.0)
+      '@mlightcad/mtext-renderer': link:../mtext-renderer/packages/mtext-renderer
       '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
       three: 0.172.0
 
   '@mlightcad/mtext-parser@1.4.1': {}
-
-  '@mlightcad/mtext-renderer@0.10.16(three@0.172.0)':
-    dependencies:
-      '@mlightcad/mtext-parser': 1.4.1
-      '@mlightcad/shx-parser': 1.3.2
-      iconv-lite: 0.7.2
-      idb: 8.0.3
-      opentype.js: 1.3.4
-      three: 0.172.0
 
   '@mlightcad/ribbon@0.1.10(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@element-plus/icons-vue': 2.3.2(vue@3.5.31(typescript@5.9.3))
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
-
-  '@mlightcad/shx-parser@1.3.2': {}
 
   '@mlightcad/text-box-cursor@0.1.1(three@0.172.0)':
     dependencies:
@@ -8655,8 +8622,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  idb@8.0.3: {}
-
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -9519,11 +9484,6 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  opentype.js@1.3.4:
-    dependencies:
-      string.prototype.codepointat: 0.2.1
-      tiny-inflate: 1.0.3
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -10000,8 +9960,6 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
-  string.prototype.codepointat@0.2.1: {}
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -10090,8 +10048,6 @@ snapshots:
     optional: true
 
   three@0.172.0: {}
-
-  tiny-inflate@1.0.3: {}
 
   tinyglobby@0.2.15:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,8 @@ allowBuilds:
 overrides:
   '@mlightcad/data-model': '^1.8.1'
   '@mlightcad/libredwg-converter': '^3.6.1'
-  '@mlightcad/mtext-input-box': '^0.2.13'
-  '@mlightcad/mtext-renderer': '../../../mtext-renderer/packages/mtext-renderer'
+  '@mlightcad/mtext-input-box': '^0.2.14'
+  '@mlightcad/mtext-renderer': '^0.11.0'
   '@mlightcad/ribbon': '^0.1.10'
   element-plus: '^2.12.0'
   glob: '^13.0.6'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ overrides:
   '@mlightcad/data-model': '^1.8.1'
   '@mlightcad/libredwg-converter': '^3.6.1'
   '@mlightcad/mtext-input-box': '^0.2.13'
-  '@mlightcad/mtext-renderer': '^0.10.16'
+  '@mlightcad/mtext-renderer': '../../../mtext-renderer/packages/mtext-renderer'
   '@mlightcad/ribbon': '^0.1.10'
   element-plus: '^2.12.0'
   glob: '^13.0.6'


### PR DESCRIPTION
## Summary

- Switch default font loading from hardcoded `simkai` to FontManager's `modern` preset (text: `hztxt` → `simsun`, symbol: `amgdt`) and initialize the preset in `AcApDocManager`.
- Update the default `cad-data` base URL from GitLab Pages to jsDelivr (`https://cdn.jsdelivr.net/gh/mlightcad/cad-data`).
- Sync the active FontManager preset to the mtext worker via `AcTrMTextRenderer.setDefaultFonts`, including deferred application when the worker initializes later.
- Adopt published `@mlightcad/mtext-renderer@0.11.0` and `@mlightcad/mtext-input-box@0.2.14` (replacing the temporary local pnpm override).
- Guard bounding box computation with `AcTrBufferGeometryUtil.safeComputeBoundingBox` to skip non-finite position data and avoid THREE.js NaN warnings during CAD conversion.

## Test plan

- [ ] Open a DXF/DWG that references missing fonts and verify text renders via the modern fallback chain.
- [ ] Confirm fonts load from the jsDelivr `cad-data` CDN when no custom `baseUrl` is set.
- [ ] Verify MText/symbol rendering uses the synced `modern` preset after worker initialization.
- [ ] Run `pnpm test` in `packages/cad-simple-viewer` (AcApDocManagerFontUrl spec) and `packages/three-renderer` (AcTrFontLoader, AcTrMTextRenderer specs).
- [ ] Smoke-test the viewer demo with a drawing that previously produced NaN bounding box warnings during conversion.
