### PR TITLE
feat(viewer): improve progressive rendering during document open

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1,12 +1,14 @@
 import {
   AcCmColor,
   AcCmEventManager,
+  AcDbDatabase,
   AcDbDatabaseConverterManager,
   AcDbDxfConverter,
   AcDbFileType,
   acdbHostApplicationServices,
   AcDbProgressdEventArgs,
   AcDbSysVarManager,
+  AcGeBox2d,
   log
 } from '@mlightcad/data-model'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
@@ -1198,10 +1200,12 @@ export class AcApDocManager {
         acdbHostApplicationServices().layoutManager.getActiveLayout(db)
       const layoutLimits = activeLayout?.limits
 
+      const view = this.curView as AcTrView2d
       if (isPaperSpaceActive && layoutLimits && !layoutLimits.isEmpty()) {
-        this.curView.zoomTo(layoutLimits)
+        view.zoomTo(layoutLimits)
       } else {
-        this.curView.zoomToFitDrawing()
+        view.beginProgressiveOpenFit(this.resolveModelSpaceExtentsBox(db))
+        view.zoomToFitDrawing()
       }
 
       // Tell the view we've already framed the startup layout, so that
@@ -1264,6 +1268,26 @@ export class AcApDocManager {
   private resetOpenFileProgress() {
     this._openFileProgressPeak = 0
     this._openFileProgressStage = undefined
+  }
+
+  /**
+   * Builds a model-space extents box from database EXTMIN/EXTMAX sysvars.
+   *
+   * Used only for an immediate provisional zoom at document open so entities
+   * become visible while the view layer still batch-converts geometry.
+   */
+  private resolveModelSpaceExtentsBox(db: AcDbDatabase) {
+    const extmin = db.extmin
+    const extmax = db.extmax
+    if (!extmin || !extmax) {
+      return undefined
+    }
+
+    const box = new AcGeBox2d(
+      { x: extmin.x, y: extmin.y },
+      { x: extmax.x, y: extmax.y }
+    )
+    return box.isEmpty() ? undefined : box
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrProgressiveOpenFitController.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrProgressiveOpenFitController.ts
@@ -1,0 +1,199 @@
+import { AcGeBox2d, AcGeVector2d } from '@mlightcad/data-model'
+
+/** Callback that applies a zoom-to-fit in the host view. */
+export type AcTrProgressiveOpenFitZoomFn = (
+  box: AcGeBox2d,
+  margin?: number
+) => void
+
+/**
+ * Coordinates camera framing while a document is opened and entities are still
+ * being batch-converted into the scene.
+ *
+ * Responsibilities:
+ * - Provisional fit from database extents (EXTMIN/EXTMAX)
+ * - Throttled incremental fit for large drawings without authoritative extents
+ * - Final fit once conversion completes
+ * - Stop auto-framing when the user pans or zooms manually
+ * - Yield to the render loop so geometry appears progressively
+ *
+ * The host view ({@link AcTrView2d}) supplies layout fit boxes and performs
+ * the actual camera updates through {@link AcTrProgressiveOpenFitZoomFn}.
+ */
+export class AcTrProgressiveOpenFitController {
+  private static readonly SMALL_ENTITY_THRESHOLD = 500
+  private static readonly BBOX_GROWTH_RATIO = 1.5
+  private static readonly FIT_INTERVAL_MS = 500
+  private static readonly YIELD_EVERY = 32
+
+  private active = false
+  private userAdjusted = false
+  private programmaticDepth = 0
+  private incrementalEnabled = false
+  private usedInitialExtents = false
+  private initialPendingCount = 0
+  private lastFittedBox?: AcGeBox2d
+  private lastZoomAt = 0
+
+  constructor(private readonly zoomTo: AcTrProgressiveOpenFitZoomFn) {}
+
+  get isActive() {
+    return this.active
+  }
+
+  /**
+   * Starts progressive open framing for the current document open operation.
+   */
+  begin(initialBox: AcGeBox2d | undefined, pendingEntityCount: number) {
+    this.active = true
+    this.userAdjusted = false
+    this.lastZoomAt = 0
+    this.initialPendingCount = pendingEntityCount
+    this.usedInitialExtents = !!(initialBox && !initialBox.isEmpty())
+    this.lastFittedBox = undefined
+    this.incrementalEnabled = this.shouldEnableIncrementalFit(initialBox)
+
+    if (initialBox && !initialBox.isEmpty()) {
+      this.applyZoom(initialBox)
+    }
+  }
+
+  /** Ends progressive open framing. */
+  end() {
+    this.active = false
+    this.incrementalEnabled = false
+    this.lastFittedBox = undefined
+  }
+
+  /**
+   * Applies the terminal fit after all entities are converted, unless the user
+   * already adjusted the view or a small drawing was framed by database extents.
+   */
+  applyFinalFit(resolveFitBox: () => AcGeBox2d | undefined) {
+    if (this.userAdjusted || this.shouldSkipFinalFit()) {
+      return
+    }
+
+    const box = resolveFitBox()
+    if (box) {
+      this.applyZoom(box)
+    }
+  }
+
+  /**
+   * Notifies the controller that the active layout camera changed. User-driven
+   * changes cancel further auto framing.
+   */
+  onLayoutViewChanged() {
+    if (!this.active || this.userAdjusted || this.programmaticDepth > 0) {
+      return
+    }
+
+    this.userAdjusted = true
+    this.end()
+  }
+
+  /**
+   * Called after one entity (or group bucket) was added to the scene during open.
+   */
+  async afterGeometryBatch(
+    resolveFitBox: () => AcGeBox2d | undefined,
+    entityIndex?: number
+  ) {
+    this.maybeIncrementalFit(resolveFitBox)
+    if (entityIndex != null) {
+      await this.yieldForRender(entityIndex)
+    }
+  }
+
+  /**
+   * Yields to {@link requestAnimationFrame} periodically so the render loop can
+   * paint converted geometry during document open.
+   */
+  async yieldForRender(entityIndex: number) {
+    if (!this.active || entityIndex % AcTrProgressiveOpenFitController.YIELD_EVERY !== 0) {
+      return
+    }
+
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+  }
+
+  private maybeIncrementalFit(resolveFitBox: () => AcGeBox2d | undefined) {
+    if (!this.active || !this.incrementalEnabled || this.userAdjusted) {
+      return
+    }
+
+    const now = performance.now()
+    if (now - this.lastZoomAt < AcTrProgressiveOpenFitController.FIT_INTERVAL_MS) {
+      return
+    }
+
+    const box = resolveFitBox()
+    if (!box || !this.shouldApplyIncrementalFit(box)) {
+      return
+    }
+
+    this.lastZoomAt = now
+    this.applyZoom(box)
+  }
+
+  private shouldEnableIncrementalFit(initialBox?: AcGeBox2d) {
+    if (initialBox && !initialBox.isEmpty()) {
+      return false
+    }
+    return (
+      this.initialPendingCount >=
+      AcTrProgressiveOpenFitController.SMALL_ENTITY_THRESHOLD
+    )
+  }
+
+  private shouldSkipFinalFit() {
+    return (
+      this.usedInitialExtents &&
+      this.initialPendingCount <
+        AcTrProgressiveOpenFitController.SMALL_ENTITY_THRESHOLD
+    )
+  }
+
+  private shouldApplyIncrementalFit(box: AcGeBox2d) {
+    const lastBox = this.lastFittedBox
+    if (!lastBox) {
+      return true
+    }
+
+    const lastArea = this.estimateBoxArea(lastBox)
+    if (lastArea <= Number.EPSILON) {
+      return true
+    }
+
+    return (
+      this.estimateBoxArea(box) >=
+      lastArea * AcTrProgressiveOpenFitController.BBOX_GROWTH_RATIO
+    )
+  }
+
+  private applyZoom(box: AcGeBox2d, margin: number = 1.1) {
+    this.programmaticDepth++
+    try {
+      this.zoomTo(box, margin)
+      this.lastFittedBox = this.snapshotFitBox(box)
+    } finally {
+      this.programmaticDepth--
+    }
+  }
+
+  private estimateBoxArea(box: AcGeBox2d) {
+    const size = new AcGeVector2d()
+    box.getSize(size)
+    return Math.abs(size.x) * Math.abs(size.y)
+  }
+
+  private snapshotFitBox(box: AcGeBox2d) {
+    return new AcGeBox2d(
+      { x: box.min.x, y: box.min.y },
+      { x: box.max.x, y: box.max.y }
+    )
+  }
+}

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -58,6 +58,7 @@ import { AcTrGeometryUtil } from '../util'
 import { AcTrLayoutView } from './AcTrLayoutView'
 import { AcTrLayoutViewManager } from './AcTrLayoutViewManager'
 import { sortPickResults } from './AcTrPickResultUtil'
+import { AcTrProgressiveOpenFitController } from './AcTrProgressiveOpenFitController'
 import { AcTrScene } from './AcTrScene'
 
 /**
@@ -173,6 +174,8 @@ export class AcTrView2d extends AcEdBaseView {
    * race during document open.
    */
   private _externallyFramedLayouts: Set<AcDbObjectId> = new Set()
+  /** Progressive camera framing while entities batch-convert at document open. */
+  private readonly _progressiveOpenFit: AcTrProgressiveOpenFitController
 
   /**
    * Creates a new 2D CAD viewer instance.
@@ -447,6 +450,12 @@ export class AcTrView2d extends AcEdBaseView {
 
     this._missedImages = new Map()
     this._layoutViewManager = new AcTrLayoutViewManager()
+    this._progressiveOpenFit = new AcTrProgressiveOpenFitController(
+      (box, margin) => {
+        this.activeLayoutView.zoomTo(box, margin ?? 1.1)
+        this._isDirty = true
+      }
+    )
     this.initialize()
     this.onWindowResize()
     this._isDirty = true
@@ -508,6 +517,35 @@ export class AcTrView2d extends AcEdBaseView {
    */
   get isDirty() {
     return this._isDirty
+  }
+
+  /**
+   * True while {@link addEntity} batch-conversion callbacks are still running.
+   *
+   * Parsing can report 100% before this reaches zero; callers opening files
+   * should wait on this (as {@link zoomToFitDrawing} does) before hiding
+   * progress UI or assuming the canvas is ready.
+   */
+  get isProcessingEntities() {
+    return this._numOfEntitiesToProcess > 0
+  }
+
+  /**
+   * Enables progressive camera framing while entities are batch-converted at
+   * document open. Pair with {@link zoomToFitDrawing} for the final accurate fit.
+   *
+   * @param initialBox - Optional provisional extents (e.g. EXTMIN/EXTMAX) applied
+   * before the first converted entities land.
+   */
+  beginProgressiveOpenFit(initialBox?: AcGeBox2d) {
+    this._progressiveOpenFit.begin(initialBox, this._numOfEntitiesToProcess)
+  }
+
+  /**
+   * Disables progressive open framing after the final zoom-to-fit runs.
+   */
+  endProgressiveOpenFit() {
+    this._progressiveOpenFit.end()
   }
 
   /**
@@ -733,13 +771,13 @@ export class AcTrView2d extends AcEdBaseView {
           layoutBtrId &&
           this._externallyFramedLayouts.delete(layoutBtrId)
         ) {
+          this.endProgressiveOpenFit()
           return
         }
-        const box = this.resolveLayoutFitBox()
-        if (box) {
-          this.zoomTo(box)
-          this._isDirty = true
-        }
+        this._progressiveOpenFit.applyFinalFit(() =>
+          this.resolveLayoutFitBox()
+        )
+        this.endProgressiveOpenFit()
       },
       300, // check every 300 ms
       timeout
@@ -1444,6 +1482,7 @@ export class AcTrView2d extends AcEdBaseView {
         this.height
       )
       layoutView.events.viewChanged.addEventListener(() => {
+        this._progressiveOpenFit.onLayoutViewChanged()
         this._isDirty = true
         this.events.viewChanged.dispatch()
         this.clearHover()
@@ -1696,6 +1735,10 @@ export class AcTrView2d extends AcEdBaseView {
           // Release memory occupied by this entity
           threeEntity.dispose()
           this._isDirty = true
+          await this._progressiveOpenFit.afterGeometryBatch(
+            () => this.resolveLayoutFitBox(),
+            i
+          )
         }
 
         if (entity instanceof AcDbViewport) {
@@ -1832,6 +1875,9 @@ export class AcTrView2d extends AcEdBaseView {
     group.dispose()
 
     this._isDirty = true
+    void this._progressiveOpenFit.afterGeometryBatch(() =>
+      this.resolveLayoutFitBox()
+    )
   }
 
   /**


### PR DESCRIPTION
## Summary

- Extract progressive open-fit camera logic into internal `AcTrProgressiveOpenFitController` so entities appear incrementally on canvas during document open
- Apply provisional zoom-to-fit from database EXTMIN/EXTMAX at open; skip incremental refits when initial extents are valid to avoid viewport jumping on small/fast drawings
- Cancel further auto framing when the user pans or zooms during progressive rendering
- Yield to the browser every 32 entities so the canvas can paint progressively

## Test plan

- [ ] Open a small DWG/DXF: entities appear progressively without repeated viewport jumps
- [ ] Open a large DWG: progressive display; final fit when load completes if user did not pan/zoom
- [ ] Pan or zoom during load: auto fit stops and view stays where the user left it
- [ ] Paper space with limits: layout limits zoom still works (unchanged path)

Made with [Cursor](https://cursor.com)