### PR TITLE
feat: add /register subpath for lazy plugin registration

### DIFF
--- a/packages/cad-html-plugin/README.md
+++ b/packages/cad-html-plugin/README.md
@@ -40,7 +40,8 @@ The package produces two artifacts:
 
 | Output | Description |
 |--------|-------------|
-| `dist/index.js` | Library entry (snapshot types, codec, `packHtml`, plugin helpers, …) |
+| `dist/index.js` | Library entry (snapshot types, codec, `packHtml`, `createHtmlPlugin`, …) |
+| `dist/register.js` | Lightweight lazy-registration entry (safe for static import in app bundles) |
 | `dist/viewer-runtime.iife.js` | Offline viewer bootstrap (loaded/inlined into exported HTML) |
 
 ```bash
@@ -53,11 +54,11 @@ Copy or serve `viewer-runtime.iife.js` from your app assets when using the brows
 
 ### Lazy registration (recommended)
 
-Register the plugin with the document manager's plugin manager. The module chunk loads on first use of `chtml`:
+Register the plugin with the document manager's plugin manager. Import from the `/register` subpath so only the registration stub enters your initial bundle; the main plugin chunk loads on first use of `chtml`:
 
 ```typescript
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
-import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin'
+import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin/register'
 
 AcApDocManager.createInstance({
   container: document.getElementById('cad-container')!,
@@ -66,6 +67,8 @@ AcApDocManager.createInstance({
 
 registerLazyHtmlPlugin(AcApDocManager.instance.pluginManager)
 ```
+
+Do **not** import `registerLazyHtmlPlugin` from the package root (`@mlightcad/cad-html-plugin`) in application code — that resolves to the full library build and defeats lazy loading.
 
 After registration:
 
@@ -128,15 +131,16 @@ For DXF/DWG → HTML without a browser UI, use [`@mlightcad/cad-html-exporter-cl
 When embedding HTML export in a web app:
 
 1. Build `@mlightcad/cad-html-plugin` and expose `viewer-runtime.iife.js` at a URL your app can `fetch` (e.g. Vite `public/` copy — see `cad-viewer-example` / `cad-simple-viewer-example` vite configs).
-2. Register `registerLazyHtmlPlugin` (or load the plugin eagerly).
+2. Register via `@mlightcad/cad-html-plugin/register` (or load the plugin eagerly).
 3. Optionally set `htmlViewerRuntimeUrl` on `AcApDocManager.createInstance()` to override the default `./viewer-runtime.iife.js` path.
 4. Ensure fonts used by the drawing are reachable during export if you rely on web-font substitution.
 
 The generated HTML itself needs **no backend**; only the export step may fetch the runtime bundle and fonts.
 
-Subpath export:
+Subpath exports:
 
 ```typescript
+import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin/register'
 import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.js
 ```
 
@@ -144,8 +148,9 @@ import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.j
 
 | Export | Role |
 |--------|------|
-| `registerLazyHtmlPlugin`, `createHtmlPlugin` | Lazy plugin registration |
+| `createHtmlPlugin` | Async factory used by the lazy loader |
 | `HTML_PLUGIN_NAME`, `HTML_PLUGIN_TRIGGERS` | Plugin id and command triggers |
+| `@mlightcad/cad-html-plugin/register` | `registerLazyHtmlPlugin` and registration constants |
 | `AcApExportHtmlCmd`, `AcApHtmlConvertor` | `chtml` command and full export workflow |
 | `AcApHtmlSnapshotBuilder` | Live Three.js scene → `AcExSnapshotV1` |
 | `packHtml`, `AcExPackHtmlOptions` | Assemble HTML from snapshot + runtime source |
@@ -161,7 +166,7 @@ import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.j
 
 | Path | Role |
 |------|------|
-| `src/registerLazyHtmlPlugin.ts` | Lazy plugin registration API |
+| `src/register.ts` | Lazy plugin registration (`/register` entry) and `createHtmlPlugin` |
 | `src/AcApHtmlPlugin.ts` | Plugin lifecycle (`onLoad` / `onUnload`) |
 | `src/AcApExportHtmlCmd.ts` | `chtml` command |
 | `src/AcApHtmlConvertor.ts` | Export orchestration (snapshot, runtime fetch, download) |

--- a/packages/cad-html-plugin/package.json
+++ b/packages/cad-html-plugin/package.json
@@ -16,11 +16,24 @@
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
   "types": "./lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "register": [
+        "lib/register.d.ts"
+      ]
+    }
+  },
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
+    },
+    "./register": {
+      "types": "./lib/register.d.ts",
+      "import": "./dist/register.js",
+      "require": "./dist/register.umd.cjs"
     },
     "./viewer-runtime": {
       "import": "./dist/viewer-runtime.iife.js"

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -60,6 +60,5 @@ export {
 export {
   createHtmlPlugin,
   HTML_PLUGIN_NAME,
-  HTML_PLUGIN_TRIGGERS,
-  registerLazyHtmlPlugin
-} from './registerLazyHtmlPlugin'
+  HTML_PLUGIN_TRIGGERS
+} from './register'

--- a/packages/cad-html-plugin/src/register.ts
+++ b/packages/cad-html-plugin/src/register.ts
@@ -23,7 +23,8 @@ export async function createHtmlPlugin() {
 /**
  * Registers the HTML export plugin for lazy loading.
  *
- * The plugin bundle is not fetched until the `chtml` command runs.
+ * Import from `@mlightcad/cad-html-plugin/register` so the main plugin bundle
+ * is not pulled into the application entry chunk.
  *
  * @param pluginManager - Plugin manager that receives the lazy registration
  */
@@ -31,6 +32,9 @@ export function registerLazyHtmlPlugin(pluginManager: AcApPluginManager): void {
   pluginManager.registerLazyPlugin({
     name: HTML_PLUGIN_NAME,
     triggers: [...HTML_PLUGIN_TRIGGERS],
-    loader: createHtmlPlugin
+    loader: async () => {
+      const { createHtmlPlugin } = await import('@mlightcad/cad-html-plugin')
+      return createHtmlPlugin()
+    }
   })
 }

--- a/packages/cad-html-plugin/tsconfig.json
+++ b/packages/cad-html-plugin/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "paths": {
+      "@mlightcad/cad-html-plugin": ["./src/index.ts"]
+    }
   },
   "include": [
     "src"

--- a/packages/cad-html-plugin/vite.config.ts
+++ b/packages/cad-html-plugin/vite.config.ts
@@ -1,5 +1,8 @@
+import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
+
+const packageName = '@mlightcad/cad-html-plugin'
 
 export default defineConfig({
   build: {
@@ -8,11 +11,18 @@ export default defineConfig({
     // delete viewer-runtime.iife.js produced by a concurrent viewer build.
     emptyOutDir: false,
     lib: {
-      entry: 'src/index.ts',
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        register: resolve(__dirname, 'src/register.ts')
+      },
       name: 'cad-html-plugin',
-      fileName: 'index'
+      fileName: (format, entryName) =>
+        format === 'es' ? `${entryName}.js` : `${entryName}.umd.cjs`
     },
-    minify: true
+    minify: true,
+    rollupOptions: {
+      external: [packageName]
+    }
   },
   plugins: [peerDepsExternal() as PluginOption]
 })

--- a/packages/cad-pdf-plugin/README.md
+++ b/packages/cad-pdf-plugin/README.md
@@ -36,6 +36,8 @@ Runtime dependencies (bundled with this package):
 
 ## Build
 
+Produces `dist/index.js` (main library) and `dist/register.js` (lazy-registration entry).
+
 ```bash
 pnpm --filter @mlightcad/cad-pdf-plugin build
 ```
@@ -44,14 +46,16 @@ pnpm --filter @mlightcad/cad-pdf-plugin build
 
 ### Lazy registration (recommended)
 
-Register the plugin with the document manager's plugin manager. The module chunk loads on first use of `cpdf` or `ipdf`:
+Register the plugin with the document manager's plugin manager. Import from the `/register` subpath so only the registration stub enters your initial bundle; the main plugin chunk loads on first use of `cpdf` or `ipdf`:
 
 ```typescript
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
-import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin'
+import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin/register'
 
 registerLazyPdfPlugin(AcApDocManager.instance.pluginManager)
 ```
+
+Do **not** import `registerLazyPdfPlugin` from the package root in application code — that resolves to the full library build and defeats lazy loading.
 
 Equivalent manual registration:
 
@@ -128,9 +132,9 @@ Import is **vector-only**; raster/scanned PDF pages produce no entities. Only th
 
 | Export | Role |
 |--------|------|
-| `registerLazyPdfPlugin` | One-line lazy registration helper |
 | `createPdfPlugin` | Async factory used by lazy loader |
 | `PDF_PLUGIN_NAME`, `PDF_PLUGIN_TRIGGERS` | Plugin id and command triggers |
+| `@mlightcad/cad-pdf-plugin/register` | `registerLazyPdfPlugin` and registration constants |
 | `AcApPdfPlugin` | `AcApPlugin` implementation |
 | `AcApConvertToPdfCmd` | `cpdf` command class |
 | `AcApImportPdfCmd` | `ipdf` command class |
@@ -141,7 +145,7 @@ Import is **vector-only**; raster/scanned PDF pages produce no entities. Only th
 
 | Path | Role |
 |------|------|
-| `src/registerLazyPdfPlugin.ts` | Lazy plugin registration API |
+| `src/register.ts` | Lazy plugin registration (`/register` entry) and `createPdfPlugin` |
 | `src/AcApPdfPlugin.ts` | Plugin lifecycle (`onLoad` / `onUnload`) |
 | `src/AcApConvertToPdfCmd.ts` | `cpdf` command |
 | `src/AcApImportPdfCmd.ts` | `ipdf` command |

--- a/packages/cad-pdf-plugin/package.json
+++ b/packages/cad-pdf-plugin/package.json
@@ -15,12 +15,25 @@
   ],
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
+  "sideEffects": false,
   "types": "./lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "register": [
+        "lib/register.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
+    },
+    "./register": {
+      "types": "./lib/register.d.ts",
+      "import": "./dist/register.js",
+      "require": "./dist/register.umd.cjs"
     }
   },
   "scripts": {

--- a/packages/cad-pdf-plugin/src/index.ts
+++ b/packages/cad-pdf-plugin/src/index.ts
@@ -11,6 +11,5 @@ export { AcApPdfImportConvertor } from './AcApPdfImportConvertor'
 export {
   createPdfPlugin,
   PDF_PLUGIN_NAME,
-  PDF_PLUGIN_TRIGGERS,
-  registerLazyPdfPlugin
-} from './registerLazyPdfPlugin'
+  PDF_PLUGIN_TRIGGERS
+} from './register'

