### PR TITLE
feat: default Write mode and disable progressive rendering

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1150,7 +1150,7 @@ export class AcApDocManager {
       mode: this.getDocumentEventMode(options)
     })
     ;(this.curView as AcTrView2d).progressiveRendering =
-      options?.progressiveRendering ?? true
+      options?.progressiveRendering ?? false
     this.curView.clear()
   }
 
@@ -1204,7 +1204,7 @@ export class AcApDocManager {
       const layoutLimits = activeLayout?.limits
 
       const view = this.curView as AcTrView2d
-      const progressiveRendering = options?.progressiveRendering ?? true
+      const progressiveRendering = options?.progressiveRendering ?? false
       if (isPaperSpaceActive && layoutLimits && !layoutLimits.isEmpty()) {
         view.zoomTo(layoutLimits)
       } else {
@@ -1243,7 +1243,7 @@ export class AcApDocManager {
       options = {
         fontLoader: this._fontLoader,
         drawNoPlotLayers: false,
-        progressiveRendering: true
+        progressiveRendering: false
       }
     } else {
       if (options.fontLoader == null) {
@@ -1253,7 +1253,7 @@ export class AcApDocManager {
         options.drawNoPlotLayers = false
       }
       if (options.progressiveRendering == null) {
-        options.progressiveRendering = true
+        options.progressiveRendering = false
       }
     }
     return options

--- a/packages/cad-simple-viewer/src/app/AcDbOpenDatabaseOptions.ts
+++ b/packages/cad-simple-viewer/src/app/AcDbOpenDatabaseOptions.ts
@@ -35,9 +35,9 @@ export interface AcApOpenDatabaseOptions extends Omit<
   /**
    * Whether to render entities incrementally while a drawing is opening.
    *
-   * When `true` (default), entity conversion is deferred across event-loop
-   * turns so geometry appears progressively and the camera can reframe as
-   * batches land. When `false`, conversion still runs asynchronously but the
+   * When `true`, entity conversion is deferred across event-loop turns so
+   * geometry appears progressively and the camera can reframe as batches
+   * land. When `false` (default), conversion still runs asynchronously but the
    * canvas is not redrawn until every entity is converted; zoom-to-fit also
    * waits for conversion to finish.
    */

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -180,7 +180,7 @@ export class AcTrView2d extends AcEdBaseView {
    * When true, entity conversion during document open is deferred across
    * event-loop turns so geometry appears incrementally.
    */
-  private _progressiveRendering = true
+  private _progressiveRendering = false
 
   /**
    * Creates a new 2D CAD viewer instance.

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -65,10 +65,10 @@ const initialize = () => {
 // AcApSettingManager.instance.isShowStats = false
 // AcApSettingManager.instance.isShowCoordinate = false
 
-const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
+const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Write)
 const useMainThreadDraw = ref(false)
 const drawNoPlotLayers = ref(false)
-const progressiveRendering = ref(true)
+const progressiveRendering = ref(false)
 
 // Handle file selection from upload component
 const handleFileSelect = (

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -199,10 +199,10 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Read)
+const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Write)
 const useMainThreadDraw = ref(false)
 const drawNoPlotLayers = ref(false)
-const progressiveRendering = ref(true)
+const progressiveRendering = ref(false)
 
 const accessModes = [
   {

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -174,7 +174,7 @@ interface Props {
   drawNoPlotLayers?: boolean
   /**
    * Whether to render entities incrementally while a drawing is opening.
-   * When omitted, {@link AcApDocManager} defaults to `true`.
+   * When omitted, {@link AcApDocManager} defaults to `false`.
    */
   progressiveRendering?: boolean
 }
@@ -189,7 +189,7 @@ const props = withDefaults(defineProps<Props>(), {
   useMainThreadDraw: true,
   theme: 'dark',
   mode: AcEdOpenMode.Write,
-  progressiveRendering: true
+  progressiveRendering: false
 })
 
 const { t } = useI18n()


### PR DESCRIPTION
## Summary
- Default **cad-viewer-example** upload screen access mode to **Write** instead of Read.
- Change **progressiveRendering** default from `true` to `false` in `AcApDocManager`, `AcTrView2d`, `MlCadViewer`, and the example upload screen so document open waits for full conversion before redraw/zoom-to-fit unless explicitly enabled.

## Test plan
- [ ] Open cad-viewer-example homepage and confirm **Write** and **Disabled** progressive rendering are pre-selected.
- [ ] Upload a DWG/DXF file and verify editing commands are available without switching mode.
- [ ] Confirm opening a drawing without progressive rendering waits for conversion before showing geometry and zoom-to-fit.
- [ ] Enable progressive rendering on the upload screen and confirm incremental geometry display still works.