### PR TITLE
fix: render paper-space viewport that libredwg numbered 1 (default detection by structure)

### DIFF
--- a/packages/three-renderer/src/viewport/AcTrViewportView.ts
+++ b/packages/three-renderer/src/viewport/AcTrViewportView.ts
@@ -36,23 +36,31 @@ export class AcTrViewportView extends AcTrBaseView {
    * that exists in every paper-space layout and does not correspond to a
    * user-created viewport.
    *
-   * The legacy heuristic was "`number === 1`", but that fails on files
-   * parsed by libredwg-web: its
-   * `bindings/javascript/src/converter/converter.ts` reassigns
-   * `viewportId` by sorting all VIEWPORT entities on objectId and
-   * indexing from 1. Files whose default viewport's handle sorts after
-   * a user viewport end up with the default getting `number = 2` (or
-   * higher). In `test-file-tower.dwg` the default lands on `2` and gets
-   * rendered as if it were a real viewport — a 12×9 (drawing-unit)
-   * rectangle that stretches the paper layout's bounding box, ruins
-   * `zoomToFitDrawing`, and squeezes the actual user viewports into
-   * ~5% of the canvas.
+   * The legacy heuristic was "`number === 1`", but `number` is **not a
+   * reliable signal at all** on files parsed by libredwg-web: it reassigns
+   * `viewportId` by sorting all VIEWPORT entities on objectId and indexing
+   * from 1. This breaks the numeric assumption in **both** directions:
    *
-   * The **structural** fingerprint is much more reliable than the
-   * numeric one: the default viewport "looks at itself" in paper space,
-   * so its `centerPoint` (paper WCS) coincides with its `viewCenter`
-   * (model DCS). Real user viewports always pan the model view to a
-   * different center.
+   * - **The default gets `number ≠ 1`** — when the template default's
+   *   handle sorts after a real viewport it lands on `2` (or higher). The
+   *   old `number === 1` check missed it, so it rendered as a 12×9
+   *   (drawing-unit) rectangle that stretched the layout's bounding box,
+   *   ruined `zoomToFitDrawing`, and squeezed the real viewports into a
+   *   sliver of the canvas.
+   * - **A real viewport gets `number === 1`** — when a genuine user
+   *   viewport's handle sorts first it receives `number = 1`. The old
+   *   shortcut then **false-positived** it and skipped rendering its
+   *   content entirely, leaving a large empty area where AutoCAD shows the
+   *   viewport's model content (e.g. a large site-plan viewport whose paper
+   *   box spans most of the sheet).
+   *
+   * Because `number` misfires both ways, we rely **solely** on the
+   * structural fingerprint: the default viewport "looks at itself" in
+   * paper space, so its `centerPoint` (paper WCS) coincides with its
+   * `viewCenter` (model DCS). The genuine template default is the
+   * `(0,0)-(12,9)` viewport with `centerPoint == viewCenter == (6,4.5)`,
+   * while every real viewport pans the model view to a `viewCenter`
+   * tens-to-hundreds of units away from its paper `centerPoint`.
    *
    * @param viewport the viewport read from `AcDbViewport.toGiViewport()`
    *                 (or the database entity, which exposes the same
@@ -63,7 +71,6 @@ export class AcTrViewportView extends AcTrBaseView {
     centerPoint: { x: number; y: number }
     viewCenter: { x: number; y: number }
   }): boolean {
-    if (viewport.number === 1) return true
     // Tolerance ~1µ in drawing units — generous enough to absorb
     // floating-point round-tripping through the parser, tight enough
     // that no real user viewport (even one panned to (0,0) of model


### PR DESCRIPTION
## Problem

In paper-space layouts, a real user viewport could be skipped entirely, leaving a large empty/black area where AutoCAD renders model content (e.g. a big site-plan viewport). Reproduced on three production DWGs.

## Root cause

`AcTrViewportView.isDefaultPaperSpaceViewport` kept a legacy `number === 1` shortcut on top of the structural fingerprint added in #284. But libredwg-web reassigns viewport ids by sorting VIEWPORT entities on objectId, so `number` is unreliable **in both directions**:

- **Default gets `number != 1`** — handled since #284 by the structural check (the `(0,0)-(12,9)` template default with `centerPoint == viewCenter`).
- **A real viewport gets `number === 1`** — *not* handled. The shortcut false-positived it and skipped rendering its content.

## Fix

Rely **solely** on the structural fingerprint (`centerPoint == viewCenter`): the default viewport "looks at itself" in paper space, while every real viewport pans the model view to a different center. Removed the `number === 1` shortcut; updated the JSDoc to document both failure directions.

One-line behavioral change in `isDefaultPaperSpaceViewport`; no API change.

## Validation

Verified on the affected DWGs: the previously-empty viewport now renders its model content, matching AutoCAD. `test-file-tower.dwg` (the #284 case) is unaffected — its template default is still detected structurally.

## Note

A separate paper-space issue (an *off* viewport rendered as an empty frame) is tracked as a follow-up and needs a viewport on/off flag surfaced through realdwg-web; it is **not** part of this PR.