--- a/packages/cad-pdf-plugin/src/register.ts
+++ b/packages/cad-pdf-plugin/src/register.ts
@@ -24,7 +24,8 @@ export async function createPdfPlugin() {
 /**
  * Registers the PDF plugin for lazy loading.
  *
- * The plugin bundle is not fetched until one of its trigger commands runs.
+ * Import from `@mlightcad/cad-pdf-plugin/register` so the main plugin bundle
+ * is not pulled into the application entry chunk.
  *
  * @param pluginManager - Plugin manager that receives the lazy registration
  */
@@ -32,6 +33,9 @@ export function registerLazyPdfPlugin(pluginManager: AcApPluginManager): void {
   pluginManager.registerLazyPlugin({
     name: PDF_PLUGIN_NAME,
     triggers: [...PDF_PLUGIN_TRIGGERS],
-    loader: createPdfPlugin
+    loader: async () => {
+      const { createPdfPlugin } = await import('@mlightcad/cad-pdf-plugin')
+      return createPdfPlugin()
+    }
   })
 }

--- a/packages/cad-pdf-plugin/tsconfig.json
+++ b/packages/cad-pdf-plugin/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "paths": {
+      "@mlightcad/cad-pdf-plugin": ["./src/index.ts"]
+    }
   },
   "include": [
     "src"

--- a/packages/cad-pdf-plugin/vite.config.ts
+++ b/packages/cad-pdf-plugin/vite.config.ts
@@ -1,16 +1,26 @@
+import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
+
+const packageName = '@mlightcad/cad-pdf-plugin'
 
 export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
     lib: {
-      entry: 'src/index.ts',
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        register: resolve(__dirname, 'src/register.ts')
+      },
       name: 'cad-pdf-plugin',
-      fileName: 'index'
+      fileName: (format, entryName) =>
+        format === 'es' ? `${entryName}.js` : `${entryName}.umd.cjs`
     },
