### PR TITLE
feat: add PNG export to main menu and use drawing name for download

### DIFF
--- a/packages/cad-simple-viewer/src/command/convert/AcApPngConvertor.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApPngConvertor.ts
@@ -2,6 +2,7 @@ import { AcGeBox2d, AcGeVector2d } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
 import { AcApDocManager } from '../../app'
+import { resolveExportDownloadName } from '../../util/AcApExportFileNameUtil'
 import { AcTrView2d } from '../../view'
 
 /**
@@ -296,20 +297,26 @@ export class AcApPngConvertor {
    *
    * This method:
    * - Exports the canvas to a PNG data URL
-   * - Generates a timestamped filename
+   * - Uses the drawing file name as the download file name
    * - Creates and triggers a download link
    *
    * @param canvas - The canvas element containing the image
    * @private
    */
   private createFileAndDownloadIt(canvas: HTMLCanvasElement) {
+    const doc = AcApDocManager.instance.curDocument
+    const downloadName = resolveExportDownloadName(
+      doc.fileName || doc.docTitle,
+      'png'
+    )
+
     // Export canvas to PNG data URL
     const dataURL = canvas.toDataURL('image/png')
 
     // Create a download link and trigger the download
     const downloadLink = document.createElement('a')
     downloadLink.href = dataURL
-    downloadLink.download = `cad-export-${Date.now()}.png`
+    downloadLink.download = downloadName
 
     // Trigger the download
     document.body.appendChild(downloadLink)

--- a/packages/cad-viewer/src/component/layout/MlMainMenu.vue
+++ b/packages/cad-viewer/src/component/layout/MlMainMenu.vue
@@ -3,6 +3,7 @@
     v-if="features.isShowMainMenu"
     aria-hidden="false"
     class="ml-main-menu-container"
+    popper-class="ml-main-menu-popper"
     @command="handleCommand"
   >
     <el-icon class="ml-main-menu-icon" size="30">
@@ -19,6 +20,7 @@
         <el-dropdown-item class="ml-main-menu-export-item">
           <el-dropdown
             placement="right-start"
+            popper-class="ml-main-menu-export-submenu"
             trigger="hover"
             @command="handleCommand"
           >
@@ -39,6 +41,9 @@
                 }}</el-dropdown-item>
                 <el-dropdown-item command="ExportSvg">{{
                   t('main.mainMenu.exportSvg')
+                }}</el-dropdown-item>
+                <el-dropdown-item command="PngOut">{{
+                  t('main.mainMenu.exportImage')
                 }}</el-dropdown-item>
               </el-dropdown-menu>
             </template>
@@ -81,6 +86,8 @@ const handleCommand = async (command: string) => {
     AcApDocManager.instance.sendStringToExecute('cpdf')
   } else if (command === 'ExportSvg') {
     AcApDocManager.instance.sendStringToExecute('csvg')
+  } else if (command === 'PngOut') {
+    AcApDocManager.instance.sendStringToExecute('pngout')
   } else if (command === 'QNew') {
     const cmd = new AcApQNewCmd()
     cmd.trigger(AcApDocManager.instance.context)
@@ -113,11 +120,6 @@ const handleCommand = async (command: string) => {
   padding: 0;
 }
 
-.ml-main-menu-export-item :deep(.el-dropdown) {
-  display: block;
-  width: 100%;
-}
-
 .ml-main-menu-export-trigger {
   display: flex;
   align-items: center;
@@ -126,5 +128,37 @@ const handleCommand = async (command: string) => {
   padding: 5px 16px;
   line-height: 22px;
   box-sizing: border-box;
+  text-align: left;
+}
+
+:global(.ml-main-menu-popper .el-dropdown-menu__item) {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+:global(.ml-main-menu-popper .ml-main-menu-export-item) {
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: 0;
+}
+
+:global(.ml-main-menu-popper .ml-main-menu-export-item > .el-dropdown) {
+  display: flex;
+  flex: 1 1 auto;
+  width: 100%;
+  justify-content: flex-start;
+}
+
+:global(.ml-main-menu-popper .ml-main-menu-export-item .el-tooltip__trigger) {
+  display: flex;
+  flex: 1 1 auto;
+  width: 100%;
+  justify-content: flex-start;
+}
+
+:global(.ml-main-menu-export-submenu .el-dropdown-menu__item) {
+  justify-content: flex-start;
+  text-align: left;
 }
 </style>


### PR DESCRIPTION
## Summary
- Add **Export to Image** (`pngout`) to the main menu export submenu, matching the ribbon export options.
- Fix main menu export submenu layout with dedicated popper classes so items align left consistently.
- Use the current drawing file name (via `resolveExportDownloadName`) for PNG downloads instead of a timestamped `cad-export-*.png` name.

## Test plan
- [ ] Open a drawing and use Main Menu → Export → Export to Image; confirm the `pngout` command runs.
- [ ] Complete PNG export and verify the downloaded file uses the drawing name with `.png` extension.
- [ ] Check main menu and export submenu alignment (left-aligned items, export trigger fills row width).
- [ ] Smoke test other export items (PDF, SVG) still work from the main menu.