### PR TITLE
fix(viewer): use batch geometry bounds instead of EXTMIN/EXTMAX for open zoom

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1,14 +1,12 @@
 import {
   AcCmColor,
   AcCmEventManager,
-  AcDbDatabase,
   AcDbDatabaseConverterManager,
   AcDbDxfConverter,
   AcDbFileType,
   acdbHostApplicationServices,
   AcDbProgressdEventArgs,
   AcDbSysVarManager,
-  AcGeBox2d,
   log
 } from '@mlightcad/data-model'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
@@ -1189,7 +1187,10 @@ export class AcApDocManager {
       //    actual paper to a grain.
       //
       // 2. **Otherwise**: poll `zoomToFitDrawing` and frame batch-derived
-      //    geometry bounds once entities land.
+      //    geometry bounds once entities land. Do not use database
+      //    EXTMIN/EXTMAX for a provisional zoom — real-world DXFs often
+      //    carry stale header extents that diverge wildly from rendered
+      //    geometry (e.g. outlier entities at unrelated coordinates).
       //
       // The pre-fix code used `db.extmin/db.extmax` (always model-space
       // EXTMIN/EXTMAX sysvars) even when opening into paper, landing on
@@ -1208,11 +1209,8 @@ export class AcApDocManager {
       if (isPaperSpaceActive && layoutLimits && !layoutLimits.isEmpty()) {
         view.zoomTo(layoutLimits)
       } else {
-        const extentsBox = this.resolveModelSpaceExtentsBox(db)
         if (progressiveRendering) {
-          view.beginProgressiveOpenFit(extentsBox)
-        } else if (extentsBox && !extentsBox.isEmpty()) {
-          view.zoomTo(extentsBox)
+          view.beginProgressiveOpenFit()
         }
         view.zoomToFitDrawing()
       }
@@ -1289,26 +1287,6 @@ export class AcApDocManager {
   private resetOpenFileProgress() {
     this._openFileProgressPeak = 0
     this._openFileProgressStage = undefined
-  }
-
-  /**
-   * Builds a model-space extents box from database EXTMIN/EXTMAX sysvars.
-   *
-   * Used only for an immediate provisional zoom at document open so entities
-   * become visible while the view layer still batch-converts geometry.
-   */
-  private resolveModelSpaceExtentsBox(db: AcDbDatabase) {
-    const extmin = db.extmin
-    const extmax = db.extmax
-    if (!extmin || !extmax) {
-      return undefined
-    }
-
-    const box = new AcGeBox2d(
-      { x: extmin.x, y: extmin.y },
-      { x: extmax.x, y: extmax.y }
-    )
-    return box.isEmpty() ? undefined : box
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrProgressiveOpenFitController.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrProgressiveOpenFitController.ts
@@ -11,9 +11,8 @@ export type AcTrProgressiveOpenFitZoomFn = (
  * being batch-converted into the scene.
  *
  * Responsibilities:
- * - Provisional fit from database extents (EXTMIN/EXTMAX)
- * - Throttled incremental fit for large drawings without authoritative extents
- * - Final fit once conversion completes
+ * - Throttled incremental fit for large drawings while entities convert
+ * - Final fit once conversion completes (always from batch geometry bounds)
  * - Stop auto-framing when the user pans or zooms manually
  * - Yield to the render loop so geometry appears progressively
  *
@@ -30,7 +29,6 @@ export class AcTrProgressiveOpenFitController {
   private userAdjusted = false
   private programmaticDepth = 0
   private incrementalEnabled = false
-  private usedInitialExtents = false
   private initialPendingCount = 0
   private lastFittedBox?: AcGeBox2d
   private lastZoomAt = 0
@@ -44,18 +42,13 @@ export class AcTrProgressiveOpenFitController {
   /**
    * Starts progressive open framing for the current document open operation.
    */
-  begin(initialBox: AcGeBox2d | undefined, pendingEntityCount: number) {
+  begin(pendingEntityCount: number) {
     this.active = true
     this.userAdjusted = false
     this.lastZoomAt = 0
     this.initialPendingCount = pendingEntityCount
-    this.usedInitialExtents = !!(initialBox && !initialBox.isEmpty())
     this.lastFittedBox = undefined
-    this.incrementalEnabled = this.shouldEnableIncrementalFit(initialBox)
-
-    if (initialBox && !initialBox.isEmpty()) {
-      this.applyZoom(initialBox)
-    }
+    this.incrementalEnabled = this.shouldEnableIncrementalFit()
   }
 
   /** Ends progressive open framing. */
@@ -67,10 +60,10 @@ export class AcTrProgressiveOpenFitController {
 
   /**
    * Applies the terminal fit after all entities are converted, unless the user
-   * already adjusted the view or a small drawing was framed by database extents.
+   * already adjusted the view manually.
    */
   applyFinalFit(resolveFitBox: () => AcGeBox2d | undefined) {
-    if (this.userAdjusted || this.shouldSkipFinalFit()) {
+    if (this.userAdjusted) {
       return
     }
 
@@ -139,21 +132,10 @@ export class AcTrProgressiveOpenFitController {
     this.applyZoom(box)
   }
 
-  private shouldEnableIncrementalFit(initialBox?: AcGeBox2d) {
-    if (initialBox && !initialBox.isEmpty()) {
-      return false
-    }
+  private shouldEnableIncrementalFit() {
     return (
       this.initialPendingCount >=
       AcTrProgressiveOpenFitController.SMALL_ENTITY_THRESHOLD
-    )
-  }
-
-  private shouldSkipFinalFit() {
-    return (
-      this.usedInitialExtents &&
-      this.initialPendingCount <
-        AcTrProgressiveOpenFitController.SMALL_ENTITY_THRESHOLD
     )
   }
 

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -565,12 +565,9 @@ export class AcTrView2d extends AcEdBaseView {
   /**
    * Enables progressive camera framing while entities are batch-converted at
    * document open. Pair with {@link zoomToFitDrawing} for the final accurate fit.
-   *
-   * @param initialBox - Optional provisional extents (e.g. EXTMIN/EXTMAX) applied
-   * before the first converted entities land.
    */
-  beginProgressiveOpenFit(initialBox?: AcGeBox2d) {
-    this._progressiveOpenFit.begin(initialBox, this._numOfEntitiesToProcess)
+  beginProgressiveOpenFit() {
+    this._progressiveOpenFit.begin(this._numOfEntitiesToProcess)
   }
 
   /**


### PR DESCRIPTION
## Summary

- Remove provisional zoom from database EXTMIN/EXTMAX at document open; real-world DXFs often carry stale header extents that diverge from rendered geometry.
- Simplify progressive open fit to always derive framing from batch-converted geometry bounds (incremental fit for large drawings, final fit via zoomToFitDrawing).
- Drop resolveModelSpaceExtentsBox and related skip-final-fit logic tied to initial extents.

## Test plan

- [ ] Open a DXF/DWG with stale or outlier EXTMIN/EXTMAX header values and confirm the view frames rendered geometry, not unrelated coordinates.
- [ ] Open a small drawing with progressiveRendering enabled and verify final zoom-to-fit is correct.
- [ ] Open a large drawing with progressiveRendering enabled and verify incremental framing during conversion, then final fit when complete.
- [ ] Open into paper space with layout limits and confirm layout-based zoom still works.
- [ ] Pan/zoom manually during progressive open and confirm auto-framing stops.

Made with [Cursor](https://cursor.com)