### PR TITLE
feat(viewer): add progressiveRendering option for document open

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1149,6 +1149,8 @@ export class AcApDocManager {
       doc: this.context.doc,
       mode: this.getDocumentEventMode(options)
     })
+    ;(this.curView as AcTrView2d).progressiveRendering =
+      options?.progressiveRendering ?? true
     this.curView.clear()
   }
 
@@ -1202,10 +1204,16 @@ export class AcApDocManager {
       const layoutLimits = activeLayout?.limits
 
       const view = this.curView as AcTrView2d
+      const progressiveRendering = options?.progressiveRendering ?? true
       if (isPaperSpaceActive && layoutLimits && !layoutLimits.isEmpty()) {
         view.zoomTo(layoutLimits)
       } else {
-        view.beginProgressiveOpenFit(this.resolveModelSpaceExtentsBox(db))
+        const extentsBox = this.resolveModelSpaceExtentsBox(db)
+        if (progressiveRendering) {
+          view.beginProgressiveOpenFit(extentsBox)
+        } else if (extentsBox && !extentsBox.isEmpty()) {
+          view.zoomTo(extentsBox)
+        }
         view.zoomToFitDrawing()
       }
 
@@ -1234,7 +1242,8 @@ export class AcApDocManager {
     if (options == null) {
       options = {
         fontLoader: this._fontLoader,
-        drawNoPlotLayers: false
+        drawNoPlotLayers: false,
+        progressiveRendering: true
       }
     } else {
       if (options.fontLoader == null) {
@@ -1242,6 +1251,9 @@ export class AcApDocManager {
       }
       if (options.drawNoPlotLayers == null) {
         options.drawNoPlotLayers = false
+      }
+      if (options.progressiveRendering == null) {
+        options.progressiveRendering = true
       }
     }
     return options

--- a/packages/cad-simple-viewer/src/app/AcDbOpenDatabaseOptions.ts
+++ b/packages/cad-simple-viewer/src/app/AcDbOpenDatabaseOptions.ts
@@ -32,4 +32,14 @@ export interface AcApOpenDatabaseOptions extends Omit<
    * - Write (8): Full read/write access, compatible with Review and Read
    */
   mode?: AcEdOpenMode
+  /**
+   * Whether to render entities incrementally while a drawing is opening.
+   *
+   * When `true` (default), entity conversion is deferred across event-loop
+   * turns so geometry appears progressively and the camera can reframe as
+   * batches land. When `false`, conversion still runs asynchronously but the
+   * canvas is not redrawn until every entity is converted; zoom-to-fit also
+   * waits for conversion to finish.
+   */
+  progressiveRendering?: boolean
 }

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -176,6 +176,11 @@ export class AcTrView2d extends AcEdBaseView {
   private _externallyFramedLayouts: Set<AcDbObjectId> = new Set()
   /** Progressive camera framing while entities batch-convert at document open. */
   private readonly _progressiveOpenFit: AcTrProgressiveOpenFitController
+  /**
+   * When true, entity conversion during document open is deferred across
+   * event-loop turns so geometry appears incrementally.
+   */
+  private _progressiveRendering = true
 
   /**
    * Creates a new 2D CAD viewer instance.
@@ -528,6 +533,16 @@ export class AcTrView2d extends AcEdBaseView {
    */
   get isProcessingEntities() {
     return this._numOfEntitiesToProcess > 0
+  }
+
+  /**
+   * Whether entity conversion during document open is deferred for progressive display.
+   */
+  get progressiveRendering() {
+    return this._progressiveRendering
+  }
+  set progressiveRendering(value: boolean) {
+    this._progressiveRendering = value
   }
 
   /**
@@ -1147,10 +1162,15 @@ export class AcTrView2d extends AcEdBaseView {
   addEntity(entity: AcDbEntity | AcDbEntity[]) {
     const entities = Array.isArray(entity) ? entity : [entity]
     this._numOfEntitiesToProcess += entities.length
-    setTimeout(async () => {
+    const convert = async () => {
       await this.batchConvert(entities)
-    })
-    this._isDirty = true
+    }
+    if (this._progressiveRendering) {
+      setTimeout(convert)
+      this._isDirty = true
+    } else {
+      void convert()
+    }
   }
 
   /**
@@ -1442,14 +1462,18 @@ export class AcTrView2d extends AcEdBaseView {
     })
 
     const stillLoading = this._numOfEntitiesToProcess > 0
+    const deferRenderWhileLoading =
+      stillLoading && !this._progressiveRendering
     if (!this._isDirty && !stillLoading) return
+    if (deferRenderWhileLoading) return
 
     const needsRedraw = this._layoutViewManager.render(this._scene)
     if (this.internalCamera) {
       this._css2dRenderer.render(this._scene.internalScene, this.internalCamera)
     }
     this._stats?.update()
-    this._isDirty = stillLoading || needsRedraw
+    this._isDirty =
+      (this._progressiveRendering && stillLoading) || needsRedraw
   }
 
   private startAnimationLoop() {
@@ -1588,10 +1612,10 @@ export class AcTrView2d extends AcEdBaseView {
         return
       }
 
-      // Load entities asynchronously
+      // Load entities asynchronously when progressive rendering is enabled.
       this._loadingLayouts.add(layoutBtrId)
       this._numOfEntitiesToProcess += entities.length
-      setTimeout(async () => {
+      const convert = async () => {
         try {
           await this.batchConvert(entities)
           const layout = this._scene.layouts.get(layoutBtrId)
@@ -1601,7 +1625,12 @@ export class AcTrView2d extends AcEdBaseView {
         } finally {
           this._loadingLayouts.delete(layoutBtrId)
         }
-      })
+      }
+      if (this._progressiveRendering) {
+        setTimeout(convert)
+      } else {
+        void convert()
+      }
     } catch (error) {
       log.error('[AcTrView2d] Error loading layout entities:', error)
     }
@@ -1631,6 +1660,28 @@ export class AcTrView2d extends AcEdBaseView {
 
   private drawEntity(entity: AcDbEntity, delay?: boolean) {
     return entity.worldDraw(this._renderer, delay) as AcTrEntity | null
+  }
+
+  /**
+   * Finishes geometry for a converted entity. Progressive mode defers MTEXT/SHAPE
+   * to async workers; non-progressive mode uses synchronous drawing from
+   * {@link drawEntity}(..., false).
+   */
+  private async finishEntityGeometry(threeEntity: AcTrEntity, progressive: boolean) {
+    if (progressive) {
+      await threeEntity.draw()
+      return
+    }
+    if (this.entityUsedSyncDraw(threeEntity)) {
+      return
+    }
+    await threeEntity.draw()
+  }
+
+  /** MTEXT/SHAPE entities expose syncDraw and render synchronously when delay=false. */
+  private entityUsedSyncDraw(threeEntity: AcTrEntity) {
+    return typeof (threeEntity as { syncDraw?: () => unknown }).syncDraw ===
+      'function'
   }
 
   /**
@@ -1674,6 +1725,7 @@ export class AcTrView2d extends AcEdBaseView {
    * @returns The converted three entities
    */
   private async batchConvert(entities: AcDbEntity[]) {
+    const progressive = this._progressiveRendering
     for (let i = 0; i < entities.length; ++i) {
       const entity = entities[i]
       try {
@@ -1699,7 +1751,7 @@ export class AcTrView2d extends AcEdBaseView {
           continue
         }
 
-        const threeEntity: AcTrEntity | null = this.drawEntity(entity, true)
+        const threeEntity: AcTrEntity | null = this.drawEntity(entity, progressive)
         // Viewports may produce no border geometry (e.g. on a no-plot layer) while
         // still needing an AcTrViewportView for model content below.
         if (!threeEntity && !(entity instanceof AcDbViewport)) continue
@@ -1731,16 +1783,18 @@ export class AcTrView2d extends AcEdBaseView {
               entity instanceof AcDbRay || entity instanceof AcDbXline
             )
 
-            await threeEntity.draw()
+            await this.finishEntityGeometry(threeEntity, progressive)
             this._scene.addEntity(threeEntity, isExtendBbox)
             this.applySessionHiddenObjectState(entity.objectId)
             // Release memory occupied by this entity
             threeEntity.dispose()
-            this._isDirty = true
-            await this._progressiveOpenFit.afterGeometryBatch(
-              () => this.resolveLayoutFitBox(),
-              i
-            )
+            if (progressive) {
+              this._isDirty = true
+              await this._progressiveOpenFit.afterGeometryBatch(
+                () => this.resolveLayoutFitBox(),
+                i
+              )
+            }
           }
         }
 
@@ -1877,10 +1931,12 @@ export class AcTrView2d extends AcEdBaseView {
     })
     group.dispose()
 
-    this._isDirty = true
-    void this._progressiveOpenFit.afterGeometryBatch(() =>
-      this.resolveLayoutFitBox()
-    )
+    if (this._progressiveRendering) {
+      this._isDirty = true
+      void this._progressiveOpenFit.afterGeometryBatch(() =>
+        this.resolveLayoutFitBox()
+      )
+    }
   }
 
   /**
@@ -1988,6 +2044,11 @@ export class AcTrView2d extends AcEdBaseView {
       log.warn(
         'Something wrong! The number of entities to process should not be less than 0.'
       )
+    } else if (
+      this._numOfEntitiesToProcess === 0 &&
+      !this._progressiveRendering
+    ) {
+      this._isDirty = true
     }
   }
 }

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -13,6 +13,7 @@
         :mode="selectedMode"
         :use-main-thread-draw="useMainThreadDraw"
         :draw-no-plot-layers="drawNoPlotLayers"
+        :progressive-rendering="progressiveRendering"
         @create="initialize"
         base-url="https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/"
       />
@@ -67,18 +68,21 @@ const initialize = () => {
 const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
 const useMainThreadDraw = ref(false)
 const drawNoPlotLayers = ref(false)
+const progressiveRendering = ref(true)
 
 // Handle file selection from upload component
 const handleFileSelect = (
   file: File,
   mode: AcEdOpenMode,
   mainThreadDraw: boolean,
-  showNoPlotLayers: boolean
+  showNoPlotLayers: boolean,
+  enableProgressiveRendering: boolean
 ) => {
   store.selectedFile = file
   selectedMode.value = mode
   useMainThreadDraw.value = mainThreadDraw
   drawNoPlotLayers.value = showNoPlotLayers
+  progressiveRendering.value = enableProgressiveRendering
 }
 </script>
 
@@ -93,10 +97,12 @@ const handleFileSelect = (
   width: 100vw;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  overflow-y: auto;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   margin: 0;
-  padding: 0;
+  padding: 24px 0;
+  box-sizing: border-box;
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -1,117 +1,177 @@
 <template>
   <div class="file-upload-container">
     <div class="upload-panel">
-      <section class="upload-hero">
-        <div class="upload-icon">
-          <el-icon :size="28">
-            <UploadFilled />
-          </el-icon>
-        </div>
-        <h1 class="upload-title">Select CAD File to View</h1>
-        <p class="upload-subtitle">Import DWG or DXF drawings into the viewer</p>
-      </section>
-
-      <el-upload
-        class="upload-dropzone"
-        drag
-        :auto-upload="false"
-        accept=".dwg,.dxf"
-        :on-change="handleFileChange"
-        :before-upload="beforeUpload"
-      >
-        <div class="dropzone-content">
-          <p class="dropzone-title">Drop your file here</p>
-          <p class="dropzone-hint">
-            or <span class="dropzone-link">browse files</span>
-          </p>
-          <div class="format-tags">
-            <span class="format-tag">DWG</span>
-            <span class="format-tag">DXF</span>
+      <div class="upload-main">
+        <section class="upload-hero">
+          <div class="upload-icon">
+            <el-icon :size="24">
+              <UploadFilled />
+            </el-icon>
           </div>
-        </div>
-      </el-upload>
+          <div class="upload-hero-text">
+            <h1 class="upload-title">Select CAD File to View</h1>
+            <p class="upload-subtitle">
+              Import DWG or DXF drawings into the viewer
+            </p>
+          </div>
+        </section>
+
+        <el-upload
+          class="upload-dropzone"
+          drag
+          :auto-upload="false"
+          accept=".dwg,.dxf"
+          :on-change="handleFileChange"
+          :before-upload="beforeUpload"
+        >
+          <div class="dropzone-content">
+            <p class="dropzone-title">Drop your file here</p>
+            <p class="dropzone-hint">
+              or <span class="dropzone-link">browse files</span>
+            </p>
+            <div class="format-tags">
+              <span class="format-tag">DWG</span>
+              <span class="format-tag">DXF</span>
+            </div>
+          </div>
+        </el-upload>
+      </div>
 
       <section class="settings-section">
-        <div class="setting-block">
-          <h2 class="setting-label">Access mode</h2>
-          <div class="mode-segment" role="radiogroup" aria-label="Access mode">
-            <button
-              v-for="mode in accessModes"
-              :key="mode.value"
-              type="button"
-              class="mode-option"
-              :class="{ 'is-active': selectedMode === mode.value }"
-              role="radio"
-              :aria-checked="selectedMode === mode.value"
-              @click="selectedMode = mode.value"
-            >
-              <span class="mode-option-title">{{ mode.label }}</span>
-              <span class="mode-option-desc">{{ mode.description }}</span>
-            </button>
-          </div>
-        </div>
+        <header class="settings-header">
+          <h2 class="settings-title">Open options</h2>
+          <p class="settings-subtitle">Applied when the file is loaded</p>
+        </header>
 
-        <div class="setting-block">
-          <h2 class="setting-label">Text rendering</h2>
-          <div
-            class="render-segment"
-            role="radiogroup"
-            aria-label="Text rendering"
-          >
-            <button
-              type="button"
-              class="render-option"
-              :class="{ 'is-active': !useMainThreadDraw }"
-              role="radio"
-              :aria-checked="!useMainThreadDraw"
-              @click="useMainThreadDraw = false"
-            >
-              <span class="render-option-title">Web worker</span>
-              <span class="render-option-desc">Faster, more memory</span>
-            </button>
-            <button
-              type="button"
-              class="render-option"
-              :class="{ 'is-active': useMainThreadDraw }"
-              role="radio"
-              :aria-checked="useMainThreadDraw"
-              @click="useMainThreadDraw = true"
-            >
-              <span class="render-option-title">Main thread</span>
-              <span class="render-option-desc">Slower, less memory</span>
-            </button>
+        <div class="settings-grid">
+          <div class="setting-block setting-block--full">
+            <h3 class="setting-label">Access mode</h3>
+            <div class="mode-segment" role="radiogroup" aria-label="Access mode">
+              <button
+                v-for="mode in accessModes"
+                :key="mode.value"
+                type="button"
+                class="mode-option"
+                :class="{ 'is-active': selectedMode === mode.value }"
+                role="radio"
+                :aria-checked="selectedMode === mode.value"
+                @click="selectedMode = mode.value"
+              >
+                <span class="option-title">{{ mode.label }}</span>
+                <span class="option-desc">{{ mode.description }}</span>
+              </button>
+            </div>
           </div>
-        </div>
 
-        <div class="setting-block">
-          <h2 class="setting-label">Non-plottable layers</h2>
-          <div
-            class="render-segment"
-            role="radiogroup"
-            aria-label="Non-plottable layers"
-          >
-            <button
-              type="button"
-              class="render-option"
-              :class="{ 'is-active': !drawNoPlotLayers }"
-              role="radio"
-              :aria-checked="!drawNoPlotLayers"
-              @click="drawNoPlotLayers = false"
+          <div class="setting-block">
+            <h3 class="setting-label">Text rendering</h3>
+            <div
+              class="pill-segment"
+              role="radiogroup"
+              aria-label="Text rendering"
             >
-              <span class="render-option-title">Hide</span>
-              <span class="render-option-desc">Web viewer default</span>
-            </button>
-            <button
-              type="button"
-              class="render-option"
-              :class="{ 'is-active': drawNoPlotLayers }"
-              role="radio"
-              :aria-checked="drawNoPlotLayers"
-              @click="drawNoPlotLayers = true"
+              <button
+                type="button"
+                class="pill-option"
+                :class="{ 'is-active': !useMainThreadDraw }"
+                role="radio"
+                :aria-checked="!useMainThreadDraw"
+                @click="useMainThreadDraw = false"
+              >
+                Web worker
+              </button>
+              <button
+                type="button"
+                class="pill-option"
+                :class="{ 'is-active': useMainThreadDraw }"
+                role="radio"
+                :aria-checked="useMainThreadDraw"
+                @click="useMainThreadDraw = true"
+              >
+                Main thread
+              </button>
+            </div>
+            <p class="setting-hint">
+              {{
+                useMainThreadDraw
+                  ? 'Slower, less memory'
+                  : 'Faster, more memory'
+              }}
+            </p>
+          </div>
+
+          <div class="setting-block">
+            <h3 class="setting-label">Progressive rendering</h3>
+            <div
+              class="pill-segment"
+              role="radiogroup"
+              aria-label="Progressive rendering"
             >
-              <span class="render-option-title">Show</span>
-              <span class="render-option-desc">AutoCAD editor semantics</span>
-            </button>
+              <button
+                type="button"
+                class="pill-option"
+                :class="{ 'is-active': progressiveRendering }"
+                role="radio"
+                :aria-checked="progressiveRendering"
+                @click="progressiveRendering = true"
+              >
+                Enabled
+              </button>
+              <button
+                type="button"
+                class="pill-option"
+                :class="{ 'is-active': !progressiveRendering }"
+                role="radio"
+                :aria-checked="!progressiveRendering"
+                @click="progressiveRendering = false"
+              >
+                Disabled
+              </button>
+            </div>
+            <p class="setting-hint">
+              {{
+                progressiveRendering
+                  ? 'Show geometry while loading'
+                  : 'Wait until fully converted'
+              }}
+            </p>
+          </div>
+
+          <div class="setting-block">
+            <h3 class="setting-label">Non-plottable layers</h3>
+            <div
+              class="pill-segment"
+              role="radiogroup"
+              aria-label="Non-plottable layers"
+            >
+              <button
+                type="button"
+                class="pill-option"
+                :class="{ 'is-active': !drawNoPlotLayers }"
+                role="radio"
+                :aria-checked="!drawNoPlotLayers"
+                @click="drawNoPlotLayers = false"
+              >
+                Hide
+              </button>
+              <button
+                type="button"
+                class="pill-option"
+                :class="{ 'is-active': drawNoPlotLayers }"
+                role="radio"
+                :aria-checked="drawNoPlotLayers"
+                @click="drawNoPlotLayers = true"
+              >
+                Show
+              </button>
+            </div>
+            <p class="setting-hint">
+              {{
+                drawNoPlotLayers
+                  ? 'AutoCAD editor semantics'
+                  : 'Web viewer default'
+              }}
+            </p>
           </div>
         </div>
       </section>
@@ -132,7 +192,8 @@ interface Props {
     file: File,
     mode: AcEdOpenMode,
     useMainThreadDraw: boolean,
-    drawNoPlotLayers: boolean
+    drawNoPlotLayers: boolean,
+    progressiveRendering: boolean
   ) => void
 }
 
@@ -141,6 +202,7 @@ const props = defineProps<Props>()
 const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
 const useMainThreadDraw = ref(false)
 const drawNoPlotLayers = ref(false)
+const progressiveRendering = ref(true)
 
 const accessModes = [
   {
@@ -167,7 +229,8 @@ const handleFileChange: UploadProps['onChange'] = (uploadFile: UploadFile) => {
         uploadFile.raw,
         selectedMode.value,
         useMainThreadDraw.value,
-        drawNoPlotLayers.value
+        drawNoPlotLayers.value,
+        progressiveRendering.value
       )
     }
   }
@@ -192,63 +255,70 @@ const isValidFile = (file: File): boolean => {
 .file-upload-container {
   display: flex;
   justify-content: center;
-  align-items: center;
   width: 100%;
-  max-width: 560px;
-  padding: 24px;
+  max-width: 640px;
+  padding: 20px 24px;
+  box-sizing: border-box;
 }
 
 .upload-panel {
   display: flex;
   flex-direction: column;
   width: 100%;
-  border-radius: 20px;
+  border-radius: 16px;
   background: #ffffff;
   box-shadow:
-    0 24px 48px rgba(15, 23, 42, 0.18),
+    0 20px 40px rgba(15, 23, 42, 0.16),
     0 0 0 1px rgba(255, 255, 255, 0.08);
   overflow: hidden;
 }
 
+.upload-main {
+  padding: 24px 24px 20px;
+}
+
 .upload-hero {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  padding: 36px 32px 8px;
-  text-align: center;
+  gap: 14px;
+  margin-bottom: 16px;
 }
 
 .upload-icon {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  width: 52px;
-  height: 52px;
-  border-radius: 14px;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
   background: linear-gradient(135deg, #667eea 0%, #5b6fd6 100%);
   color: #ffffff;
-  box-shadow: 0 8px 20px rgba(102, 126, 234, 0.35);
+  box-shadow: 0 6px 16px rgba(102, 126, 234, 0.3);
+}
+
+.upload-hero-text {
+  min-width: 0;
 }
 
 .upload-title {
-  margin: 8px 0 0;
-  font-size: 24px;
+  margin: 0;
+  font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.02em;
   color: #0f172a;
+  line-height: 1.3;
 }
 
 .upload-subtitle {
-  margin: 0;
-  font-size: 14px;
+  margin: 4px 0 0;
+  font-size: 13px;
   color: #64748b;
-  line-height: 1.5;
+  line-height: 1.4;
 }
 
 .upload-dropzone {
   width: 100%;
-  padding: 0 28px;
   box-sizing: border-box;
 }
 
@@ -263,9 +333,9 @@ const isValidFile = (file: File): boolean => {
   justify-content: center;
   width: 100%;
   box-sizing: border-box;
-  padding: 28px 20px;
+  padding: 20px 16px;
   border: 1.5px dashed #c7d2fe;
-  border-radius: 14px;
+  border-radius: 12px;
   background: #f8faff;
   transition:
     border-color 0.2s ease,
@@ -283,12 +353,12 @@ const isValidFile = (file: File): boolean => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
 }
 
 .dropzone-title {
   margin: 0;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   color: #1e293b;
 }
@@ -306,112 +376,166 @@ const isValidFile = (file: File): boolean => {
 
 .format-tags {
   display: flex;
-  gap: 8px;
-  margin-top: 10px;
+  gap: 6px;
+  margin-top: 8px;
 }
 
 .format-tag {
-  padding: 3px 10px;
+  padding: 2px 8px;
   border-radius: 999px;
   background: #e8edff;
   color: #4f5fd0;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.04em;
 }
 
 .settings-section {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-top: 24px;
-  padding: 24px 28px 28px;
+  padding: 16px 24px 20px;
   background: #f8fafc;
   border-top: 1px solid #e8edf5;
+}
+
+.settings-header {
+  margin-bottom: 14px;
+}
+
+.settings-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.settings-subtitle {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 20px;
 }
 
 .setting-block {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 6px;
+}
+
+.setting-block--full {
+  grid-column: 1 / -1;
 }
 
 .setting-label {
   margin: 0;
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   color: #94a3b8;
 }
 
-.mode-segment,
-.render-segment {
-  display: grid;
-  gap: 8px;
+.setting-hint {
+  margin: 0;
+  font-size: 11px;
+  color: #94a3b8;
+  line-height: 1.35;
 }
 
 .mode-segment {
-  grid-template-columns: repeat(3, 1fr);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
 }
 
-.render-segment {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.mode-option,
-.render-option {
+.mode-option {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-  padding: 12px 14px;
+  align-items: center;
+  gap: 1px;
+  padding: 8px 6px;
   border: 1.5px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 10px;
   background: #ffffff;
   cursor: pointer;
-  text-align: left;
+  text-align: center;
   transition:
     border-color 0.2s ease,
     background-color 0.2s ease,
     box-shadow 0.2s ease;
 }
 
-.mode-option:hover,
-.render-option:hover {
+.mode-option:hover {
   border-color: #c7d2fe;
   background: #fafbff;
 }
 
-.mode-option.is-active,
-.render-option.is-active {
+.mode-option.is-active {
   border-color: #667eea;
   background: #f1f5ff;
-  box-shadow: 0 0 0 1px rgba(102, 126, 234, 0.15);
+  box-shadow: 0 0 0 1px rgba(102, 126, 234, 0.12);
 }
 
-.mode-option-title,
-.render-option-title {
-  font-size: 14px;
+.option-title {
+  font-size: 13px;
   font-weight: 600;
   color: #1e293b;
+  line-height: 1.3;
 }
 
-.mode-option.is-active .mode-option-title,
-.render-option.is-active .render-option-title {
+.mode-option.is-active .option-title {
   color: #4f5fd0;
 }
 
-.mode-option-desc,
-.render-option-desc {
-  font-size: 12px;
+.option-desc {
+  font-size: 10px;
   color: #94a3b8;
-  line-height: 1.4;
+  line-height: 1.3;
 }
 
-.mode-option.is-active .mode-option-desc,
-.render-option.is-active .render-option-desc {
+.mode-option.is-active .option-desc {
   color: #64748b;
+}
+
+.pill-segment {
+  display: flex;
+  gap: 0;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+.pill-option {
+  flex: 1;
+  padding: 7px 10px;
+  border: none;
+  background: transparent;
+  font-size: 12px;
+  font-weight: 600;
+  color: #64748b;
+  cursor: pointer;
+  text-align: center;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.pill-option:not(:last-child) {
+  border-right: 1px solid #e2e8f0;
+}
+
+.pill-option:hover:not(.is-active) {
+  background: #f8fafc;
+  color: #475569;
+}
+
+.pill-option.is-active {
+  background: #f1f5ff;
+  color: #4f5fd0;
 }
 
 @media (max-width: 520px) {
@@ -419,18 +543,29 @@ const isValidFile = (file: File): boolean => {
     padding: 16px;
   }
 
-  .upload-hero {
-    padding: 28px 20px 8px;
+  .upload-main,
+  .settings-section {
+    padding-left: 16px;
+    padding-right: 16px;
   }
 
-  .upload-dropzone,
-  .settings-section {
-    padding-left: 20px;
-    padding-right: 20px;
+  .settings-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .setting-block--full {
+    grid-column: auto;
   }
 
   .mode-segment {
     grid-template-columns: 1fr;
+  }
+
+  .mode-option {
+    flex-direction: row;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 12px;
   }
 }
 </style>

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -172,6 +172,11 @@ interface Props {
    * When omitted, {@link AcApDocManager} defaults to `false` (web viewer semantics).
    */
   drawNoPlotLayers?: boolean
+  /**
+   * Whether to render entities incrementally while a drawing is opening.
+   * When omitted, {@link AcApDocManager} defaults to `true`.
+   */
+  progressiveRendering?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -183,7 +188,8 @@ const props = withDefaults(defineProps<Props>(), {
   htmlViewerRuntimeUrl: './assets/viewer-runtime.iife.js',
   useMainThreadDraw: true,
   theme: 'dark',
-  mode: AcEdOpenMode.Write
+  mode: AcEdOpenMode.Write,
+  progressiveRendering: true
 })
 
 const { t } = useI18n()
@@ -305,7 +311,8 @@ const handleFileRead = async (fileName: string, fileContent: ArrayBuffer) => {
   const options: AcApOpenDatabaseOptions = {
     minimumChunkSize: 1000,
     mode: props.mode,
-    drawNoPlotLayers: props.drawNoPlotLayers
+    drawNoPlotLayers: props.drawNoPlotLayers,
+    progressiveRendering: props.progressiveRendering
   }
   beginDocumentOpening()
   beginPendingOpen(options.mode ?? AcEdOpenMode.Read)
@@ -335,7 +342,8 @@ const openFileFromUrl = async (url: string) => {
   const options: AcApOpenDatabaseOptions = {
     minimumChunkSize: 1000,
     mode: props.mode,
-    drawNoPlotLayers: props.drawNoPlotLayers
+    drawNoPlotLayers: props.drawNoPlotLayers,
+    progressiveRendering: props.progressiveRendering
   }
   beginDocumentOpening()
   beginPendingOpen(options.mode ?? AcEdOpenMode.Read)
@@ -366,7 +374,8 @@ const openLocalFile = async (file: File) => {
   const options: AcApOpenDatabaseOptions = {
     minimumChunkSize: 1000,
     mode: props.mode,
-    drawNoPlotLayers: props.drawNoPlotLayers
+    drawNoPlotLayers: props.drawNoPlotLayers,
+    progressiveRendering: props.progressiveRendering
   }
   beginDocumentOpening()
   beginPendingOpen(options.mode ?? AcEdOpenMode.Read)


### PR DESCRIPTION
## Summary
- Add optional `progressiveRendering` flag to `AcApOpenDatabaseOptions` (defaults to `true`) so callers can disable incremental entity rendering while a drawing opens.
- When disabled, entity conversion still runs asynchronously but the canvas is not redrawn until all entities are converted; zoom-to-fit waits for conversion to finish.
- Expose the option via `MlCadViewer` prop and a new toggle in the example upload panel (with refreshed settings layout).

## Test plan
- [ ] Open a large DWG/DXF with progressive rendering enabled (default) and confirm geometry appears incrementally.
- [ ] Toggle progressive rendering off in the example upload panel, open the same file, and confirm the canvas stays blank until loading completes, then shows the full drawing at once.
- [ ] Verify `MlCadViewer` with `:progressive-rendering="false"` behaves the same as the example toggle.
- [ ] Confirm paper-space layouts and zoom-to-fit still work correctly in both modes.