### PR TITLE
refactor: centralize command messaging in AcEdCommand

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApLayerCurCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerCurCmd.spec.ts
@@ -11,8 +11,18 @@ jest.mock('../src/app', () => ({
 }))
 
 jest.mock('../src/editor', () => {
+  const { AcApDocManager } = jest.requireMock('../src/app')
+
   class AcEdCommand {
     mode: unknown
+
+    showMessage(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
+
+    notify(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
   }
 
   class AcEdPromptSelectionOptions {

--- a/packages/cad-simple-viewer/__tests__/AcApLayerFreezeCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerFreezeCmd.spec.ts
@@ -10,8 +10,18 @@ jest.mock('../src/app', () => ({
 }))
 
 jest.mock('../src/editor', () => {
+  const { AcApDocManager } = jest.requireMock('../src/app')
+
   class AcEdCommand {
     mode: unknown
+
+    showMessage(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
+
+    notify(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
   }
 
   class MockKeywordCollection {

--- a/packages/cad-simple-viewer/__tests__/AcApLayerIsoCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerIsoCmd.spec.ts
@@ -11,8 +11,18 @@ jest.mock('../src/app', () => ({
 }))
 
 jest.mock('../src/editor', () => {
+  const { AcApDocManager } = jest.requireMock('../src/app')
+
   class AcEdCommand {
     mode: unknown
+
+    showMessage(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
+
+    notify(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
   }
 
   class MockKeywordCollection {

--- a/packages/cad-simple-viewer/__tests__/AcApLayerLockCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerLockCmd.spec.ts
@@ -10,8 +10,18 @@ jest.mock('../src/app', () => ({
 }))
 
 jest.mock('../src/editor', () => {
+  const { AcApDocManager } = jest.requireMock('../src/app')
+
   class AcEdCommand {
     mode: unknown
+
+    showMessage(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
+
+    notify(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
   }
 
   class AcEdPromptEntityOptions {

--- a/packages/cad-simple-viewer/__tests__/AcApLayerThawCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerThawCmd.spec.ts
@@ -9,8 +9,18 @@ jest.mock('../src/app', () => ({
 }))
 
 jest.mock('../src/editor', () => {
+  const { AcApDocManager } = jest.requireMock('../src/app')
+
   class AcEdCommand {
     mode: unknown
+
+    showMessage(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
+
+    notify(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
   }
 
   return {

--- a/packages/cad-simple-viewer/__tests__/AcApLayerUnisoCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerUnisoCmd.spec.ts
@@ -11,8 +11,18 @@ jest.mock('../src/app', () => ({
 }))
 
 jest.mock('../src/editor', () => {
+  const { AcApDocManager } = jest.requireMock('../src/app')
+
   class AcEdCommand {
     mode: unknown
+
+    showMessage(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
+
+    notify(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
   }
 
   class MockKeywordCollection {

--- a/packages/cad-simple-viewer/__tests__/AcApLayerUnlockCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerUnlockCmd.spec.ts
@@ -10,8 +10,18 @@ jest.mock('../src/app', () => ({
 }))
 
 jest.mock('../src/editor', () => {
+  const { AcApDocManager } = jest.requireMock('../src/app')
+
   class AcEdCommand {
     mode: unknown
+
+    showMessage(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
+
+    notify(message: string, type: string = 'info') {
+      AcApDocManager.instance.editor.showMessage(message, type)
+    }
   }
 
   class AcEdPromptEntityOptions {

--- a/packages/cad-simple-viewer/src/command/AcApCacheFontCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApCacheFontCmd.ts
@@ -41,7 +41,8 @@ export class AcApCacheFontCmd extends AcEdCommand {
     file: File,
     options?: AcApCacheFontOptions
   ): Promise<FontLoadStatus> {
-    const notify = options?.notify ?? true
+    const shouldNotify = options?.notify ?? true
+    const cmd = new AcApCacheFontCmd()
 
     try {
       const status = await AcApFontUtil.cacheFont(
@@ -50,27 +51,27 @@ export class AcApCacheFontCmd extends AcEdCommand {
         options?.aliases
       )
 
-      if (notify) {
+      if (shouldNotify) {
         if (status.status === 'Success') {
-          eventBus.emit('message', {
-            message: `${AcApI18n.t('main.message.fontCached')}: ${status.fontName}`,
-            type: 'success'
-          })
+          cmd.notify(
+            `${AcApI18n.t('main.message.fontCached')}: ${status.fontName}`,
+            'success'
+          )
         } else {
-          eventBus.emit('message', {
-            message: `${AcApI18n.t('main.message.fontCacheFailed')}: ${file.name}`,
-            type: 'error'
-          })
+          cmd.notify(
+            `${AcApI18n.t('main.message.fontCacheFailed')}: ${file.name}`,
+            'error'
+          )
         }
       }
 
       return status
     } catch {
-      if (notify) {
-        eventBus.emit('message', {
-          message: `${AcApI18n.t('main.message.fontCacheFailed')}: ${file.name}`,
-          type: 'error'
-        })
+      if (shouldNotify) {
+        cmd.notify(
+          `${AcApI18n.t('main.message.fontCacheFailed')}: ${file.name}`,
+          'error'
+        )
       }
 
       return {

--- a/packages/cad-simple-viewer/src/command/draw/AcApArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApArcCmd.ts
@@ -18,8 +18,7 @@ import {
   AcEdPromptDistanceOptions,
   AcEdPromptDoubleOptions,
   AcEdPromptPointOptions,
-  AcEdPromptStatus,
-  eventBus
+  AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 
@@ -975,10 +974,7 @@ export class AcApArcCmd extends AcEdCommand {
    * @param key - Invalid-input category key.
    */
   private warnInvalidGeometry(key: ArcInvalidKey) {
-    eventBus.emit('message', {
-      message: AcApI18n.t(`jig.arc.invalid.${key}`),
-      type: 'warning'
-    })
+    this.notify(AcApI18n.t(`jig.arc.invalid.${key}`), 'warning')
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/draw/AcApEllipseCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApEllipseCmd.ts
@@ -16,8 +16,7 @@ import {
   AcEdPromptAngleOptions,
   AcEdPromptDoubleOptions,
   AcEdPromptPointOptions,
-  AcEdPromptStatus,
-  eventBus
+  AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import { AcApLineJig } from './AcApLineCmd'
@@ -351,10 +350,7 @@ export class AcApEllipseCmd extends AcEdCommand {
    * @param key - Invalid-input category key.
    */
   private warnInvalidInput(key: 'axis' | 'otherAxis' | 'rotation') {
-    eventBus.emit('message', {
-      message: AcApI18n.t(`jig.ellipse.invalid.${key}`),
-      type: 'warning'
-    })
+    this.notify(AcApI18n.t(`jig.ellipse.invalid.${key}`), 'warning')
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/draw/AcApMLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApMLineCmd.ts
@@ -189,13 +189,13 @@ export class AcApMLineCmd extends AcEdCommand {
         ([name]) => name
       )
       if (styleNames.length <= 0) {
-        AcApDocManager.instance.editor.showMessage(
+        this.showMessage(
           AcApI18n.t('jig.mline.styleListEmpty'),
           'warning'
         )
         return
       }
-      AcApDocManager.instance.editor.showMessage(
+      this.showMessage(
         `${AcApI18n.t('jig.mline.styleListHeader')} ${styleNames.join(', ')}`,
         'info'
       )

--- a/packages/cad-simple-viewer/src/command/draw/AcApPolygonCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApPolygonCmd.ts
@@ -14,8 +14,7 @@ import {
   AcEdPreviewJig,
   AcEdPromptPointOptions,
   AcEdPromptStatus,
-  AcEdPromptStringOptions,
-  eventBus
+  AcEdPromptStringOptions
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 
@@ -308,10 +307,7 @@ export class AcApPolygonCmd extends AcEdCommand {
    * @param key - Invalid-input category.
    */
   private warnInvalidInput(key: PolygonInvalidKey) {
-    eventBus.emit('message', {
-      message: AcApI18n.t(`jig.polygon.invalid.${key}`),
-      type: 'warning'
-    })
+    this.notify(AcApI18n.t(`jig.polygon.invalid.${key}`), 'warning')
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/draw/AcApRectCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApRectCmd.ts
@@ -19,8 +19,7 @@ import {
   AcEdPromptState,
   AcEdPromptStateMachine,
   AcEdPromptStateStep,
-  AcEdPromptStatus,
-  eventBus
+  AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 
@@ -91,13 +90,6 @@ function addDoubleKeyword(
     AcApI18n.t(`jig.rect.keywords.${key}.global`),
     AcApI18n.t(`jig.rect.keywords.${key}.local`)
   )
-}
-
-function warnRectMessage(key: string) {
-  eventBus.emit('message', {
-    message: AcApI18n.t(`jig.rect.${key}`),
-    type: 'warning'
-  })
 }
 
 function toWorldPoint(
@@ -428,16 +420,25 @@ export class AcApRectCmd extends AcEdCommand {
     const rect = new AcDbPolyline()
     const isValid = updateRect(rect, firstPoint, secondInput, settings)
     if (!isValid) {
-      warnRectMessage('invalidRect')
+      this.warnRectMessage('invalidRect')
       return
     }
 
     if (AcGeTol.isPositive(settings.thickness)) {
-      warnRectMessage('thicknessNotSupported')
+      this.warnRectMessage('thicknessNotSupported')
     }
 
     context.doc.database.tables.blockTable.modelSpace.appendEntity(rect)
     AcApRectCmd._settings = cloneRectSettings(settings)
+  }
+
+  /**
+   * Emits a warning message for invalid rectangle input.
+   *
+   * @param key - Invalid-input category key under `jig.rect`.
+   */
+  private warnRectMessage(key: string) {
+    this.notify(AcApI18n.t(`jig.rect.${key}`), 'warning')
   }
 
   /**
@@ -610,7 +611,7 @@ export class AcApRectCmd extends AcEdCommand {
       const result = await AcApDocManager.instance.editor.getDouble(prompt)
       if (result.status !== AcEdPromptStatus.OK) return undefined
       if (isPositive(result.value)) return result.value!
-      warnRectMessage('invalidPositive')
+      this.warnRectMessage('invalidPositive')
     }
   }
 

--- a/packages/cad-simple-viewer/src/command/draw/AcApXLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApXLineCmd.ts
@@ -88,7 +88,7 @@ export class AcApXLineCmd extends AcEdCommand {
           z: secondResult.value.z - startResult.value.z
         }
         if (!this.appendFiniteXLine(context, startResult.value, direction)) {
-          AcApDocManager.instance.editor.showMessage(
+          this.showMessage(
             AcApI18n.t('jig.xline.invalidDirection'),
             'warning'
           )

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerCmd.ts
@@ -7,7 +7,6 @@ import {
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdCommand,
-  AcEdMessageType,
   AcEdOpenMode,
   AcEdPromptKeywordOptions,
   AcEdPromptStatus,
@@ -170,16 +169,6 @@ export class AcApLayerCmd extends AcEdCommand {
   }
 
   /**
-   * Emits one user-facing message through the command-line output.
-   *
-   * @param message - Message text to display.
-   * @param type - Message severity category.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
-  }
-
-  /**
    * Prints all layer states to browser console and reports summary in UI.
    *
    * The list contains the current-layer marker and common status columns
@@ -199,7 +188,7 @@ export class AcApLayerCmd extends AcEdCommand {
       color: layer.color.toString()
     }))
     console.table(rows)
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.layer.listSummary')} (${rows.length})`,
       'info'
     )
@@ -297,7 +286,7 @@ export class AcApLayerCmd extends AcEdCommand {
     ].map(layer => layer.name)
     const names = this.parseLayerNameInput(result.stringResult ?? '', allNames)
     if (!names.length) {
-      this.notify(AcApI18n.t('jig.layer.emptyInput'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layer.emptyInput'), 'warning')
       return undefined
     }
     return names
@@ -358,10 +347,10 @@ export class AcApLayerCmd extends AcEdCommand {
     })
 
     if (created > 0) {
-      this.notify(`${AcApI18n.t('jig.layer.created')}: ${created}`, 'success')
+      this.showMessage(`${AcApI18n.t('jig.layer.created')}: ${created}`, 'success')
     }
     if (existed.length > 0) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layer.alreadyExists')}: ${existed.join(', ')}`,
         'warning'
       )
@@ -385,7 +374,7 @@ export class AcApLayerCmd extends AcEdCommand {
 
     const layer = context.doc.database.tables.layerTable.getAt(name)
     if (!layer) {
-      this.notify(`${AcApI18n.t('jig.layer.notFound')}: ${name}`, 'warning')
+      this.showMessage(`${AcApI18n.t('jig.layer.notFound')}: ${name}`, 'warning')
       return
     }
 
@@ -449,7 +438,7 @@ export class AcApLayerCmd extends AcEdCommand {
     const db = context.doc.database
     const { layers, missing } = this.resolveLayers(context, names)
     if (missing.length > 0) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layer.notFound')}: ${missing.join(', ')}`,
         'warning'
       )
@@ -465,7 +454,7 @@ export class AcApLayerCmd extends AcEdCommand {
     })
 
     if (skippedCurrent.length > 0) {
-      this.notify(AcApI18n.t('jig.layer.cannotChangeCurrent'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layer.cannotChangeCurrent'), 'warning')
     }
   }
 
@@ -491,7 +480,7 @@ export class AcApLayerCmd extends AcEdCommand {
     const db = context.doc.database
     const { layers, missing } = this.resolveLayers(context, names)
     if (missing.length > 0) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layer.notFound')}: ${missing.join(', ')}`,
         'warning'
       )
@@ -507,7 +496,7 @@ export class AcApLayerCmd extends AcEdCommand {
     })
 
     if (skippedCurrent.length > 0) {
-      this.notify(AcApI18n.t('jig.layer.cannotChangeCurrent'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layer.cannotChangeCurrent'), 'warning')
     }
   }
 
@@ -531,7 +520,7 @@ export class AcApLayerCmd extends AcEdCommand {
 
     const { layers, missing } = this.resolveLayers(context, names)
     if (missing.length > 0) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layer.notFound')}: ${missing.join(', ')}`,
         'warning'
       )
@@ -593,7 +582,7 @@ export class AcApLayerCmd extends AcEdCommand {
 
     const { layers, missing } = this.resolveLayers(context, names)
     if (missing.length > 0) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layer.notFound')}: ${missing.join(', ')}`,
         'warning'
       )
@@ -610,7 +599,7 @@ export class AcApLayerCmd extends AcEdCommand {
 
     const color = this.parseColorInput(colorResult.stringResult ?? '')
     if (!color) {
-      this.notify(AcApI18n.t('jig.layer.invalidColor'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layer.invalidColor'), 'warning')
       return
     }
 
@@ -636,7 +625,7 @@ export class AcApLayerCmd extends AcEdCommand {
 
     const layer = context.doc.database.tables.layerTable.getAt(name)
     if (!layer) {
-      this.notify(`${AcApI18n.t('jig.layer.notFound')}: ${name}`, 'warning')
+      this.showMessage(`${AcApI18n.t('jig.layer.notFound')}: ${name}`, 'warning')
       return
     }
 

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerCurCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerCurCmd.ts
@@ -3,7 +3,6 @@ import { AcDbEntity, AcDbObjectId } from '@mlightcad/data-model'
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdCommand,
-  AcEdMessageType,
   AcEdOpenMode,
   AcEdPromptSelectionOptions,
   AcEdPromptStatus
@@ -73,7 +72,7 @@ export class AcApLayerCurCmd extends AcEdCommand {
       : undefined
 
     if (!currentLayer) {
-      this.notify(AcApI18n.t('jig.laycur.currentLayerNotFound'), 'warning')
+      this.showMessage(AcApI18n.t('jig.laycur.currentLayerNotFound'), 'warning')
       return
     }
 
@@ -98,7 +97,7 @@ export class AcApLayerCurCmd extends AcEdCommand {
     })
 
     if (changedEntities.length === 0) {
-      this.notify(
+      this.showMessage(
         alreadyCurrent > 0
           ? AcApI18n.t('jig.laycur.alreadyCurrent')
           : AcApI18n.t('jig.laycur.noObjects'),
@@ -111,19 +110,9 @@ export class AcApLayerCurCmd extends AcEdCommand {
     context.view.selectionSet.clear()
     // Layer changes move entities between render buckets, so rebuild the view.
     AcApDocManager.instance.regen()
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.laycur.changed')}: ${changedEntities.length} (${currentLayer.name})`,
       'success'
     )
-  }
-
-  /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerDelCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerDelCmd.ts
@@ -7,7 +7,6 @@ import {
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdCommand,
-  AcEdMessageType,
   AcEdOpenMode,
   AcEdPromptEntityOptions,
   AcEdPromptStatus,
@@ -144,16 +143,6 @@ export class AcApLayerDelCmd extends AcEdCommand {
   }
 
   /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
-  }
-
-  /**
    * Registers a localized keyword on an entity or string prompt.
    *
    * @param prompt - Prompt instance that should expose the keyword.
@@ -272,7 +261,7 @@ export class AcApLayerDelCmd extends AcEdCommand {
       locked: layer.isLocked ? 'Yes' : 'No'
     }))
     console.table(rows)
-    this.notify(AcApI18n.t('jig.laydel.layerListSummary'), 'info')
+    this.showMessage(AcApI18n.t('jig.laydel.layerListSummary'), 'info')
   }
 
   /**
@@ -287,7 +276,7 @@ export class AcApLayerDelCmd extends AcEdCommand {
     const layerName = entity?.layer?.trim()
 
     if (!layerName) {
-      this.notify(AcApI18n.t('jig.laydel.invalidSelection'), 'warning')
+      this.showMessage(AcApI18n.t('jig.laydel.invalidSelection'), 'warning')
       return
     }
 
@@ -308,17 +297,17 @@ export class AcApLayerDelCmd extends AcEdCommand {
     const layer = db.tables.layerTable.getAt(layerName)
 
     if (!layer) {
-      this.notify(`${AcApI18n.t('jig.laydel.layerNotFound')}: ${layerName}`)
+      this.showMessage(`${AcApI18n.t('jig.laydel.layerNotFound')}: ${layerName}`)
       return
     }
 
     if (layer.name === '0') {
-      this.notify(AcApI18n.t('jig.laydel.cannotDeleteZeroLayer'), 'warning')
+      this.showMessage(AcApI18n.t('jig.laydel.cannotDeleteZeroLayer'), 'warning')
       return
     }
 
     if (layer.name === db.clayer) {
-      this.notify(AcApI18n.t('jig.laydel.cannotDeleteCurrent'), 'warning')
+      this.showMessage(AcApI18n.t('jig.laydel.cannotDeleteCurrent'), 'warning')
       return
     }
 
@@ -336,7 +325,7 @@ export class AcApLayerDelCmd extends AcEdCommand {
 
     context.view.selectionSet.clear()
     AcApDocManager.instance.regen()
-    this.notify(`${AcApI18n.t('jig.laydel.deleted')}: ${layer.name}`, 'success')
+    this.showMessage(`${AcApI18n.t('jig.laydel.deleted')}: ${layer.name}`, 'success')
   }
 
   /**
@@ -400,7 +389,7 @@ export class AcApLayerDelCmd extends AcEdCommand {
   private runUndo(context: AcApContext) {
     const entry = this._history.pop()
     if (!entry) {
-      this.notify(AcApI18n.t('jig.laydel.nothingToUndo'), 'warning')
+      this.showMessage(AcApI18n.t('jig.laydel.nothingToUndo'), 'warning')
       return
     }
 
@@ -424,7 +413,7 @@ export class AcApLayerDelCmd extends AcEdCommand {
 
     context.view.selectionSet.clear()
     AcApDocManager.instance.regen()
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.laydel.restored')}: ${entry.layer.name}`,
       'success'
     )

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerFreezeCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerFreezeCmd.ts
@@ -3,7 +3,6 @@ import { AcDbLayerTableRecord, AcDbObjectId } from '@mlightcad/data-model'
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdCommand,
-  AcEdMessageType,
   AcEdOpenMode,
   AcEdPromptEntityOptions,
   AcEdPromptKeywordOptions,
@@ -144,16 +143,6 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
   }
 
   /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
-  }
-
-  /**
    * Registers a localized keyword on an entity or keyword prompt.
    *
    * @param prompt - Prompt instance that should expose the keyword to the user.
@@ -282,7 +271,7 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
     AcApLayerFreezeCmd._settings.viewportMode = keyword
     if (keyword === 'Vpfreeze') {
       this._vpfreezeHintShown = true
-      this.notify(AcApI18n.t('jig.layfrz.vpfreezeFallback'))
+      this.showMessage(AcApI18n.t('jig.layfrz.vpfreezeFallback'))
     } else {
       this._vpfreezeHintShown = false
     }
@@ -332,7 +321,7 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
     if (!keyword) return
 
     AcApLayerFreezeCmd._settings.blockSelectionMode = keyword
-    this.notify(AcApI18n.t('jig.layfrz.nestedSelectionLimited'))
+    this.showMessage(AcApI18n.t('jig.layfrz.nestedSelectionLimited'))
   }
 
   /**
@@ -361,13 +350,13 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
     const layerName = entity?.layer?.trim()
 
     if (!layerName) {
-      this.notify(AcApI18n.t('jig.layfrz.invalidSelection'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layfrz.invalidSelection'), 'warning')
       return
     }
 
     const layer = db.tables.layerTable.getAt(layerName)
     if (!layer) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layfrz.layerNotFound')}: ${layerName}`,
         'warning'
       )
@@ -375,12 +364,12 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
     }
 
     if (layer.name === db.clayer) {
-      this.notify(AcApI18n.t('jig.layfrz.cannotFreezeCurrent'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layfrz.cannotFreezeCurrent'), 'warning')
       return
     }
 
     if (layer.isFrozen) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layfrz.alreadyFrozen')}: ${layer.name}`,
         'info'
       )
@@ -391,7 +380,7 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
       AcApLayerFreezeCmd._settings.viewportMode === 'Vpfreeze' &&
       !this._vpfreezeHintShown
     ) {
-      this.notify(AcApI18n.t('jig.layfrz.vpfreezeFallback'))
+      this.showMessage(AcApI18n.t('jig.layfrz.vpfreezeFallback'))
       this._vpfreezeHintShown = true
     }
 
@@ -402,7 +391,7 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
 
     this.setLayerFrozen(layer, true)
     context.view.selectionSet.clear()
-    this.notify(`${AcApI18n.t('jig.layfrz.frozen')}: ${layer.name}`, 'success')
+    this.showMessage(`${AcApI18n.t('jig.layfrz.frozen')}: ${layer.name}`, 'success')
   }
 
   /**
@@ -413,7 +402,7 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
   private runUndo(context: AcApContext) {
     const history = this._history.pop()
     if (!history) {
-      this.notify(AcApI18n.t('jig.layfrz.nothingToUndo'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layfrz.nothingToUndo'), 'warning')
       return
     }
 
@@ -421,7 +410,7 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
       history.layerName
     )
     if (!layer) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layfrz.layerNotFound')}: ${history.layerName}`,
         'warning'
       )
@@ -430,7 +419,7 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
 
     this.setLayerFrozen(layer, history.wasFrozen)
     context.view.selectionSet.clear()
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.layfrz.restored')}: ${layer.name}`,
       'success'
     )

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerIsoCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerIsoCmd.ts
@@ -3,7 +3,6 @@ import { AcDbLayerTableRecord, AcDbObjectId } from '@mlightcad/data-model'
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdCommand,
-  AcEdMessageType,
   AcEdOpenMode,
   AcEdPromptKeywordOptions,
   AcEdPromptSelectionOptions,
@@ -130,16 +129,6 @@ export class AcApLayerIsoCmd extends AcEdCommand {
   }
 
   /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
-  }
-
-  /**
    * Registers a localized keyword on a prompt.
    *
    * @param prompt - Prompt instance that should expose the keyword.
@@ -229,7 +218,7 @@ export class AcApLayerIsoCmd extends AcEdCommand {
     }
 
     this._lockFadeHintShown = true
-    this.notify(AcApI18n.t('jig.layiso.lockFadeFallback'))
+    this.showMessage(AcApI18n.t('jig.layiso.lockFadeFallback'))
   }
 
   /**
@@ -269,7 +258,7 @@ export class AcApLayerIsoCmd extends AcEdCommand {
     AcApLayerIsoCmd._settings.offMode = keyword
     if (keyword === 'Vpfreeze') {
       this._vpfreezeHintShown = true
-      this.notify(AcApI18n.t('jig.layiso.vpfreezeFallback'))
+      this.showMessage(AcApI18n.t('jig.layiso.vpfreezeFallback'))
     } else {
       this._vpfreezeHintShown = false
     }
@@ -309,7 +298,7 @@ export class AcApLayerIsoCmd extends AcEdCommand {
   ) {
     const layerNames = this.collectSelectedLayerNames(context, objectIds)
     if (layerNames.length === 0) {
-      this.notify(AcApI18n.t('jig.layiso.noLayers'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layiso.noLayers'), 'warning')
       return
     }
 
@@ -387,7 +376,7 @@ export class AcApLayerIsoCmd extends AcEdCommand {
       AcApLayerIsoCmd._settings.offMode === 'Vpfreeze' &&
       !this._vpfreezeHintShown
     ) {
-      this.notify(AcApI18n.t('jig.layiso.vpfreezeFallback'))
+      this.showMessage(AcApI18n.t('jig.layiso.vpfreezeFallback'))
       this._vpfreezeHintShown = true
     }
 
@@ -395,12 +384,12 @@ export class AcApLayerIsoCmd extends AcEdCommand {
       AcApLayerIsoCmd._settings.isolationMode === 'LockAndFade' &&
       !this._lockFadeHintShown
     ) {
-      this.notify(AcApI18n.t('jig.layiso.lockFadeFallback'))
+      this.showMessage(AcApI18n.t('jig.layiso.lockFadeFallback'))
       this._lockFadeHintShown = true
     }
 
     context.view.selectionSet.clear()
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.layiso.isolated')}: ${layerNames.join(', ')} (${AcApI18n.t('jig.layiso.affectedLayers')}: ${affectedLayerNames.size})`,
       'success'
     )
@@ -435,7 +424,7 @@ export class AcApLayerIsoCmd extends AcEdCommand {
     })
 
     if (missing.size > 0) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layiso.layerNotFound')}: ${[...missing].join(', ')}`,
         'warning'
       )

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerLockCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerLockCmd.ts
@@ -3,7 +3,6 @@ import { AcDbLayerTableRecord, AcDbObjectId } from '@mlightcad/data-model'
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdCommand,
-  AcEdMessageType,
   AcEdOpenMode,
   AcEdPromptEntityOptions,
   AcEdPromptStatus
@@ -83,13 +82,13 @@ export class AcApLayerLockCmd extends AcEdCommand {
     const layerName = entity?.layer?.trim()
 
     if (!layerName) {
-      this.notify(AcApI18n.t('jig.laylck.invalidSelection'), 'warning')
+      this.showMessage(AcApI18n.t('jig.laylck.invalidSelection'), 'warning')
       return
     }
 
     const layer = db.tables.layerTable.getAt(layerName)
     if (!layer) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.laylck.layerNotFound')}: ${layerName}`,
         'warning'
       )
@@ -97,7 +96,7 @@ export class AcApLayerLockCmd extends AcEdCommand {
     }
 
     if (layer.isLocked) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.laylck.alreadyLocked')}: ${layer.name}`,
         'info'
       )
@@ -106,16 +105,6 @@ export class AcApLayerLockCmd extends AcEdCommand {
 
     this.setLayerLocked(layer, true)
     context.view.selectionSet.clear()
-    this.notify(`${AcApI18n.t('jig.laylck.locked')}: ${layer.name}`, 'success')
-  }
-
-  /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
+    this.showMessage(`${AcApI18n.t('jig.laylck.locked')}: ${layer.name}`, 'success')
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerOffCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerOffCmd.ts
@@ -3,7 +3,6 @@ import { AcDbObjectId } from '@mlightcad/data-model'
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdCommand,
-  AcEdMessageType,
   AcEdOpenMode,
   AcEdPromptEntityOptions,
   AcEdPromptKeywordOptions,
@@ -143,16 +142,6 @@ export class AcApLayoffCmd extends AcEdCommand {
   }
 
   /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
-  }
-
-  /**
    * Registers a localized keyword on an entity or keyword prompt.
    *
    * @param prompt - Prompt instance that should expose the keyword to the user.
@@ -279,7 +268,7 @@ export class AcApLayoffCmd extends AcEdCommand {
     AcApLayoffCmd._settings.viewportMode = keyword
     if (keyword === 'Vpfreeze') {
       this._vpfreezeHintShown = true
-      this.notify(AcApI18n.t('jig.layoff.vpfreezeFallback'))
+      this.showMessage(AcApI18n.t('jig.layoff.vpfreezeFallback'))
     } else {
       this._vpfreezeHintShown = false
     }
@@ -329,7 +318,7 @@ export class AcApLayoffCmd extends AcEdCommand {
     if (!keyword) return
 
     AcApLayoffCmd._settings.blockSelectionMode = keyword
-    this.notify(AcApI18n.t('jig.layoff.nestedSelectionLimited'))
+    this.showMessage(AcApI18n.t('jig.layoff.nestedSelectionLimited'))
   }
 
   /**
@@ -347,13 +336,13 @@ export class AcApLayoffCmd extends AcEdCommand {
     const layerName = entity?.layer?.trim()
 
     if (!layerName) {
-      this.notify(AcApI18n.t('jig.layoff.invalidSelection'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layoff.invalidSelection'), 'warning')
       return
     }
 
     const layer = db.tables.layerTable.getAt(layerName)
     if (!layer) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layoff.layerNotFound')}: ${layerName}`,
         'warning'
       )
@@ -361,12 +350,12 @@ export class AcApLayoffCmd extends AcEdCommand {
     }
 
     if (layer.name === db.clayer) {
-      this.notify(AcApI18n.t('jig.layoff.cannotTurnOffCurrent'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layoff.cannotTurnOffCurrent'), 'warning')
       return
     }
 
     if (layer.isOff) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layoff.alreadyOff')}: ${layer.name}`,
         'info'
       )
@@ -377,7 +366,7 @@ export class AcApLayoffCmd extends AcEdCommand {
       AcApLayoffCmd._settings.viewportMode === 'Vpfreeze' &&
       !this._vpfreezeHintShown
     ) {
-      this.notify(AcApI18n.t('jig.layoff.vpfreezeFallback'))
+      this.showMessage(AcApI18n.t('jig.layoff.vpfreezeFallback'))
       this._vpfreezeHintShown = true
     }
 
@@ -388,7 +377,7 @@ export class AcApLayoffCmd extends AcEdCommand {
 
     layer.isOff = true
     context.view.selectionSet.clear()
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.layoff.turnedOff')}: ${layer.name}`,
       'success'
     )
@@ -402,7 +391,7 @@ export class AcApLayoffCmd extends AcEdCommand {
   private runUndo(context: AcApContext) {
     const history = this._history.pop()
     if (!history) {
-      this.notify(AcApI18n.t('jig.layoff.nothingToUndo'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layoff.nothingToUndo'), 'warning')
       return
     }
 
@@ -410,7 +399,7 @@ export class AcApLayoffCmd extends AcEdCommand {
       history.layerName
     )
     if (!layer) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layoff.layerNotFound')}: ${history.layerName}`,
         'warning'
       )
@@ -419,7 +408,7 @@ export class AcApLayoffCmd extends AcEdCommand {
 
     layer.isOff = history.wasOff
     context.view.selectionSet.clear()
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.layoff.restored')}: ${layer.name}`,
       'success'
     )

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerOnCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerOnCmd.ts
@@ -1,5 +1,5 @@
-import { AcApContext, AcApDocManager } from '../../app'
-import { AcEdCommand, AcEdMessageType, AcEdOpenMode } from '../../editor'
+import { AcApContext } from '../../app'
+import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcApI18n } from '../../i18n'
 
 /**
@@ -37,20 +37,10 @@ export class AcApLayerOnCmd extends AcEdCommand {
     context.view.selectionSet.clear()
 
     if (turnedOn === 0) {
-      this.notify(AcApI18n.t('jig.layon.alreadyOn'))
+      this.showMessage(AcApI18n.t('jig.layon.alreadyOn'))
       return
     }
 
-    this.notify(`${AcApI18n.t('jig.layon.turnedOn')}: ${turnedOn}`, 'success')
-  }
-
-  /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
+    this.showMessage(`${AcApI18n.t('jig.layon.turnedOn')}: ${turnedOn}`, 'success')
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerPCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerPCmd.ts
@@ -1,7 +1,7 @@
 import { AcDbLayerTableRecord } from '@mlightcad/data-model'
 
-import { AcApContext, AcApDocManager } from '../../app'
-import { AcEdCommand, AcEdMessageType, AcEdOpenMode } from '../../editor'
+import { AcApContext } from '../../app'
+import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcApI18n } from '../../i18n'
 
 /**
@@ -150,22 +150,12 @@ export class AcApLayerPCmd extends AcEdCommand {
    */
   async execute(context: AcApContext) {
     if (layerPreviousStateManager.restorePreviousState(context)) {
-      this.notify(AcApI18n.t('jig.layerp.restored'), 'success')
+      this.showMessage(AcApI18n.t('jig.layerp.restored'), 'success')
     } else {
-      this.notify(AcApI18n.t('jig.layerp.noPreviousState'))
+      this.showMessage(AcApI18n.t('jig.layerp.noPreviousState'))
     }
 
     context.view.selectionSet.clear()
-  }
-
-  /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerThawCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerThawCmd.ts
@@ -1,7 +1,7 @@
 import { AcDbLayerTableRecord } from '@mlightcad/data-model'
 
-import { AcApContext, AcApDocManager } from '../../app'
-import { AcEdCommand, AcEdMessageType, AcEdOpenMode } from '../../editor'
+import { AcApContext } from '../../app'
+import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcApI18n } from '../../i18n'
 
 /**
@@ -39,11 +39,11 @@ export class AcApLayerThawCmd extends AcEdCommand {
     context.view.selectionSet.clear()
 
     if (thawed === 0) {
-      this.notify(AcApI18n.t('jig.laythw.alreadyThawed'))
+      this.showMessage(AcApI18n.t('jig.laythw.alreadyThawed'))
       return
     }
 
-    this.notify(`${AcApI18n.t('jig.laythw.thawed')}: ${thawed}`, 'success')
+    this.showMessage(`${AcApI18n.t('jig.laythw.thawed')}: ${thawed}`, 'success')
   }
 
   /**
@@ -55,15 +55,5 @@ export class AcApLayerThawCmd extends AcEdCommand {
   private setLayerFrozen(layer: AcDbLayerTableRecord, frozen: boolean) {
     const flags = layer.standardFlags ?? 0
     layer.standardFlags = frozen ? flags | 0x01 : flags & ~0x01
-  }
-
-  /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerUnisoCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerUnisoCmd.ts
@@ -1,7 +1,7 @@
 import { AcDbLayerTableRecord } from '@mlightcad/data-model'
 
-import { AcApContext, AcApDocManager } from '../../app'
-import { AcEdCommand, AcEdMessageType, AcEdOpenMode } from '../../editor'
+import { AcApContext } from '../../app'
+import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import {
   AcApLayerIsoLayerSnapshot,
@@ -33,7 +33,7 @@ export class AcApLayerUnisoCmd extends AcEdCommand {
   async execute(context: AcApContext) {
     const snapshot = AcApLayerIsoState.consume()
     if (!snapshot) {
-      this.notify(AcApI18n.t('jig.layuniso.noPrevious'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layuniso.noPrevious'), 'warning')
       return
     }
 
@@ -44,7 +44,7 @@ export class AcApLayerUnisoCmd extends AcEdCommand {
     for (const entry of snapshot.layers) {
       const layer = table.getAt(entry.name)
       if (!layer) {
-        this.notify(
+        this.showMessage(
           `${AcApI18n.t('jig.layuniso.layerNotFound')}: ${entry.name}`,
           'warning'
         )
@@ -67,11 +67,11 @@ export class AcApLayerUnisoCmd extends AcEdCommand {
     context.view.selectionSet.clear()
 
     if (restoredLayers === 0) {
-      this.notify(AcApI18n.t('jig.layuniso.nothingRestored'))
+      this.showMessage(AcApI18n.t('jig.layuniso.nothingRestored'))
       return
     }
 
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.layuniso.restored')}: ${restoredLayers}`,
       'success'
     )
@@ -137,15 +137,5 @@ export class AcApLayerUnisoCmd extends AcEdCommand {
   private setLayerLocked(layer: AcDbLayerTableRecord, locked: boolean) {
     const flags = layer.standardFlags ?? 0
     layer.standardFlags = locked ? flags | 0x04 : flags & ~0x04
-  }
-
-  /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerUnlockCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerUnlockCmd.ts
@@ -3,7 +3,6 @@ import { AcDbLayerTableRecord, AcDbObjectId } from '@mlightcad/data-model'
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdCommand,
-  AcEdMessageType,
   AcEdOpenMode,
   AcEdPromptEntityOptions,
   AcEdPromptStatus
@@ -83,13 +82,13 @@ export class AcApLayerUnlockCmd extends AcEdCommand {
     const layerName = entity?.layer?.trim()
 
     if (!layerName) {
-      this.notify(AcApI18n.t('jig.layulk.invalidSelection'), 'warning')
+      this.showMessage(AcApI18n.t('jig.layulk.invalidSelection'), 'warning')
       return
     }
 
     const layer = db.tables.layerTable.getAt(layerName)
     if (!layer) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layulk.layerNotFound')}: ${layerName}`,
         'warning'
       )
@@ -97,7 +96,7 @@ export class AcApLayerUnlockCmd extends AcEdCommand {
     }
 
     if (!layer.isLocked) {
-      this.notify(
+      this.showMessage(
         `${AcApI18n.t('jig.layulk.alreadyUnlocked')}: ${layer.name}`,
         'info'
       )
@@ -106,19 +105,9 @@ export class AcApLayerUnlockCmd extends AcEdCommand {
 
     this.setLayerLocked(layer, false)
     context.view.selectionSet.clear()
-    this.notify(
+    this.showMessage(
       `${AcApI18n.t('jig.layulk.unlocked')}: ${layer.name}`,
       'success'
     )
-  }
-
-  /**
-   * Sends a localized status message through the command-line output.
-   *
-   * @param message - Text to display to the user.
-   * @param type - Visual severity mapped to command-line message styles.
-   */
-  private notify(message: string, type: AcEdMessageType = 'info') {
-    AcApDocManager.instance.editor.showMessage(message, type)
   }
 }

--- a/packages/cad-simple-viewer/src/command/modify/AcApHideObjectsCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApHideObjectsCmd.ts
@@ -39,7 +39,7 @@ export class AcApHideObjectsCmd extends AcEdCommand {
 
     const count = hideObjects(context, objectIds)
     if (count > 0) {
-      AcApDocManager.instance.editor.showMessage(
+      this.showMessage(
         `${count} ${AcApI18n.t('jig.hideobjects.hidden')}`,
         'success'
       )

--- a/packages/cad-simple-viewer/src/command/modify/AcApOffsetCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApOffsetCmd.ts
@@ -216,6 +216,7 @@ export class AcApOffsetCmd extends AcEdCommand {
    * @param context - Current application/document context.
    */
   async execute(context: AcApContext) {
+    const cmd = this
     const blockTable = context.doc.database.tables.blockTable
     const annotation = new AcApAnnotation(context.doc.database)
     let offsetDistance: number | undefined
@@ -287,7 +288,7 @@ export class AcApOffsetCmd extends AcEdCommand {
           !Number.isFinite(result.value) ||
           AcGeTol.isNonPositive(result.value)
         ) {
-          AcApDocManager.instance.editor.showMessage(
+          cmd.showMessage(
             AcApI18n.t('jig.offset.invalidDistance'),
             'warning'
           )
@@ -351,7 +352,7 @@ export class AcApOffsetCmd extends AcEdCommand {
             : [result.objectId]
         const entity = blockTable.getEntityById(validIds[0])
         if (!isOffsettableCurve(entity)) {
-          AcApDocManager.instance.editor.showMessage(
+          cmd.showMessage(
             AcApI18n.t('jig.offset.invalidSelection'),
             'warning'
           )
@@ -431,7 +432,7 @@ export class AcApOffsetCmd extends AcEdCommand {
           new AcGePoint3d(result.value)
         )
         if (offsetCurves.length === 0) {
-          AcApDocManager.instance.editor.showMessage(
+          cmd.showMessage(
             AcApI18n.t('jig.offset.offsetFailed'),
             'warning'
           )

--- a/packages/cad-simple-viewer/src/command/modify/AcApOffsetCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApOffsetCmd.ts
@@ -10,6 +10,7 @@ import { AcApAnnotation, AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdBaseView,
   AcEdCommand,
+  AcEdMessageType,
   AcEdOpenMode,
   AcEdPreviewJig,
   AcEdPromptDistanceOptions,
@@ -21,8 +22,7 @@ import {
   AcEdPromptState,
   AcEdPromptStateMachine,
   AcEdPromptStateStep,
-  AcEdPromptStatus
-} from '../../editor'
+  AcEdPromptStatus} from '../../editor'
 import { AcApI18n } from '../../i18n'
 
 /**
@@ -216,7 +216,12 @@ export class AcApOffsetCmd extends AcEdCommand {
    * @param context - Current application/document context.
    */
   async execute(context: AcApContext) {
-    const cmd = this
+    const showCommandMessage = (
+      message: string,
+      type: AcEdMessageType = 'info'
+    ) => {
+      this.showMessage(message, type)
+    }
     const blockTable = context.doc.database.tables.blockTable
     const annotation = new AcApAnnotation(context.doc.database)
     let offsetDistance: number | undefined
@@ -288,7 +293,7 @@ export class AcApOffsetCmd extends AcEdCommand {
           !Number.isFinite(result.value) ||
           AcGeTol.isNonPositive(result.value)
         ) {
-          cmd.showMessage(
+          showCommandMessage(
             AcApI18n.t('jig.offset.invalidDistance'),
             'warning'
           )
@@ -352,7 +357,7 @@ export class AcApOffsetCmd extends AcEdCommand {
             : [result.objectId]
         const entity = blockTable.getEntityById(validIds[0])
         if (!isOffsettableCurve(entity)) {
-          cmd.showMessage(
+          showCommandMessage(
             AcApI18n.t('jig.offset.invalidSelection'),
             'warning'
           )
@@ -432,7 +437,7 @@ export class AcApOffsetCmd extends AcEdCommand {
           new AcGePoint3d(result.value)
         )
         if (offsetCurves.length === 0) {
-          cmd.showMessage(
+          showCommandMessage(
             AcApI18n.t('jig.offset.offsetFailed'),
             'warning'
           )

--- a/packages/cad-simple-viewer/src/command/modify/AcApRotateCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApRotateCmd.ts
@@ -15,8 +15,7 @@ import {
   AcEdPromptAngleOptions,
   AcEdPromptPointOptions,
   AcEdPromptSelectionOptions,
-  AcEdPromptStatus,
-  eventBus
+  AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 
@@ -221,10 +220,7 @@ export class AcApRotateCmd extends AcEdCommand {
    * @param key - Warning message key suffix.
    */
   private warnInvalidInput(key: 'referencePoints') {
-    eventBus.emit('message', {
-      message: AcApI18n.t(`jig.rotate.invalid.${key}`),
-      type: 'warning'
-    })
+    this.notify(AcApI18n.t(`jig.rotate.invalid.${key}`), 'warning')
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/modify/AcApUnisolateObjectsCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApUnisolateObjectsCmd.ts
@@ -1,4 +1,4 @@
-import { AcApContext, AcApDocManager, unisolateObjects } from '../../app'
+import { AcApContext, unisolateObjects } from '../../app'
 import { AcEdCommand } from '../../editor'
 import { AcApI18n } from '../../i18n'
 
@@ -14,14 +14,14 @@ export class AcApUnisolateObjectsCmd extends AcEdCommand {
   async execute(context: AcApContext) {
     const count = unisolateObjects(context)
     if (count > 0) {
-      AcApDocManager.instance.editor.showMessage(
+      this.showMessage(
         `${count} ${AcApI18n.t('jig.hideobjects.restored')}`,
         'success'
       )
       return
     }
 
-    AcApDocManager.instance.editor.showMessage(
+    this.showMessage(
       AcApI18n.t('jig.hideobjects.nothingToRestore'),
       'info'
     )

--- a/packages/cad-simple-viewer/src/editor/command/AcEdCommand.ts
+++ b/packages/cad-simple-viewer/src/editor/command/AcEdCommand.ts
@@ -1,4 +1,6 @@
-import { AcApContext } from '../../app'
+import { AcApContext, AcApDocManager } from '../../app'
+import { eventBus } from '../global/eventBus'
+import { AcEdMessageType } from '../input/ui/AcEdMessageType'
 import { AcEdOpenMode } from '../view'
 
 /**
@@ -252,5 +254,30 @@ export abstract class AcEdCommand<TUserData extends object = {}> {
    */
   async execute(_context: AcApContext) {
     // Do nothing - subclasses should override this method
+  }
+
+  /**
+   * Displays a message in the command-line output.
+   *
+   * @param message - Message text to render
+   * @param type - Message severity controlling the rendered style
+   * @param msgKey - Optional localization key associated with the message
+   */
+  protected showMessage(
+    message: string,
+    type: AcEdMessageType = 'info',
+    msgKey?: string
+  ): void {
+    AcApDocManager.instance.editor.showMessage(message, type, msgKey)
+  }
+
+  /**
+   * Sends a message to the UI module through the global event bus.
+   *
+   * @param message - Message text to display
+   * @param type - Message severity controlling the rendered style
+   */
+  protected notify(message: string, type: AcEdMessageType = 'info'): void {
+    eventBus.emit('message', { message, type })
   }
 }


### PR DESCRIPTION
## Summary
- Add \showMessage\ and \
otify\ protected helpers on \AcEdCommand\ for command-line output and UI toast notifications via eventBus.
- Replace direct \ditor.showMessage\ / \ventBus.emit('message')\ calls across layer, draw, and modify commands with the new helpers.
- Update layer command unit test mocks to expose the new base-class messaging methods.

## Test plan
- [x] \pnpm run build\ in \packages/cad-simple-viewer\`n- [x] Layer command unit tests (\AcApLayerCurCmd\, \AcApLayerFreezeCmd\, \AcApLayerIsoCmd\, \AcApLayerThawCmd\, \AcApLayerLockCmd\, \AcApLayerUnlockCmd\, \AcApLayerUnisoCmd\)
- [ ] Smoke test a few commands in the viewer (e.g. LAYER, RECT, OFFSET) and confirm command-line vs toast messages still appear correctly