-    minify: true
+    minify: true,
+    rollupOptions: {
+      external: [packageName]
+    }
   },
   plugins: [peerDepsExternal() as PluginOption]
 })

--- a/packages/cad-simple-viewer-example/README.md
+++ b/packages/cad-simple-viewer-example/README.md
@@ -7,7 +7,7 @@ A vanilla TypeScript demo that shows how to embed [`@mlightcad/cad-simple-viewer
 - **Local files** — Open `.dxf` / `.dwg` via file picker (toolbar **Open** or center **Open File**)
 - **Sample drawings** — Sidebar loads predefined files from the [cad-data](https://github.com/mlightcad/cad-data) CDN
 - **Viewer toolbar** — Zoom fit, zoom window, background toggle, pickbox size, line-weight display, export HTML/PDF
-- **Lazy plugins** — `@mlightcad/cad-html-plugin` (`chtml`), `@mlightcad/cad-pdf-plugin` (`cpdf`), and `@mlightcad/cad-svg-plugin` (`csvg`) load on demand
+- **Lazy plugins** — registered from `@mlightcad/cad-*-plugin/register` in `src/register.ts`; `chtml` / `cpdf` / `csvg` load plugin chunks on demand
 - **Browser-only** — Parsing and rendering run in the browser (Web Workers + WebAssembly for DWG)
 - **Responsive layout** — Sidebar + viewer pane; stacks vertically on narrow screens
 
@@ -92,7 +92,7 @@ Integration patterns useful when building your own host app (not a full CAD UI l
 | Remote open | `openUrl(url, options)` for CDN sample files |
 | Commands | `sendStringToExecute('zoom\\nall')`, `switchbg`, plugin commands `chtml` / `cpdf` |
 | System variables | `AcDbSysVarManager` + `sendStringToExecute` (e.g. `PICKBOX`) |
-| Plugins | `registerLazyHtmlPlugin` / `registerLazyPdfPlugin` / `registerLazySvgPlugin` on `pluginManager` |
+| Plugins | Lazy registration via `@mlightcad/*/register` in `src/register.ts` (only needed plugins) |
 | Command aliases | Demo overrides (`LINE` → `LX`, etc.) via `commandAliases` |
 | Workers & assets | `webworkerFileUrls`, `htmlViewerRuntimeUrl`, static copy in Vite |
 
@@ -103,7 +103,8 @@ Lazy initialization: `AcApDocManager` is created on first file open, not at page
 | Path | Role |
 |------|------|
 | `index.html` | Layout: sidebar, toolbar, canvas container, styles |
-| `src/main.ts` | `CadViewerApp` — wiring UI to `AcApDocManager` and plugins |
+| `src/main.ts` | `CadViewerApp` — wiring UI to `AcApDocManager` |
+| `src/register.ts` | Registers export plugins from `@mlightcad/cad-*-plugin/register` |
 | `vite.config.ts` | `base: './'`, copies workers + `viewer-runtime.iife.js` |
 | `package.json` | Scripts and workspace dependencies |
 

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -1,16 +1,15 @@
-import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin'
-import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin'
 import {
   AcApDocManager,
   AcApOpenDatabaseOptions,
   AcEdOpenMode
 } from '@mlightcad/cad-simple-viewer'
-import { registerLazySvgPlugin } from '@mlightcad/cad-svg-plugin'
 import {
   AcDbSystemVariables,
   AcDbSysVarManager,
   log
 } from '@mlightcad/data-model'
+
+import { registerLazyPlugins } from './register'
 
 /**
  * Demo-only command alias overrides used by the example app.
@@ -111,10 +110,7 @@ class CadViewerApp {
           htmlViewerRuntimeUrl: './viewer-runtime.iife.js'
         })
 
-        const pluginManager = AcApDocManager.instance.pluginManager
-        registerLazyHtmlPlugin(pluginManager)
-        registerLazyPdfPlugin(pluginManager)
-        registerLazySvgPlugin(pluginManager)
+        registerLazyPlugins()
 
         AcApDocManager.instance.events.documentActivated.addEventListener(
           args => {

--- a/packages/cad-simple-viewer-example/src/register.ts
+++ b/packages/cad-simple-viewer-example/src/register.ts
@@ -1,0 +1,26 @@
+import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin/register'
+import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin/register'
+import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { registerLazySvgPlugin } from '@mlightcad/cad-svg-plugin/register'
+
+let isLazyPluginRegistered = false
+
+/**
+ * Registers export plugins used by this example app.
+ *
+ * Import from each plugin's `/register` subpath so only the registration stub is in the
+ * initial bundle; plugin code loads when a trigger command runs.
+ * Safe to call multiple times; registration runs once per application lifetime.
+ */
+export const registerLazyPlugins = () => {
+  if (isLazyPluginRegistered) {
+    return
+  }
+
+  const pluginManager = AcApDocManager.instance.pluginManager
+  registerLazyHtmlPlugin(pluginManager)
+  registerLazyPdfPlugin(pluginManager)
+  registerLazySvgPlugin(pluginManager)
+
+  isLazyPluginRegistered = true
+}

--- a/packages/cad-simple-viewer/src/plugin/AcApLazyPluginRegistration.ts
+++ b/packages/cad-simple-viewer/src/plugin/AcApLazyPluginRegistration.ts
@@ -8,14 +8,9 @@ import { AcApPlugin } from './AcApPlugin'
  *
  * @example
  * ```typescript
- * pluginManager.registerLazyPlugin({
- *   name: 'PdfPlugin',
- *   triggers: ['cpdf', 'ipdf'],
- *   loader: async () => {
- *     const { createPdfPlugin } = await import('@mlightcad/cad-pdf-plugin')
- *     return createPdfPlugin()
- *   }
- * })
+ * import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin/register'
+ *
+ * registerLazyPdfPlugin(pluginManager)
  * ```
  */
 export interface AcApLazyPluginRegistration {

--- a/packages/cad-svg-plugin/README.md
+++ b/packages/cad-svg-plugin/README.md
@@ -29,6 +29,8 @@ Peer dependencies:
 
 ## Build
 
+Produces `dist/index.js` (main library) and `dist/register.js` (lazy-registration entry).
+
 ```bash
 pnpm --filter @mlightcad/cad-svg-plugin build
 ```
@@ -37,14 +39,16 @@ pnpm --filter @mlightcad/cad-svg-plugin build
 
 ### Lazy registration (recommended)
 
-Register the plugin with the document manager's plugin manager. The module chunk loads on first use of `csvg`:
+Register the plugin with the document manager's plugin manager. Import from the `/register` subpath so only the registration stub enters your initial bundle; the main plugin chunk loads on first use of `csvg`:
 
 ```typescript
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
-import { registerLazySvgPlugin } from '@mlightcad/cad-svg-plugin'
+import { registerLazySvgPlugin } from '@mlightcad/cad-svg-plugin/register'
 
 registerLazySvgPlugin(AcApDocManager.instance.pluginManager)
 ```
+
+Do **not** import `registerLazySvgPlugin` from the package root in application code — that resolves to the full library build and defeats lazy loading.
 
 Equivalent manual registration:
 
@@ -85,9 +89,9 @@ const svg = await renderer.exportAsync()
 
 | Export | Description |
 |--------|-------------|
-| `registerLazySvgPlugin` | One-line lazy registration helper |
 | `createSvgPlugin` | Async factory used by lazy loader |
 | `SVG_PLUGIN_NAME`, `SVG_PLUGIN_TRIGGERS` | Plugin metadata constants |
+| `@mlightcad/cad-svg-plugin/register` | `registerLazySvgPlugin` and registration constants |
 | `AcApSvgPlugin` | `AcApPlugin` implementation |
 | `AcApConvertToSvgCmd` | `csvg` command class |
 | `AcApSvgConvertor` | SVG export workflow |
@@ -97,7 +101,7 @@ const svg = await renderer.exportAsync()
 
 | Path | Role |
 |------|------|
-| `src/registerLazySvgPlugin.ts` | Lazy plugin registration API |
+| `src/register.ts` | Lazy plugin registration (`/register` entry) and `createSvgPlugin` |
 | `src/AcApSvgPlugin.ts` | Plugin lifecycle (`onLoad` / `onUnload`) |
 | `src/AcApConvertToSvgCmd.ts` | `csvg` command |
 | `src/AcApSvgConvertor.ts` | Export orchestration |

--- a/packages/cad-svg-plugin/package.json
+++ b/packages/cad-svg-plugin/package.json
@@ -15,12 +15,25 @@
   ],
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
+  "sideEffects": false,
   "types": "./lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "register": [
+        "lib/register.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
+    },
+    "./register": {
+      "types": "./lib/register.d.ts",
+      "import": "./dist/register.js",
+      "require": "./dist/register.umd.cjs"
     }
   },
   "scripts": {

--- a/packages/cad-svg-plugin/src/index.ts
+++ b/packages/cad-svg-plugin/src/index.ts
@@ -10,6 +10,5 @@ export { AcApSvgConvertor } from './AcApSvgConvertor'
 export {
   createSvgPlugin,
   SVG_PLUGIN_NAME,
-  SVG_PLUGIN_TRIGGERS,
-  registerLazySvgPlugin
-} from './registerLazySvgPlugin'
+  SVG_PLUGIN_TRIGGERS
+} from './register'

