### PR TITLE
feat(viewer): add AutoCAD-style command-line point and mixed prompt input

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcEdPointHandler.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdPointHandler.spec.ts
@@ -1,0 +1,59 @@
+import { AcEdDistanceHandler } from '../src/editor/input/handler/AcEdDistanceHandler'
+import { AcEdPointHandler } from '../src/editor/input/handler/AcEdPointHandler'
+import { AcEdPromptDistanceOptions } from '../src/editor/input/prompt/AcEdPromptDistanceOptions'
+import { AcEdPromptPointOptions } from '../src/editor/input/prompt/AcEdPromptPointOptions'
+
+describe('AcEdPointHandler.parseCommandLine', () => {
+  const pointHandler = new AcEdPointHandler(new AcEdPromptPointOptions('point'))
+
+  it('parses absolute cartesian coordinates', () => {
+    expect(pointHandler.parseCommandLine('50,30')).toEqual({
+      x: 50,
+      y: 30,
+      z: 0
+    })
+  })
+
+  it('parses relative cartesian coordinates', () => {
+    expect(
+      pointHandler.parseCommandLine('@10,5', {
+        referencePoint: { x: 100, y: 200 }
+      })
+    ).toEqual({ x: 110, y: 205, z: 0 })
+  })
+
+  it('parses absolute polar coordinates', () => {
+    const point = pointHandler.parseCommandLine('10<90')
+    expect(point?.x).toBeCloseTo(0, 5)
+    expect(point?.y).toBeCloseTo(10, 5)
+  })
+
+  it('parses relative polar coordinates', () => {
+    const point = pointHandler.parseCommandLine('@10<0', {
+      referencePoint: { x: 5, y: 5 }
+    })
+    expect(point).toEqual({ x: 15, y: 5, z: 0 })
+  })
+
+  it('parses rubber-band distance along cursor direction', () => {
+    const point = pointHandler.parseCommandLine('10', {
+      referencePoint: { x: 0, y: 0 },
+      cursorPoint: { x: 0, y: 5 }
+    })
+    expect(point?.x).toBeCloseTo(0, 5)
+    expect(point?.y).toBeCloseTo(10, 5)
+  })
+
+  it('returns null for ambiguous keyword-like point tokens', () => {
+    expect(pointHandler.parseCommandLine('C')).toBeNull()
+  })
+})
+
+describe('AcEdDistanceHandler.parseCommandLine', () => {
+  it('delegates numeric parsing to parse', () => {
+    const handler = new AcEdDistanceHandler(
+      new AcEdPromptDistanceOptions('distance')
+    )
+    expect(handler.parseCommandLine('12.5')).toBe(12.5)
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcEdPromptInputSession.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdPromptInputSession.spec.ts
@@ -1,0 +1,62 @@
+import { AcEdPointHandler } from '../src/editor/input/handler/AcEdPointHandler'
+import { AcEdPromptKeywordOptions } from '../src/editor/input/prompt/AcEdPromptKeywordOptions'
+import { AcEdPromptPointOptions } from '../src/editor/input/prompt/AcEdPromptPointOptions'
+import { AcEdPromptInputSession } from '../src/editor/input/session/AcEdPromptInputSession'
+
+describe('AcEdPromptInputSession precedence', () => {
+  const createCliStub = () =>
+    ({
+      clearInput: jest.fn(),
+      setInputReadOnly: jest.fn(),
+      renderKeywordPrompt: jest.fn(),
+      focusInput: jest.fn(),
+      clear: jest.fn()
+    }) as any
+
+  const createSession = (
+    options: AcEdPromptKeywordOptions,
+    mode: 'geometric' | 'string' | 'keyword'
+  ) => {
+    const handler = new AcEdPointHandler(new AcEdPromptPointOptions('point'))
+    const session = new AcEdPromptInputSession(
+      createCliStub(),
+      options,
+      text => {
+        if (text === '50,30') return { x: 50, y: 30, z: 0 }
+        return null
+      },
+      mode,
+      false,
+      true
+    )
+    const resolved: Array<{ kind: string; value?: unknown; keyword?: string }> =
+      []
+    ;(session as any).resolve = (value: unknown) => resolved.push(value as any)
+    return { session, resolved }
+  }
+
+  test('geometric mode prefers coordinates over keywords', () => {
+    const options = new AcEdPromptKeywordOptions('pick')
+    options.keywords.add('Close', 'Close', 'C')
+
+    const { session, resolved } = createSession(options, 'geometric')
+    const handled = session.handleEnter('50,30')
+
+    expect(handled).toBe(true)
+    expect(resolved[0]).toEqual({
+      kind: 'value',
+      value: { x: 50, y: 30, z: 0 }
+    })
+  })
+
+  test('geometric mode resolves keyword when coordinate parse fails', () => {
+    const options = new AcEdPromptKeywordOptions('pick')
+    options.keywords.add('Close', 'Close', 'C')
+
+    const { session, resolved } = createSession(options, 'geometric')
+    const handled = session.handleEnter('C')
+
+    expect(handled).toBe(true)
+    expect(resolved[0]).toEqual({ kind: 'keyword', keyword: 'Close' })
+  })
+})

--- a/packages/cad-simple-viewer/src/editor/input/handler/AcEdAngleHandler.ts
+++ b/packages/cad-simple-viewer/src/editor/input/handler/AcEdAngleHandler.ts
@@ -1,5 +1,5 @@
 import { AcEdPromptAngleOptions } from '../prompt/AcEdPromptAngleOptions'
-import { AcEdInputHandler } from './AcEdInputHandler'
+import { AcEdInputHandler, AcEdPointInputContext } from './AcEdInputHandler'
 
 /**
  * Validates angular numeric input.
@@ -28,5 +28,11 @@ export class AcEdAngleHandler implements AcEdInputHandler<number> {
     }
 
     return n
+  }
+
+  parseCommandLine(token: string, _context?: AcEdPointInputContext) {
+    const trimmed = token.trim()
+    if (!trimmed) return null
+    return this.parse(trimmed)
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/handler/AcEdInputHandler.ts
+++ b/packages/cad-simple-viewer/src/editor/input/handler/AcEdInputHandler.ts
@@ -1,13 +1,38 @@
+import { AcGePoint2dLike } from '@mlightcad/data-model'
+
+/**
+ * Optional context for AutoCAD-style command-line point entry.
+ */
+export interface AcEdPointInputContext {
+  /** Last picked point or prompt base point for relative (`@`) entry. */
+  referencePoint?: AcGePoint2dLike | null
+  /**
+   * Current cursor position in WCS. Required to interpret a lone distance value
+   * as a point along the active rubber-band direction.
+   */
+  cursorPoint?: AcGePoint2dLike | null
+}
+
 /**
  * Base class for all input handlers.
  * @template T The final parsed value type (number, string, point, etc.).
  */
 export interface AcEdInputHandler<T> {
   /**
-   * Parses `value` using rules implemented in subclasses.
+   * Parses floating-input box values using rules implemented in subclasses.
    * @param x - Texts in the first input box
    * @param y - Texts in the second input box
    * @returns parsed value if valid, otherwise null.
    */
   parse(x: string, y?: string): T | null
+
+  /**
+   * Parses one AutoCAD-style command-line token.
+   *
+   * Handlers that only accept a single value typically delegate to {@link parse}.
+   */
+  parseCommandLine(
+    token: string,
+    context?: AcEdPointInputContext
+  ): T | null
 }

--- a/packages/cad-simple-viewer/src/editor/input/handler/AcEdKeywordHandler.ts
+++ b/packages/cad-simple-viewer/src/editor/input/handler/AcEdKeywordHandler.ts
@@ -1,5 +1,5 @@
 import { AcEdPromptKeywordOptions } from '../prompt/AcEdPromptKeywordOptions'
-import { AcEdInputHandler } from './AcEdInputHandler'
+import { AcEdInputHandler, AcEdPointInputContext } from './AcEdInputHandler'
 
 /**
  * Validates keyword input according to {@link AcEdPromptKeywordOptions}.
@@ -35,5 +35,9 @@ export class AcEdKeywordHandler implements AcEdInputHandler<string> {
 
     // 4. Invalid input
     return null
+  }
+
+  parseCommandLine(token: string, _context?: AcEdPointInputContext) {
+    return this.parse(token)
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/handler/AcEdNumericalHandler.ts
+++ b/packages/cad-simple-viewer/src/editor/input/handler/AcEdNumericalHandler.ts
@@ -1,5 +1,5 @@
 import { AcEdPromptNumericalOptions } from '../prompt/AcEdPromptNumericalOptions'
-import { AcEdInputHandler } from './AcEdInputHandler'
+import { AcEdInputHandler, AcEdPointInputContext } from './AcEdInputHandler'
 
 /**
  * Handles validation and parsing of numerical user input.
@@ -27,5 +27,11 @@ export class AcEdNumericalHandler implements AcEdInputHandler<number> {
     }
 
     return n
+  }
+
+  parseCommandLine(token: string, _context?: AcEdPointInputContext) {
+    const trimmed = token.trim()
+    if (!trimmed) return null
+    return this.parse(trimmed)
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/handler/AcEdPointHandler.ts
+++ b/packages/cad-simple-viewer/src/editor/input/handler/AcEdPointHandler.ts
@@ -1,7 +1,33 @@
 import { AcGePoint3dLike } from '@mlightcad/data-model'
 
 import { AcEdPromptPointOptions } from '../prompt/AcEdPromptPointOptions'
-import { AcEdInputHandler } from './AcEdInputHandler'
+import { AcEdInputHandler, AcEdPointInputContext } from './AcEdInputHandler'
+
+const NUMERIC_TOKEN = /^-?(?:\d+\.?\d*|\.\d+)$/
+
+/**
+ * Splits a Cartesian point token into x/y components.
+ *
+ * Accepts comma-separated (`50,30`) or whitespace-separated (`50 30`) forms.
+ * An optional third `z` component is tolerated but ignored by 2D prompts.
+ */
+function splitCartesianPointToken(
+  token: string
+): { x: string; y: string } | undefined {
+  const trimmed = token.trim()
+  if (!trimmed) return undefined
+
+  if (trimmed.includes(',')) {
+    const parts = trimmed.split(',').map(v => v.trim())
+    if (parts.length !== 2 && parts.length !== 3) return undefined
+    if (parts.length === 3 && Number.isNaN(Number(parts[2]))) return undefined
+    return { x: parts[0], y: parts[1] }
+  }
+
+  const parts = trimmed.split(/\s+/)
+  if (parts.length < 2) return undefined
+  return { x: parts[0], y: parts[1] }
+}
 
 /**
  * Handles validation and parsing of point user input.
@@ -22,5 +48,84 @@ export class AcEdPointHandler implements AcEdInputHandler<AcGePoint3dLike> {
     }
 
     return { x: nx, y: ny, z: 0 }
+  }
+
+  /**
+   * Parses an AutoCAD-style point token from the command line.
+   *
+   * Supported forms:
+   * - Absolute Cartesian: `X,Y` or `X Y`
+   * - Relative Cartesian: `@X,Y` or `@X Y`
+   * - Absolute polar: `distance<angle`
+   * - Relative polar: `@distance<angle`
+   * - Rubber-band distance: plain number when a reference point and cursor
+   *   position are available
+   */
+  parseCommandLine(token: string, context?: AcEdPointInputContext) {
+    const trimmed = token.trim()
+    if (!trimmed) return null
+
+    const isRelative = trimmed.startsWith('@')
+    const body = isRelative ? trimmed.slice(1).trim() : trimmed
+    if (!body) return null
+
+    const reference = context?.referencePoint ?? undefined
+
+    const ltIndex = body.indexOf('<')
+    if (ltIndex >= 0) {
+      const distStr = body.slice(0, ltIndex).trim()
+      const angleStr = body.slice(ltIndex + 1).trim()
+      const dist = Number(distStr)
+      const angleDeg = Number(angleStr)
+      if (Number.isNaN(dist) || Number.isNaN(angleDeg)) return null
+
+      const angleRad = (angleDeg * Math.PI) / 180
+      const offsetX = dist * Math.cos(angleRad)
+      const offsetY = dist * Math.sin(angleRad)
+
+      if (isRelative) {
+        if (!reference) return null
+        return this.parse(
+          String(reference.x + offsetX),
+          String(reference.y + offsetY)
+        )
+      }
+
+      return this.parse(String(offsetX), String(offsetY))
+    }
+
+    const cartesian = splitCartesianPointToken(body)
+    if (cartesian) {
+      const offsetX = Number(cartesian.x)
+      const offsetY = Number(cartesian.y)
+      if (Number.isNaN(offsetX) || Number.isNaN(offsetY)) return null
+
+      if (isRelative) {
+        if (!reference) return null
+        return this.parse(
+          String(reference.x + offsetX),
+          String(reference.y + offsetY)
+        )
+      }
+
+      return this.parse(cartesian.x, cartesian.y)
+    }
+
+    if (NUMERIC_TOKEN.test(body)) {
+      const distance = Number(body)
+      const cursor = context?.cursorPoint
+      if (!reference || !cursor || Number.isNaN(distance)) return null
+
+      const dx = cursor.x - reference.x
+      const dy = cursor.y - reference.y
+      const len = Math.hypot(dx, dy)
+      const angleRad = len > 1e-10 ? Math.atan2(dy, dx) : 0
+      return this.parse(
+        String(reference.x + distance * Math.cos(angleRad)),
+        String(reference.y + distance * Math.sin(angleRad))
+      )
+    }
+
+    return null
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/handler/AcEdStringHandler.ts
+++ b/packages/cad-simple-viewer/src/editor/input/handler/AcEdStringHandler.ts
@@ -1,5 +1,5 @@
 import { AcEdPromptStringOptions } from '../prompt/AcEdPromptStringOptions'
-import { AcEdInputHandler } from './AcEdInputHandler'
+import { AcEdInputHandler, AcEdPointInputContext } from './AcEdInputHandler'
 
 /**
  * Validates string input according to {@link AcEdPromptStringOptions}.
@@ -26,5 +26,9 @@ export class AcEdStringHandler implements AcEdInputHandler<string> {
     }
 
     return value
+  }
+
+  parseCommandLine(token: string, _context?: AcEdPointInputContext) {
+    return this.parse(token)
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/session/AcEdInputSession.ts
+++ b/packages/cad-simple-viewer/src/editor/input/session/AcEdInputSession.ts
@@ -1,4 +1,15 @@
-export abstract class AcEdInputSession<T> {
+/**
+ * Minimal command-line session surface used while a prompt is active.
+ *
+ * Stored without a result-type parameter so keyword and mixed-input sessions
+ * can share the same active-session slot.
+ */
+export interface AcEdCommandLineSessionControl {
+  handleEnter(value: string): boolean
+  handleEscape(): void
+}
+
+export abstract class AcEdInputSession<T> implements AcEdCommandLineSessionControl {
   protected resolve!: (value: T) => void
 
   start(): Promise<T> {

--- a/packages/cad-simple-viewer/src/editor/input/session/AcEdPromptInputSession.ts
+++ b/packages/cad-simple-viewer/src/editor/input/session/AcEdPromptInputSession.ts
@@ -1,0 +1,118 @@
+import { AcEdKeywordHandler } from '../handler/AcEdKeywordHandler'
+import { AcEdPromptKeywordOptions } from '../prompt/AcEdPromptKeywordOptions'
+import { AcEdCommandLine } from '../ui/AcEdCommandLine'
+import { AcEdInputSession } from './AcEdInputSession'
+
+/**
+ * Resolution mode for mixed command-line prompt sessions.
+ *
+ * - `geometric`: try coordinate/numeric parsing first, then keywords
+ * - `string`: try keywords first, then accept arbitrary string input
+ * - `keyword`: keywords only (same as {@link AcEdKeywordSession})
+ */
+export type AcEdPromptInputMode = 'geometric' | 'string' | 'keyword'
+
+/**
+ * Result produced by a mixed prompt-input session.
+ */
+export type AcEdPromptInputResult<T> =
+  | { kind: 'value'; value: T }
+  | { kind: 'keyword'; keyword: string }
+  | { kind: 'none' }
+
+/**
+ * Interactive command-line session that accepts geometric or textual prompt
+ * input together with optional keywords, using AutoCAD-style precedence rules.
+ */
+export class AcEdPromptInputSession<T> extends AcEdInputSession<
+  AcEdPromptInputResult<T>
+> {
+  private keywordHandler?: AcEdKeywordHandler
+
+  /**
+   * @param cli - Command-line UI adapter
+   * @param options - Keyword prompt options used for rendering and keyword parsing
+   * @param parseValue - Parser for the prompt's primary value type
+   * @param mode - Precedence rules between data and keyword resolution
+   * @param allowNone - Whether empty Enter is accepted as `none`
+   * @param allowTyping - Whether typed input is accepted
+   */
+  constructor(
+    private cli: AcEdCommandLine,
+    private options: AcEdPromptKeywordOptions,
+    private parseValue: (text: string) => T | null,
+    private mode: AcEdPromptInputMode,
+    private allowNone: boolean,
+    private allowTyping: boolean = true
+  ) {
+    super()
+    if (this.options.keywords.count > 0) {
+      this.keywordHandler = new AcEdKeywordHandler(this.options)
+    }
+  }
+
+  protected onStart(): void {
+    this.cli.clearInput()
+    this.cli.setInputReadOnly(!this.allowTyping)
+    this.cli.renderKeywordPrompt(this.options, kw =>
+      this.finish({ kind: 'keyword', keyword: kw })
+    )
+    this.cli.focusInput()
+  }
+
+  handleEnter(value: string): boolean {
+    if (!this.allowTyping) return true
+
+    if (!value.trim()) {
+      const defaultKeyword = this.options.keywords.default
+      if (defaultKeyword?.enabled) {
+        this.finish({ kind: 'keyword', keyword: defaultKeyword.globalName })
+        return true
+      }
+      if (this.allowNone) {
+        this.finish({ kind: 'none' })
+        return true
+      }
+      return false
+    }
+
+    if (this.mode === 'keyword') {
+      return this.tryResolveKeyword(value)
+    }
+
+    if (this.mode === 'string') {
+      if (this.tryResolveKeyword(value)) return true
+      const parsed = this.parseValue(value)
+      if (parsed !== null) {
+        this.finish({ kind: 'value', value: parsed })
+        return true
+      }
+      return false
+    }
+
+    const parsed = this.parseValue(value)
+    if (parsed !== null) {
+      this.finish({ kind: 'value', value: parsed })
+      return true
+    }
+
+    return this.tryResolveKeyword(value)
+  }
+
+  handleEscape(): void {
+    this.finish({ kind: 'none' })
+  }
+
+  protected cleanup(): void {
+    this.cli.setInputReadOnly(false)
+    this.cli.clear()
+  }
+
+  private tryResolveKeyword(value: string): boolean {
+    if (!this.keywordHandler) return false
+    const parsed = this.keywordHandler.parse(value)
+    if (parsed === null) return false
+    this.finish({ kind: 'keyword', keyword: parsed })
+    return true
+  }
+}

--- a/packages/cad-simple-viewer/src/editor/input/session/index.ts
+++ b/packages/cad-simple-viewer/src/editor/input/session/index.ts
@@ -1,2 +1,3 @@
 export * from './AcEdKeywordSession'
 export * from './AcEdInputSession'
+export * from './AcEdPromptInputSession'

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
@@ -1,7 +1,13 @@
 import { AcApDocManager, AcApSettingManager } from '../../../app'
 import { AcApI18n } from '../../../i18n'
 import { AcEdPromptKeywordOptions } from '../prompt'
-import { AcEdKeywordSession } from '../session'
+import {
+  AcEdCommandLineSessionControl,
+  AcEdKeywordSession,
+  AcEdPromptInputMode,
+  AcEdPromptInputResult,
+  AcEdPromptInputSession
+} from '../session'
 import { AcEdMessageType } from './AcEdMessageType'
 
 /**
@@ -41,7 +47,7 @@ export class AcEdCommandLine {
   private cmdPopup!: HTMLDivElement
   private msgPanel!: HTMLDivElement
   private autoCompleteIndex: number
-  private activeSession?: AcEdKeywordSession
+  private activeSession?: AcEdCommandLineSessionControl
   private resizeObserver?: ResizeObserver
   private isPromptActive: boolean = false
   private readonly recentMessages: string[] = []
@@ -136,10 +142,42 @@ export class AcEdCommandLine {
     options: AcEdPromptKeywordOptions,
     allowTyping: boolean = true
   ): Promise<string> {
-    this.activeSession = new AcEdKeywordSession(this, options, allowTyping)
-    const result = await this.activeSession.start()
-    this.activeSession = undefined
-    return result
+    const session = new AcEdKeywordSession(this, options, allowTyping)
+    this.activeSession = session
+    try {
+      return await session.start()
+    } finally {
+      this.activeSession = undefined
+    }
+  }
+
+  /**
+   * Runs a mixed prompt-input session that accepts typed geometric or textual
+   * values together with optional keywords.
+   */
+  async getPromptInput<T>(
+    options: AcEdPromptKeywordOptions,
+    parseValue: (text: string) => T | null,
+    config: {
+      mode: AcEdPromptInputMode
+      allowNone: boolean
+      allowTyping?: boolean
+    }
+  ): Promise<AcEdPromptInputResult<T>> {
+    const session = new AcEdPromptInputSession(
+      this,
+      options,
+      parseValue,
+      config.mode,
+      config.allowNone,
+      config.allowTyping ?? true
+    )
+    this.activeSession = session
+    try {
+      return await session.start()
+    } finally {
+      this.activeSession = undefined
+    }
   }
 
   /**
@@ -633,7 +671,10 @@ export class AcEdCommandLine {
           const handled = this.activeSession.handleEnter(this.getInputText())
           if (!handled) {
             this.showMessage(
-              this.localize('main.commandLine.invalidKeyword'),
+              this.localize(
+                'main.commandLine.invalidInput',
+                'Invalid input.'
+              ),
               'warning'
             )
           }
@@ -787,33 +828,33 @@ export class AcEdCommandLine {
     }
 
     const promptFormat = options.getKeywordPromptFormat()
-    if (!promptFormat.visibleKeywords.length) return
-    const keywords = options.keywords?.toArray().filter(k => k.visible)
-    if (!keywords?.length) return
+    const keywords = options.keywords?.toArray().filter(k => k.visible) ?? []
 
-    this.promptEl.append('[')
+    if (keywords.length) {
+      this.promptEl.append('[')
 
-    keywords.forEach((kw, i) => {
-      if (i > 0) this.promptEl.append('/')
+      keywords.forEach((kw, i) => {
+        if (i > 0) this.promptEl.append('/')
 
-      const span = document.createElement('span')
-      span.className = 'ml-cli-option'
-      span.textContent = kw.displayName
+        const span = document.createElement('span')
+        span.className = 'ml-cli-option'
+        span.textContent = kw.displayName
 
-      if (!kw.enabled) {
-        span.style.opacity = '0.45'
-        span.style.pointerEvents = 'none'
-      } else {
-        span.onclick = () => onClick(kw.globalName)
+        if (!kw.enabled) {
+          span.style.opacity = '0.45'
+          span.style.pointerEvents = 'none'
+        } else {
+          span.onclick = () => onClick(kw.globalName)
+        }
+
+        this.promptEl.append(span)
+      })
+
+      this.promptEl.append(']')
+
+      if (promptFormat.defaultKeyword) {
+        this.promptEl.append(` <${promptFormat.defaultKeyword}>`)
       }
-
-      this.promptEl.append(span)
-    })
-
-    this.promptEl.append(']')
-
-    if (promptFormat.defaultKeyword) {
-      this.promptEl.append(` <${promptFormat.defaultKeyword}>`)
     }
 
     this.promptEl.append(': ')

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -24,6 +24,7 @@ import {
   AcEdPointHandler,
   AcEdStringHandler
 } from '../handler'
+import { AcEdPointInputContext } from '../handler/AcEdInputHandler'
 import { AcEdKeywordHandler } from '../handler/AcEdKeywordHandler'
 import {
   AcEdPromptAngleOptions,
@@ -47,6 +48,7 @@ import {
   AcEdPromptStatus,
   AcEdPromptStringOptions
 } from '../prompt'
+import { AcEdPromptInputMode } from '../session/AcEdPromptInputSession'
 import { AcEdCommandLine } from './AcEdCommandLine'
 import { AcEdFloatingInput } from './AcEdFloatingInput'
 import {
@@ -459,17 +461,8 @@ export class AcEdInputManager {
   }
 
   /**
-   * Starts a command-line keyword session for the given prompt when needed.
-   *
-   * Many interactive prompts accept both mouse-driven input and typed keywords
-   * at the same time. This helper lazily creates the command-line keyword
-   * session only when keywords are actually configured, and returns a small
-   * control object that lets callers await or cancel that session.
-   *
-   * @param options - Prompt options that may define keywords
-   * @param allowTyping - Whether arbitrary typing is allowed alongside keyword completion
-   * @returns An object containing the keyword promise and cancel callback, or
-   * `undefined` when the prompt has no keywords
+   * Starts a keyword-only command-line session for prompts that do not accept
+   * typed geometric values (selection, entity pick, etc.).
    */
   private startKeywordSession(
     options: AcEdPromptOptions<unknown>,
@@ -481,6 +474,94 @@ export class AcEdInputManager {
       promise: this._commandLine.getKeywords(keywordOptions, allowTyping),
       cancel: () => this._commandLine.cancelActiveSession()
     }
+  }
+
+  /**
+   * Starts a mixed command-line session for floating-input prompts.
+   *
+   * AutoCAD-style precedence is applied: geometric or numeric values are parsed
+   * before keywords for point/distance/angle/number prompts; string prompts try
+   * keywords first because arbitrary text is otherwise always valid.
+   */
+  private startPromptInputSession<T>(
+    options: AcEdPromptOptions<T>,
+    handler: AcEdInputHandler<T>,
+    inputCount: AcEdFloatingInputBoxCount,
+    allowTyping: boolean
+  ) {
+    const keywordOptions = this.buildKeywordOptions(options)
+    const allowNone =
+      'allowNone' in options
+        ? (options as { allowNone: boolean }).allowNone
+        : false
+
+    return {
+      promise: this._commandLine.getPromptInput(
+        keywordOptions,
+        text =>
+          this.parseCommandLineInput(text, handler, inputCount, options),
+        {
+          mode: this.resolvePromptInputMode(handler, inputCount),
+          allowNone,
+          allowTyping
+        }
+      ),
+      cancel: () => this._commandLine.cancelActiveSession()
+    }
+  }
+
+  /**
+   * Resolves command-line precedence rules for the active handler.
+   */
+  private resolvePromptInputMode(
+    handler: AcEdInputHandler<unknown>,
+    inputCount: AcEdFloatingInputBoxCount
+  ): AcEdPromptInputMode {
+    if (handler instanceof AcEdStringHandler) return 'string'
+    if (inputCount === 2 || handler instanceof AcEdPointHandler) {
+      return 'geometric'
+    }
+    return 'geometric'
+  }
+
+  /**
+   * Builds command-line point context for {@link AcEdPointHandler.parseCommandLine}.
+   */
+  private resolvePointInputContext(
+    promptOptions: AcEdPromptOptions<unknown>
+  ): AcEdPointInputContext {
+    const promptDefaults = this.resolvePromptDefaults(promptOptions)
+    const referencePoint =
+      promptDefaults.useBasePoint && promptDefaults.basePoint
+        ? promptDefaults.basePoint
+        : (this.lastPoint ?? undefined)
+
+    return {
+      referencePoint,
+      cursorPoint: this.view.screenToWorld(
+        this.view.viewportToCanvas(this.view.curMousePos)
+      )
+    }
+  }
+
+  /**
+   * Parses one command-line token into the value expected by the active prompt.
+   */
+  private parseCommandLineInput<T>(
+    text: string,
+    handler: AcEdInputHandler<T>,
+    inputCount: AcEdFloatingInputBoxCount,
+    promptOptions: AcEdPromptOptions<T>
+  ): T | null {
+    const trimmed = text.trim()
+    if (!trimmed) return null
+
+    const pointContext =
+      handler instanceof AcEdPointHandler || inputCount === 2
+        ? this.resolvePointInputContext(promptOptions)
+        : undefined
+
+    return handler.parseCommandLine(trimmed, pointContext)
   }
 
   /**
@@ -764,7 +845,7 @@ export class AcEdInputManager {
     options: AcEdPromptDistanceOptions
   ): Promise<AcEdPromptDoubleResult> {
     const handler = new AcEdDistanceHandler(options)
-    const scriptedValue = this.tryGetScriptedNumber(handler)
+    const scriptedValue = this.tryGetScriptedNumber(handler, options)
     if (scriptedValue != null) {
       return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, scriptedValue)
     }
@@ -803,7 +884,7 @@ export class AcEdInputManager {
     options: AcEdPromptAngleOptions
   ): Promise<AcEdPromptDoubleResult> {
     const handler = new AcEdAngleHandler(options)
-    const scriptedValue = this.tryGetScriptedNumber(handler)
+    const scriptedValue = this.tryGetScriptedNumber(handler, options)
     if (scriptedValue != null) {
       return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, scriptedValue)
     }
@@ -863,7 +944,7 @@ export class AcEdInputManager {
     options: AcEdPromptDoubleOptions
   ): Promise<AcEdPromptDoubleResult> {
     const handler = new AcEdDoubleHandler(options)
-    const scriptedValue = this.tryGetScriptedNumber(handler)
+    const scriptedValue = this.tryGetScriptedNumber(handler, options)
     if (scriptedValue != null) {
       return new AcEdPromptDoubleResult(AcEdPromptStatus.OK, scriptedValue)
     }
@@ -888,7 +969,8 @@ export class AcEdInputManager {
     options: AcEdPromptIntegerOptions
   ): Promise<AcEdPromptIntegerResult> {
     const scriptedValue = this.tryGetScriptedNumber(
-      new AcEdIntegerHandler(options)
+      new AcEdIntegerHandler(options),
+      options
     )
     if (scriptedValue != null) {
       return new AcEdPromptIntegerResult(AcEdPromptStatus.OK, scriptedValue)
@@ -913,7 +995,8 @@ export class AcEdInputManager {
    */
   async getString(options: AcEdPromptStringOptions): Promise<AcEdPromptResult> {
     const scriptedValue = this.tryGetScriptedValue(
-      new AcEdStringHandler(options)
+      new AcEdStringHandler(options),
+      options
     )
     if (scriptedValue != null) {
       return new AcEdPromptResult(AcEdPromptStatus.OK, scriptedValue)
@@ -1515,23 +1598,31 @@ export class AcEdInputManager {
       throw new AcEdNoneInputError()
     }
 
-    const keyword = options.keywords.findByName(trimmed)
+    const handler = new AcEdPointHandler(options)
+    const value = handler.parseCommandLine(token, {
+      referencePoint: this.resolvePointInputContext(options).referencePoint
+    })
+    if (value != null) {
+      this.lastPoint = { x: value.x, y: value.y }
+      return value
+    }
+
+    this.tryResolveScriptedKeyword(trimmed, options)
+    throw new Error(`Invalid point input '${token}'`)
+  }
+
+  /**
+   * Throws {@link AcEdKeywordInputError} when a scripted token matches a keyword.
+   */
+  private tryResolveScriptedKeyword(
+    token: string,
+    options?: AcEdPromptOptions<unknown>
+  ) {
+    if (!token || !options?.keywords) return
+    const keyword = options.keywords.findByName(token)
     if (keyword) {
       throw new AcEdKeywordInputError(keyword.globalName)
     }
-
-    const parsed = this.splitScriptedPoint(token)
-    if (!parsed) {
-      throw new Error(`Invalid point input '${token}'`)
-    }
-
-    const value = new AcEdPointHandler(options).parse(parsed.x, parsed.y)
-    if (value == null) {
-      throw new Error(`Invalid point input '${token}'`)
-    }
-
-    this.lastPoint = { x: value.x, y: value.y }
-    return value
   }
 
   /**
@@ -1547,15 +1638,42 @@ export class AcEdInputManager {
    * @returns Parsed value, or `undefined` when no scripted token is available
    * @throws Error if a queued token exists but fails validation
    */
-  private tryGetScriptedValue<T>(handler: AcEdInputHandler<T>): T | undefined {
+  private tryGetScriptedValue<T>(
+    handler: AcEdInputHandler<T>,
+    options?: AcEdPromptOptions<unknown>
+  ): T | undefined {
     const token = this.dequeueScriptInput()
     if (token === undefined) return undefined
 
-    const value = handler.parse(token)
-    if (value == null) {
+    const trimmed = token.trim()
+    if (
+      !trimmed &&
+      options &&
+      'allowNone' in options &&
+      (options as { allowNone: boolean }).allowNone
+    ) {
+      throw new AcEdNoneInputError()
+    }
+
+    if (handler instanceof AcEdStringHandler) {
+      this.tryResolveScriptedKeyword(trimmed, options)
+      const stringValue = handler.parse(token)
+      if (stringValue != null) return stringValue
       throw new Error(`Invalid scripted input '${token}'`)
     }
-    return value
+
+    const value = this.parseCommandLineInput(
+      token,
+      handler,
+      handler instanceof AcEdPointHandler ? 2 : 1,
+      (options ?? new AcEdPromptOptions('')) as AcEdPromptOptions<T>
+    )
+    if (value != null) {
+      return value as T
+    }
+
+    this.tryResolveScriptedKeyword(trimmed, options)
+    throw new Error(`Invalid scripted input '${token}'`)
   }
 
   /**
@@ -1568,9 +1686,10 @@ export class AcEdInputManager {
    * @returns Parsed numeric value, or `undefined` when no scripted token is queued
    */
   private tryGetScriptedNumber(
-    handler: AcEdNumericalHandler | AcEdAngleHandler
+    handler: AcEdNumericalHandler | AcEdAngleHandler,
+    options?: AcEdPromptOptions<unknown>
   ): number | undefined {
-    return this.tryGetScriptedValue(handler)
+    return this.tryGetScriptedValue(handler, options)
   }
 
   /**
@@ -1581,35 +1700,6 @@ export class AcEdInputManager {
   private dequeueScriptInput() {
     if (!this._scriptInputs.length) return undefined
     return this._scriptInputs.shift()
-  }
-
-  /**
-   * Splits a scripted point token into x/y coordinate components.
-   *
-   * The accepted formats intentionally mirror common CAD command-line point
-   * entry conventions, including comma-separated coordinates and whitespace-
-   * separated coordinates. An optional third `z` component is tolerated for
-   * compatibility, but only the `x` and `y` values are used by 2D prompts.
-   *
-   * @param token - Raw scripted point token
-   * @returns Extracted x/y string pair, or `undefined` if the token is malformed
-   */
-  private splitScriptedPoint(
-    token: string
-  ): { x: string; y: string } | undefined {
-    const trimmed = token.trim()
-    if (!trimmed) return undefined
-
-    if (trimmed.includes(',')) {
-      const parts = trimmed.split(',').map(v => v.trim())
-      if (parts.length !== 2 && parts.length !== 3) return undefined
-      if (parts.length === 3 && Number.isNaN(Number(parts[2]))) return undefined
-      return { x: parts[0], y: parts[1] }
-    }
-
-    const parts = trimmed.split(/\s+/)
-    if (parts.length < 2) return undefined
-    return { x: parts[0], y: parts[1] }
   }
 
   /**
@@ -1798,8 +1888,10 @@ export class AcEdInputManager {
       }
 
       const promptDefaults = this.resolvePromptDefaults(options.promptOptions)
-      const keywordSession = this.startKeywordSession(
+      const promptInputSession = this.startPromptInputSession(
         options.promptOptions,
+        options.handler,
+        options.inputCount ?? 1,
         true
       )
 
@@ -1812,11 +1904,6 @@ export class AcEdInputManager {
         promptDefaults.useBasePoint && promptDefaults.basePoint
           ? promptDefaults.basePoint
           : (this.lastPoint ?? undefined)
-
-      const commandLineMessage = promptDefaults.message
-      if (!keywordSession) {
-        this._commandLine.setPrompt(commandLineMessage)
-      }
       const allowNone =
         'allowNone' in options.promptOptions
           ? (options.promptOptions as { allowNone: boolean }).allowNone
@@ -1877,7 +1964,7 @@ export class AcEdInputManager {
         document.removeEventListener('keyup', modifierHandler)
         this.view.canvas.removeEventListener('contextmenu', contextMenuHandler)
         floatingInput.dispose()
-        keywordSession?.cancel()
+        promptInputSession.cancel()
         this._commandLine.clear()
       }
 
@@ -1923,13 +2010,29 @@ export class AcEdInputManager {
       // showAt() expects viewport coordinates; curMousePos is canvas-local.
       floatingInput.showAt(this.view.canvasToViewport(this.view.curMousePos))
 
-      keywordSession?.promise.then(keyword => {
+      promptInputSession.promise.then(result => {
         if (settled) return
-        if (!keyword) {
-          rejector()
-          return
+        switch (result.kind) {
+          case 'value':
+            if (options.handler instanceof AcEdPointHandler) {
+              const point = result.value as unknown as AcGePoint3dLike
+              if (point && Number.isFinite(point.x) && Number.isFinite(point.y)) {
+                this.lastPoint = { x: point.x, y: point.y }
+              }
+            }
+            resolver(result.value)
+            break
+          case 'keyword':
+            keywordRejector(result.keyword)
+            break
+          case 'none':
+            if (allowNone) {
+              noneRejector()
+            } else {
+              rejector()
+            }
+            break
         }
-        keywordRejector(keyword)
       })
     })
   }

--- a/packages/cad-simple-viewer/src/i18n/en/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/main.ts
@@ -8,6 +8,7 @@ export default {
     showMessages: 'Show message history',
     canceled: '*Canceled*',
     noHistory: '(no history)',
+    invalidInput: 'Invalid input.',
     close: 'Close command line'
   },
   inputManager: {

--- a/packages/cad-simple-viewer/src/i18n/zh/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/main.ts
@@ -8,6 +8,7 @@ export default {
     showMessages: '显示消息历史',
     canceled: '*已取消*',
     noHistory: '(无历史记录)',
+    invalidInput: '输入无效。',
     close: '关闭命令行'
   },
   inputManager: {


### PR DESCRIPTION
## Summary
- Add `parseCommandLine` to input handlers with `AcEdPointInputContext` for `reference/cursor-aware` point parsing (absolute/relative Cartesian, polar, rubber-band distance)
- Introduce `AcEdPromptInputSession` to unify command-line keyword and typed input with AutoCAD-style precedence (geometric before keywords; strings try keywords first)
- Route floating prompts and scripted input through the same parsing path; show localized invalid-input feedback on the command line

## Test plan
- [x] pm test -- --testPathPatterns=AcEdPointHandler|AcEdPromptInputSession (9 tests)
- [x] px tsc --noEmit in `\packages\cad-simple-viewer`
- [ ] Manually pick a point prompt with keywords and verify `50,30` resolves as coordinates while `C` resolves as keyword
- [ ] Verify relative (@10,5) and polar (10<90) point entry during interactive prompts