### PR TITLE
feat: use meaningful bundle names for plugins and viewer packages

### DIFF
--- a/packages/cad-html-plugin/package.json
+++ b/packages/cad-html-plugin/package.json
@@ -13,8 +13,8 @@
     "README.md",
     "package.json"
   ],
-  "main": "./dist/index.umd.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/cad-html-plugin.umd.cjs",
+  "module": "./dist/cad-html-plugin.js",
   "types": "./lib/index.d.ts",
   "typesVersions": {
     "*": {
@@ -27,13 +27,13 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "import": "./dist/cad-html-plugin.js",
+      "require": "./dist/cad-html-plugin.umd.cjs"
     },
     "./register": {
       "types": "./lib/register.d.ts",
-      "import": "./dist/register.js",
-      "require": "./dist/register.umd.cjs"
+      "import": "./dist/cad-html-plugin-register.js",
+      "require": "./dist/cad-html-plugin-register.umd.cjs"
     },
     "./viewer-runtime": {
       "import": "./dist/viewer-runtime.iife.js"

--- a/packages/cad-html-plugin/src/createHtmlPlugin.ts
+++ b/packages/cad-html-plugin/src/createHtmlPlugin.ts
@@ -1,0 +1,10 @@
+import { AcApHtmlPlugin } from './AcApHtmlPlugin'
+
+/**
+ * Creates an HTML export plugin instance.
+ *
+ * @returns A loaded {@link AcApHtmlPlugin} instance
+ */
+export async function createHtmlPlugin() {
+  return new AcApHtmlPlugin()
+}

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -57,8 +57,5 @@ export {
   AcApHtmlSnapshotBuilder,
   type AcApHtmlSnapshotBuilderOptions
 } from './AcApHtmlSnapshotBuilder'
-export {
-  createHtmlPlugin,
-  HTML_PLUGIN_NAME,
-  HTML_PLUGIN_TRIGGERS
-} from './register'
+export { createHtmlPlugin } from './createHtmlPlugin'
+export { HTML_PLUGIN_NAME, HTML_PLUGIN_TRIGGERS } from './register'

--- a/packages/cad-html-plugin/src/register.ts
+++ b/packages/cad-html-plugin/src/register.ts
@@ -11,16 +11,6 @@ export const HTML_PLUGIN_NAME = 'HtmlPlugin'
 export const HTML_PLUGIN_TRIGGERS = ['chtml'] as const
 
 /**
- * Creates an HTML export plugin instance after loading the plugin module chunk.
- *
- * @returns A loaded {@link AcApHtmlPlugin} instance
- */
-export async function createHtmlPlugin() {
-  const { AcApHtmlPlugin } = await import('./AcApHtmlPlugin')
-  return new AcApHtmlPlugin()
-}
-
-/**
  * Registers the HTML export plugin for lazy loading.
  *
  * Import from `@mlightcad/cad-html-plugin/register` so the main plugin bundle

--- a/packages/cad-html-plugin/vite.config.ts
+++ b/packages/cad-html-plugin/vite.config.ts
@@ -1,27 +1,31 @@
 import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
+import {
+  createPluginEntryFileName,
+  createPluginLibRollupOutput
+} from '../vite-config/pluginRollupOutput'
 
 const packageName = '@mlightcad/cad-html-plugin'
+const pluginId = 'cad-html-plugin'
 
 export default defineConfig({
   build: {
     outDir: 'dist',
-    // Keep false so parallel builds (nx run-many + example prebuild) do not
-    // delete viewer-runtime.iife.js produced by a concurrent viewer build.
-    emptyOutDir: false,
+    emptyOutDir: true,
     lib: {
       entry: {
         index: resolve(__dirname, 'src/index.ts'),
         register: resolve(__dirname, 'src/register.ts')
       },
-      name: 'cad-html-plugin',
+      name: pluginId,
       fileName: (format, entryName) =>
-        format === 'es' ? `${entryName}.js` : `${entryName}.umd.cjs`
+        createPluginEntryFileName(pluginId, format, entryName)
     },
     minify: true,
     rollupOptions: {
-      external: [packageName]
+      external: [packageName],
+      output: createPluginLibRollupOutput(pluginId)
     }
   },
   plugins: [peerDepsExternal() as PluginOption]

--- a/packages/cad-pdf-plugin/package.json
+++ b/packages/cad-pdf-plugin/package.json
@@ -13,8 +13,8 @@
     "README.md",
     "package.json"
   ],
-  "main": "./dist/index.umd.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/cad-pdf-plugin.umd.cjs",
+  "module": "./dist/cad-pdf-plugin.js",
   "sideEffects": false,
   "types": "./lib/index.d.ts",
   "typesVersions": {
@@ -27,13 +27,13 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "import": "./dist/cad-pdf-plugin.js",
+      "require": "./dist/cad-pdf-plugin.umd.cjs"
     },
     "./register": {
       "types": "./lib/register.d.ts",
-      "import": "./dist/register.js",
-      "require": "./dist/register.umd.cjs"
+      "import": "./dist/cad-pdf-plugin-register.js",
+      "require": "./dist/cad-pdf-plugin-register.umd.cjs"
     }
   },
   "scripts": {

--- a/packages/cad-pdf-plugin/src/createPdfPlugin.ts
+++ b/packages/cad-pdf-plugin/src/createPdfPlugin.ts
@@ -1,0 +1,10 @@
+import { AcApPdfPlugin } from './AcApPdfPlugin'
+
+/**
+ * Creates a PDF plugin instance.
+ *
+ * @returns A loaded {@link AcApPdfPlugin} instance
+ */
+export async function createPdfPlugin() {
+  return new AcApPdfPlugin()
+}

--- a/packages/cad-pdf-plugin/src/index.ts
+++ b/packages/cad-pdf-plugin/src/index.ts
@@ -8,8 +8,5 @@ export { AcApConvertToPdfCmd } from './AcApConvertToPdfCmd'
 export { AcApImportPdfCmd } from './AcApImportPdfCmd'
 export { AcApPdfConvertor } from './AcApPdfConvertor'
 export { AcApPdfImportConvertor } from './AcApPdfImportConvertor'
-export {
-  createPdfPlugin,
-  PDF_PLUGIN_NAME,
-  PDF_PLUGIN_TRIGGERS
-} from './register'
+export { createPdfPlugin } from './createPdfPlugin'
+export { PDF_PLUGIN_NAME, PDF_PLUGIN_TRIGGERS } from './register'

--- a/packages/cad-pdf-plugin/src/register.ts
+++ b/packages/cad-pdf-plugin/src/register.ts
@@ -12,16 +12,6 @@ export const PDF_PLUGIN_NAME = 'PdfPlugin'
 export const PDF_PLUGIN_TRIGGERS = ['cpdf', 'ipdf'] as const
 
 /**
- * Creates a PDF plugin instance after loading the plugin module chunk.
- *
- * @returns A loaded {@link AcApPdfPlugin} instance
- */
-export async function createPdfPlugin() {
-  const { AcApPdfPlugin } = await import('./AcApPdfPlugin')
-  return new AcApPdfPlugin()
-}
-
-/**
  * Registers the PDF plugin for lazy loading.
  *
  * Import from `@mlightcad/cad-pdf-plugin/register` so the main plugin bundle

--- a/packages/cad-pdf-plugin/vite.config.ts
+++ b/packages/cad-pdf-plugin/vite.config.ts
@@ -1,8 +1,13 @@
 import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
+import {
+  createPluginEntryFileName,
+  createPluginLibRollupOutput
+} from '../vite-config/pluginRollupOutput'
 
 const packageName = '@mlightcad/cad-pdf-plugin'
+const pluginId = 'cad-pdf-plugin'
 
 export default defineConfig({
   build: {
@@ -13,13 +18,14 @@ export default defineConfig({
         index: resolve(__dirname, 'src/index.ts'),
         register: resolve(__dirname, 'src/register.ts')
       },
-      name: 'cad-pdf-plugin',
+      name: pluginId,
       fileName: (format, entryName) =>
-        format === 'es' ? `${entryName}.js` : `${entryName}.umd.cjs`
+        createPluginEntryFileName(pluginId, format, entryName)
     },
     minify: true,
     rollupOptions: {
-      external: [packageName]
+      external: [packageName],
+      output: createPluginLibRollupOutput(pluginId)
     }
   },
   plugins: [peerDepsExternal() as PluginOption]

--- a/packages/cad-simple-viewer-example/vite.config.ts
+++ b/packages/cad-simple-viewer-example/vite.config.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { defineConfig } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
+import { exampleRollupOutput } from '../vite-config/pluginRollupOutput'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -30,7 +31,8 @@ export default defineConfig(() => {
       rollupOptions: {
         input: {
           main: resolve(__dirname, 'index.html')
-        }
+        },
+        output: exampleRollupOutput
       }
     },
     plugins: [

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -24,14 +24,14 @@
     "README.md",
     "package.json"
   ],
-  "main": "./dist/index.umd.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/cad-simple-viewer.umd.cjs",
+  "module": "./dist/cad-simple-viewer.js",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "import": "./dist/cad-simple-viewer.js",
+      "require": "./dist/cad-simple-viewer.umd.cjs"
     }
   },
   "scripts": {

--- a/packages/cad-simple-viewer/vite.config.ts
+++ b/packages/cad-simple-viewer/vite.config.ts
@@ -1,16 +1,27 @@
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
+import {
+  createLibEntryFileName
+} from '../vite-config/pluginRollupOutput'
+
+const packageId = 'cad-simple-viewer'
 
 export default defineConfig({
   build: {
     outDir: 'dist',
+    emptyOutDir: true,
     lib: {
       entry: 'src/index.ts',
-      name: 'cad-simple-viewer',
-      fileName: 'index'
+      name: packageId,
+      fileName: format => createLibEntryFileName(packageId, format)
     },
-    minify: true
+    minify: true,
+    rollupOptions: {
+      output: {
+        chunkFileNames: `${packageId}-[name]-[hash].js`
+      }
+    }
   },
   plugins: [
     peerDepsExternal() as PluginOption,

--- a/packages/cad-svg-plugin/package.json
+++ b/packages/cad-svg-plugin/package.json
@@ -13,8 +13,8 @@
     "README.md",
     "package.json"
   ],
-  "main": "./dist/index.umd.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/cad-svg-plugin.umd.cjs",
+  "module": "./dist/cad-svg-plugin.js",
   "sideEffects": false,
   "types": "./lib/index.d.ts",
   "typesVersions": {
@@ -27,13 +27,13 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "import": "./dist/cad-svg-plugin.js",
+      "require": "./dist/cad-svg-plugin.umd.cjs"
     },
     "./register": {
       "types": "./lib/register.d.ts",
-      "import": "./dist/register.js",
-      "require": "./dist/register.umd.cjs"
+      "import": "./dist/cad-svg-plugin-register.js",
+      "require": "./dist/cad-svg-plugin-register.umd.cjs"
     }
   },
   "scripts": {

--- a/packages/cad-svg-plugin/src/createSvgPlugin.ts
+++ b/packages/cad-svg-plugin/src/createSvgPlugin.ts
@@ -1,0 +1,10 @@
+import { AcApSvgPlugin } from './AcApSvgPlugin'
+
+/**
+ * Creates an SVG export plugin instance.
+ *
+ * @returns A loaded {@link AcApSvgPlugin} instance
+ */
+export async function createSvgPlugin() {
+  return new AcApSvgPlugin()
+}

--- a/packages/cad-svg-plugin/src/index.ts
+++ b/packages/cad-svg-plugin/src/index.ts
@@ -7,8 +7,5 @@
 export * from './AcSvgRenderer'
 export { AcApConvertToSvgCmd } from './AcApConvertToSvgCmd'
 export { AcApSvgConvertor } from './AcApSvgConvertor'
-export {
-  createSvgPlugin,
-  SVG_PLUGIN_NAME,
-  SVG_PLUGIN_TRIGGERS
-} from './register'
+export { createSvgPlugin } from './createSvgPlugin'
+export { SVG_PLUGIN_NAME, SVG_PLUGIN_TRIGGERS } from './register'

--- a/packages/cad-svg-plugin/src/register.ts
+++ b/packages/cad-svg-plugin/src/register.ts
@@ -11,16 +11,6 @@ export const SVG_PLUGIN_NAME = 'SvgPlugin'
 export const SVG_PLUGIN_TRIGGERS = ['csvg'] as const
 
 /**
- * Creates an SVG export plugin instance after loading the plugin module chunk.
- *
- * @returns A loaded {@link AcApSvgPlugin} instance
- */
-export async function createSvgPlugin() {
-  const { AcApSvgPlugin } = await import('./AcApSvgPlugin')
-  return new AcApSvgPlugin()
-}
-
-/**
  * Registers the SVG export plugin for lazy loading.
  *
  * Import from `@mlightcad/cad-svg-plugin/register` so the main plugin bundle

--- a/packages/cad-svg-plugin/vite.config.ts
+++ b/packages/cad-svg-plugin/vite.config.ts
@@ -1,8 +1,13 @@
 import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
+import {
+  createPluginEntryFileName,
+  createPluginLibRollupOutput
+} from '../vite-config/pluginRollupOutput'
 
 const packageName = '@mlightcad/cad-svg-plugin'
+const pluginId = 'cad-svg-plugin'
 
 export default defineConfig({
   build: {
@@ -13,13 +18,14 @@ export default defineConfig({
         index: resolve(__dirname, 'src/index.ts'),
         register: resolve(__dirname, 'src/register.ts')
       },
-      name: 'cad-svg-plugin',
+      name: pluginId,
       fileName: (format, entryName) =>
-        format === 'es' ? `${entryName}.js` : `${entryName}.umd.cjs`
+        createPluginEntryFileName(pluginId, format, entryName)
     },
     minify: true,
     rollupOptions: {
-      external: [packageName]
+      external: [packageName],
+      output: createPluginLibRollupOutput(pluginId)
     }
   },
   plugins: [peerDepsExternal() as PluginOption]

--- a/packages/cad-viewer-example/vite.config.ts
+++ b/packages/cad-viewer-example/vite.config.ts
@@ -6,6 +6,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy'
 import svgLoader from 'vite-svg-loader'
 import { visualizer } from 'rollup-plugin-visualizer'
 import vue from '@vitejs/plugin-vue'
+import { exampleRollupOutput } from '../vite-config/pluginRollupOutput'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const VIEWER_RUNTIME_SRC = '../cad-html-plugin/dist/viewer-runtime.iife.js'
@@ -94,7 +95,8 @@ export default defineConfig(({ command, mode }) => {
         // Main entry point for the app
         input: {
           main: resolve(__dirname, 'index.html')
-        }
+        },
+        output: exampleRollupOutput
       }
     },
     plugins: plugins

--- a/packages/cad-viewer/__tests__/EsmImportSupport.spec.ts
+++ b/packages/cad-viewer/__tests__/EsmImportSupport.spec.ts
@@ -14,8 +14,8 @@ describe('cad-viewer ESM import support', () => {
 
     expect(pkgJson.exports).toBeDefined()
     expect(pkgJson.exports['.']).toEqual({
-      types: './dist/index.d.ts',
-      import: './dist/index.js'
+      types: './dist/cad-viewer.d.ts',
+      import: './dist/cad-viewer.js'
     })
   })
 
@@ -53,7 +53,7 @@ describe('cad-viewer ESM import support', () => {
       ).trim()
 
       const resolvedPath = fileURLToPath(output)
-      const expectedPath = path.join(cadViewerRoot, 'dist', 'index.js')
+      const expectedPath = path.join(cadViewerRoot, 'dist', 'cad-viewer.js')
 
       expect(path.normalize(resolvedPath)).toBe(path.normalize(expectedPath))
     } finally {

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -18,13 +18,13 @@
     "mlight",
     "mlightcad"
   ],
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/cad-viewer.js",
+  "module": "./dist/cad-viewer.js",
+  "types": "./dist/cad-viewer.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/cad-viewer.d.ts",
+      "import": "./dist/cad-viewer.js"
     }
   },
   "files": [

--- a/packages/cad-viewer/vite.config.ts
+++ b/packages/cad-viewer/vite.config.ts
@@ -10,6 +10,11 @@ import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import vue from '@vitejs/plugin-vue'
 import dts from 'vite-plugin-dts'
 import { libInjectCss } from 'vite-plugin-lib-inject-css'
+import {
+  createLibEntryFileName
+} from '../vite-config/pluginRollupOutput'
+
+const packageId = 'cad-viewer'
 
 export default defineConfig(({ mode }: ConfigEnv) => {
   const plugins: PluginOption[] = [
@@ -19,7 +24,19 @@ export default defineConfig(({ mode }: ConfigEnv) => {
     peerDepsExternal() as PluginOption,
     dts({
       include: ['src/**/*.ts', 'src/**/*.vue'],
-      exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts']
+      exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+      beforeWriteFile: (filePath, content) => {
+        const normalized = filePath.replace(/\\/g, '/')
+        if (normalized.endsWith('/dist/index.d.ts')) {
+          return {
+            filePath: filePath.replace(/index\.d\.ts$/, `${packageId}.d.ts`),
+            content: content.replace(
+              '//# sourceMappingURL=index.d.ts.map',
+              `//# sourceMappingURL=${packageId}.d.ts.map`
+            )
+          }
+        }
+      }
     }) as PluginOption
   ]
 