--- a/packages/cad-svg-plugin/src/register.ts
+++ b/packages/cad-svg-plugin/src/register.ts
@@ -23,7 +23,8 @@ export async function createSvgPlugin() {
 /**
  * Registers the SVG export plugin for lazy loading.
  *
- * The plugin bundle is not fetched until the `csvg` command runs.
+ * Import from `@mlightcad/cad-svg-plugin/register` so the main plugin bundle
+ * is not pulled into the application entry chunk.
  *
  * @param pluginManager - Plugin manager that receives the lazy registration
  */
@@ -31,6 +32,9 @@ export function registerLazySvgPlugin(pluginManager: AcApPluginManager): void {
   pluginManager.registerLazyPlugin({
     name: SVG_PLUGIN_NAME,
     triggers: [...SVG_PLUGIN_TRIGGERS],
-    loader: createSvgPlugin
+    loader: async () => {
+      const { createSvgPlugin } = await import('@mlightcad/cad-svg-plugin')
+      return createSvgPlugin()
+    }
   })
 }

--- a/packages/cad-svg-plugin/tsconfig.json
+++ b/packages/cad-svg-plugin/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "paths": {
+      "@mlightcad/cad-svg-plugin": ["./index.ts"]
+    }
   },
   "include": [
     "src"

--- a/packages/cad-svg-plugin/vite.config.ts
+++ b/packages/cad-svg-plugin/vite.config.ts
@@ -1,16 +1,26 @@
+import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
+
+const packageName = '@mlightcad/cad-svg-plugin'
 
 export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
     lib: {
-      entry: 'src/index.ts',
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        register: resolve(__dirname, 'src/register.ts')
+      },
       name: 'cad-svg-plugin',
-      fileName: 'index'
+      fileName: (format, entryName) =>
+        format === 'es' ? `${entryName}.js` : `${entryName}.umd.cjs`
     },
