### PR TITLE
fix: improve PNG export with offscreen camera and correct frustum math

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApObjectDisplay.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApObjectDisplay.spec.ts
@@ -1,9 +1,6 @@
 import { AcDbObjectId } from '@mlightcad/data-model'
 
-import {
-  hideObjects,
-  unisolateObjects
-} from '../src/app/AcApObjectDisplay'
+import { hideObjects, unisolateObjects } from '../src/app/AcApObjectDisplay'
 import { AcApDocument } from '../src/app/AcApDocument'
 import { AcApContext } from '../src/app/AcApContext'
 
@@ -71,14 +68,8 @@ describe('AcApObjectDisplay', () => {
   it('hides visible scene entities without changing database visibility', () => {
     const { context, hidden, entities, selectionSet } = createMockContext({
       entities: new Map([
-        [
-          'a',
-          { visibility: true, inScene: true, sceneVisible: true }
-        ],
-        [
-          'b',
-          { visibility: true, inScene: true, sceneVisible: true }
-        ]
+        ['a', { visibility: true, inScene: true, sceneVisible: true }],
+        ['b', { visibility: true, inScene: true, sceneVisible: true }]
       ])
     })
 
@@ -97,14 +88,8 @@ describe('AcApObjectDisplay', () => {
     const { context, entities, selectionSet } = createMockContext({
       hidden,
       entities: new Map([
-        [
-          'a',
-          { visibility: true, inScene: true, sceneVisible: false }
-        ],
-        [
-          'b',
-          { visibility: false, inScene: true, sceneVisible: false }
-        ]
+        ['a', { visibility: true, inScene: true, sceneVisible: false }],
+        ['b', { visibility: false, inScene: true, sceneVisible: false }]
       ])
     })
 

--- a/packages/cad-simple-viewer/__tests__/AcApPngConvertor.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApPngConvertor.spec.ts
@@ -1,0 +1,80 @@
+jest.mock('../src/app', () => ({
+  AcApDocManager: {
+    instance: {
+      curView: null
+    }
+  }
+}))
+
+jest.mock('../src/view', () => ({
+  AcTrView2d: class AcTrView2d {}
+}))
+
+import { AcGeBox2d, AcGePoint2d } from '@mlightcad/data-model'
+
+import { AcApPngConvertor } from '../src/command/convert/AcApPngConvertor'
+
+type PngConvertorTestApi = {
+  resolveOutputSize: (
+    longSide: number,
+    aspect: number
+  ) => { width: number; height: number }
+  resolveRenderSizeForCenterCrop: (
+    targetWidth: number,
+    targetHeight: number,
+    sourceAspect: number
+  ) => { width: number; height: number }
+  getBoundsAspect: (bounds: AcGeBox2d) => number
+}
+
+function convertorApi(): PngConvertorTestApi {
+  return new AcApPngConvertor() as unknown as PngConvertorTestApi
+}
+
+describe('AcApPngConvertor sizing helpers', () => {
+  it('resolveOutputSize keeps long side on width for landscape aspect', () => {
+    const api = convertorApi()
+
+    expect(api.resolveOutputSize(1024, 2)).toEqual({
+      width: 1024,
+      height: 512
+    })
+  })
+
+  it('resolveOutputSize keeps long side on height for portrait aspect', () => {
+    const api = convertorApi()
+
+    expect(api.resolveOutputSize(1024, 0.5)).toEqual({
+      width: 512,
+      height: 1024
+    })
+  })
+
+  it('resolveRenderSizeForCenterCrop extends width when source is wider', () => {
+    const api = convertorApi()
+
+    expect(api.resolveRenderSizeForCenterCrop(800, 600, 2)).toEqual({
+      width: 1200,
+      height: 600
+    })
+  })
+
+  it('resolveRenderSizeForCenterCrop extends height when source is taller', () => {
+    const api = convertorApi()
+
+    expect(api.resolveRenderSizeForCenterCrop(800, 600, 0.5)).toEqual({
+      width: 800,
+      height: 1600
+    })
+  })
+
+  it('getBoundsAspect uses absolute box dimensions', () => {
+    const api = convertorApi()
+    const bounds = new AcGeBox2d(
+      new AcGePoint2d(0, 0),
+      new AcGePoint2d(200, 50)
+    )
+
+    expect(api.getBoundsAspect(bounds)).toBeCloseTo(4)
+  })
+})

--- a/packages/cad-simple-viewer/src/command/convert/AcApConvertToPngCmd.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApConvertToPngCmd.ts
@@ -59,11 +59,7 @@ export class AcApConvertToPngCmd extends AcEdCommand {
 
     let bounds: AcGeBox2d
     if (boxResult.status === AcEdPromptStatus.OK && boxResult.value) {
-      const expandedBounds = this.expandBoundsToEntityExtents(
-        boxResult.value,
-        view
-      )
-      bounds = expandedBounds.bounds
+      bounds = boxResult.value
     } else if (boxResult.status === AcEdPromptStatus.None) {
       bounds = this.getCurrentDrawingBounds()
     } else {
@@ -109,63 +105,6 @@ export class AcApConvertToPngCmd extends AcEdCommand {
       new AcGePoint2d(ext.min.x, ext.min.y),
       new AcGePoint2d(ext.max.x, ext.max.y)
     )
-  }
-
-  /**
-   * Expands user-picked bounds to include extents of intersected entities.
-   *
-   * This avoids cutting entities when the pick box touches their geometry
-   * edges (for example anti-aliased line caps or text glyph overhangs).
-   */
-  private expandBoundsToEntityExtents(
-    userBounds: AcGeBox2d,
-    view: AcTrView2d
-  ): { bounds: AcGeBox2d; expanded: boolean } {
-    const hits = view.search(userBounds)
-    const entityBounds = new AcGeBox2d()
-    let hasEntityBounds = false
-
-    const expandByItem = (item: {
-      minX: number
-      minY: number
-      maxX: number
-      maxY: number
-      children?: Array<{
-        minX: number
-        minY: number
-        maxX: number
-        maxY: number
-      }>
-    }) => {
-      entityBounds.expandByPoint(new AcGePoint2d(item.minX, item.minY))
-      entityBounds.expandByPoint(new AcGePoint2d(item.maxX, item.maxY))
-      hasEntityBounds = true
-
-      item.children?.forEach(child => {
-        entityBounds.expandByPoint(new AcGePoint2d(child.minX, child.minY))
-        entityBounds.expandByPoint(new AcGePoint2d(child.maxX, child.maxY))
-      })
-    }
-
-    hits.forEach(hit => expandByItem(hit))
-
-    if (!hasEntityBounds || entityBounds.isEmpty()) {
-      return { bounds: userBounds, expanded: false }
-    }
-
-    const merged = new AcGeBox2d()
-      .expandByPoint(userBounds.min)
-      .expandByPoint(userBounds.max)
-      .expandByPoint(entityBounds.min)
-      .expandByPoint(entityBounds.max)
-
-    const expanded =
-      merged.min.x !== userBounds.min.x ||
-      merged.min.y !== userBounds.min.y ||
-      merged.max.x !== userBounds.max.x ||
-      merged.max.y !== userBounds.max.y
-
-    return { bounds: merged, expanded }
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/convert/AcApPngConvertor.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApPngConvertor.ts
@@ -7,35 +7,25 @@ import { AcTrView2d } from '../../view'
 /**
  * Utility class for converting CAD drawings to PNG format.
  *
- * This class provides functionality to export the current CAD drawing
- * to PNG format and download it as a file. It renders the current view
- * using WebGLRenderTarget for optimal performance without requiring
- * preserveDrawingBuffer to be enabled on the renderer.
+ * Offscreen export temporarily adjusts the camera only. It does not resize
+ * the layout view or touch OrbitControls so the interactive view stays intact.
  */
 export class AcApPngConvertor {
   /**
    * Converts the current CAD drawing to PNG format and initiates download.
    *
-   * This method:
-   * - Retrieves the current view, renderer, scene, and camera
-   * - Creates a WebGLRenderTarget for offscreen rendering
-   * - Renders the scene to the render target
-   * - Reads pixel data and flips it vertically to correct WebGL's upside-down rendering
-   * - Creates a canvas with the pixel data
-   * - Exports as PNG and downloads with timestamp-based filename
-   *
    * @param bounds - Optional world coordinate bounding box to export.
-   *                 If provided, the camera will zoom to fit this region.
-   *                 If not provided, exports the current view.
    * @param longSide - Optional maximum dimension (width or height) in pixels.
    */
   convert(bounds?: AcGeBox2d, longSide?: number) {
     const view = AcApDocManager.instance.curView as AcTrView2d
-    const renderer = view.renderer.internalRenderer
+    const layoutView = view.activeLayoutView
+    const rendererWrapper = view.renderer
+    const renderer = rendererWrapper.internalRenderer
     const scene = view.internalScene
     const camera = view.internalCamera
 
-    if (!scene || !camera) {
+    if (!scene || !camera || !layoutView) {
       console.error('[PNGOUT] Scene or camera not available')
       return
     }
@@ -51,102 +41,108 @@ export class AcApPngConvertor {
       outputHeight = outputSize.height
     }
 
-    // Keep stable render path at view aspect, then center-crop to target aspect.
-    const renderSize = this.resolveRenderSizeForCenterCrop(
-      outputWidth,
-      outputHeight,
-      viewAspect
-    )
+    const renderSize = bounds
+      ? { width: outputWidth, height: outputHeight }
+      : this.resolveRenderSizeForCenterCrop(
+          outputWidth,
+          outputHeight,
+          viewAspect
+        )
     const renderWidth = renderSize.width
     const renderHeight = renderSize.height
     const needsCrop =
-      renderWidth !== outputWidth || renderHeight !== outputHeight
+      !bounds && (renderWidth !== outputWidth || renderHeight !== outputHeight)
 
-    // Save original camera state for restoration later (keep legacy fitting path).
     const originalZoom = camera.zoom
     const originalPosition = camera.position.clone()
+    const originalLeft = camera.left
+    const originalRight = camera.right
+    const originalTop = camera.top
+    const originalBottom = camera.bottom
 
-    // Legacy zoom-based fitting; this path historically produced correct bounds.
-    if (bounds) {
-      const size = new AcGeVector2d()
-      bounds.getSize(size)
+    const savedScissorTest = renderer.getScissorTest()
+    const savedPixelRatio = renderer.getPixelRatio()
+    const originalRenderTarget = renderer.getRenderTarget()
 
-      const center = new AcGeVector2d()
-      bounds.getCenter(center)
+    let renderTarget: THREE.WebGLRenderTarget | undefined
 
-      const boundsWidth = Math.max(Math.abs(size.x), Number.EPSILON)
-      const boundsHeight = Math.max(Math.abs(size.y), Number.EPSILON)
-      const widthRatio = view.width / boundsWidth
-      const heightRatio = view.height / boundsHeight
-      const scale = Math.min(widthRatio, heightRatio)
+    try {
+      if (bounds) {
+        layoutView.applyExportCamera(bounds, renderWidth, renderHeight)
+      }
 
-      // Set camera position to center of bounds and adjust zoom
-      camera.position.set(center.x, center.y, camera.position.z)
-      camera.zoom = scale
-      camera.updateProjectionMatrix()
-    }
+      // Viewport is multiplied by pixelRatio internally; force 1:1 for RT export.
+      renderer.setPixelRatio(1)
+      rendererWrapper.updateLineResolution(renderWidth, renderHeight)
 
-    const renderTarget = new THREE.WebGLRenderTarget(
-      renderWidth,
-      renderHeight,
-      {
+      renderTarget = new THREE.WebGLRenderTarget(renderWidth, renderHeight, {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
         format: THREE.RGBAFormat,
         type: THREE.UnsignedByteType
-      }
-    )
+      })
 
-    const originalRenderTarget = renderer.getRenderTarget()
+      renderer.setRenderTarget(renderTarget)
+      renderer.setViewport(0, 0, renderWidth, renderHeight)
+      renderer.setScissorTest(false)
 
-    renderer.setRenderTarget(renderTarget)
+      layoutView.renderObject(scene)
 
-    renderer.render(scene, camera)
+      const pixels = new Uint8Array(renderWidth * renderHeight * 4)
+      renderer.readRenderTargetPixels(
+        renderTarget,
+        0,
+        0,
+        renderWidth,
+        renderHeight,
+        pixels
+      )
 
-    const pixels = new Uint8Array(renderWidth * renderHeight * 4)
-    renderer.readRenderTargetPixels(
-      renderTarget,
-      0,
-      0,
-      renderWidth,
-      renderHeight,
-      pixels
-    )
+      const flippedPixels = this.flipPixelsVertically(
+        pixels,
+        renderWidth,
+        renderHeight
+      )
+      const finalPixels = needsCrop
+        ? this.cropPixelsCentered(
+            flippedPixels,
+            renderWidth,
+            renderHeight,
+            outputWidth,
+            outputHeight
+          )
+        : flippedPixels
 
-    renderer.setRenderTarget(originalRenderTarget)
-    renderTarget.dispose()
+      const canvas = this.createCanvasFromPixels(
+        finalPixels,
+        outputWidth,
+        outputHeight
+      )
 
-    camera.zoom = originalZoom
-    camera.position.copy(originalPosition)
-    camera.updateProjectionMatrix()
+      this.createFileAndDownloadIt(canvas)
+    } finally {
+      renderer.setRenderTarget(originalRenderTarget)
+      renderTarget?.dispose()
 
-    const flippedPixels = this.flipPixelsVertically(
-      pixels,
-      renderWidth,
-      renderHeight
-    )
-    const finalPixels = needsCrop
-      ? this.cropPixelsCentered(
-          flippedPixels,
-          renderWidth,
-          renderHeight,
-          outputWidth,
-          outputHeight
-        )
-      : flippedPixels
+      camera.zoom = originalZoom
+      camera.position.copy(originalPosition)
+      camera.left = originalLeft
+      camera.right = originalRight
+      camera.top = originalTop
+      camera.bottom = originalBottom
+      camera.updateProjectionMatrix()
 
-    const canvas = this.createCanvasFromPixels(
-      finalPixels,
-      outputWidth,
-      outputHeight
-    )
+      renderer.setPixelRatio(savedPixelRatio)
+      rendererWrapper.setSize(view.width, view.height)
+      renderer.setScissorTest(savedScissorTest)
+      rendererWrapper.syncCameraZoom(originalZoom)
 
-    this.createFileAndDownloadIt(canvas)
+      // pixelRatio / render-target changes resize the canvas buffer; redraw now.
+      layoutView.render(view.cadScene)
+      view.isDirty = true
+    }
   }
 
-  /**
-   * Resolves a pixel output size from a long-side target and aspect ratio.
-   */
   private resolveOutputSize(
     longSide: number,
     aspect: number

--- a/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
@@ -176,6 +176,7 @@ export class AcTrLayoutView extends AcTrBaseView {
   resize(width: number, height: number) {
     this._height = height
     this._width = width
+    this._frustum = height / 2
     this.updateCameraFrustum()
     this._viewportViews.forEach(viewportView => {
       viewportView.update()

--- a/packages/three-renderer/__tests__/AcTrBaseView.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBaseView.spec.ts
@@ -1,0 +1,136 @@
+import { AcGeBox2d, AcGePoint2d } from '@mlightcad/data-model'
+import * as THREE from 'three'
+
+import { AcTrRenderer } from '../src/renderer'
+import { AcTrBaseView } from '../src/viewport/AcTrBaseView'
+
+class TestView extends AcTrBaseView {
+  get frustum() {
+    return this._frustum
+  }
+}
+
+function createMockRenderer(): AcTrRenderer {
+  return {
+    domElement: {} as HTMLCanvasElement,
+    render: jest.fn()
+  } as unknown as AcTrRenderer
+}
+
+function getVisibleWorldExtents(camera: THREE.OrthographicCamera) {
+  const worldWidth = (camera.right - camera.left) / camera.zoom
+  const worldHeight = (camera.top - camera.bottom) / camera.zoom
+
+  return {
+    worldWidth,
+    worldHeight,
+    minX: camera.position.x - worldWidth / 2,
+    maxX: camera.position.x + worldWidth / 2,
+    minY: camera.position.y - worldHeight / 2,
+    maxY: camera.position.y + worldHeight / 2
+  }
+}
+
+describe('AcTrBaseView camera fitting', () => {
+  it('initializes frustum from view height', () => {
+    const view = new TestView(createMockRenderer(), 800, 600)
+
+    expect(view.frustum).toBe(300)
+    expect(view.internalCamera.top).toBe(300)
+    expect(view.internalCamera.bottom).toBe(-300)
+    expect(view.internalCamera.right).toBe(400)
+    expect(view.internalCamera.left).toBe(-400)
+  })
+
+  it('applyExportCamera fits bounds to export pixel dimensions', () => {
+    const view = new TestView(createMockRenderer(), 1280, 720)
+    const bounds = new AcGeBox2d(
+      new AcGePoint2d(10, 20),
+      new AcGePoint2d(110, 70)
+    )
+
+    view.applyExportCamera(bounds, 800, 400)
+
+    const visible = getVisibleWorldExtents(view.internalCamera)
+
+    expect(view.internalCamera.position.x).toBeCloseTo(60)
+    expect(view.internalCamera.position.y).toBeCloseTo(45)
+    expect(visible.worldWidth).toBeCloseTo(100, 5)
+    expect(visible.worldHeight).toBeCloseTo(50, 5)
+    expect(visible.minX).toBeCloseTo(10, 5)
+    expect(visible.maxX).toBeCloseTo(110, 5)
+    expect(visible.minY).toBeCloseTo(20, 5)
+    expect(visible.maxY).toBeCloseTo(70, 5)
+  })
+
+  it('applyExportCamera leaves OrbitControls target unchanged', () => {
+    const view = new TestView(createMockRenderer(), 800, 600)
+    const orbitTarget = (
+      view as unknown as {
+        _cameraControls: { target: { x: number; y: number; z: number } }
+      }
+    )._cameraControls.target
+    orbitTarget.x = 12
+    orbitTarget.y = 34
+    orbitTarget.z = 0
+
+    view.applyExportCamera(
+      new AcGeBox2d(new AcGePoint2d(0, 0), new AcGePoint2d(100, 100)),
+      512,
+      512
+    )
+
+    expect(orbitTarget.x).toBe(12)
+    expect(orbitTarget.y).toBe(34)
+    expect(orbitTarget.z).toBe(0)
+  })
+
+  it('zoomTo matches min(width/fitWidth, height/fitHeight) when frustum is height/2', () => {
+    const view = new TestView(createMockRenderer(), 800, 600)
+    const bounds = new AcGeBox2d(
+      new AcGePoint2d(0, 0),
+      new AcGePoint2d(200, 100)
+    )
+    const margin = 1.1
+    const fitWidth = 200 * margin
+    const fitHeight = 100 * margin
+    const expectedScale = Math.min(800 / fitWidth, 600 / fitHeight)
+
+    view.zoomTo(bounds, margin)
+
+    expect(view.internalCamera.zoom).toBeCloseTo(expectedScale, 8)
+
+    const visible = getVisibleWorldExtents(view.internalCamera)
+    expect(visible.worldWidth).toBeGreaterThanOrEqual(fitWidth - 1e-6)
+    expect(visible.worldHeight).toBeGreaterThanOrEqual(fitHeight - 1e-6)
+    expect(visible.worldWidth / visible.worldHeight).toBeCloseTo(800 / 600, 8)
+  })
+
+  it('zoomTo centers on the box center', () => {
+    const view = new TestView(createMockRenderer(), 800, 600)
+    const bounds = new AcGeBox2d(
+      new AcGePoint2d(10, 20),
+      new AcGePoint2d(110, 70)
+    )
+
+    view.zoomTo(bounds, 1)
+
+    expect(view.internalCamera.position.x).toBeCloseTo(60)
+    expect(view.internalCamera.position.y).toBeCloseTo(45)
+  })
+
+  it('applyExportCamera uses export aspect rather than view aspect', () => {
+    const view = new TestView(createMockRenderer(), 1600, 900)
+    const bounds = new AcGeBox2d(
+      new AcGePoint2d(0, 0),
+      new AcGePoint2d(100, 100)
+    )
+
+    view.applyExportCamera(bounds, 400, 800)
+
+    const visible = getVisibleWorldExtents(view.internalCamera)
+    expect(visible.worldWidth / visible.worldHeight).toBeCloseTo(0.5, 8)
+    expect(visible.worldWidth).toBeCloseTo(100, 5)
+    expect(visible.worldHeight).toBeCloseTo(200, 5)
+  })
+})

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -89,6 +89,20 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
     this._styleManager.updateLineResolution(width, height)
   }
 
+  /**
+   * Updates wide-line shader resolution without resizing the canvas.
+   */
+  updateLineResolution(width: number, height: number) {
+    this._styleManager.updateLineResolution(width, height)
+  }
+
+  /**
+   * Syncs shader uniforms that depend on the active camera zoom.
+   */
+  syncCameraZoom(zoom: number) {
+    this.updateCameraZoomUniform(zoom)
+  }
+
   getViewport(target: THREE.Vector4) {
     return this._renderer.getViewport(target)
   }

--- a/packages/three-renderer/src/viewport/AcTrBaseView.ts
+++ b/packages/three-renderer/src/viewport/AcTrBaseView.ts
@@ -19,7 +19,7 @@ export interface AcTrBaseViewEventArgs {
  * The base class for all kinds of views.
  */
 export class AcTrBaseView {
-  protected _frustum = 400
+  protected _frustum: number
   protected _width: number
   protected _height: number
   protected _renderer: AcTrRenderer
@@ -41,6 +41,7 @@ export class AcTrBaseView {
     this._renderer = renderer
     this._width = width
     this._height = height
+    this._frustum = height / 2
     const camera = this.createCamera()
     this._camera = new AcTrCamera(camera)
     this._cameraControls = this.createCameraControls()
@@ -154,6 +155,57 @@ export class AcTrBaseView {
     return this._raycaster
   }
 
+  /**
+   * The internal THREE camera used by this layout view.
+   */
+  get internalCamera() {
+    return this._camera.internalCamera
+  }
+
+  /**
+   * The camera wrapper used by the renderer pipeline.
+   */
+  get trCamera() {
+    return this._camera
+  }
+
+  /**
+   * Renders a THREE scene with this view's camera and renderer-side uniforms.
+   */
+  renderObject(scene: THREE.Object3D) {
+    this._renderer.render(scene, this._camera)
+  }
+
+  /**
+   * Fits the camera to a world box using export pixel dimensions.
+   *
+   * Does not update OrbitControls target so interactive pan/zoom stay intact.
+   */
+  applyExportCamera(box: AcGeBox2d, pixelWidth: number, pixelHeight: number) {
+    const size = new AcGeVector2d()
+    box.getSize(size)
+
+    const center = new AcGeVector2d()
+    box.getCenter(center)
+
+    const fitWidth = Math.max(Math.abs(size.x), Number.EPSILON)
+    const fitHeight = Math.max(Math.abs(size.y), Number.EPSILON)
+    const aspect = pixelWidth / Math.max(pixelHeight, 1)
+    const frustum = pixelHeight / 2
+    const scale = Math.min(
+      (2 * aspect * frustum) / fitWidth,
+      (2 * frustum) / fitHeight
+    )
+
+    this._camera.left = -aspect * frustum
+    this._camera.right = aspect * frustum
+    this._camera.top = frustum
+    this._camera.bottom = -frustum
+    this._camera.position.set(center.x, center.y, this._camera.position.z)
+    this._camera.zoom = scale
+    this._camera.updateProjectionMatrix()
+  }
+
   zoomTo(box: AcGeBox2d, margin: number = 1.1) {
     const size = new AcGeVector2d()
     box.getSize(size)
@@ -161,11 +213,13 @@ export class AcTrBaseView {
     const center = new AcGeVector2d()
     box.getCenter(center)
 
-    const width = size.x * margin
-    const height = size.y * margin
-    const widthRatio = this._width / width
-    const heightRatio = this._height / height
-    const scale = Math.min(widthRatio, heightRatio)
+    const fitWidth = Math.max(Math.abs(size.x) * margin, Number.EPSILON)
+    const fitHeight = Math.max(Math.abs(size.y) * margin, Number.EPSILON)
+    const aspect = this._width / Math.max(this._height, 1)
+    const scale = Math.min(
+      (2 * aspect * this._frustum) / fitWidth,
+      (2 * this._frustum) / fitHeight
+    )
 
     this.flyTo(center, scale)
     this.updateCameraFrustum()

--- a/test/mocks/three/OrbitControls.js
+++ b/test/mocks/three/OrbitControls.js
@@ -1,9 +1,10 @@
 class OrbitControls {
   constructor() {
     this.enabled = true
-    this.target = { set: () => {} }
+    this.target = { x: 0, y: 0, z: 0, set: () => {} }
   }
 
+  addEventListener() {}
   update() {}
   dispose() {}
 }


### PR DESCRIPTION
## Summary

- Refactor PNG export to use offscreen render-target rendering with temporary camera adjustments only; the layout view and OrbitControls are no longer resized during export.
- Add `applyExportCamera` on `AcTrBaseView` to fit bounds using export pixel dimensions and aspect ratio, and fix `zoomTo` frustum math by deriving frustum from view height (`height / 2`).
- Remove entity-extent expansion from `PNGOUT` window selection; use the user-picked bounds directly.
- Add unit tests for PNG sizing helpers and camera fitting behavior.

## Test plan

- [ ] Run `pnpm nx test cad-simple-viewer` and `pnpm nx test three-renderer`
- [ ] Export full view to PNG and confirm the interactive view is unchanged afterward
- [ ] Export a window-selected region to PNG and verify bounds match the selection
- [ ] Resize the viewer and confirm zoom-to-fit still frames entities correctly
