### PR TITLE
feat(example): add upload options for text rendering and no-plot layers

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1231,9 +1231,17 @@ export class AcApDocManager {
    */
   private setOptions(options?: AcApOpenDatabaseOptions) {
     if (options == null) {
-      options = { fontLoader: this._fontLoader }
-    } else if (options.fontLoader == null) {
-      options.fontLoader = this._fontLoader
+      options = {
+        fontLoader: this._fontLoader,
+        drawNoPlotLayers: false
+      }
+    } else {
+      if (options.fontLoader == null) {
+        options.fontLoader = this._fontLoader
+      }
+      if (options.drawNoPlotLayers == null) {
+        options.drawNoPlotLayers = false
+      }
     }
     return options
   }

--- a/packages/cad-simple-viewer/src/app/AcDbOpenDatabaseOptions.ts
+++ b/packages/cad-simple-viewer/src/app/AcDbOpenDatabaseOptions.ts
@@ -9,6 +9,9 @@ import { AcEdOpenMode } from '../editor/view'
  * the `readOnly` property with a `mode` property that provides more granular
  * access control.
  *
+ * Inherits {@link AcDbOpenDatabaseOptions.drawNoPlotLayers} from the data model.
+ * {@link AcApDocManager} defaults it to `false` (web viewer semantics) when omitted.
+ *
  * @example
  * ```typescript
  * const options: AcApOpenDatabaseOptions = {

--- a/packages/cad-simple-viewer/src/view/AcTrLayer.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayer.ts
@@ -68,6 +68,16 @@ export type AcTrLayerStats = AcTrBatchedGroupStats & {
  */
 export class AcTrLayer {
   /**
+   * Resolves whether a layer should be visible in the view.
+   *
+   * Non-plottable layer suppression is handled in {@link AcDbEntity.worldDraw};
+   * only freeze/off state is reflected here.
+   */
+  static isLayerVisible(info: AcEdLayerInfo): boolean {
+    return !(info.isFrozen || info.isOff)
+  }
+
+  /**
    * Layer name
    */
   private _name: string
@@ -91,7 +101,7 @@ export class AcTrLayer {
     this._name = layer.name
     this._cachedBox = new THREE.Box3()
     this._boxDirty = true
-    this._group.visible = !(layer.isFrozen || layer.isOff)
+    this._group.visible = AcTrLayer.isLayerVisible(layer)
   }
 
   /**
@@ -169,7 +179,7 @@ export class AcTrLayer {
   update(value: AcEdLayerInfo) {
     const wasVisible = this.visible
     this._name = value.name
-    this._group.visible = !(value.isFrozen || value.isOff)
+    this._group.visible = AcTrLayer.isLayerVisible(value)
     if (wasVisible !== this.visible) {
       this._boxDirty = true
     }

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -1061,12 +1061,7 @@ export class AcTrView2d extends AcEdBaseView {
    * @inheritdoc
    */
   addLayer(layer: AcDbLayerTableRecord) {
-    const updatedLayers = this._scene.addLayer({
-      name: layer.name,
-      isFrozen: layer.isFrozen,
-      isOff: layer.isOff,
-      color: layer.color
-    })
+    const updatedLayers = this._scene.addLayer(this.toLayerInfo(layer))
 
     const traits: Partial<AcGiSubEntityTraits> = {
       layer: layer.name,
@@ -1093,12 +1088,7 @@ export class AcTrView2d extends AcEdBaseView {
     layer: AcDbLayerTableRecord,
     changes: Partial<AcDbLayerTableRecordAttrs>
   ) {
-    const updatedLayers = this._scene.updateLayer({
-      name: layer.name,
-      isFrozen: layer.isFrozen,
-      isOff: layer.isOff,
-      color: layer.color
-    })
+    const updatedLayers = this._scene.updateLayer(this.toLayerInfo(layer))
     const traits: Record<string, unknown> = {}
     if (changes.color) {
       traits.color = changes.color.clone()
@@ -1630,6 +1620,15 @@ export class AcTrView2d extends AcEdBaseView {
     }
   }
 
+  private toLayerInfo(layer: AcDbLayerTableRecord) {
+    return {
+      name: layer.name,
+      isFrozen: layer.isFrozen,
+      isOff: layer.isOff,
+      color: layer.color
+    }
+  }
+
   private drawEntity(entity: AcDbEntity, delay?: boolean) {
     return entity.worldDraw(this._renderer, delay) as AcTrEntity | null
   }
@@ -1701,44 +1700,48 @@ export class AcTrView2d extends AcEdBaseView {
         }
 
         const threeEntity: AcTrEntity | null = this.drawEntity(entity, true)
-        if (!threeEntity) continue
+        // Viewports may produce no border geometry (e.g. on a no-plot layer) while
+        // still needing an AcTrViewportView for model content below.
+        if (!threeEntity && !(entity instanceof AcDbViewport)) continue
 
-        threeEntity.objectId = entity.objectId
-        threeEntity.ownerId = entity.ownerId
-        threeEntity.layerName = entity.layer
-        threeEntity.visible = entity.visibility
-        if (
-          threeEntity instanceof AcTrGroup &&
-          (threeEntity as AcTrGroup).isOnTheSameLayer
-        ) {
-          // Even when a block expands to a single layer bucket, children authored on
-          // layer "0" still inherit the INSERT layer for ByLayer traits (color, etc.).
-          this.remapInheritedLayerObjects(
-            (threeEntity as AcTrGroup).children,
-            '0',
-            threeEntity.layerName
-          )
-        }
-        if (
-          threeEntity instanceof AcTrGroup &&
-          !(threeEntity as AcTrGroup).isOnTheSameLayer
-        ) {
-          this.handleGroup(threeEntity as AcTrGroup)
-        } else {
-          const isExtendBbox = !(
-            entity instanceof AcDbRay || entity instanceof AcDbXline
-          )
+        if (threeEntity) {
+          threeEntity.objectId = entity.objectId
+          threeEntity.ownerId = entity.ownerId
+          threeEntity.layerName = entity.layer
+          threeEntity.visible = entity.visibility
+          if (
+            threeEntity instanceof AcTrGroup &&
+            (threeEntity as AcTrGroup).isOnTheSameLayer
+          ) {
+            // Even when a block expands to a single layer bucket, children authored on
+            // layer "0" still inherit the INSERT layer for ByLayer traits (color, etc.).
+            this.remapInheritedLayerObjects(
+              (threeEntity as AcTrGroup).children,
+              '0',
+              threeEntity.layerName
+            )
+          }
+          if (
+            threeEntity instanceof AcTrGroup &&
+            !(threeEntity as AcTrGroup).isOnTheSameLayer
+          ) {
+            this.handleGroup(threeEntity as AcTrGroup)
+          } else {
+            const isExtendBbox = !(
+              entity instanceof AcDbRay || entity instanceof AcDbXline
+            )
 
-          await threeEntity.draw()
-          this._scene.addEntity(threeEntity, isExtendBbox)
-          this.applySessionHiddenObjectState(entity.objectId)
-          // Release memory occupied by this entity
-          threeEntity.dispose()
-          this._isDirty = true
-          await this._progressiveOpenFit.afterGeometryBatch(
-            () => this.resolveLayoutFitBox(),
-            i
-          )
+            await threeEntity.draw()
+            this._scene.addEntity(threeEntity, isExtendBbox)
+            this.applySessionHiddenObjectState(entity.objectId)
+            // Release memory occupied by this entity
+            threeEntity.dispose()
+            this._isDirty = true
+            await this._progressiveOpenFit.afterGeometryBatch(
+              () => this.resolveLayoutFitBox(),
+              i
+            )
+          }
         }
 
         if (entity instanceof AcDbViewport) {

--- a/packages/cad-viewer-example/e2e/tests/invisible-entities.spec.ts
+++ b/packages/cad-viewer-example/e2e/tests/invisible-entities.spec.ts
@@ -31,9 +31,16 @@ const visibleInBlockFixturePath = path.resolve(
 
 test.describe.configure({ mode: 'serial' })
 
+async function selectAccessMode(page: Page, mode: 'Read' | 'Review' | 'Write') {
+  await page.getByRole('radio', { name: new RegExp(`^${mode}\\b`) }).click()
+}
+
 async function uploadFixture(page: Page, filePath: string) {
   const fileInput = page.locator('input[type="file"]').first()
   await expect(fileInput).toBeAttached()
+  // Match the historical example default (Write) so pixel baselines stay stable
+  // when the upload screen defaults to Read-only mode.
+  await selectAccessMode(page, 'Write')
   await fileInput.setInputFiles(filePath)
 }
 

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -12,6 +12,7 @@
         :local-file="store.selectedFile"
         :mode="selectedMode"
         :use-main-thread-draw="useMainThreadDraw"
+        :draw-no-plot-layers="drawNoPlotLayers"
         @create="initialize"
         base-url="https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/"
       />
@@ -65,16 +66,19 @@ const initialize = () => {
 
 const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
 const useMainThreadDraw = ref(false)
+const drawNoPlotLayers = ref(false)
 
 // Handle file selection from upload component
 const handleFileSelect = (
   file: File,
   mode: AcEdOpenMode,
-  mainThreadDraw: boolean
+  mainThreadDraw: boolean,
+  showNoPlotLayers: boolean
 ) => {
   store.selectedFile = file
   selectedMode.value = mode
   useMainThreadDraw.value = mainThreadDraw
+  drawNoPlotLayers.value = showNoPlotLayers
 }
 </script>
 

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -11,6 +11,7 @@
         locale="en"
         :local-file="store.selectedFile"
         :mode="selectedMode"
+        :use-main-thread-draw="useMainThreadDraw"
         @create="initialize"
         base-url="https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/"
       />
@@ -63,11 +64,17 @@ const initialize = () => {
 // AcApSettingManager.instance.isShowCoordinate = false
 
 const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
+const useMainThreadDraw = ref(false)
 
 // Handle file selection from upload component
-const handleFileSelect = (file: File, mode: AcEdOpenMode) => {
+const handleFileSelect = (
+  file: File,
+  mode: AcEdOpenMode,
+  mainThreadDraw: boolean
+) => {
   store.selectedFile = file
   selectedMode.value = mode
+  useMainThreadDraw.value = mainThreadDraw
 }
 </script>
 

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -1,402 +1,436 @@
-<template>
-  <div class="file-upload-container">
-    <div class="upload-panel">
-      <section class="upload-hero">
-        <div class="upload-icon">
-          <el-icon :size="28">
-            <UploadFilled />
-          </el-icon>
-        </div>
-        <h1 class="upload-title">Select CAD File to View</h1>
-        <p class="upload-subtitle">Import DWG or DXF drawings into the viewer</p>
-      </section>
-
-      <el-upload
-        class="upload-dropzone"
-        drag
-        :auto-upload="false"
-        accept=".dwg,.dxf"
-        :on-change="handleFileChange"
-        :before-upload="beforeUpload"
-      >
-        <div class="dropzone-content">
-          <p class="dropzone-title">Drop your file here</p>
-          <p class="dropzone-hint">
-            or <span class="dropzone-link">browse files</span>
-          </p>
-          <div class="format-tags">
-            <span class="format-tag">DWG</span>
-            <span class="format-tag">DXF</span>
-          </div>
-        </div>
-      </el-upload>
-
-      <section class="settings-section">
-        <div class="setting-block">
-          <h2 class="setting-label">Access mode</h2>
-          <div class="mode-segment" role="radiogroup" aria-label="Access mode">
-            <button
-              v-for="mode in accessModes"
-              :key="mode.value"
-              type="button"
-              class="mode-option"
-              :class="{ 'is-active': selectedMode === mode.value }"
-              role="radio"
-              :aria-checked="selectedMode === mode.value"
-              @click="selectedMode = mode.value"
-            >
-              <span class="mode-option-title">{{ mode.label }}</span>
-              <span class="mode-option-desc">{{ mode.description }}</span>
-            </button>
-          </div>
-        </div>
-
-        <div class="setting-block">
-          <h2 class="setting-label">Text rendering</h2>
-          <div
-            class="render-segment"
-            role="radiogroup"
-            aria-label="Text rendering"
-          >
-            <button
-              type="button"
-              class="render-option"
-              :class="{ 'is-active': !useMainThreadDraw }"
-              role="radio"
-              :aria-checked="!useMainThreadDraw"
-              @click="useMainThreadDraw = false"
-            >
-              <span class="render-option-title">Web worker</span>
-              <span class="render-option-desc">Faster, more memory</span>
-            </button>
-            <button
-              type="button"
-              class="render-option"
-              :class="{ 'is-active': useMainThreadDraw }"
-              role="radio"
-              :aria-checked="useMainThreadDraw"
-              @click="useMainThreadDraw = true"
-            >
-              <span class="render-option-title">Main thread</span>
-              <span class="render-option-desc">Slower, less memory</span>
-            </button>
-          </div>
-        </div>
-      </section>
-    </div>
-  </div>
-</template>
-
-<script setup lang="ts">
-import { UploadFilled } from '@element-plus/icons-vue'
-import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
-import { log } from '@mlightcad/data-model'
-import type { UploadFile, UploadProps } from 'element-plus'
-import { ElIcon, ElUpload } from 'element-plus'
-import { ref } from 'vue'
-
-interface Props {
-  onFileSelect: (
-    file: File,
-    mode: AcEdOpenMode,
-    useMainThreadDraw: boolean
-  ) => void
-}
-
-const props = defineProps<Props>()
-
-const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
-const useMainThreadDraw = ref(false)
-
-const accessModes = [
-  {
-    value: AcEdOpenMode.Read,
-    label: 'Read',
-    description: 'View only'
-  },
-  {
-    value: AcEdOpenMode.Review,
-    label: 'Review',
-    description: 'View & review'
-  },
-  {
-    value: AcEdOpenMode.Write,
-    label: 'Write',
-    description: 'Full access'
-  }
-] as const
-
-const handleFileChange: UploadProps['onChange'] = (uploadFile: UploadFile) => {
-  if (uploadFile.raw) {
-    if (isValidFile(uploadFile.raw)) {
-      props.onFileSelect(
-        uploadFile.raw,
-        selectedMode.value,
-        useMainThreadDraw.value
-      )
-    }
-  }
-}
-
-const beforeUpload: UploadProps['beforeUpload'] = (rawFile: File) => {
-  if (!isValidFile(rawFile)) {
-    log.warn('Invalid file type. Please upload DWG or DXF files.')
-    return false
-  }
-  return true
-}
-
-const isValidFile = (file: File): boolean => {
-  const validExtensions = ['.dwg', '.dxf']
-  const fileName = file.name.toLowerCase()
-  return validExtensions.some(ext => fileName.endsWith(ext))
-}
-</script>
-
-<style scoped>
-.file-upload-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  max-width: 560px;
-  padding: 24px;
-}
-
-.upload-panel {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  border-radius: 20px;
-  background: #ffffff;
-  box-shadow:
-    0 24px 48px rgba(15, 23, 42, 0.18),
-    0 0 0 1px rgba(255, 255, 255, 0.08);
-  overflow: hidden;
-}
-
-.upload-hero {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  padding: 36px 32px 8px;
-  text-align: center;
-}
-
-.upload-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 52px;
-  border-radius: 14px;
-  background: linear-gradient(135deg, #667eea 0%, #5b6fd6 100%);
-  color: #ffffff;
-  box-shadow: 0 8px 20px rgba(102, 126, 234, 0.35);
-}
-
-.upload-title {
-  margin: 8px 0 0;
-  font-size: 24px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: #0f172a;
-}
-
-.upload-subtitle {
-  margin: 0;
-  font-size: 14px;
-  color: #64748b;
-  line-height: 1.5;
-}
-
-.upload-dropzone {
-  width: 100%;
-  padding: 0 28px;
-  box-sizing: border-box;
-}
-
-.upload-dropzone :deep(.el-upload) {
-  display: block;
-  width: 100%;
-}
-
-.upload-dropzone :deep(.el-upload-dragger) {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  box-sizing: border-box;
-  padding: 28px 20px;
-  border: 1.5px dashed #c7d2fe;
-  border-radius: 14px;
-  background: #f8faff;
-  transition:
-    border-color 0.2s ease,
-    background-color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.upload-dropzone :deep(.el-upload-dragger:hover) {
-  border-color: #667eea;
-  background: #f1f5ff;
-  box-shadow: inset 0 0 0 1px rgba(102, 126, 234, 0.08);
-}
-
-.dropzone-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-
-.dropzone-title {
-  margin: 0;
-  font-size: 15px;
-  font-weight: 600;
-  color: #1e293b;
-}
-
-.dropzone-hint {
-  margin: 0;
-  font-size: 13px;
-  color: #64748b;
-}
-
-.dropzone-link {
-  color: #667eea;
-  font-weight: 600;
-}
-
-.format-tags {
-  display: flex;
-  gap: 8px;
-  margin-top: 10px;
-}
-
-.format-tag {
-  padding: 3px 10px;
-  border-radius: 999px;
-  background: #e8edff;
-  color: #4f5fd0;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-}
-
-.settings-section {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-top: 24px;
-  padding: 24px 28px 28px;
-  background: #f8fafc;
-  border-top: 1px solid #e8edf5;
-}
-
-.setting-block {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.setting-label {
-  margin: 0;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #94a3b8;
-}
-
-.mode-segment,
-.render-segment {
-  display: grid;
-  gap: 8px;
-}
-
-.mode-segment {
-  grid-template-columns: repeat(3, 1fr);
-}
-
-.render-segment {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.mode-option,
-.render-option {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-  padding: 12px 14px;
-  border: 1.5px solid #e2e8f0;
-  border-radius: 12px;
-  background: #ffffff;
-  cursor: pointer;
-  text-align: left;
-  transition:
-    border-color 0.2s ease,
-    background-color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.mode-option:hover,
-.render-option:hover {
-  border-color: #c7d2fe;
-  background: #fafbff;
-}
-
-.mode-option.is-active,
-.render-option.is-active {
-  border-color: #667eea;
-  background: #f1f5ff;
-  box-shadow: 0 0 0 1px rgba(102, 126, 234, 0.15);
-}
-
-.mode-option-title,
-.render-option-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: #1e293b;
-}
-
-.mode-option.is-active .mode-option-title,
-.render-option.is-active .render-option-title {
-  color: #4f5fd0;
-}
-
-.mode-option-desc,
-.render-option-desc {
-  font-size: 12px;
-  color: #94a3b8;
-  line-height: 1.4;
-}
-
-.mode-option.is-active .mode-option-desc,
-.render-option.is-active .render-option-desc {
-  color: #64748b;
-}
-
-@media (max-width: 520px) {
-  .file-upload-container {
-    padding: 16px;
-  }
-
-  .upload-hero {
-    padding: 28px 20px 8px;
-  }
-
-  .upload-dropzone,
-  .settings-section {
-    padding-left: 20px;
-    padding-right: 20px;
-  }
-
-  .mode-segment {
-    grid-template-columns: 1fr;
-  }
-}
-</style>
-
+<template>
+  <div class="file-upload-container">
+    <div class="upload-panel">
+      <section class="upload-hero">
+        <div class="upload-icon">
+          <el-icon :size="28">
+            <UploadFilled />
+          </el-icon>
+        </div>
+        <h1 class="upload-title">Select CAD File to View</h1>
+        <p class="upload-subtitle">Import DWG or DXF drawings into the viewer</p>
+      </section>
+
+      <el-upload
+        class="upload-dropzone"
+        drag
+        :auto-upload="false"
+        accept=".dwg,.dxf"
+        :on-change="handleFileChange"
+        :before-upload="beforeUpload"
+      >
+        <div class="dropzone-content">
+          <p class="dropzone-title">Drop your file here</p>
+          <p class="dropzone-hint">
+            or <span class="dropzone-link">browse files</span>
+          </p>
+          <div class="format-tags">
+            <span class="format-tag">DWG</span>
+            <span class="format-tag">DXF</span>
+          </div>
+        </div>
+      </el-upload>
+
+      <section class="settings-section">
+        <div class="setting-block">
+          <h2 class="setting-label">Access mode</h2>
+          <div class="mode-segment" role="radiogroup" aria-label="Access mode">
+            <button
+              v-for="mode in accessModes"
+              :key="mode.value"
+              type="button"
+              class="mode-option"
+              :class="{ 'is-active': selectedMode === mode.value }"
+              role="radio"
+              :aria-checked="selectedMode === mode.value"
+              @click="selectedMode = mode.value"
+            >
+              <span class="mode-option-title">{{ mode.label }}</span>
+              <span class="mode-option-desc">{{ mode.description }}</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="setting-block">
+          <h2 class="setting-label">Text rendering</h2>
+          <div
+            class="render-segment"
+            role="radiogroup"
+            aria-label="Text rendering"
+          >
+            <button
+              type="button"
+              class="render-option"
+              :class="{ 'is-active': !useMainThreadDraw }"
+              role="radio"
+              :aria-checked="!useMainThreadDraw"
+              @click="useMainThreadDraw = false"
+            >
+              <span class="render-option-title">Web worker</span>
+              <span class="render-option-desc">Faster, more memory</span>
+            </button>
+            <button
+              type="button"
+              class="render-option"
+              :class="{ 'is-active': useMainThreadDraw }"
+              role="radio"
+              :aria-checked="useMainThreadDraw"
+              @click="useMainThreadDraw = true"
+            >
+              <span class="render-option-title">Main thread</span>
+              <span class="render-option-desc">Slower, less memory</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="setting-block">
+          <h2 class="setting-label">Non-plottable layers</h2>
+          <div
+            class="render-segment"
+            role="radiogroup"
+            aria-label="Non-plottable layers"
+          >
+            <button
+              type="button"
+              class="render-option"
+              :class="{ 'is-active': !drawNoPlotLayers }"
+              role="radio"
+              :aria-checked="!drawNoPlotLayers"
+              @click="drawNoPlotLayers = false"
+            >
+              <span class="render-option-title">Hide</span>
+              <span class="render-option-desc">Web viewer default</span>
+            </button>
+            <button
+              type="button"
+              class="render-option"
+              :class="{ 'is-active': drawNoPlotLayers }"
+              role="radio"
+              :aria-checked="drawNoPlotLayers"
+              @click="drawNoPlotLayers = true"
+            >
+              <span class="render-option-title">Show</span>
+              <span class="render-option-desc">AutoCAD editor semantics</span>
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { UploadFilled } from '@element-plus/icons-vue'
+import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
+import { log } from '@mlightcad/data-model'
+import type { UploadFile, UploadProps } from 'element-plus'
+import { ElIcon, ElUpload } from 'element-plus'
+import { ref } from 'vue'
+
+interface Props {
+  onFileSelect: (
+    file: File,
+    mode: AcEdOpenMode,
+    useMainThreadDraw: boolean,
+    drawNoPlotLayers: boolean
+  ) => void
+}
+
+const props = defineProps<Props>()
+
+const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
+const useMainThreadDraw = ref(false)
+const drawNoPlotLayers = ref(false)
+
+const accessModes = [
+  {
+    value: AcEdOpenMode.Read,
+    label: 'Read',
+    description: 'View only'
+  },
+  {
+    value: AcEdOpenMode.Review,
+    label: 'Review',
+    description: 'View & review'
+  },
+  {
+    value: AcEdOpenMode.Write,
+    label: 'Write',
+    description: 'Full access'
+  }
+] as const
+
+const handleFileChange: UploadProps['onChange'] = (uploadFile: UploadFile) => {
+  if (uploadFile.raw) {
+    if (isValidFile(uploadFile.raw)) {
+      props.onFileSelect(
+        uploadFile.raw,
+        selectedMode.value,
+        useMainThreadDraw.value,
+        drawNoPlotLayers.value
+      )
+    }
+  }
+}
+
+const beforeUpload: UploadProps['beforeUpload'] = (rawFile: File) => {
+  if (!isValidFile(rawFile)) {
+    log.warn('Invalid file type. Please upload DWG or DXF files.')
+    return false
+  }
+  return true
+}
+
+const isValidFile = (file: File): boolean => {
+  const validExtensions = ['.dwg', '.dxf']
+  const fileName = file.name.toLowerCase()
+  return validExtensions.some(ext => fileName.endsWith(ext))
+}
+</script>
+
+<style scoped>
+.file-upload-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-width: 560px;
+  padding: 24px;
+}
+
+.upload-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow:
+    0 24px 48px rgba(15, 23, 42, 0.18),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.upload-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 36px 32px 8px;
+  text-align: center;
+}
+
+.upload-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #667eea 0%, #5b6fd6 100%);
+  color: #ffffff;
+  box-shadow: 0 8px 20px rgba(102, 126, 234, 0.35);
+}
+
+.upload-title {
+  margin: 8px 0 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+}
+
+.upload-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.upload-dropzone {
+  width: 100%;
+  padding: 0 28px;
+  box-sizing: border-box;
+}
+
+.upload-dropzone :deep(.el-upload) {
+  display: block;
+  width: 100%;
+}
+
+.upload-dropzone :deep(.el-upload-dragger) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 28px 20px;
+  border: 1.5px dashed #c7d2fe;
+  border-radius: 14px;
+  background: #f8faff;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.upload-dropzone :deep(.el-upload-dragger:hover) {
+  border-color: #667eea;
+  background: #f1f5ff;
+  box-shadow: inset 0 0 0 1px rgba(102, 126, 234, 0.08);
+}
+
+.dropzone-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.dropzone-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.dropzone-hint {
+  margin: 0;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.dropzone-link {
+  color: #667eea;
+  font-weight: 600;
+}
+
+.format-tags {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.format-tag {
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: #e8edff;
+  color: #4f5fd0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 24px;
+  padding: 24px 28px 28px;
+  background: #f8fafc;
+  border-top: 1px solid #e8edf5;
+}
+
+.setting-block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.setting-label {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.mode-segment,
+.render-segment {
+  display: grid;
+  gap: 8px;
+}
+
+.mode-segment {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.render-segment {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.mode-option,
+.render-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 12px 14px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 12px;
+  background: #ffffff;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.mode-option:hover,
+.render-option:hover {
+  border-color: #c7d2fe;
+  background: #fafbff;
+}
+
+.mode-option.is-active,
+.render-option.is-active {
+  border-color: #667eea;
+  background: #f1f5ff;
+  box-shadow: 0 0 0 1px rgba(102, 126, 234, 0.15);
+}
+
+.mode-option-title,
+.render-option-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.mode-option.is-active .mode-option-title,
+.render-option.is-active .render-option-title {
+  color: #4f5fd0;
+}
+
+.mode-option-desc,
+.render-option-desc {
+  font-size: 12px;
+  color: #94a3b8;
+  line-height: 1.4;
+}
+
+.mode-option.is-active .mode-option-desc,
+.render-option.is-active .render-option-desc {
+  color: #64748b;
+}
+
+@media (max-width: 520px) {
+  .file-upload-container {
+    padding: 16px;
+  }
+
+  .upload-hero {
+    padding: 28px 20px 8px;
+  }
+
+  .upload-dropzone,
+  .settings-section {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .mode-segment {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -1,192 +1,402 @@
-<template>
-  <div class="file-upload-container">
-    <el-upload
-      class="upload-demo"
-      drag
-      :auto-upload="false"
-      accept=".dwg,.dxf"
-      :on-change="handleFileChange"
-      :before-upload="beforeUpload"
-    >
-      <el-icon class="el-icon--upload" size="64">
-        <UploadFilled />
-      </el-icon>
-      <div class="el-upload__text">
-        <h2 class="upload-title">Select CAD File to View</h2>
-        <p class="upload-description">
-          Drop file here or <em>click to select</em>
-        </p>
-        <div>
-          <el-radio-group v-model="selectedMode" class="mode-radio-group">
-            <el-radio :value="0" border>Read</el-radio>
-            <el-radio :value="4" border>Review</el-radio>
-            <el-radio :value="8" border>Write</el-radio>
-          </el-radio-group>
-          <div class="mode-description">
-            <p v-if="selectedMode === 0" class="mode-info">
-              <strong>Read:</strong> View-only access
-            </p>
-            <p v-else-if="selectedMode === 4" class="mode-info">
-              <strong>Review:</strong> View and review access
-            </p>
-            <p v-else-if="selectedMode === 8" class="mode-info">
-              <strong>Write:</strong> Full read/write access
-            </p>
-          </div>
-        </div>
-      </div>
-      <template #tip>
-        <div class="el-upload__tip">Supported formats: DWG, DXF</div>
-      </template>
-    </el-upload>
-  </div>
-</template>
-
-<script setup lang="ts">
-import { UploadFilled } from '@element-plus/icons-vue'
-import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
-import { log } from '@mlightcad/data-model'
-import type { UploadFile, UploadProps } from 'element-plus'
-import { ElIcon, ElRadio, ElRadioGroup, ElUpload } from 'element-plus'
-import { ref } from 'vue'
-
-interface Props {
-  onFileSelect: (file: File, mode: AcEdOpenMode) => void
-}
-
-const props = defineProps<Props>()
-
-const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Write)
-
-const handleFileChange: UploadProps['onChange'] = (uploadFile: UploadFile) => {
-  if (uploadFile.raw) {
-    if (isValidFile(uploadFile.raw)) {
-      props.onFileSelect(uploadFile.raw, selectedMode.value)
-    }
-  }
-}
-
-const beforeUpload: UploadProps['beforeUpload'] = (rawFile: File) => {
-  if (!isValidFile(rawFile)) {
-    log.warn('Invalid file type. Please upload DWG or DXF files.')
-    return false
-  }
-  return true
-}
-
-const isValidFile = (file: File): boolean => {
-  const validExtensions = ['.dwg', '.dxf']
-  const fileName = file.name.toLowerCase()
-  return validExtensions.some(ext => fileName.endsWith(ext))
-}
-</script>
-
-<style scoped>
-.file-upload-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  max-width: 500px;
-  width: 100%;
-  height: 100%;
-}
-
-.upload-demo :deep(.el-upload) {
-  border: 3px dashed #d9d9d9;
-  border-radius: 16px;
-  cursor: pointer;
-  position: relative;
-  overflow: hidden;
-  transition: all 0.3s ease;
-  background: white;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(10px);
-}
-
-.upload-demo :deep(.el-upload:hover) {
-  border-color: #409eff;
-  transform: translateY(-4px);
-  box-shadow: 0 16px 50px rgba(0, 0, 0, 0.4);
-}
-
-.upload-demo :deep(.el-upload-dragger) {
-  width: 100%;
-  height: auto;
-  padding: 60px 50px;
-  background: transparent;
-  border: none;
-  border-radius: 16px;
-}
-
-.upload-demo :deep(.el-upload-dragger:hover) {
-  background: transparent;
-}
-
-.el-icon--upload {
-  color: #409eff;
-  margin-bottom: 16px;
-}
-
-.el-upload__text {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
-}
-
-.upload-title {
-  margin: 0;
-  font-size: 32px;
-  font-weight: 600;
-  color: #303133;
-}
-
-.upload-description {
-  margin: 0;
-  font-size: 18px;
-  color: #606266;
-  line-height: 1.5;
-}
-
-.upload-description em {
-  color: #409eff;
-  font-style: normal;
-  font-weight: 600;
-}
-
-.el-upload__tip {
-  margin-top: 16px;
-  font-size: 14px;
-  color: #ffffff;
-  text-align: center;
-}
-
-.mode-radio-group {
-  display: flex;
-  gap: 12px;
-  margin-bottom: 16px;
-  flex-wrap: wrap;
-}
-
-.mode-radio-group :deep(.el-radio) {
-  margin-right: 0;
-  margin-bottom: 0;
-}
-
-.mode-description {
-  margin-top: 12px;
-}
-
-.mode-info {
-  margin: 0;
-  font-size: 14px;
-  color: #606266;
-  line-height: 1.6;
-}
-
-.mode-info strong {
-  color: #409eff;
-  font-weight: 600;
-}
-</style>
+<template>
+  <div class="file-upload-container">
+    <div class="upload-panel">
+      <section class="upload-hero">
+        <div class="upload-icon">
+          <el-icon :size="28">
+            <UploadFilled />
+          </el-icon>
+        </div>
+        <h1 class="upload-title">Select CAD File to View</h1>
+        <p class="upload-subtitle">Import DWG or DXF drawings into the viewer</p>
+      </section>
+
+      <el-upload
+        class="upload-dropzone"
+        drag
+        :auto-upload="false"
+        accept=".dwg,.dxf"
+        :on-change="handleFileChange"
+        :before-upload="beforeUpload"
+      >
+        <div class="dropzone-content">
+          <p class="dropzone-title">Drop your file here</p>
+          <p class="dropzone-hint">
+            or <span class="dropzone-link">browse files</span>
+          </p>
+          <div class="format-tags">
+            <span class="format-tag">DWG</span>
+            <span class="format-tag">DXF</span>
+          </div>
+        </div>
+      </el-upload>
+
+      <section class="settings-section">
+        <div class="setting-block">
+          <h2 class="setting-label">Access mode</h2>
+          <div class="mode-segment" role="radiogroup" aria-label="Access mode">
+            <button
+              v-for="mode in accessModes"
+              :key="mode.value"
+              type="button"
+              class="mode-option"
+              :class="{ 'is-active': selectedMode === mode.value }"
+              role="radio"
+              :aria-checked="selectedMode === mode.value"
+              @click="selectedMode = mode.value"
+            >
+              <span class="mode-option-title">{{ mode.label }}</span>
+              <span class="mode-option-desc">{{ mode.description }}</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="setting-block">
+          <h2 class="setting-label">Text rendering</h2>
+          <div
+            class="render-segment"
+            role="radiogroup"
+            aria-label="Text rendering"
+          >
+            <button
+              type="button"
+              class="render-option"
+              :class="{ 'is-active': !useMainThreadDraw }"
+              role="radio"
+              :aria-checked="!useMainThreadDraw"
+              @click="useMainThreadDraw = false"
+            >
+              <span class="render-option-title">Web worker</span>
+              <span class="render-option-desc">Faster, more memory</span>
+            </button>
+            <button
+              type="button"
+              class="render-option"
+              :class="{ 'is-active': useMainThreadDraw }"
+              role="radio"
+              :aria-checked="useMainThreadDraw"
+              @click="useMainThreadDraw = true"
+            >
+              <span class="render-option-title">Main thread</span>
+              <span class="render-option-desc">Slower, less memory</span>
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { UploadFilled } from '@element-plus/icons-vue'
+import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
+import { log } from '@mlightcad/data-model'
+import type { UploadFile, UploadProps } from 'element-plus'
+import { ElIcon, ElUpload } from 'element-plus'
+import { ref } from 'vue'
+
+interface Props {
+  onFileSelect: (
+    file: File,
+    mode: AcEdOpenMode,
+    useMainThreadDraw: boolean
+  ) => void
+}
+
+const props = defineProps<Props>()
+
+const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
+const useMainThreadDraw = ref(false)
+
+const accessModes = [
+  {
+    value: AcEdOpenMode.Read,
+    label: 'Read',
+    description: 'View only'
+  },
+  {
+    value: AcEdOpenMode.Review,
+    label: 'Review',
+    description: 'View & review'
+  },
+  {
+    value: AcEdOpenMode.Write,
+    label: 'Write',
+    description: 'Full access'
+  }
+] as const
+
+const handleFileChange: UploadProps['onChange'] = (uploadFile: UploadFile) => {
+  if (uploadFile.raw) {
+    if (isValidFile(uploadFile.raw)) {
+      props.onFileSelect(
+        uploadFile.raw,
+        selectedMode.value,
+        useMainThreadDraw.value
+      )
+    }
+  }
+}
+
+const beforeUpload: UploadProps['beforeUpload'] = (rawFile: File) => {
+  if (!isValidFile(rawFile)) {
+    log.warn('Invalid file type. Please upload DWG or DXF files.')
+    return false
+  }
+  return true
+}
+
+const isValidFile = (file: File): boolean => {
+  const validExtensions = ['.dwg', '.dxf']
+  const fileName = file.name.toLowerCase()
+  return validExtensions.some(ext => fileName.endsWith(ext))
+}
+</script>
+
+<style scoped>
+.file-upload-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-width: 560px;
+  padding: 24px;
+}
+
+.upload-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow:
+    0 24px 48px rgba(15, 23, 42, 0.18),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.upload-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 36px 32px 8px;
+  text-align: center;
+}
+
+.upload-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #667eea 0%, #5b6fd6 100%);
+  color: #ffffff;
+  box-shadow: 0 8px 20px rgba(102, 126, 234, 0.35);
+}
+
+.upload-title {
+  margin: 8px 0 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+}
+
+.upload-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.upload-dropzone {
+  width: 100%;
+  padding: 0 28px;
+  box-sizing: border-box;
+}
+
+.upload-dropzone :deep(.el-upload) {
+  display: block;
+  width: 100%;
+}
+
+.upload-dropzone :deep(.el-upload-dragger) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 28px 20px;
+  border: 1.5px dashed #c7d2fe;
+  border-radius: 14px;
+  background: #f8faff;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.upload-dropzone :deep(.el-upload-dragger:hover) {
+  border-color: #667eea;
+  background: #f1f5ff;
+  box-shadow: inset 0 0 0 1px rgba(102, 126, 234, 0.08);
+}
+
+.dropzone-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.dropzone-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.dropzone-hint {
+  margin: 0;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.dropzone-link {
+  color: #667eea;
+  font-weight: 600;
+}
+
+.format-tags {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.format-tag {
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: #e8edff;
+  color: #4f5fd0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 24px;
+  padding: 24px 28px 28px;
+  background: #f8fafc;
+  border-top: 1px solid #e8edf5;
+}
+
+.setting-block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.setting-label {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.mode-segment,
+.render-segment {
+  display: grid;
+  gap: 8px;
+}
+
+.mode-segment {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.render-segment {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.mode-option,
+.render-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 12px 14px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 12px;
+  background: #ffffff;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.mode-option:hover,
+.render-option:hover {
+  border-color: #c7d2fe;
+  background: #fafbff;
+}
+
+.mode-option.is-active,
+.render-option.is-active {
+  border-color: #667eea;
+  background: #f1f5ff;
+  box-shadow: 0 0 0 1px rgba(102, 126, 234, 0.15);
+}
+
+.mode-option-title,
+.render-option-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.mode-option.is-active .mode-option-title,
+.render-option.is-active .render-option-title {
+  color: #4f5fd0;
+}
+
+.mode-option-desc,
+.render-option-desc {
+  font-size: 12px;
+  color: #94a3b8;
+  line-height: 1.4;
+}
+
+.mode-option.is-active .mode-option-desc,
+.render-option.is-active .render-option-desc {
+  color: #64748b;
+}
+
+@media (max-width: 520px) {
+  .file-upload-container {
+    padding: 16px;
+  }
+
+  .upload-hero {
+    padding: 28px 20px 8px;
+  }
+
+  .upload-dropzone,
+  .settings-section {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .mode-segment {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -167,6 +167,11 @@ interface Props {
    * - Write (8): Full read/write access, compatible with Review and Read
    */
   mode?: AcEdOpenMode
+  /**
+   * Whether entities on non-plottable ("no-plot") layers are drawn.
+   * When omitted, {@link AcApDocManager} defaults to `false` (web viewer semantics).
+   */
+  drawNoPlotLayers?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -299,7 +304,8 @@ const endPendingOpen = () => {
 const handleFileRead = async (fileName: string, fileContent: ArrayBuffer) => {
   const options: AcApOpenDatabaseOptions = {
     minimumChunkSize: 1000,
-    mode: props.mode
+    mode: props.mode,
+    drawNoPlotLayers: props.drawNoPlotLayers
   }
   beginDocumentOpening()
   beginPendingOpen(options.mode ?? AcEdOpenMode.Read)
@@ -328,7 +334,8 @@ const handleFileRead = async (fileName: string, fileContent: ArrayBuffer) => {
 const openFileFromUrl = async (url: string) => {
   const options: AcApOpenDatabaseOptions = {
     minimumChunkSize: 1000,
-    mode: props.mode
+    mode: props.mode,
+    drawNoPlotLayers: props.drawNoPlotLayers
   }
   beginDocumentOpening()
   beginPendingOpen(options.mode ?? AcEdOpenMode.Read)
@@ -358,7 +365,8 @@ const openFileFromUrl = async (url: string) => {
 const openLocalFile = async (file: File) => {
   const options: AcApOpenDatabaseOptions = {
     minimumChunkSize: 1000,
-    mode: props.mode
+    mode: props.mode,
+    drawNoPlotLayers: props.drawNoPlotLayers
   }
   beginDocumentOpening()
   beginPendingOpen(options.mode ?? AcEdOpenMode.Read)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.8.3
-  '@mlightcad/libredwg-converter': ^3.6.3
+  '@mlightcad/data-model': ^1.8.4
+  '@mlightcad/libredwg-converter': ^3.6.4
   '@mlightcad/mtext-input-box': ^0.2.16
   '@mlightcad/mtext-renderer': ^0.11.2
   '@mlightcad/ribbon': ^0.1.10
@@ -115,11 +115,11 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       '@mlightcad/libredwg-converter':
-        specifier: ^3.6.3
-        version: 3.6.3(@mlightcad/data-model@1.8.3)
+        specifier: ^3.6.4
+        version: 3.6.4(@mlightcad/data-model@1.8.4)
       '@mlightcad/mtext-renderer':
         specifier: ^0.11.2
         version: 0.11.2(three@0.172.0)
@@ -149,8 +149,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -176,8 +176,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1
@@ -191,11 +191,11 @@ importers:
   packages/cad-simple-viewer:
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       '@mlightcad/libredwg-converter':
-        specifier: ^3.6.3
-        version: 3.6.3(@mlightcad/data-model@1.8.3)
+        specifier: ^3.6.4
+        version: 3.6.4(@mlightcad/data-model@1.8.4)
       '@mlightcad/mtext-input-box':
         specifier: ^0.2.16
         version: 0.2.16(@mlightcad/mtext-renderer@0.11.2(three@0.172.0))(three@0.172.0)
@@ -245,8 +245,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -260,8 +260,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       '@mlightcad/mtext-parser':
         specifier: ^1.4.1
         version: 1.4.1
@@ -287,8 +287,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       '@mlightcad/ribbon':
         specifier: ^0.1.10
         version: 0.1.10(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
@@ -359,8 +359,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -424,8 +424,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.4
+        version: 1.8.4
       '@mlightcad/mtext-renderer':
         specifier: ^0.11.2
         version: 0.11.2(three@0.172.0)
@@ -1522,30 +1522,30 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.5.3':
-    resolution: {integrity: sha512-IrpCbldYJPG/+b8wcIA/usycvvD4SYAVYnlfnzS0xRbpYg73I+1YV+DTC6SBrHtPtUQVRmkRHWUbRWLkW9hHLA==}
+  '@mlightcad/common@1.5.4':
+    resolution: {integrity: sha512-l9h42P0KkDggryBjOu77o5dBECZoLALMidLzXxokWGDY2sgGiX3jrqw8ak7GFn9deZmSWxchWanQRP5t8Dk1bA==}
 
-  '@mlightcad/data-model@1.8.3':
-    resolution: {integrity: sha512-2uvjCW1y1iWS7slGRgpFqJJ6QdoI3QloIqOX9jWK5fQ9IzV4q95hgU9pdeK3t5ozws4670e6vAgigBT8wQOzlw==}
+  '@mlightcad/data-model@1.8.4':
+    resolution: {integrity: sha512-ptuPq/ScOLjsv7jItC/yysYhgHcuGlz8Ax6rIWK1Vkxso28iObbNV3I7hd40GHQydpRG+1MO9/t//iexurKo1g==}
 
   '@mlightcad/dxf-json@1.2.2':
     resolution: {integrity: sha512-ASvN/DuaO/jBR2rxbgQy4d5oOseVIZIOFYtsgoWu8XNmNWtg9EyMXoVMamJdIp0aRxtP5bMBtrgfQ7A+wSqNzQ==}
 
-  '@mlightcad/geometry-engine@3.3.3':
-    resolution: {integrity: sha512-B1MtpW+LfCx3gt6a8A7yp2/z2soP5TWHwr84HptnjS9JLX/pYDc1KTq9z/KnQZBzHdMDHBcoW3v7ZwDpTTcmBA==}
+  '@mlightcad/geometry-engine@3.3.4':
+    resolution: {integrity: sha512-W+6Fzbs4U0bc0gzkde4fdwseoiE8+733VVBoMZ+WuYZSgRz7s0A7Z752Ynz/XKfA6rc4IUSsb2Q+RRUtpM2dhQ==}
     peerDependencies:
-      '@mlightcad/common': 1.5.3
+      '@mlightcad/common': 1.5.4
 
-  '@mlightcad/graphic-interface@3.4.3':
-    resolution: {integrity: sha512-IlZZyi0JzOqVxe+1VDJrjT/5EGSh4UjMHr3fM6x0jW/dPMCOJ4q9WdW9O/MtO/5KoPZ6T+Kzd+owD131ymhhRg==}
+  '@mlightcad/graphic-interface@3.4.4':
+    resolution: {integrity: sha512-mYpwjTGjnSR9YcAkocDqAEYuvgD+o6c+PyWUU18mMhU+H7oH1DS8WRHTN3bjeSwEwZ1cSZc59DWdjL1/3Eltag==}
     peerDependencies:
-      '@mlightcad/common': 1.5.3
-      '@mlightcad/geometry-engine': 3.3.3
+      '@mlightcad/common': 1.5.4
+      '@mlightcad/geometry-engine': 3.3.4
 
-  '@mlightcad/libredwg-converter@3.6.3':
-    resolution: {integrity: sha512-hpSV0U5Dw1Fj85TtrkeIubJCYD6QLdarnA6xOoNW/qvbfTcfPylunAcv+jyP6SEPEW+6SRV4tI8K4HlO8ViY5w==}
+  '@mlightcad/libredwg-converter@3.6.4':
+    resolution: {integrity: sha512-Uex3duZdhERdQHQF5M7xOWZ1HRvKY3B7iOpRDRvxzCdbX+OIVClVPhPiSGcEGRMdFLbQlr/LiTWEsi1o824XxA==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.8.3
+      '@mlightcad/data-model': ^1.8.4
 
   '@mlightcad/libredwg-web@0.7.2':
     resolution: {integrity: sha512-MPbVtnuUokzvCS4pdibiNw7PLdnSJo9R1pZcBnzRCyzWQqMHuZOxLVwtsV9aGk1SBmJ2186Hbu3Umt2B7hFS4Q==}
@@ -6623,16 +6623,16 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.5.3':
+  '@mlightcad/common@1.5.4':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.8.3':
+  '@mlightcad/data-model@1.8.4':
     dependencies:
-      '@mlightcad/common': 1.5.3
+      '@mlightcad/common': 1.5.4
       '@mlightcad/dxf-json': 1.2.2
-      '@mlightcad/geometry-engine': 3.3.3(@mlightcad/common@1.5.3)
-      '@mlightcad/graphic-interface': 3.4.3(@mlightcad/common@1.5.3)(@mlightcad/geometry-engine@3.3.3(@mlightcad/common@1.5.3))
+      '@mlightcad/geometry-engine': 3.3.4(@mlightcad/common@1.5.4)
+      '@mlightcad/graphic-interface': 3.4.4(@mlightcad/common@1.5.4)(@mlightcad/geometry-engine@3.3.4(@mlightcad/common@1.5.4))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
@@ -6640,18 +6640,18 @@ snapshots:
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.3.3(@mlightcad/common@1.5.3)':
+  '@mlightcad/geometry-engine@3.3.4(@mlightcad/common@1.5.4)':
     dependencies:
-      '@mlightcad/common': 1.5.3
+      '@mlightcad/common': 1.5.4
 
-  '@mlightcad/graphic-interface@3.4.3(@mlightcad/common@1.5.3)(@mlightcad/geometry-engine@3.3.3(@mlightcad/common@1.5.3))':
+  '@mlightcad/graphic-interface@3.4.4(@mlightcad/common@1.5.4)(@mlightcad/geometry-engine@3.3.4(@mlightcad/common@1.5.4))':
     dependencies:
-      '@mlightcad/common': 1.5.3
-      '@mlightcad/geometry-engine': 3.3.3(@mlightcad/common@1.5.3)
+      '@mlightcad/common': 1.5.4
+      '@mlightcad/geometry-engine': 3.3.4(@mlightcad/common@1.5.4)
 
-  '@mlightcad/libredwg-converter@3.6.3(@mlightcad/data-model@1.8.3)':
+  '@mlightcad/libredwg-converter@3.6.4(@mlightcad/data-model@1.8.4)':
     dependencies:
-      '@mlightcad/data-model': 1.8.3
+      '@mlightcad/data-model': 1.8.4
       '@mlightcad/libredwg-web': 0.7.2
 
   '@mlightcad/libredwg-web@0.7.2': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ allowBuilds:
   unrs-resolver: true
   vue-demi: true
 overrides:
-  '@mlightcad/data-model': '^1.8.3'
-  '@mlightcad/libredwg-converter': '^3.6.3'
+  '@mlightcad/data-model': '^1.8.4'
+  '@mlightcad/libredwg-converter': '^3.6.4'
   '@mlightcad/mtext-input-box': '^0.2.16'
   '@mlightcad/mtext-renderer': '^0.11.2'
   '@mlightcad/ribbon': '^0.1.10'


### PR DESCRIPTION
## Summary

- Redesign the cad-viewer-example upload screen with a card layout, segmented access mode controls, and settings separated from the file picker so option clicks do not open the file dialog.
- Add a text rendering selector (Web worker / Main thread), defaulting to web worker, and pass the choice into `AcApDocManager` via `MlCadViewer`'s `useMainThreadDraw` prop.
- Add a no-plot layer selector (Hide / Show), defaulting to hide, and pass the choice via `MlCadViewer`'s `drawNoPlotLayers` prop.
- Default web viewer open options to `drawNoPlotLayers: false` and bump `@mlightcad/data-model` to `^1.8.4`.
- Fix viewport rendering when border geometry is suppressed on no-plot layers, and move non-plottable layer suppression to `worldDraw` instead of layer visibility.

## Test plan

- [ ] Open cad-viewer-example and verify the upload screen renders with the redesigned layout.
- [ ] Select Read / Review / Write and confirm the choice is applied after opening a file.
- [ ] Toggle Web worker vs Main thread and confirm clicking the options does not open the file picker.
- [ ] Open a DWG/DXF with Web worker selected and verify text rendering uses worker mode.
- [ ] Open a DWG/DXF with Main thread selected and verify text rendering uses main thread mode.
- [ ] Toggle Hide vs Show no-plot layers and confirm clicking the options does not open the file picker.
- [ ] Open a drawing with no-plot layers using Hide and verify those layers are not drawn.
- [ ] Open the same drawing with Show and verify no-plot layer content appears.
- [ ] Open a drawing whose viewports sit on no-plot layers and verify model content below still renders.