-    minify: true
+    minify: true,
+    rollupOptions: {
+      external: [packageName]
+    }
   },
   plugins: [peerDepsExternal() as PluginOption]
 })

--- a/packages/cad-viewer-example/README.md
+++ b/packages/cad-viewer-example/README.md
@@ -90,7 +90,7 @@ Integration patterns useful when embedding `@mlightcad/cad-viewer` in your own V
 | Custom commands | `AcApDocManager.instance.commandManager.addCommand(…)` — see `quit` / `exit` in `src/commands/` |
 | Upload flow | Reactive store + conditional render: upload screen until `selectedFile` is set |
 | Workers & runtime | `vite-plugin-static-copy` copies DXF/DWG workers and `viewer-runtime.iife.js` |
-| Export plugins | Declared in `package.json`; `MlCadViewer` lazy-loads `@mlightcad/cad-html-plugin` / `@mlightcad/cad-pdf-plugin` |
+| Export plugins | Declared in `package.json`; `@mlightcad/cad-viewer` registers them via `@mlightcad/cad-*-plugin/register` on bootstrap |
 
 Minimal host wiring in `App.vue`:
 

--- a/packages/cad-viewer/src/app/register.ts
+++ b/packages/cad-viewer/src/app/register.ts
@@ -1,8 +1,11 @@
+import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin/register'
+import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin/register'
 import {
   AcApDocManager,
   AcEdCommandStack,
   AcEdMTextEditor
 } from '@mlightcad/cad-simple-viewer'
