### PR TITLE
feat(three-renderer): add pluggable batch draw policy for large coordinates

### DIFF
--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -1857,7 +1857,7 @@ export class AcTrView2d extends AcEdBaseView {
       child.parent = null
     }
 
-    const styleManager = group.styleManager
+    const renderContext = group.renderContext
     const groupObjectId = group.objectId
     const groupLayerName = group.layerName
     const worldGroupBox = group.box.clone()
@@ -1906,7 +1906,7 @@ export class AcTrView2d extends AcEdBaseView {
       // render entity per layer bucket but preserve the INSERT object id for all
       // buckets, so selection/highlight still maps back to the same database object.
       // Within each layer bucket, the object id remains unique in scene indexing.
-      const entity = new AcTrEntity(styleManager)
+      const entity = new AcTrEntity(renderContext)
       entity.applyMatrix4(group.matrix)
       entity.objectId = groupObjectId
       entity.ownerId = group.ownerId

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -97,11 +97,11 @@ const handleFileSelect = (
   width: 100vw;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: safe center;
   overflow-y: auto;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   margin: 0;
-  padding: 24px 0;
+  padding: 24px;
   box-sizing: border-box;
   position: absolute;
   top: 0;

--- a/packages/three-renderer/__tests__/AcTrBatchDrawPolicy.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchDrawPolicy.spec.ts
@@ -1,0 +1,78 @@
+import * as THREE from 'three'
+
+import {
+  defaultBatchDrawPolicy,
+  isLargeWorldCoordinatePoint,
+  resolveAnchorFromBox,
+  resolveAnchorFromPoints,
+  RTE_REBASE_THRESHOLD
+} from '../src/draw/AcTrBatchDrawPolicy'
+
+describe('AcTrBatchDrawPolicy', () => {
+  it('detects large-world insertion points', () => {
+    expect(isLargeWorldCoordinatePoint({ x: 10, y: 20, z: 0 })).toBe(false)
+    expect(
+      isLargeWorldCoordinatePoint({
+        x: RTE_REBASE_THRESHOLD + 1,
+        y: 0,
+        z: 0
+      })
+    ).toBe(true)
+  })
+
+  it('defaults to batch at small coordinates', () => {
+    expect(
+      defaultBatchDrawPolicy.resolveDrawMode({
+        position: { x: 10, y: 20, z: 0 }
+      })
+    ).toBe('batch')
+    expect(
+      defaultBatchDrawPolicy.resolveDrawMode({
+        anchor: { x: 0, y: 0, z: 0 }
+      })
+    ).toBe('batch')
+  })
+
+  it('defaults to unbatch at large coordinates', () => {
+    expect(
+      defaultBatchDrawPolicy.resolveDrawMode({
+        position: { x: RTE_REBASE_THRESHOLD + 500, y: 0, z: 0 }
+      })
+    ).toBe('unbatch')
+    expect(
+      defaultBatchDrawPolicy.resolveDrawMode({
+        anchor: { x: RTE_REBASE_THRESHOLD + 1, y: 0, z: 0 }
+      })
+    ).toBe('unbatch')
+  })
+
+  it('prefers anchor over position when both are provided', () => {
+    expect(
+      defaultBatchDrawPolicy.resolveDrawMode({
+        position: { x: 0, y: 0, z: 0 },
+        anchor: { x: RTE_REBASE_THRESHOLD + 1, y: 0, z: 0 }
+      })
+    ).toBe('unbatch')
+  })
+
+  it('derives anchor center from a bounding box', () => {
+    const box = new THREE.Box3(
+      new THREE.Vector3(10, 20, 30),
+      new THREE.Vector3(30, 40, 50)
+    )
+
+    expect(resolveAnchorFromBox(box)).toEqual({ x: 20, y: 30, z: 40 })
+    expect(resolveAnchorFromBox(new THREE.Box3())).toBeUndefined()
+  })
+
+  it('matches point-list anchor when box encloses the same vertices', () => {
+    const points = [
+      { x: 10, y: 20, z: 30 },
+      { x: 30, y: 40, z: 50 }
+    ]
+    const box = new THREE.Box3()
+    points.forEach(point => box.expandByPoint(new THREE.Vector3(point.x, point.y, point.z)))
+
+    expect(resolveAnchorFromBox(box)).toEqual(resolveAnchorFromPoints(points))
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrBatchedBounds.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedBounds.spec.ts
@@ -2,7 +2,10 @@ import * as THREE from 'three'
 
 import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
 import { AcTrBatchedLine } from '../src/batch/AcTrBatchedLine'
+import { AcTrBatchedMesh } from '../src/batch/AcTrBatchedMesh'
+import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
 import { AcTrEntity } from '../src/object/AcTrEntity'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
 import { AcTrStyleManager } from '../src/style/AcTrStyleManager'
 import { getSceneDrawableUserData } from '../src/util/AcTrObjectUserData'
 
@@ -56,7 +59,7 @@ function createEntity(
   objectId: string,
   ...drawables: THREE.Object3D[]
 ): AcTrEntity {
-  const entity = new AcTrEntity(new AcTrStyleManager())
+  const entity = new AcTrEntity(new AcTrRenderContext())
   entity.objectId = objectId
   entity.visible = true
   for (const drawable of drawables) {
@@ -65,7 +68,81 @@ function createEntity(
   return entity
 }
 
-describe('AcTrBatchedLine batch bounds', () => {
+function createGlyphMesh(localMinX: number, width = 4, height = 2) {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(
+      [
+        localMinX,
+        0,
+        0,
+        localMinX + width,
+        0,
+        0,
+        localMinX + width,
+        height,
+        0,
+        localMinX,
+        height,
+        0
+      ],
+      3
+    )
+  )
+  geometry.setIndex([0, 1, 2, 0, 2, 3])
+  return new THREE.Mesh(geometry, new THREE.MeshBasicMaterial())
+}
+
+function createPlacementRoot(
+  insertion: THREE.Vector3Like,
+  glyphOffsets: number[]
+) {
+  const placementRoot = new THREE.Group()
+  placementRoot.position.set(insertion.x, insertion.y, insertion.z ?? 0)
+  for (const offset of glyphOffsets) {
+    placementRoot.add(createGlyphMesh(offset))
+  }
+  placementRoot.updateMatrixWorld(true)
+  return placementRoot
+}
+
+function getLocalGeometrySpan(mesh: THREE.Mesh) {
+  const position = mesh.geometry.getAttribute('position')
+  let minX = Infinity
+  let maxX = -Infinity
+  for (let i = 0; i < position.count; i++) {
+    const x = position.getX(i)
+    minX = Math.min(minX, x)
+    maxX = Math.max(maxX, x)
+  }
+  return maxX - minX
+}
+
+function findUnbatchedPlacementClone(group: AcTrBatchedGroup) {
+  let clone: THREE.Object3D | undefined
+  group.traverse(child => {
+    if (clone || !(child instanceof THREE.Group)) {
+      return
+    }
+    const meshChildren = child.children.filter(
+      grandchild => grandchild instanceof THREE.Mesh
+    )
+    if (meshChildren.length < 2) {
+      return
+    }
+    if (
+      Math.max(Math.abs(child.position.x), Math.abs(child.position.y)) <
+      RTE_REBASE_THRESHOLD
+    ) {
+      return
+    }
+    clone = child
+  })
+  return clone
+}
+
+describe('AcTrBatchedLine', () => {
   it('unionActiveVisibleBoundingBoxInto returns world-space bounds after origin rebase', () => {
     const worldOffset = new THREE.Vector3(1_000_000, 2_000_000, 0)
     const geometry = new THREE.BufferGeometry()
@@ -90,7 +167,7 @@ describe('AcTrBatchedLine batch bounds', () => {
   })
 })
 
-describe('AcTrBatchedGroup.computeBoundingBox', () => {
+describe('AcTrBatchedGroup', () => {
   it('returns world-space bounds for batched line entities', () => {
     const group = new AcTrBatchedGroup()
     const worldOffset = new THREE.Vector3(1_000_000, 2_000_000, 0)
@@ -128,6 +205,41 @@ describe('AcTrBatchedGroup.computeBoundingBox', () => {
       { x: 300_000, y: 400_000, z: 0 },
       { x: 300_050, y: 400_025, z: 0 }
     )
+  })
+
+  it('keeps local line geometry when cloning large-world unbatched drawables', () => {
+    const group = new AcTrBatchedGroup()
+    const worldOffset = new THREE.Vector3(1_200_000, 3_000_000, 0)
+    const line = createLineSegments(
+      { x: -10, y: 0, z: 0 },
+      { x: 10, y: 0, z: 0 },
+      worldOffset,
+      { noBatch: true }
+    )
+
+    group.addEntity(createEntity('line-large-unbatched', line))
+
+    let clonedLine: THREE.LineSegments | undefined
+    group.traverse(child => {
+      if (clonedLine || !(child instanceof THREE.LineSegments)) {
+        return
+      }
+      if (Math.abs(child.position.x - worldOffset.x) > 1) {
+        return
+      }
+      clonedLine = child
+    })
+
+    expect(clonedLine).toBeDefined()
+    if (!clonedLine) {
+      return
+    }
+
+    const position = clonedLine.geometry.getAttribute('position')
+    expect(position.getX(0)).toBeCloseTo(-10, 5)
+    expect(position.getX(1)).toBeCloseTo(10, 5)
+    expect(clonedLine.position.x).toBeCloseTo(worldOffset.x, 3)
+    expect(clonedLine.position.y).toBeCloseTo(worldOffset.y, 3)
   })
 
   it('unions batched and unbatched entity bounds', () => {
@@ -193,5 +305,60 @@ describe('AcTrBatchedGroup.computeBoundingBox', () => {
       { x: 300_000, y: 400_000, z: 0 },
       { x: 300_050, y: 400_025, z: 0 }
     )
+  })
+
+  it('clones a noBatch MTEXT placement root once and preserves glyph spacing', () => {
+    const group = new AcTrBatchedGroup()
+    const placementRoot = createPlacementRoot(
+      { x: RTE_REBASE_THRESHOLD + 100, y: 3_000_000, z: 0 },
+      [0, 8]
+    )
+    getSceneDrawableUserData(placementRoot).noBatch = true
+    getSceneDrawableUserData(placementRoot).bboxIntersectionCheck = true
+
+    const entity = createEntity('mtext-1', placementRoot)
+    group.addEntity(entity)
+
+    expect(group.stats.unbatched.count).toBe(1)
+
+    const clonedRoot = findUnbatchedPlacementClone(group)
+    expect(clonedRoot).toBeDefined()
+    if (!clonedRoot) {
+      return
+    }
+    expect(
+      clonedRoot.children.filter(child => child instanceof THREE.Mesh)
+    ).toHaveLength(2)
+
+    const [firstMesh, secondMesh] = clonedRoot.children as THREE.Mesh[]
+    expect(getLocalGeometrySpan(firstMesh)).toBeCloseTo(4, 3)
+    expect(getLocalGeometrySpan(secondMesh)).toBeCloseTo(4, 3)
+    expect(secondMesh.geometry.getAttribute('position').getX(0)).toBeCloseTo(
+      8,
+      3
+    )
+    expect(clonedRoot.position.x).toBeCloseTo(RTE_REBASE_THRESHOLD + 100, 3)
+    expect(clonedRoot.position.y).toBeCloseTo(3_000_000, 3)
+
+    const batchedMeshes = group.children.filter(
+      child => child instanceof AcTrBatchedMesh
+    )
+    expect(batchedMeshes).toHaveLength(0)
+  })
+
+  it('still batches small-coordinate flattened MTEXT leaves', () => {
+    const group = new AcTrBatchedGroup()
+    const entity = createEntity(
+      'mtext-small',
+      createGlyphMesh(0),
+      createGlyphMesh(8)
+    )
+
+    group.addEntity(entity)
+
+    expect(group.stats.unbatched.count).toBe(0)
+    expect(
+      group.children.some(child => child instanceof AcTrBatchedMesh)
+    ).toBe(true)
   })
 })

--- a/packages/three-renderer/__tests__/AcTrBatchedGroupUnbatchedOps.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupUnbatchedOps.spec.ts
@@ -1,0 +1,219 @@
+import * as THREE from 'three'
+
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
+import { AcTrEntity } from '../src/object/AcTrEntity'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { getHighlightUserData, getSceneDrawableUserData } from '../src/util/AcTrObjectUserData'
+
+function createEntity(objectId: string, ...drawables: THREE.Object3D[]): AcTrEntity {
+  const entity = new AcTrEntity(new AcTrRenderContext())
+  entity.objectId = objectId
+  entity.visible = true
+  for (const drawable of drawables) {
+    entity.add(drawable)
+  }
+  return entity
+}
+
+function createGlyphMesh(localMinX: number, width = 4, height = 2) {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(
+      [
+        localMinX,
+        0,
+        0,
+        localMinX + width,
+        0,
+        0,
+        localMinX + width,
+        height,
+        0,
+        localMinX,
+        height,
+        0
+      ],
+      3
+    )
+  )
+  geometry.setIndex([0, 1, 2, 0, 2, 3])
+  return new THREE.Mesh(geometry, new THREE.MeshBasicMaterial())
+}
+
+function createPlacementRoot(
+  insertion: THREE.Vector3Like,
+  glyphOffsets: number[]
+) {
+  const placementRoot = new THREE.Group()
+  placementRoot.position.set(insertion.x, insertion.y, insertion.z ?? 0)
+  for (const offset of glyphOffsets) {
+    placementRoot.add(createGlyphMesh(offset))
+  }
+  placementRoot.updateMatrixWorld(true)
+  return placementRoot
+}
+
+function findUnbatchedPlacementClone(group: AcTrBatchedGroup) {
+  let clone: THREE.Object3D | undefined
+  group.traverse(child => {
+    if (clone || !(child instanceof THREE.Group)) {
+      return
+    }
+    const meshChildren = child.children.filter(
+      grandchild => grandchild instanceof THREE.Mesh
+    )
+    if (meshChildren.length < 2) {
+      return
+    }
+    if (
+      Math.max(Math.abs(child.position.x), Math.abs(child.position.y)) <
+      RTE_REBASE_THRESHOLD
+    ) {
+      return
+    }
+    clone = child
+  })
+  return clone
+}
+
+describe('AcTrBatchedGroup unbatched operations', () => {
+  it('selects and unselects an unbatched placement root', () => {
+    const group = new AcTrBatchedGroup()
+    const placementRoot = createPlacementRoot(
+      { x: RTE_REBASE_THRESHOLD + 100, y: 3_000_000, z: 0 },
+      [0, 8]
+    )
+    getSceneDrawableUserData(placementRoot).noBatch = true
+    getSceneDrawableUserData(placementRoot).bboxIntersectionCheck = true
+
+    group.addEntity(createEntity('mtext-1', placementRoot))
+    group.select('mtext-1')
+
+    const selectedGroup = group.children[1] as THREE.Group
+    expect(selectedGroup.children).toHaveLength(1)
+    expect(getHighlightUserData(selectedGroup.children[0]).objectId).toBe(
+      'mtext-1'
+    )
+
+    group.unselect('mtext-1')
+    expect(selectedGroup.children).toHaveLength(0)
+  })
+
+  it('disposes highlight materials for unbatched subtree children on unselect', () => {
+    const group = new AcTrBatchedGroup()
+    const placementRoot = createPlacementRoot(
+      { x: RTE_REBASE_THRESHOLD + 100, y: 3_000_000, z: 0 },
+      [0, 8]
+    )
+    getSceneDrawableUserData(placementRoot).noBatch = true
+
+    group.addEntity(createEntity('mtext-1', placementRoot))
+    group.select('mtext-1')
+
+    const selectedGroup = group.children[1] as THREE.Group
+    const highlightRoot = selectedGroup.children[0]
+    const highlightMeshes = highlightRoot.children.filter(
+      child => child instanceof THREE.Mesh
+    ) as THREE.Mesh[]
+    expect(highlightMeshes.length).toBeGreaterThan(0)
+
+    const disposeSpy = jest.spyOn(THREE.Material.prototype, 'dispose')
+    group.unselect('mtext-1')
+
+    expect(disposeSpy.mock.calls.length).toBeGreaterThanOrEqual(
+      highlightMeshes.length
+    )
+    disposeSpy.mockRestore()
+  })
+
+  it('removes unbatched entities and clears selection highlights', () => {
+    const group = new AcTrBatchedGroup()
+    const line = createUnbatchedLine()
+    group.addEntity(createEntity('line-1', line))
+    group.select('line-1')
+
+    expect(group.hasEntity('line-1')).toBe(true)
+    expect(group.removeEntity('line-1')).toBe(true)
+    expect(group.hasEntity('line-1')).toBe(false)
+    expect((group.children[1] as THREE.Group).children).toHaveLength(0)
+    expect(group.stats.unbatched.count).toBe(0)
+  })
+
+  it('uses bbox intersection for unbatched drawables flagged with bboxIntersectionCheck', () => {
+    const group = new AcTrBatchedGroup()
+    const insertion = {
+      x: RTE_REBASE_THRESHOLD + 100,
+      y: 3_000_000,
+      z: 0
+    }
+    const placementRoot = createPlacementRoot(insertion, [0, 8])
+    getSceneDrawableUserData(placementRoot).noBatch = true
+    getSceneDrawableUserData(placementRoot).bboxIntersectionCheck = true
+
+    group.addEntity(createEntity('mtext-1', placementRoot))
+
+    const clonedRoot = findUnbatchedPlacementClone(group)
+    expect(clonedRoot).toBeDefined()
+    if (!clonedRoot) {
+      return
+    }
+
+    const raycaster = new THREE.Raycaster()
+    const center = new THREE.Vector3(
+      insertion.x + 6,
+      insertion.y + 1,
+      insertion.z ?? 0
+    )
+    raycaster.set(
+      new THREE.Vector3(center.x, center.y, center.z + 100),
+      new THREE.Vector3(0, 0, -1)
+    )
+
+    expect(
+      raycaster.intersectObject(clonedRoot, true)
+    ).toHaveLength(0)
+    expect(group.isIntersectWith('mtext-1', raycaster)).toBe(true)
+  })
+
+  it('unions bounds from unbatched placement-root children in computeBoundingBox', () => {
+    const group = new AcTrBatchedGroup()
+    const insertion = {
+      x: RTE_REBASE_THRESHOLD + 100,
+      y: 3_000_000,
+      z: 0
+    }
+    const placementRoot = createPlacementRoot(insertion, [0, 8])
+    getSceneDrawableUserData(placementRoot).noBatch = true
+
+    group.addEntity(createEntity('mtext-1', placementRoot))
+
+    const box = group.computeBoundingBox(new THREE.Box3())
+    expect(box.isEmpty()).toBe(false)
+    expect(box.min.x).toBeCloseTo(insertion.x, 0)
+    expect(box.max.x).toBeCloseTo(insertion.x + 12, 0)
+    expect(box.min.y).toBeCloseTo(insertion.y, 0)
+    expect(box.max.y).toBeCloseTo(insertion.y + 2, 0)
+  })
+})
+
+function createUnbatchedLine() {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(
+      [-10, 0, 0, 10, 0, 0],
+      3
+    )
+  )
+  geometry.setIndex([0, 1])
+  const line = new THREE.LineSegments(
+    geometry,
+    new THREE.LineBasicMaterial()
+  )
+  line.position.set(RTE_REBASE_THRESHOLD + 500, 2_000_000, 0)
+  getSceneDrawableUserData(line).noBatch = true
+  line.updateMatrixWorld(true)
+  return line
+}

--- a/packages/three-renderer/__tests__/AcTrImage.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrImage.spec.ts
@@ -1,0 +1,7 @@
+import { AcTrImage } from '../src/object/AcTrImage'
+
+describe('AcTrImage', () => {
+  it('always unbatches without consulting policy', () => {
+    expect(AcTrImage.prototype.resolveDrawMode.call({})).toBe('unbatch')
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrLine.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrLine.spec.ts
@@ -1,0 +1,134 @@
+import * as THREE from 'three'
+import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
+
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import type { AcTrBatchDrawPolicy } from '../src/draw/AcTrBatchDrawPolicy'
+import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
+import { AcTrLine } from '../src/object/AcTrLine'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { AcTrStyleManager } from '../src/style/AcTrStyleManager'
+import { AcTrSubEntityTraitsUtil } from '../src/util'
+import { getSceneDrawableUserData } from '../src/util/AcTrObjectUserData'
+
+const defaultTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+const largeX = RTE_REBASE_THRESHOLD + 500_000
+
+const unbatchPolicy: AcTrBatchDrawPolicy = {
+  resolveDrawMode: () => 'unbatch'
+}
+
+const batchPolicy: AcTrBatchDrawPolicy = {
+  resolveDrawMode: () => 'batch'
+}
+
+function findUnbatchedLineDrawable(group: AcTrBatchedGroup) {
+  let drawable: THREE.Object3D | undefined
+  group.traverse(child => {
+    if (drawable) {
+      return
+    }
+    if (
+      child instanceof THREE.LineSegments ||
+      child instanceof LineSegments2
+    ) {
+      if (Math.abs(child.position.x) >= RTE_REBASE_THRESHOLD) {
+        drawable = child
+      }
+    }
+  })
+  return drawable
+}
+
+function getMaxAbsPositionComponent(geometry: THREE.BufferGeometry) {
+  const position = geometry.getAttribute('position')
+  if (position) {
+    let maxAbs = 0
+    for (let i = 0; i < position.count; i++) {
+      maxAbs = Math.max(maxAbs, Math.abs(position.getX(i)))
+      maxAbs = Math.max(maxAbs, Math.abs(position.getY(i)))
+      maxAbs = Math.max(maxAbs, Math.abs(position.getZ(i)))
+    }
+    return maxAbs
+  }
+
+  const instanceStart = geometry.getAttribute('instanceStart')
+  if (!instanceStart) {
+    return 0
+  }
+  let maxAbs = 0
+  for (let i = 0; i < instanceStart.count; i++) {
+    maxAbs = Math.max(maxAbs, Math.abs(instanceStart.getX(i)))
+    maxAbs = Math.max(maxAbs, Math.abs(instanceStart.getY(i)))
+    maxAbs = Math.max(maxAbs, Math.abs(instanceStart.getZ(i)))
+  }
+  return maxAbs
+}
+
+describe('AcTrLine', () => {
+  it('marks flat line drawables as noBatch when resolveDrawMode returns unbatch', () => {
+    const context = new AcTrRenderContext(new AcTrStyleManager(), unbatchPolicy)
+    const line = new AcTrLine(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 }
+      ],
+      defaultTraits,
+      context,
+      false
+    )
+
+    expect(line.resolveDrawMode()).toBe('unbatch')
+    const drawable = line.children[0]
+    expect(getSceneDrawableUserData(drawable).noBatch).toBe(true)
+    expect(getSceneDrawableUserData(line).noBatch).toBeUndefined()
+  })
+
+  it('leaves batchable line drawables unmarked when resolveDrawMode returns batch', () => {
+    const context = new AcTrRenderContext(new AcTrStyleManager(), batchPolicy)
+    const line = new AcTrLine(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 }
+      ],
+      defaultTraits,
+      context,
+      false
+    )
+
+    expect(line.resolveDrawMode()).toBe('batch')
+    const drawable = line.children[0] as THREE.Object3D
+    expect(getSceneDrawableUserData(drawable).noBatch).toBeUndefined()
+  })
+
+  it('keeps geometry local and visible in the unbatched group at large coordinates', () => {
+    const context = new AcTrRenderContext()
+    const lineEntity = new AcTrLine(
+      [
+        { x: largeX, y: 2_000_000, z: 0 },
+        { x: largeX + 100, y: 2_000_050, z: 0 }
+      ],
+      defaultTraits,
+      context
+    )
+    lineEntity.objectId = 'line-large'
+    lineEntity.visible = true
+
+    expect(lineEntity.resolveDrawMode()).toBe('unbatch')
+
+    const group = new AcTrBatchedGroup()
+    group.addEntity(lineEntity)
+
+    const drawable = findUnbatchedLineDrawable(group)
+    expect(
+      drawable instanceof THREE.LineSegments ||
+        drawable instanceof LineSegments2
+    ).toBe(true)
+    if (!(drawable instanceof THREE.LineSegments || drawable instanceof LineSegments2)) {
+      return
+    }
+
+    expect(drawable.frustumCulled).toBe(false)
+    expect(getMaxAbsPositionComponent(drawable.geometry)).toBeLessThan(1000)
+    expect(drawable.position.x).toBeCloseTo(largeX + 50, 0)
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrLineSegments.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrLineSegments.spec.ts
@@ -1,0 +1,95 @@
+import * as THREE from 'three'
+import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
+
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
+import { AcTrLineSegments } from '../src/object/AcTrLineSegments'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { AcTrSubEntityTraitsUtil } from '../src/util'
+
+const defaultTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+const largeX = RTE_REBASE_THRESHOLD + 500_000
+
+function findUnbatchedLineDrawable(group: AcTrBatchedGroup) {
+  let drawable: THREE.Object3D | undefined
+  group.traverse(child => {
+    if (drawable) {
+      return
+    }
+    if (
+      child instanceof THREE.LineSegments ||
+      child instanceof LineSegments2
+    ) {
+      if (Math.abs(child.position.x) >= RTE_REBASE_THRESHOLD) {
+        drawable = child
+      }
+    }
+  })
+  return drawable
+}
+
+function getMaxAbsPositionComponent(geometry: THREE.BufferGeometry) {
+  const position = geometry.getAttribute('position')
+  if (position) {
+    let maxAbs = 0
+    for (let i = 0; i < position.count; i++) {
+      maxAbs = Math.max(maxAbs, Math.abs(position.getX(i)))
+      maxAbs = Math.max(maxAbs, Math.abs(position.getY(i)))
+      maxAbs = Math.max(maxAbs, Math.abs(position.getZ(i)))
+    }
+    return maxAbs
+  }
+
+  const instanceStart = geometry.getAttribute('instanceStart')
+  if (!instanceStart) {
+    return 0
+  }
+  let maxAbs = 0
+  for (let i = 0; i < instanceStart.count; i++) {
+    maxAbs = Math.max(maxAbs, Math.abs(instanceStart.getX(i)))
+    maxAbs = Math.max(maxAbs, Math.abs(instanceStart.getY(i)))
+    maxAbs = Math.max(maxAbs, Math.abs(instanceStart.getZ(i)))
+  }
+  return maxAbs
+}
+
+describe('AcTrLineSegments', () => {
+  it('keeps geometry local and visible in the unbatched group at large coordinates', () => {
+    const context = new AcTrRenderContext()
+    const array = new Float32Array([
+      largeX,
+      3_000_000,
+      0,
+      largeX + 80,
+      3_000_040,
+      0
+    ])
+    const lineEntity = new AcTrLineSegments(
+      array,
+      3,
+      new Uint16Array([0, 1]),
+      defaultTraits,
+      context
+    )
+    lineEntity.objectId = 'lineseg-large'
+    lineEntity.visible = true
+
+    expect(lineEntity.resolveDrawMode()).toBe('unbatch')
+
+    const group = new AcTrBatchedGroup()
+    group.addEntity(lineEntity)
+
+    const drawable = findUnbatchedLineDrawable(group)
+    expect(
+      drawable instanceof THREE.LineSegments ||
+        drawable instanceof LineSegments2
+    ).toBe(true)
+    if (!(drawable instanceof THREE.LineSegments || drawable instanceof LineSegments2)) {
+      return
+    }
+
+    expect(drawable.frustumCulled).toBe(false)
+    expect(getMaxAbsPositionComponent(drawable.geometry)).toBeLessThan(100)
+    expect(drawable.position.x).toBeCloseTo(largeX + 40, 0)
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrMText.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMText.spec.ts
@@ -7,7 +7,15 @@ jest.mock('../src/renderer', () => ({
   }
 }))
 
+import type { AcTrBatchDrawPolicy } from '../src/draw/AcTrBatchDrawPolicy'
+import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
 import { AcTrMText } from '../src/object/AcTrMText'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { AcTrStyleManager } from '../src/style/AcTrStyleManager'
+import {
+  getSceneDrawableUserData,
+  resolveMTextRenderRoot
+} from '../src/util/AcTrObjectUserData'
 
 type GeometryHost = THREE.Object3D & {
   box: THREE.Box3
@@ -21,6 +29,7 @@ type RaycastHost = THREE.Object3D & {
 }
 
 const privateMethods = AcTrMText.prototype as unknown as {
+  attachMText(this: AcTrMText, mtext: MTextObject): void
   computeGeometryBox(this: GeometryHost): THREE.Box3
   updateSelectionBox(this: GeometryHost, mtext: MTextObject): void
   hasGeometry(object: THREE.Object3D): boolean
@@ -31,7 +40,15 @@ const privateMethods = AcTrMText.prototype as unknown as {
   ): void
 }
 
-describe('AcTrMText selection geometry', () => {
+const unbatchPolicy: AcTrBatchDrawPolicy = {
+  resolveDrawMode: () => 'unbatch'
+}
+
+const batchPolicy: AcTrBatchDrawPolicy = {
+  resolveDrawMode: () => 'batch'
+}
+
+describe('AcTrMText', () => {
   it('computes the selection box from transformed rendered child geometry', () => {
     const host = createGeometryHost()
     host.add(createBoxMesh({ x: 10, y: 20, z: 0 }))
@@ -139,6 +156,63 @@ describe('AcTrMText selection geometry', () => {
 
     expect(intersects).toHaveLength(0)
   })
+
+  it('returns the placement group for sync renderer output', () => {
+    const placementRoot = createPlacementRoot({ x: 0, y: 0, z: 0 }, [0, 8])
+    const wrapper = createSyncMTextObject(placementRoot)
+
+    expect(resolveMTextRenderRoot(wrapper)).toBe(placementRoot)
+  })
+
+  it('keeps the wrapper when it already contains render leaves', () => {
+    const wrapper = new THREE.Object3D()
+    wrapper.add(createGlyphMesh(0))
+
+    expect(resolveMTextRenderRoot(wrapper)).toBe(wrapper)
+  })
+
+  it('keeps renderer hierarchy when resolveDrawMode returns unbatch', () => {
+    const context = new AcTrRenderContext(new AcTrStyleManager(), unbatchPolicy)
+    const entity = new AcTrMText(
+      { text: 'AB' } as never,
+      { layer: '0', color: 7 } as never,
+      {} as never,
+      context,
+      true
+    )
+    const placementRoot = createPlacementRoot(
+      { x: RTE_REBASE_THRESHOLD + 500, y: 2_000_000, z: 0 },
+      [0, 8]
+    )
+    const mtext = createSyncMTextObject(placementRoot)
+
+    privateMethods.attachMText.call(entity, mtext)
+
+    expect(getSceneDrawableUserData(placementRoot).noBatch).toBe(true)
+    expect(entity.children).toHaveLength(1)
+    expect(placementRoot.children).toHaveLength(2)
+  })
+
+  it('flattens render leaves when resolveDrawMode returns batch', () => {
+    const context = new AcTrRenderContext(new AcTrStyleManager(), batchPolicy)
+    const entity = new AcTrMText(
+      { text: 'AB' } as never,
+      { layer: '0', color: 7 } as never,
+      {} as never,
+      context,
+      true
+    )
+    const placementRoot = createPlacementRoot({ x: 10, y: 20, z: 0 }, [0, 8])
+    const mtext = createSyncMTextObject(placementRoot)
+
+    privateMethods.attachMText.call(entity, mtext)
+
+    expect(getSceneDrawableUserData(placementRoot).noBatch).toBeUndefined()
+    expect(entity.children).toHaveLength(2)
+    expect(entity.children.every(child => child instanceof THREE.Mesh)).toBe(
+      true
+    )
+  })
 })
 
 function createGeometryHost(): GeometryHost {
@@ -197,4 +271,51 @@ function createSelectableBox() {
     new THREE.Vector3(-1, -1, -0.1),
     new THREE.Vector3(1, 1, 0.1)
   )
+}
+
+function createGlyphMesh(localMinX: number, width = 4, height = 2) {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(
+      [
+        localMinX,
+        0,
+        0,
+        localMinX + width,
+        0,
+        0,
+        localMinX + width,
+        height,
+        0,
+        localMinX,
+        height,
+        0
+      ],
+      3
+    )
+  )
+  geometry.setIndex([0, 1, 2, 0, 2, 3])
+  return new THREE.Mesh(geometry, new THREE.MeshBasicMaterial())
+}
+
+function createPlacementRoot(
+  insertion: THREE.Vector3Like,
+  glyphOffsets: number[]
+) {
+  const placementRoot = new THREE.Group()
+  placementRoot.position.set(insertion.x, insertion.y, insertion.z ?? 0)
+  for (const offset of glyphOffsets) {
+    placementRoot.add(createGlyphMesh(offset))
+  }
+  placementRoot.updateMatrixWorld(true)
+  return placementRoot
+}
+
+function createSyncMTextObject(placementRoot: THREE.Object3D): MTextObject {
+  const wrapper = new THREE.Object3D() as MTextObject
+  wrapper.box = new THREE.Box3()
+  wrapper.createLayoutData = () => ({ lines: [], chars: [] })
+  wrapper.add(placementRoot)
+  return wrapper
 }

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -160,6 +160,9 @@ export class AcTrBatchedGroup extends THREE.Group {
    */
   private _entitiesMap: Map<string, AcTrEntityInBatchedObject[]>
 
+  /**
+   * Creates an empty batched group with highlight and unbatched child containers.
+   */
   constructor() {
     super()
     this._pointBatches = new Map()
@@ -322,14 +325,7 @@ export class AcTrBatchedGroup extends THREE.Group {
       }
       for (const child of objects) {
         if (!child.visible) continue
-        const geometry = (
-          child as THREE.Mesh | THREE.LineSegments | THREE.Points
-        ).geometry
-        if (!geometry) continue
-        AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
-        if (!geometry.boundingBox) continue
-        scratch.copy(geometry.boundingBox).applyMatrix4(child.matrixWorld)
-        target.union(scratch)
+        this.unionUnbatchedObjectBounds(child, target, scratch)
       }
     })
 
@@ -480,7 +476,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     const styleManager = entity.styleManager
 
     entity.updateMatrixWorld(true)
-    entity.traverse(object => {
+    const visitDrawable = (object: THREE.Object3D) => {
       // traverse() visits descendants even when an intermediate AcTrEntity is invisible.
       if (!isObjectHierarchyVisible(object)) {
         return
@@ -488,16 +484,6 @@ export class AcTrBatchedGroup extends THREE.Group {
 
       const drawableUserData = getSceneDrawableUserData(object)
       const bboxIntersectionCheck = !!drawableUserData.bboxIntersectionCheck
-
-      if (object instanceof LineSegments2) {
-        const item = this.addLine2(object, {
-          objectId,
-          bboxIntersectionCheck: bboxIntersectionCheck
-        })
-        entityInfo.push(item)
-        this.applyBatchSlotVisibility(item, entityVisible && object.visible)
-        return
-      }
 
       if (drawableUserData.noBatch) {
         const cloned = this.cloneUnbatchedObject(object)
@@ -509,6 +495,17 @@ export class AcTrBatchedGroup extends THREE.Group {
         hasUnbatched = true
         return
       }
+
+      if (object instanceof LineSegments2) {
+        const item = this.addLine2(object, {
+          objectId,
+          bboxIntersectionCheck: bboxIntersectionCheck
+        })
+        entityInfo.push(item)
+        this.applyBatchSlotVisibility(item, entityVisible && object.visible)
+        return
+      }
+
       if (object instanceof THREE.LineSegments) {
         const item = this.addLine(object, {
           position: drawableUserData.position,
@@ -536,7 +533,12 @@ export class AcTrBatchedGroup extends THREE.Group {
         entityInfo.push(item)
         this.applyBatchSlotVisibility(item, entityVisible && object.visible)
       }
-    })
+
+      for (const child of object.children) {
+        visitDrawable(child)
+      }
+    }
+    visitDrawable(entity)
 
     if (hasUnbatched) {
       this._unbatchedEntities.set(objectId, unbatchedObjects)
@@ -604,9 +606,9 @@ export class AcTrBatchedGroup extends THREE.Group {
     const unbatchedObjects = this._unbatchedEntities.get(objectId)
     if (unbatchedObjects) {
       for (let i = 0; i < unbatchedObjects.length; i++) {
-        const object = unbatchedObjects[i]
-        const intersects = raycaster.intersectObject(object, true)
-        if (intersects.length > 0) return true
+        if (this.isUnbatchedDrawableIntersecting(unbatchedObjects[i], raycaster)) {
+          return true
+        }
       }
     }
     return result
@@ -692,6 +694,9 @@ export class AcTrBatchedGroup extends THREE.Group {
     }
   }
 
+  /**
+   * Recursively clones and recolors materials on a highlight object subtree.
+   */
   private applyHighlightMaterial(object: THREE.Object3D) {
     if (this.hasMaterial(object)) {
       const clonedMaterial = AcTrMaterialUtil.cloneMaterial(object.material)
@@ -702,6 +707,9 @@ export class AcTrBatchedGroup extends THREE.Group {
     object.children.forEach(child => this.applyHighlightMaterial(child))
   }
 
+  /**
+   * Copies highlight-related user-data flags from source to target object.
+   */
   private copyHighlightMetadata(
     source: THREE.Object3D,
     target: THREE.Object3D
@@ -737,6 +745,9 @@ export class AcTrBatchedGroup extends THREE.Group {
     batchedObject?.setVisibleAt(item.batchId, visible)
   }
 
+  /**
+   * Returns visibility state for one batched geometry slot.
+   */
   private getBatchItemVisible(item: AcTrEntityInBatchedObject): boolean {
     const batchedObject = this.getObjectById(item.batchedObjectId) as
       | (AcTrBatchedObject & { getVisibleAt(geometryId: number): boolean })
@@ -1052,28 +1063,114 @@ export class AcTrBatchedGroup extends THREE.Group {
 
   /**
    * Clones an unbatched object into world space for group ownership.
+   *
+   * Leaf drawables keep local geometry buffers and receive the source world
+   * transform on the clone root. This preserves precision for entities that
+   * rebase vertices around a local origin (lines, wide lines) instead of baking
+   * large world coordinates into float32 attributes.
    */
   private cloneUnbatchedObject(source: THREE.Object3D) {
-    const cloned = source.clone() as THREE.Object3D
-    if (this.hasGeometry(source) && this.hasGeometry(cloned)) {
-      const geometry = source.geometry
-      const clonedGeometry = geometry.clone()
-      clonedGeometry.applyMatrix4(source.matrixWorld)
-      cloned.geometry = clonedGeometry
+    if (this.shouldCloneUnbatchedSubtree(source)) {
+      return this.cloneUnbatchedSubtree(source)
     }
+
+    const cloned = source.clone() as THREE.Object3D
+    source.updateMatrixWorld(true)
+    source.matrixWorld.decompose(_v1, _unbatchedQuaternion, _unbatchedScale)
+    cloned.position.copy(_v1)
+    cloned.quaternion.copy(_unbatchedQuaternion)
+    cloned.scale.copy(_unbatchedScale)
     if (this.hasMaterial(source) && this.hasMaterial(cloned)) {
       cloned.material = source.material
       const sourceDrawable = getSceneDrawableUserData(source)
       const clonedDrawable = getSceneDrawableUserData(cloned)
       clonedDrawable.styleMaterialId =
         sourceDrawable.styleMaterialId ?? this.getMaterialId(source.material)
+      clonedDrawable.bboxIntersectionCheck = sourceDrawable.bboxIntersectionCheck
       clonedDrawable.bakedWorldMatrix = source.matrixWorld.toArray()
     }
-    cloned.position.set(0, 0, 0)
-    cloned.rotation.set(0, 0, 0)
-    cloned.scale.set(1, 1, 1)
     cloned.updateMatrix()
     cloned.updateMatrixWorld(true)
+    this.finalizeUnbatchedLineClone(cloned)
+    return cloned
+  }
+
+  /**
+   * Applies line-specific setup so unbatched wide/basic lines render reliably
+   * at large world coordinates (matches batched line frustum-culling behavior).
+   */
+  private finalizeUnbatchedLineClone(cloned: THREE.Object3D) {
+    if (!this.isLineObject(cloned)) {
+      return
+    }
+
+    cloned.frustumCulled = false
+    const geometry = this.getDrawableGeometry(cloned)
+    if (!geometry) {
+      return
+    }
+    AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+    geometry.computeBoundingSphere()
+  }
+
+  /**
+   * Resolves drawable geometry from supported line/mesh/point object types.
+   */
+  private getDrawableGeometry(
+    object: THREE.Object3D
+  ): THREE.BufferGeometry | undefined {
+    if (object instanceof LineSegments2) {
+      return object.geometry as THREE.BufferGeometry
+    }
+    if (
+      object instanceof THREE.Mesh ||
+      object instanceof THREE.LineSegments ||
+      object instanceof THREE.Line ||
+      object instanceof THREE.Points
+    ) {
+      return object.geometry
+    }
+    return undefined
+  }
+
+  /**
+   * Returns true when an unbatched source is a placement root with child drawables.
+   */
+  private shouldCloneUnbatchedSubtree(source: THREE.Object3D) {
+    return source.children.length > 0 && !this.hasGeometry(source)
+  }
+
+  /**
+   * Clones a no-batch placement root together with its render children. MTEXT
+   * keeps merged glyph geometry in local space under one insertion transform.
+   */
+  private cloneUnbatchedSubtree(source: THREE.Object3D) {
+    const cloned = source.clone(true) as THREE.Object3D
+    source.updateMatrixWorld(true)
+    source.matrixWorld.decompose(_v1, _unbatchedQuaternion, _unbatchedScale)
+    cloned.position.copy(_v1)
+    cloned.quaternion.copy(_unbatchedQuaternion)
+    cloned.scale.copy(_unbatchedScale)
+    cloned.updateMatrix()
+    cloned.updateMatrixWorld(true)
+
+    const sourceDrawable = getSceneDrawableUserData(source)
+    const clonedDrawable = getSceneDrawableUserData(cloned)
+    clonedDrawable.bboxIntersectionCheck = sourceDrawable.bboxIntersectionCheck
+    clonedDrawable.bakedWorldMatrix = source.matrixWorld.toArray()
+
+    cloned.traverse(child => {
+      if (!this.hasMaterial(child)) {
+        return
+      }
+      const childDrawable = getSceneDrawableUserData(child)
+      if (childDrawable.styleMaterialId == null) {
+        childDrawable.styleMaterialId = this.getMaterialId(
+          (child as THREE.Mesh).material as THREE.Material
+        )
+      }
+    })
+
     return cloned
   }
 
@@ -1142,6 +1239,7 @@ export class AcTrBatchedGroup extends THREE.Group {
    * Disposes highlight object resources (cloned material and optional geometry).
    */
   private disposeHighlightObject(object: THREE.Object3D) {
+    object.children.forEach(child => this.disposeHighlightObject(child))
     if (this.hasMaterial(object)) {
       const material = object.material as THREE.Material | THREE.Material[]
       if (Array.isArray(material)) {
@@ -1156,6 +1254,71 @@ export class AcTrBatchedGroup extends THREE.Group {
     ) {
       object.geometry.dispose()
     }
+  }
+
+  /**
+   * Unions world-space bounds from one unbatched drawable or its geometry leaves.
+   */
+  private unionUnbatchedObjectBounds(
+    object: THREE.Object3D,
+    target: THREE.Box3,
+    scratch: THREE.Box3
+  ) {
+    const geometry = this.getDrawableGeometry(object)
+    if (geometry) {
+      AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+      if (!geometry.boundingBox) {
+        return
+      }
+      scratch.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld)
+      target.union(scratch)
+      return
+    }
+
+    for (const child of object.children) {
+      if (!child.visible) continue
+      this.unionUnbatchedObjectBounds(child, target, scratch)
+    }
+  }
+
+  /**
+   * Ray-tests one unbatched drawable, honoring bbox-only pick metadata.
+   */
+  private isUnbatchedDrawableIntersecting(
+    object: THREE.Object3D,
+    raycaster: THREE.Raycaster
+  ) {
+    if (getSceneDrawableUserData(object).bboxIntersectionCheck) {
+      return this.isUnbatchedBboxIntersecting(object, raycaster)
+    }
+    return raycaster.intersectObject(object, true).length > 0
+  }
+
+  /**
+   * Tests ray intersection against the world-space bounds of one unbatched drawable.
+   */
+  private isUnbatchedBboxIntersecting(
+    object: THREE.Object3D,
+    raycaster: THREE.Raycaster
+  ) {
+    object.updateMatrixWorld(true)
+    _intersectBox.makeEmpty()
+
+    const geometry = this.getDrawableGeometry(object)
+    if (geometry) {
+      AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+      if (!geometry.boundingBox) {
+        return false
+      }
+      _intersectBox.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld)
+    } else {
+      this.unionUnbatchedObjectBounds(object, _intersectBox, _intersectScratchBox)
+      if (_intersectBox.isEmpty()) {
+        return false
+      }
+    }
+
+    return raycaster.ray.intersectBox(_intersectBox, _v1) !== null
   }
 
   /**
@@ -1215,3 +1378,7 @@ export class AcTrBatchedGroup extends THREE.Group {
 
 const _v1 = /*@__PURE__*/ new THREE.Vector3()
 const _v2 = /*@__PURE__*/ new THREE.Vector3()
+const _unbatchedQuaternion = /*@__PURE__*/ new THREE.Quaternion()
+const _unbatchedScale = /*@__PURE__*/ new THREE.Vector3()
+const _intersectBox = /*@__PURE__*/ new THREE.Box3()
+const _intersectScratchBox = /*@__PURE__*/ new THREE.Box3()

--- a/packages/three-renderer/src/draw/AcTrBatchDrawPolicy.ts
+++ b/packages/three-renderer/src/draw/AcTrBatchDrawPolicy.ts
@@ -1,0 +1,181 @@
+import { AcGePoint3dLike } from '@mlightcad/data-model'
+import * as THREE from 'three'
+
+import type { AcTrDrawMode } from './AcTrDrawMode'
+
+/**
+ * World-coordinate magnitude above which {@link defaultBatchDrawPolicy} chooses
+ * the unbatched draw path.
+ *
+ * The check uses the maximum absolute value among `x`, `y`, and `z` on the
+ * representative point passed to the policy (see {@link isLargeWorldCoordinatePoint}).
+ * Values at or above this threshold are treated as large enough that merging geometry
+ * in {@link AcTrBatchedGroup} risks float precision loss or incorrect placement.
+ */
+export const RTE_REBASE_THRESHOLD = 1e6
+
+/**
+ * Coordinate context supplied by an {@link AcTrEntity} subclass when it delegates
+ * a batch/unbatch decision to {@link AcTrBatchDrawPolicy}.
+ *
+ * Most entities provide either a single insertion {@link AcTrBatchDrawContext.position}
+ * (MTEXT, SHAPE, POINT) or a geometry {@link AcTrBatchDrawContext.anchor} derived from
+ * vertex data (lines, polygons). Policies typically evaluate `anchor ?? position`.
+ *
+ * @see AcTrEntity.resolveDrawMode
+ * @see defaultBatchDrawPolicy
+ */
+export interface AcTrBatchDrawContext {
+  /**
+   * Primary world-space insertion or reference point for the entity.
+   *
+   * Used when the entity has one canonical location (for example MTEXT/SHAPE
+   * insertion, or a POINT entity coordinate).
+   */
+  position?: AcGePoint3dLike
+
+  /**
+   * Representative world-space point for geometry that spans multiple vertices.
+   *
+   * Usually the axis-aligned bounding-box center of the entity geometry,
+   * computed by {@link resolveAnchorFromBox}. Used by line-like entities and
+   * hatches that do not have a single insertion point.
+   */
+  anchor?: AcGePoint3dLike
+}
+
+/**
+ * Pluggable strategy that maps coordinate context to a {@link AcTrDrawMode}.
+ *
+ * Inject an implementation on {@link AcTrRenderContext.batchDrawPolicy} (via
+ * {@link AcTrRenderer.batchDrawPolicy}) to customize when entities that delegate
+ * when entities that delegate to the policy should merge in
+ * {@link AcTrBatchedGroup} versus stay on the unbatched path.
+ *
+ * Entity types that must never batch (images, pattern hatches, …) should not rely
+ * on this interface; they should return `'unbatch'` directly from
+ * {@link AcTrEntity.resolveDrawMode}.
+ *
+ * @see defaultBatchDrawPolicy
+ */
+export interface AcTrBatchDrawPolicy {
+  /**
+   * Resolves the draw mode for one entity based on its coordinate context.
+   *
+   * @param context - Insertion point and/or geometry anchor supplied by the
+   *   calling entity's {@link AcTrEntity.resolveDrawMode} implementation.
+   * @returns `'batch'` to flatten and merge drawables, or `'unbatch'` to keep
+   *   the entity's prepared hierarchy and mark drawables with `noBatch`.
+   */
+  resolveDrawMode(context: AcTrBatchDrawContext): AcTrDrawMode
+}
+
+/**
+ * Returns whether a world-space point is large enough to prefer the unbatched path.
+ *
+ * A point is considered large when the maximum absolute component among `x`, `y`,
+ * and `z` is greater than or equal to {@link RTE_REBASE_THRESHOLD}. Missing or
+ * `undefined` input is treated as not large (returns `false`).
+ *
+ * @param position - World-space point to evaluate, typically an insertion point
+ *   or geometry anchor from {@link AcTrBatchDrawContext}.
+ * @returns `true` when the point exceeds the large-coordinate threshold.
+ */
+export function isLargeWorldCoordinatePoint(
+  position?: AcGePoint3dLike
+): boolean {
+  if (position == null) {
+    return false
+  }
+
+  return (
+    Math.max(
+      Math.abs(position.x),
+      Math.abs(position.y),
+      Math.abs(position.z ?? 0)
+    ) >= RTE_REBASE_THRESHOLD
+  )
+}
+
+/**
+ * Computes a representative anchor point from a list of world-space vertices.
+ *
+ * The anchor is the center of the axis-aligned bounding box that contains all
+ * input points. Empty input yields `undefined`, which causes coordinate-based
+ * policies to fall back to `'batch'`.
+ *
+ * @param points - Vertex or control-point samples in drawing/world coordinates.
+ * @returns Bounding-box center, or `undefined` when `points` is empty.
+ */
+export function resolveAnchorFromPoints(
+  points: AcGePoint3dLike[]
+): AcGePoint3dLike | undefined {
+  if (points.length === 0) {
+    return undefined
+  }
+
+  let minX = Infinity
+  let minY = Infinity
+  let minZ = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let maxZ = -Infinity
+
+  for (const point of points) {
+    minX = Math.min(minX, point.x)
+    minY = Math.min(minY, point.y)
+    minZ = Math.min(minZ, point.z ?? 0)
+    maxX = Math.max(maxX, point.x)
+    maxY = Math.max(maxY, point.y)
+    maxZ = Math.max(maxZ, point.z ?? 0)
+  }
+
+  return {
+    x: (minX + maxX) / 2,
+    y: (minY + maxY) / 2,
+    z: (minZ + maxZ) / 2
+  }
+}
+
+/**
+ * Computes a representative anchor point from an axis-aligned bounding box.
+ *
+ * Empty boxes yield `undefined`, which causes coordinate-based policies to
+ * fall back to `'batch'`.
+ *
+ * @param box - Entity geometry bounds in drawing/world coordinates (without
+ *   entity transform applied).
+ * @returns Bounding-box center, or `undefined` when `box` is empty.
+ */
+export function resolveAnchorFromBox(
+  box: THREE.Box3
+): AcGePoint3dLike | undefined {
+  if (box.isEmpty()) {
+    return undefined
+  }
+
+  const center = box.getCenter(_resolveAnchorCenter)
+  return {
+    x: center.x,
+    y: center.y,
+    z: center.z
+  }
+}
+
+/**
+ * Default batch-draw policy used by {@link AcTrEntity} when none is injected.
+ *
+ * Evaluates `context.anchor ?? context.position` with
+ * {@link isLargeWorldCoordinatePoint}: large coordinates return `'unbatch'`,
+ * otherwise `'batch'`. Entity-specific rules (always-unbatch images, pattern
+ * hatches, …) are handled in each subclass's {@link AcTrEntity.resolveDrawMode},
+ * not here.
+ */
+export const defaultBatchDrawPolicy: AcTrBatchDrawPolicy = {
+  resolveDrawMode(context) {
+    const anchor = context.anchor ?? context.position
+    return isLargeWorldCoordinatePoint(anchor) ? 'unbatch' : 'batch'
+  }
+}
+
+const _resolveAnchorCenter = /*@__PURE__*/ new THREE.Vector3()

--- a/packages/three-renderer/src/draw/AcTrDrawMode.ts
+++ b/packages/three-renderer/src/draw/AcTrDrawMode.ts
@@ -1,0 +1,7 @@
+/**
+ * How a converted entity's drawables should enter the scene graph.
+ *
+ * - `batch`: flatten render leaves and merge them in {@link AcTrBatchedGroup}.
+ * - `unbatch`: keep the renderer placement hierarchy and draw via the unbatched path.
+ */
+export type AcTrDrawMode = 'batch' | 'unbatch'

--- a/packages/three-renderer/src/draw/index.ts
+++ b/packages/three-renderer/src/draw/index.ts
@@ -1,0 +1,2 @@
+export * from './AcTrBatchDrawPolicy'
+export * from './AcTrDrawMode'

--- a/packages/three-renderer/src/index.ts
+++ b/packages/three-renderer/src/index.ts
@@ -3,6 +3,7 @@ export {
   isBatchGeometryActive,
   isBatchGeometryVisible
 } from './batch/AcTrBatchedGeometryInfo'
+export * from './draw'
 export { AcTrBatchedLine } from './batch/AcTrBatchedLine'
 export { AcTrBatchedMesh } from './batch/AcTrBatchedMesh'
 export { AcTrBatchedPoint } from './batch/AcTrBatchedPoint'

--- a/packages/three-renderer/src/object/AcTrEntity.ts
+++ b/packages/three-renderer/src/object/AcTrEntity.ts
@@ -1,7 +1,9 @@
 import { AcGeMatrix3d, AcGePoint3d, AcGiEntity } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import type { AcTrBatchDrawPolicy } from '../draw/AcTrBatchDrawPolicy'
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import {
   AcTrMaterialUtil,
   AcTrMatrixUtil,
@@ -9,7 +11,8 @@ import {
 } from '../util'
 import {
   type AcTrEntityUserData,
-  getObjectUserData
+  getObjectUserData,
+  getSceneDrawableUserData
 } from '../util/AcTrObjectUserData'
 import { AcTrObject } from './AcTrObject'
 
@@ -21,9 +24,25 @@ export class AcTrEntity extends AcTrObject implements AcGiEntity {
   protected _box: THREE.Box3
   protected _basePoint?: AcGePoint3d
 
-  constructor(styleManager: AcTrStyleManager) {
-    super(styleManager)
+  constructor(context: AcTrRenderContext) {
+    super(context)
     this._box = new THREE.Box3()
+  }
+
+  /**
+   * Shared batch/unbatch policy from the owning {@link AcTrRenderContext}.
+   */
+  protected get batchDrawPolicy(): AcTrBatchDrawPolicy {
+    return this.renderContext.batchDrawPolicy
+  }
+
+  /**
+   * Resolves how this entity should enter the scene graph. Subclasses override
+   * this to return `'unbatch'` when they cannot batch, or delegate to
+   * {@link AcTrBatchDrawPolicy} for coordinate-based rules.
+   */
+  resolveDrawMode(): AcTrDrawMode {
+    return 'batch'
   }
 
   /**
@@ -266,6 +285,39 @@ export class AcTrEntity extends AcTrObject implements AcGiEntity {
   }
 
   /**
+   * Marks one drawable or placement container for the unbatched scene path.
+   */
+  protected markDrawableUnbatched(object: THREE.Object3D) {
+    getSceneDrawableUserData(object).noBatch = true
+  }
+
+  /**
+   * Marks every geometry leaf currently under this entity as unbatched.
+   *
+   * Only render leaves (objects with both geometry and material) are tagged.
+   * Entity containers such as {@link AcTrLine} also store a geometry reference
+   * for bounds/metadata and must not enter the unbatched clone path themselves.
+   */
+  protected markUnbatchedLeaves() {
+    this.traverse(object => {
+      if (
+        !('geometry' in object) ||
+        !('material' in object) ||
+        !(object.geometry instanceof THREE.BufferGeometry)
+      ) {
+        return
+      }
+      this.markDrawableUnbatched(object)
+    })
+  }
+
+  protected finalizeLeafDrawables() {
+    if (this.resolveDrawMode() === 'unbatch') {
+      this.markUnbatchedLeaves()
+    }
+  }
+
+  /**
    * Remove this object from its parent and release geometry and material resource used by this object.
    */
   dispose() {
@@ -358,7 +410,7 @@ export class AcTrEntity extends AcTrObject implements AcGiEntity {
    * @inheritdoc
    */
   fastDeepClone() {
-    const cloned = new AcTrEntity(this.styleManager)
+    const cloned = new AcTrEntity(this.renderContext)
     cloned.copy(this, false)
     this.copyGeometry(this, cloned)
     return cloned

--- a/packages/three-renderer/src/object/AcTrGroup.ts
+++ b/packages/three-renderer/src/object/AcTrGroup.ts
@@ -1,7 +1,7 @@
 import { AcDbObjectId, AcGeMatrix3d } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrMatrixUtil } from '../util'
 import { AcTrEntity } from './AcTrEntity'
 export interface AcTrEntityBox {
@@ -20,12 +20,12 @@ export class AcTrGroup extends AcTrEntity {
   private _isOnTheSameLayer: boolean
   private _boxes: AcTrEntityBox[] = []
 
-  constructor(entities: AcTrEntity[], styleManager: AcTrStyleManager) {
-    super(styleManager)
+  constructor(entities: AcTrEntity[], context: AcTrRenderContext) {
+    super(context)
     entities.forEach(entity => {
       // FIXME: It looks like that code within 'Array.isArray(entity)' condition is useless.
       if (Array.isArray(entity)) {
-        const subGroup = new AcTrEntity(styleManager)
+        const subGroup = new AcTrEntity(context)
         this.add(subGroup)
         this.box.union(subGroup.box)
       } else {
@@ -116,7 +116,7 @@ export class AcTrGroup extends AcTrEntity {
    * @inheritdoc
    */
   fastDeepClone() {
-    const cloned = new AcTrGroup([], this.styleManager)
+    const cloned = new AcTrGroup([], this.renderContext)
     cloned.copy(this, false)
     this.copyGeometry(this, cloned)
     return cloned

--- a/packages/three-renderer/src/object/AcTrImage.ts
+++ b/packages/three-renderer/src/object/AcTrImage.ts
@@ -1,17 +1,17 @@
 import { AcGiImageStyle } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
-import { getSceneDrawableUserData } from '../util/AcTrObjectUserData'
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrEntity } from './AcTrEntity'
 
 export class AcTrImage extends AcTrEntity {
   constructor(
     blob: Blob,
     style: AcGiImageStyle,
-    styleManager: AcTrStyleManager
+    context: AcTrRenderContext
   ) {
-    super(styleManager)
+    super(context)
     const blobUrl = URL.createObjectURL(blob)
     const textureLoader = new THREE.TextureLoader()
     const texture = textureLoader.load(
@@ -31,8 +31,12 @@ export class AcTrImage extends AcTrEntity {
     this.generateUVs(geometry)
 
     const mesh = new THREE.Mesh(geometry, material)
-    getSceneDrawableUserData(mesh).noBatch = true
     this.add(mesh)
+    this.finalizeLeafDrawables()
+  }
+
+  override resolveDrawMode(): AcTrDrawMode {
+    return 'unbatch'
   }
 
   /**

--- a/packages/three-renderer/src/object/AcTrLine.ts
+++ b/packages/three-renderer/src/object/AcTrLine.ts
@@ -4,7 +4,9 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { resolveAnchorFromBox } from '../draw/AcTrBatchDrawPolicy'
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrBufferGeometryUtil, getSceneDrawableUserData } from '../util'
 import { AcTrEntity } from './AcTrEntity'
 
@@ -14,10 +16,10 @@ export class AcTrLine extends AcTrEntity {
   constructor(
     points: AcGePoint3dLike[],
     traits: AcGiSubEntityTraits,
-    styleManager: AcTrStyleManager,
+    context: AcTrRenderContext,
     basicMaterialOnly: boolean = false
   ) {
-    super(styleManager)
+    super(context)
 
     const material = this.styleManager.getLineMaterial(
       traits,
@@ -53,6 +55,7 @@ export class AcTrLine extends AcTrEntity {
       line.position.set(localOrigin.x, localOrigin.y, localOrigin.z)
       getSceneDrawableUserData(line).styleMaterialId = material.id
       this.add(line)
+      this.finalizeLeafDrawables()
       return
     }
 
@@ -82,6 +85,13 @@ export class AcTrLine extends AcTrEntity {
     line.position.set(localOrigin.x, localOrigin.y, localOrigin.z)
     AcTrBufferGeometryUtil.computeLineDistances(line)
     this.add(line)
+    this.finalizeLeafDrawables()
+  }
+
+  override resolveDrawMode(): AcTrDrawMode {
+    return this.batchDrawPolicy.resolveDrawMode({
+      anchor: resolveAnchorFromBox(this.box)
+    })
   }
 
   private setBoundingBox(

--- a/packages/three-renderer/src/object/AcTrLineSegments.ts
+++ b/packages/three-renderer/src/object/AcTrLineSegments.ts
@@ -4,7 +4,9 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { resolveAnchorFromBox } from '../draw/AcTrBatchDrawPolicy'
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrBufferGeometryUtil, getSceneDrawableUserData } from '../util'
 import { AcTrEntity } from './AcTrEntity'
 
@@ -14,60 +16,93 @@ export class AcTrLineSegments extends AcTrEntity {
     itemSize: number,
     indices: Uint16Array,
     traits: AcGiSubEntityTraits,
-    styleManager: AcTrStyleManager
+    context: AcTrRenderContext
   ) {
-    super(styleManager)
+    super(context)
 
     const material = this.styleManager.getLineMaterial(traits)
+    const box = new THREE.Box3()
+
+    for (let i = 0; i < array.length; i += itemSize) {
+      box.expandByPoint(
+        _point.set(array[i], array[i + 1], array[i + 2] ?? 0)
+      )
+    }
+
+    const localOrigin = box.getCenter(new THREE.Vector3())
 
     if (material instanceof LineMaterial) {
       const segmentCount = Math.floor(indices.length / 2)
       const segmentPositions = new Float32Array(segmentCount * 6)
-      const box = new THREE.Box3()
-      for (let i = 0; i < array.length; i += itemSize) {
-        box.expandByPoint(
-          _point.set(array[i], array[i + 1], (array[i + 2] as number) ?? 0)
-        )
-      }
       for (let i = 0, pos = 0; i < segmentCount; i++) {
         const i1 = indices[i * 2]
         const i2 = indices[i * 2 + 1]
         const base1 = i1 * itemSize
         const base2 = i2 * itemSize
-        segmentPositions[pos++] = array[base1]
-        segmentPositions[pos++] = array[base1 + 1]
-        segmentPositions[pos++] = array[base1 + 2] ?? 0
-        segmentPositions[pos++] = array[base2]
-        segmentPositions[pos++] = array[base2 + 1]
-        segmentPositions[pos++] = array[base2 + 2] ?? 0
+        segmentPositions[pos++] = array[base1] - localOrigin.x
+        segmentPositions[pos++] = array[base1 + 1] - localOrigin.y
+        segmentPositions[pos++] = (array[base1 + 2] ?? 0) - localOrigin.z
+        segmentPositions[pos++] = array[base2] - localOrigin.x
+        segmentPositions[pos++] = array[base2 + 1] - localOrigin.y
+        segmentPositions[pos++] = (array[base2 + 2] ?? 0) - localOrigin.z
       }
 
       const lineGeometry = new LineSegmentsGeometry()
       lineGeometry.setPositions(segmentPositions)
       lineGeometry.computeBoundingBox()
       lineGeometry.computeBoundingSphere()
-      this.box.copy(box)
+      this.setBoundingBox(
+        lineGeometry as unknown as THREE.BufferGeometry,
+        localOrigin
+      )
 
       const line = new LineSegments2(lineGeometry, material)
+      line.position.set(localOrigin.x, localOrigin.y, localOrigin.z)
       getSceneDrawableUserData(line).styleMaterialId = material.id
       this.add(line)
+      this.finalizeLeafDrawables()
       return
+    }
+
+    const rebased = new Float32Array(array.length)
+    for (let i = 0; i < array.length; i += itemSize) {
+      rebased[i] = array[i] - localOrigin.x
+      rebased[i + 1] = array[i + 1] - localOrigin.y
+      rebased[i + 2] = (array[i + 2] ?? 0) - localOrigin.z
     }
 
     const geometry = new THREE.BufferGeometry()
     geometry.setAttribute(
       'position',
-      new THREE.BufferAttribute(array, itemSize)
+      new THREE.BufferAttribute(rebased, itemSize)
     )
     geometry.setIndex(new THREE.BufferAttribute(indices, 1))
-    const boundingBox = AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
-    if (boundingBox) {
-      this.box = boundingBox
-    }
+    this.setBoundingBox(geometry, localOrigin)
 
     const line = new THREE.LineSegments(geometry, material)
+    line.position.set(localOrigin.x, localOrigin.y, localOrigin.z)
     AcTrBufferGeometryUtil.computeLineDistances(line)
     this.add(line)
+    this.finalizeLeafDrawables()
+  }
+
+  override resolveDrawMode(): AcTrDrawMode {
+    return this.batchDrawPolicy.resolveDrawMode({
+      anchor: resolveAnchorFromBox(this.box)
+    })
+  }
+
+  private setBoundingBox(
+    geometry: THREE.BufferGeometry,
+    localOrigin: THREE.Vector3
+  ) {
+    const boundingBox = AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+    if (!boundingBox) {
+      return
+    }
+    const worldBox = boundingBox.clone()
+    worldBox.translate(localOrigin)
+    this.box = worldBox
   }
 }
 

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -11,11 +11,15 @@ import {
 } from '@mlightcad/mtext-renderer'
 import * as THREE from 'three'
 
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
 import { AcTrMTextRenderer } from '../renderer'
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrMTextColorUtil } from '../util'
 import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
-import { getSceneDrawableUserData } from '../util/AcTrObjectUserData'
+import {
+  getSceneDrawableUserData,
+  resolveMTextRenderRoot
+} from '../util/AcTrObjectUserData'
 import { AcTrEntity } from './AcTrEntity'
 
 // Reuse scratch objects during hover/pick hit-testing; raycast can run very
@@ -34,10 +38,10 @@ export class AcTrMText extends AcTrEntity {
     text: AcGiMTextData,
     traits: AcGiSubEntityTraits,
     style: AcGiTextStyle,
-    styleManager: AcTrStyleManager,
+    context: AcTrRenderContext,
     delay: boolean = false
   ) {
-    super(styleManager)
+    super(context)
     this._text = text
     this._style = { ...style }
     this._colorSettings = {
@@ -151,9 +155,20 @@ export class AcTrMText extends AcTrEntity {
    *
    * @param mtext Rendered MTEXT object returned by the shared MTEXT renderer.
    */
+  override resolveDrawMode(): AcTrDrawMode {
+    return this.batchDrawPolicy.resolveDrawMode({
+      position: this._text.position
+    })
+  }
+
   private attachMText(mtext: MTextObject) {
     this.add(mtext)
-    this.flatten()
+    const renderRoot = resolveMTextRenderRoot(mtext)
+    if (this.resolveDrawMode() === 'unbatch') {
+      this.markDrawableUnbatched(renderRoot)
+    } else {
+      this.flatten()
+    }
     this.removeInvalidGeometryLeaves()
     this.traverse(object => {
       // Text picking should behave like CAD object picking: the visible glyph

--- a/packages/three-renderer/src/object/AcTrObject.ts
+++ b/packages/three-renderer/src/object/AcTrObject.ts
@@ -1,27 +1,32 @@
 import * as THREE from 'three'
 
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
 
 /**
  * Base class for all drawable object
  */
 export class AcTrObject extends THREE.Object3D {
-  private _styleManager: AcTrStyleManager
+  private _context: AcTrRenderContext
 
-  constructor(styleManager: AcTrStyleManager) {
+  constructor(context: AcTrRenderContext) {
     super()
-    this._styleManager = styleManager
+    this._context = context
   }
 
-  get styleManager() {
-    return this._styleManager
+  get renderContext() {
+    return this._context
+  }
+
+  get styleManager(): AcTrStyleManager {
+    return this._context.styleManager
   }
 
   /**
    * @inheritdoc
    */
   copy(object: AcTrObject, recursive?: boolean) {
-    this._styleManager = object._styleManager
+    this._context = object._context
     return super.copy(object, recursive)
   }
 }

--- a/packages/three-renderer/src/object/AcTrPoint.ts
+++ b/packages/three-renderer/src/object/AcTrPoint.ts
@@ -5,8 +5,9 @@ import {
 } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
 import { AcTrPointSymbolCreator } from '../geometry/AcTrPointSymbolCreator'
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
 import { getSceneDrawableUserData } from '../util/AcTrObjectUserData'
 import { AcTrEntity } from './AcTrEntity'
@@ -18,14 +19,16 @@ export class AcTrPoint extends AcTrEntity {
    * The flag whether to use one point using THREE.Points
    */
   isShowPoint: boolean
+  private _point: AcGePoint3dLike
 
   constructor(
     point: AcGePoint3dLike,
     traits: AcGiSubEntityTraits,
     style: AcGiPointStyle,
-    styleManager: AcTrStyleManager
+    context: AcTrRenderContext
   ) {
-    super(styleManager)
+    super(context)
+    this._point = point
     const pointSymbol = AcTrPointSymbolCreator.instance.create(
       style.displayMode,
       point
@@ -60,5 +63,12 @@ export class AcTrPoint extends AcTrEntity {
       lineDrawable.position = { x: point.x, y: point.y, z: point.z }
       this.add(lineSegmentsObj)
     }
+    this.finalizeLeafDrawables()
+  }
+
+  override resolveDrawMode(): AcTrDrawMode {
+    return this.batchDrawPolicy.resolveDrawMode({
+      position: this._point
+    })
   }
 }

--- a/packages/three-renderer/src/object/AcTrPolygon.ts
+++ b/packages/three-renderer/src/object/AcTrPolygon.ts
@@ -11,9 +11,10 @@ import { GeometryEpsilon, PolyBool, Segments } from '@velipso/polybool'
 import * as THREE from 'three'
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
 
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { resolveAnchorFromBox } from '../draw/AcTrBatchDrawPolicy'
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
-import { getSceneDrawableUserData } from '../util/AcTrObjectUserData'
 import { AcTrEntity } from './AcTrEntity'
 
 function toVector2(points: AcGePoint2dLike[]): THREE.Vector2[] {
@@ -31,12 +32,15 @@ function hasFillVertices(geometry: THREE.BufferGeometry | undefined): boolean {
 }
 
 export class AcTrPolygon extends AcTrEntity {
+  private _traits: AcGiSubEntityTraits
+
   constructor(
     area: AcGeArea2d,
     traits: AcGiSubEntityTraits,
-    styleManager: AcTrStyleManager
+    context: AcTrRenderContext
   ) {
-    super(styleManager)
+    super(context)
+    this._traits = traits
 
     const pointBoundaries = area.getPoints(100)
     const hierarchy = area.buildHierarchy()
@@ -78,13 +82,20 @@ export class AcTrPolygon extends AcTrEntity {
         gradientBounds
       )
       const mesh = new THREE.Mesh(geometry, material)
-      if (this.isPatternedHatch(traits)) {
-        getSceneDrawableUserData(mesh).noBatch = true
-      }
       this.add(mesh)
+      this.finalizeLeafDrawables()
     } else if (hasRenderableBoundaries) {
       log.warn('Failed to convert hatch boundaries!')
     }
+  }
+
+  override resolveDrawMode(): AcTrDrawMode {
+    if (this.isPatternedHatch(this._traits)) {
+      return 'unbatch'
+    }
+    return this.batchDrawPolicy.resolveDrawMode({
+      anchor: resolveAnchorFromBox(this.box)
+    })
   }
 
   private isPatternedHatch(traits: AcGiSubEntityTraits) {

--- a/packages/three-renderer/src/object/AcTrShape.ts
+++ b/packages/three-renderer/src/object/AcTrShape.ts
@@ -11,11 +11,15 @@ import {
 } from '@mlightcad/mtext-renderer'
 import * as THREE from 'three'
 
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
 import { AcTrMTextRenderer } from '../renderer'
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrMTextColorUtil } from '../util'
 import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
-import { getSceneDrawableUserData } from '../util/AcTrObjectUserData'
+import {
+  getSceneDrawableUserData,
+  resolveMTextRenderRoot
+} from '../util/AcTrObjectUserData'
 import { AcTrEntity } from './AcTrEntity'
 
 const _raycastBox = /*@__PURE__*/ new THREE.Box3()
@@ -31,10 +35,10 @@ export class AcTrShape extends AcTrEntity {
     shape: AcGiShapeData,
     traits: AcGiSubEntityTraits,
     style: AcGiTextStyle,
-    styleManager: AcTrStyleManager,
+    context: AcTrRenderContext,
     delay: boolean = false
   ) {
-    super(styleManager)
+    super(context)
     this._shape = shape
     this._style = { ...style }
     this._colorSettings = {
@@ -109,9 +113,20 @@ export class AcTrShape extends AcTrEntity {
     return this._shape.name?.trim() || String(this._shape.shapeNumber ?? '')
   }
 
+  override resolveDrawMode(): AcTrDrawMode {
+    return this.batchDrawPolicy.resolveDrawMode({
+      position: this._shape.position
+    })
+  }
+
   private attachRendered(rendered: MTextObject) {
     this.add(rendered)
-    this.flatten()
+    const renderRoot = resolveMTextRenderRoot(rendered)
+    if (this.resolveDrawMode() === 'unbatch') {
+      this.markDrawableUnbatched(renderRoot)
+    } else {
+      this.flatten()
+    }
     this.removeInvalidGeometryLeaves()
     this.traverse(object => {
       getSceneDrawableUserData(object).bboxIntersectionCheck = true

--- a/packages/three-renderer/src/renderer/AcTrRenderContext.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderContext.ts
@@ -1,0 +1,24 @@
+import {
+  AcTrBatchDrawPolicy,
+  defaultBatchDrawPolicy
+} from '../draw/AcTrBatchDrawPolicy'
+import { AcTrStyleManager } from '../style/AcTrStyleManager'
+
+/**
+ * Per-renderer shared services passed into drawable objects during conversion.
+ *
+ * Bundles material/style access with scene-graph policies so entity instances
+ * only hold one reference while each concern stays in its own module.
+ */
+export class AcTrRenderContext {
+  readonly styleManager: AcTrStyleManager
+  batchDrawPolicy: AcTrBatchDrawPolicy
+
+  constructor(
+    styleManager: AcTrStyleManager = new AcTrStyleManager(),
+    batchDrawPolicy: AcTrBatchDrawPolicy = defaultBatchDrawPolicy
+  ) {
+    this.styleManager = styleManager
+    this.batchDrawPolicy = batchDrawPolicy
+  }
+}

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -17,6 +17,7 @@ import {
 import { FontManager } from '@mlightcad/mtext-renderer'
 import * as THREE from 'three'
 
+import type { AcTrBatchDrawPolicy } from '../draw/AcTrBatchDrawPolicy'
 import {
   AcTrEntity,
   AcTrGroup,
@@ -30,10 +31,10 @@ import {
   AcTrShape
 } from '../object'
 import { AcTrMaterialManager } from '../style/AcTrMaterialManager'
-import { AcTrStyleManager } from '../style/AcTrStyleManager'
 import { AcTrSubEntityTraitsUtil } from '../util'
 import { AcTrCamera } from '../viewport'
 import { AcTrMTextRenderer } from './AcTrMTextRenderer'
+import { AcTrRenderContext } from './AcTrRenderContext'
 
 /** Event payload when a mapped font cannot be resolved during rendering. */
 export interface AcTrFontNotFoundEventArgs {
@@ -44,7 +45,7 @@ export interface AcTrFontNotFoundEventArgs {
 }
 
 export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
-  private _styleManager: AcTrStyleManager
+  private _context: AcTrRenderContext
   private _renderer: THREE.WebGLRenderer
   private _subEntityTraits: AcGiSubEntityTraits
 
@@ -56,10 +57,12 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
 
   constructor(renderer: THREE.WebGLRenderer) {
     this._renderer = renderer
-    this._styleManager = new AcTrStyleManager()
+    this._context = new AcTrRenderContext()
     const size = renderer.getSize(new THREE.Vector2())
-    this._styleManager.updateLineResolution(size.x, size.y)
-    AcTrMTextRenderer.getInstance().overrideStyleManager(this._styleManager)
+    this._context.styleManager.updateLineResolution(size.x, size.y)
+    AcTrMTextRenderer.getInstance().overrideStyleManager(
+      this._context.styleManager
+    )
     FontManager.instance.events.fontNotFound.addEventListener(args => {
       this.events.fontNotFound.dispatch(args)
     })
@@ -71,6 +74,16 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    */
   get subEntityTraits() {
     return this._subEntityTraits
+  }
+
+  /**
+   * Strategy that decides whether converted entities should batch or stay unbatched.
+   */
+  get batchDrawPolicy(): AcTrBatchDrawPolicy {
+    return this._context.batchDrawPolicy
+  }
+  set batchDrawPolicy(policy: AcTrBatchDrawPolicy) {
+    this._context.batchDrawPolicy = policy
   }
 
   get autoClear() {
@@ -86,14 +99,14 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
 
   setSize(width: number, height: number) {
     this._renderer.setSize(width, height)
-    this._styleManager.updateLineResolution(width, height)
+    this._context.styleManager.updateLineResolution(width, height)
   }
 
   /**
    * Updates wide-line shader resolution without resizing the canvas.
    */
   updateLineResolution(width: number, height: number) {
-    this._styleManager.updateLineResolution(width, height)
+    this._context.styleManager.updateLineResolution(width, height)
   }
 
   /**
@@ -134,7 +147,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * @param color - New background color (typically the canvas bg).
    */
   changeBackground(color: number) {
-    this._styleManager.changeBackground(color)
+    this._context.styleManager.changeBackground(color)
   }
 
   /**
@@ -146,10 +159,10 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * every background-follow material already in the cache.
    */
   get currentBackgroundColor(): number {
-    return this._styleManager.currentBackgroundColor
+    return this._context.styleManager.currentBackgroundColor
   }
   set currentBackgroundColor(value: number) {
-    this._styleManager.currentBackgroundColor = value
+    this._context.styleManager.currentBackgroundColor = value
   }
 
   /**
@@ -205,14 +218,14 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * Sets global ltscale
    */
   set ltscale(scale: number) {
-    this._styleManager.options.ltscale = scale
+    this._context.styleManager.options.ltscale = scale
   }
 
   /**
    * Sets global celtscale
    */
   set celtscale(scale: number) {
-    this._styleManager.options.celtscale = scale
+    this._context.styleManager.options.celtscale = scale
   }
 
   /**
@@ -226,7 +239,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * Gets whether entity lineweights are displayed.
    */
   get showLineWeight() {
-    return this._styleManager.showLineWeight
+    return this._context.styleManager.showLineWeight
   }
 
   /**
@@ -235,14 +248,14 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * When disabled, line entities are rendered with basic 1px materials.
    */
   set showLineWeight(value: boolean) {
-    this._styleManager.showLineWeight = value
+    this._context.styleManager.showLineWeight = value
   }
 
   updateLayerMaterial(
     layerName: string,
     newTraits: Partial<AcGiSubEntityTraits>
   ): Record<number, THREE.Material> {
-    return this._styleManager.updateLayerMaterial(layerName, newTraits)
+    return this._context.styleManager.updateLayerMaterial(layerName, newTraits)
   }
 
   /**
@@ -255,7 +268,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
     layerName: string,
     layerTraits?: Partial<AcGiSubEntityTraits>
   ) {
-    return this._styleManager.getLayerBoundMaterial(
+    return this._context.styleManager.getLayerBoundMaterial(
       material,
       layerName,
       layerTraits
@@ -266,21 +279,21 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * Create one empty drawable object
    */
   createObject() {
-    return new AcTrObject(this._styleManager)
+    return new AcTrObject(this._context)
   }
 
   /**
    * Create one empty entity
    */
   createEntity() {
-    return new AcTrEntity(this._styleManager)
+    return new AcTrEntity(this._context)
   }
 
   /**
    * @inheritdoc
    */
   group(entities: AcTrEntity[]) {
-    return new AcTrGroup(entities, this._styleManager)
+    return new AcTrGroup(entities, this._context)
   }
 
   /**
@@ -291,7 +304,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
       point,
       this._subEntityTraits,
       style,
-      this._styleManager
+      this._context
     )
     return geometry
   }
@@ -328,7 +341,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
       itemSize,
       indices,
       this._subEntityTraits,
-      this._styleManager
+      this._context
     )
   }
 
@@ -336,7 +349,11 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * @inheritdoc
    */
   area(area: AcGeArea2d) {
-    return new AcTrPolygon(area, this._subEntityTraits, this._styleManager)
+    return new AcTrPolygon(
+      area,
+      this._subEntityTraits,
+      this._context
+    )
   }
 
   /**
@@ -347,7 +364,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
       mtext,
       this._subEntityTraits,
       style,
-      this._styleManager,
+      this._context,
       delay
     )
   }
@@ -360,7 +377,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
       shape,
       this._subEntityTraits,
       style,
-      this._styleManager,
+      this._context,
       delay
     )
   }
@@ -369,19 +386,24 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * @inheritdoc
    */
   image(blob: Blob, style: AcGiImageStyle) {
-    return new AcTrImage(blob, style, this._styleManager)
+    return new AcTrImage(blob, style, this._context)
   }
 
   /**
    * Clears all cached materials and releases its memory
    */
   dispose() {
-    this._styleManager.dispose()
+    this._context.styleManager.dispose()
     FontManager.instance.missedFonts = {}
   }
 
   private linePoints(points: AcGePoint3dLike[]) {
-    return new AcTrLine(points, this._subEntityTraits, this._styleManager)
+    return new AcTrLine(
+      points,
+      this._subEntityTraits,
+      this._context,
+      false
+    )
   }
 
   /**

--- a/packages/three-renderer/src/renderer/index.ts
+++ b/packages/three-renderer/src/renderer/index.ts
@@ -1,3 +1,4 @@
 export * from './AcTrFontLoader'
 export * from './AcTrMTextRenderer'
+export * from './AcTrRenderContext'
 export * from './AcTrRenderer'

--- a/packages/three-renderer/src/style/AcTrStyleManager.ts
+++ b/packages/three-renderer/src/style/AcTrStyleManager.ts
@@ -45,7 +45,7 @@ export class AcTrStyleManager {
     this.fillMgr = new AcTrFillMaterialManager(this.options)
   }
 
-  /** Stores unsupported text styles mapped by name → usage count. */
+  /** Unsupported text styles mapped by name → usage count. */
   public unsupportedTextStyles: Record<string, number> = {}
 
   /**

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -172,6 +172,27 @@ export function getBatchedContainerUserData(
 export function markSplitTranslationFlag(_object: THREE.Object3D): void {}
 
 /**
+ * Resolves the Object3D that carries MTEXT insertion/rotation from the renderer.
+ * Worker output is already the placement root; sync output wraps it under `MText`.
+ */
+export function resolveMTextRenderRoot(mtext: THREE.Object3D): THREE.Object3D {
+  if (mtext.children.length !== 1) {
+    return mtext
+  }
+
+  const child = mtext.children[0]
+  if (
+    child instanceof THREE.Mesh ||
+    child instanceof THREE.Line ||
+    child instanceof THREE.LineSegments
+  ) {
+    return mtext
+  }
+
+  return child
+}
+
+/**
  * Copies RTE / no-batch flags from a source drawable onto a highlight clone.
  */
 export function copyHighlightObjectFlags(


### PR DESCRIPTION
## Summary

- Introduce `AcTrRenderContext` to bundle `AcTrStyleManager` with a pluggable `AcTrBatchDrawPolicy`, replacing direct `styleManager` usage across entity types.
- Add coordinate-aware batch/unbatch resolution (`AcTrDrawMode`) so entities at large world coordinates (>= 1e6) use the unbatched draw path, preserving geometry precision and correct MTEXT/line placement in `AcTrBatchedGroup`.
- Extend `AcTrBatchedGroup` to correctly clone, select, highlight, and dispose unbatched placement roots (e.g. large-coordinate MTEXT glyphs).
- Add comprehensive unit tests for draw policy, batched bounds, unbatched operations, and per-entity draw mode resolution.
- Minor `cad-viewer-example` layout fix (`align-items: safe center`, horizontal padding).

## Test plan

- [ ] Run `nx test three-renderer` and verify all new/updated specs pass
- [ ] Open a drawing with large-world-coordinate entities (>= 1e6) and confirm lines/MTEXT render at correct positions
- [ ] Verify small-coordinate entities still batch correctly (performance unchanged)
- [ ] Test selection/highlight/removal of large-coordinate MTEXT entities
- [ ] Smoke test `cad-viewer-example` layout on narrow viewports