@@ -32,8 +49,8 @@ export default defineConfig(({ mode }: ConfigEnv) => {
     build: {
       lib: {
         entry: 'src/index.ts',
-        name: 'cad-viewer',
-        fileName: 'index',
+        name: packageId,
+        fileName: format => createLibEntryFileName(packageId, format),
         formats: ['es'] as LibraryFormats[]
       },
       minify: true,
@@ -43,7 +60,11 @@ export default defineConfig(({ mode }: ConfigEnv) => {
           '@mlightcad/cad-pdf-plugin',
           '@mlightcad/cad-html-plugin',
           '@mlightcad/cad-svg-plugin'
-        ]
+        ],
+        output: {
+          chunkFileNames: `${packageId}-[name]-[hash].js`,
+          assetFileNames: `${packageId}[extname]`
+        }
       }
     },
     plugins

--- a/packages/vite-config/pluginRollupOutput.ts
+++ b/packages/vite-config/pluginRollupOutput.ts
@@ -1,0 +1,118 @@
+import type { ManualChunksOption, OutputOptions } from 'rollup'
+
+/** Export plugins with a separate lazy `/register` entry. */
+export const PLUGIN_PACKAGE_IDS = [
+  'cad-pdf-plugin',
+  'cad-html-plugin',
+  'cad-svg-plugin'
+] as const
+
+/** Core viewer libraries shipped from this monorepo. */
+export const VIEWER_PACKAGE_IDS = [
+  'cad-simple-viewer',
+  'cad-viewer',
+  'three-renderer'
+] as const
+
+function isPluginRegisterModule(id: string, pluginId: string): boolean {
+  return (
+    id.includes(`${pluginId}/register`) ||
+    id.includes(`${pluginId}\\register`) ||
+    id.includes(`${pluginId}/dist/register.`) ||
+    id.includes(`${pluginId}\\dist\\register.`) ||
+    id.includes(`${pluginId}-register`)
+  )
+}
+
+function matchMonorepoPackage(id: string, packageId: string): boolean {
+  const normalized = id.replace(/\\/g, '/')
+  return (
+    normalized.includes(`/packages/${packageId}/`) ||
+    normalized.includes(`/node_modules/@mlightcad/${packageId}/`) ||
+    normalized.includes(`@mlightcad/${packageId}/`) ||
+    normalized.includes(`@mlightcad/${packageId}`)
+  )
+}
+
+/**
+ * Groups monorepo packages into predictable Rollup chunks for example app builds.
+ */
+export const exampleManualChunks: ManualChunksOption = (id: string) => {
+  for (const pluginId of PLUGIN_PACKAGE_IDS) {
+    if (!matchMonorepoPackage(id, pluginId)) {
+      continue
+    }
+    // Register stubs are tiny; keep them in the app entry to avoid circular chunks
+    // with cad-simple-viewer (register imports plugin manager types from it).
+    if (isPluginRegisterModule(id, pluginId)) {
+      return undefined
+    }
+    return pluginId
+  }
+
+  for (const packageId of VIEWER_PACKAGE_IDS) {
+    if (matchMonorepoPackage(id, packageId)) {
+      return packageId
+    }
+  }
+}
+
+/** Rollup output options shared by cad-*-viewer-example apps. */
+export const exampleRollupOutput: OutputOptions = {
+  manualChunks: exampleManualChunks,
+  chunkFileNames: 'assets/[name]-[hash].js',
+  entryFileNames: 'assets/[name]-[hash].js',
+  assetFileNames: 'assets/[name]-[hash][extname]'
+}
+
+/** @deprecated Use {@link exampleRollupOutput}. */
+export const examplePluginRollupOutput = exampleRollupOutput
+
+/** @deprecated Use {@link exampleManualChunks}. */
+export const pluginManualChunks = exampleManualChunks
+
+export function createLibEntryFileName(
+  packageId: string,
+  format: string,
+  entryName = 'index'
+): string {
+  const base =
+    entryName === 'register' ? `${packageId}-register` : packageId
+  return format === 'es' ? `${base}.js` : `${base}.umd.cjs`
+}
+
+/** @deprecated Use {@link createLibEntryFileName}. */
+export const createPluginEntryFileName = createLibEntryFileName
+
+export function createLibChunkFileName(packageId: string): string {
+  return `${packageId}-[name]-[hash].js`
+}
+
+/** @deprecated Use {@link createLibChunkFileName}. */
+export const createPluginChunkFileName = createLibChunkFileName
+
+/**
+ * Merges all code for a library entry into a single `{packageId}` chunk
+ * (optional `{packageId}-register` when a register entry exists).
+ */
+export function createLibManualChunks(packageId: string): ManualChunksOption {
+  return (id: string) => {
+    if (/[\\/]register\.ts$/.test(id)) {
+      return `${packageId}-register`
+    }
+    return packageId
+  }
+}
+
+/** @deprecated Use {@link createLibManualChunks}. */
+export const createPluginLibManualChunks = createLibManualChunks
+
+export function createLibRollupOutput(packageId: string): OutputOptions {
+  return {
+    manualChunks: createLibManualChunks(packageId),
+    chunkFileNames: createLibChunkFileName(packageId)
+  }
+}
+
+/** @deprecated Use {@link createLibRollupOutput}. */
+export const createPluginLibRollupOutput = createLibRollupOutput


### PR DESCRIPTION
## Summary
- Rename plugin and viewer library dist outputs from generic `index.js` / `register.js` to package-scoped names (e.g. `cad-pdf-plugin.js`, `cad-simple-viewer.js`, `cad-viewer.js`).
- Consolidate plugin lazy-loading into dedicated factory modules and merge plugin lib chunks to avoid redundant intermediate bundles in dist.
- Add shared Rollup output helpers and apply `manualChunks` in example apps so assets are grouped by package (`cad-simple-viewer`, `cad-viewer`, `three-renderer`, export plugins).

## Test plan
- [x] Build `@mlightcad/cad-pdf-plugin`, `@mlightcad/cad-html-plugin`, `@mlightcad/cad-svg-plugin` and verify dist contains only prefixed entry files
- [x] Build `@mlightcad/cad-simple-viewer` and `@mlightcad/cad-viewer` and verify `cad-simple-viewer.js` / `cad-viewer.js` (+ `cad-viewer.d.ts`, `cad-viewer.css`)
- [x] Build `cad-simple-viewer-example` and `cad-viewer-example`; confirm assets named by package instead of generic `index-*.js`
- [x] `pnpm jest packages/cad-viewer/__tests__/EsmImportSupport.spec.ts` passes