+import { registerLazySvgPlugin } from '@mlightcad/cad-svg-plugin/register'
 import { markRaw } from 'vue'
 
 import {
@@ -140,32 +143,9 @@ export const registerLazyPlugins = () => {
     return
   }
 
-  AcApDocManager.instance.pluginManager.registerLazyPlugin({
-    name: 'PdfPlugin',
-    triggers: ['cpdf', 'ipdf'],
-    loader: async () => {
-      const { createPdfPlugin } = await import('@mlightcad/cad-pdf-plugin')
-      return createPdfPlugin()
-    }
-  })
-
-  AcApDocManager.instance.pluginManager.registerLazyPlugin({
-    name: 'HtmlPlugin',
-    triggers: ['chtml'],
-    loader: async () => {
-      const { createHtmlPlugin } = await import('@mlightcad/cad-html-plugin')
-      return createHtmlPlugin()
-    }
-  })
-
-  AcApDocManager.instance.pluginManager.registerLazyPlugin({
-    name: 'SvgPlugin',
-    triggers: ['csvg'],
-    loader: async () => {
-      const { createSvgPlugin } = await import('@mlightcad/cad-svg-plugin')
-      return createSvgPlugin()
-    }
-  })
-
+  const pluginManager = AcApDocManager.instance.pluginManager
+  registerLazyPdfPlugin(pluginManager)
+  registerLazyHtmlPlugin(pluginManager)
+  registerLazySvgPlugin(pluginManager)
   isLazyPluginRegistered = true
 }

--- a/packages/cad-viewer/vite.config.ts
+++ b/packages/cad-viewer/vite.config.ts
@@ -39,7 +39,11 @@ export default defineConfig(({ mode }: ConfigEnv) => {
       minify: true,
       rollupOptions: {
         // PDF/HTML plugins are peers; loaded at runtime via dynamic import in registerLazyPlugins
-        external: ['@mlightcad/cad-pdf-plugin', '@mlightcad/cad-html-plugin']
+        external: [
+          '@mlightcad/cad-pdf-plugin',
+          '@mlightcad/cad-html-plugin',
+          '@mlightcad/cad-svg-plugin'
+        ]
       }
     },
     plugins


### PR DESCRIPTION
## Summary

- Add a lightweight `/register` subpath export to `@mlightcad/cad-html-plugin`, `@mlightcad/cad-pdf-plugin`, and `@mlightcad/cad-svg-plugin` so application bundles only include a small registration stub in the initial chunk
- Move `registerLazy*Plugin` out of the package root exports; the register entry dynamically imports the full plugin on first command use
- Update `cad-viewer` and `cad-simple-viewer-example` to import from `@mlightcad/cad-*-plugin/register` instead of inlining lazy registration or importing from the package root

## Test plan

- [ ] Build all affected packages: `pnpm --filter @mlightcad/cad-html-plugin build`, PDF, SVG, cad-viewer, cad-simple-viewer-example
- [ ] Run cad-simple-viewer-example and verify `chtml`, `cpdf`, and `csvg` commands still work
- [ ] Run cad-viewer-example and verify export plugins load on demand
- [ ] Confirm initial bundle does not include full plugin code (check network tab / bundle analyzer)

Made with [Cursor](https://cursor.com)