### PR TITLE
refactor: apply formatting and tighten command-line input parsing

### DIFF
--- a/packages/cad-html-plugin/tsconfig.json
+++ b/packages/cad-html-plugin/tsconfig.json
@@ -4,7 +4,9 @@
     "rootDir": "./src",
     "outDir": "./lib",
     "paths": {
-      "@mlightcad/cad-html-plugin": ["./src/index.ts"]
+      "@mlightcad/cad-html-plugin": [
+        "./src/index.ts"
+      ]
     }
   },
   "include": [

--- a/packages/cad-pdf-plugin/tsconfig.json
+++ b/packages/cad-pdf-plugin/tsconfig.json
@@ -4,7 +4,9 @@
     "rootDir": "./src",
     "outDir": "./lib",
     "paths": {
-      "@mlightcad/cad-pdf-plugin": ["./src/index.ts"]
+      "@mlightcad/cad-pdf-plugin": [
+        "./src/index.ts"
+      ]
     }
   },
   "include": [

--- a/packages/cad-simple-viewer/__tests__/AcTrEntityDisplayController.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrEntityDisplayController.spec.ts
@@ -15,9 +15,7 @@ function createDbEntity(
   return { objectId, layer, visibility } as AcDbEntity
 }
 
-function createBlockTableRecord(
-  entities: AcDbEntity[]
-): AcDbBlockTableRecord {
+function createBlockTableRecord(entities: AcDbEntity[]): AcDbBlockTableRecord {
   return {
     newIterator: () => entities[Symbol.iterator]()
   } as unknown as AcDbBlockTableRecord
@@ -44,11 +42,7 @@ describe('AcTrEntityDisplayController', () => {
     }
 
     const controller = new AcTrEntityDisplayController(name =>
-      name === 'off'
-        ? offLayer
-        : name === 'frozen'
-          ? frozenLayer
-          : onLayer
+      name === 'off' ? offLayer : name === 'frozen' ? frozenLayer : onLayer
     )
 
     expect(controller.shouldConvert({ visibility: true, layer: 'off' })).toBe(
@@ -103,14 +97,13 @@ describe('AcTrEntityDisplayController', () => {
   it('detects layer visibility changes from isOff or standardFlags', () => {
     const controller = new AcTrEntityDisplayController(() => undefined)
 
-    expect(controller.layerVisibilityMayHaveChanged({ isOff: true })).toBe(
-      true
-    )
+    expect(controller.layerVisibilityMayHaveChanged({ isOff: true })).toBe(true)
     expect(controller.layerVisibilityMayHaveChanged({ standardFlags: 1 })).toBe(
       true
     )
-    expect(controller.layerVisibilityMayHaveChanged({ color: new AcCmColor() }))
-      .toBe(false)
+    expect(
+      controller.layerVisibilityMayHaveChanged({ color: new AcCmColor() })
+    ).toBe(false)
   })
 
   it('collectMissingEntitiesOnLayer returns drawable entities not yet in the scene', () => {

--- a/packages/cad-simple-viewer/src/command/draw/AcApMLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApMLineCmd.ts
@@ -189,10 +189,7 @@ export class AcApMLineCmd extends AcEdCommand {
         ([name]) => name
       )
       if (styleNames.length <= 0) {
-        this.showMessage(
-          AcApI18n.t('jig.mline.styleListEmpty'),
-          'warning'
-        )
+        this.showMessage(AcApI18n.t('jig.mline.styleListEmpty'), 'warning')
         return
       }
       this.showMessage(

--- a/packages/cad-simple-viewer/src/command/draw/AcApXLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApXLineCmd.ts
@@ -88,10 +88,7 @@ export class AcApXLineCmd extends AcEdCommand {
           z: secondResult.value.z - startResult.value.z
         }
         if (!this.appendFiniteXLine(context, startResult.value, direction)) {
-          this.showMessage(
-            AcApI18n.t('jig.xline.invalidDirection'),
-            'warning'
-          )
+          this.showMessage(AcApI18n.t('jig.xline.invalidDirection'), 'warning')
         }
         continue
       } else {

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerCmd.ts
@@ -347,7 +347,10 @@ export class AcApLayerCmd extends AcEdCommand {
     })
 
     if (created > 0) {
-      this.showMessage(`${AcApI18n.t('jig.layer.created')}: ${created}`, 'success')
+      this.showMessage(
+        `${AcApI18n.t('jig.layer.created')}: ${created}`,
+        'success'
+      )
     }
     if (existed.length > 0) {
       this.showMessage(
@@ -374,7 +377,10 @@ export class AcApLayerCmd extends AcEdCommand {
 
     const layer = context.doc.database.tables.layerTable.getAt(name)
     if (!layer) {
-      this.showMessage(`${AcApI18n.t('jig.layer.notFound')}: ${name}`, 'warning')
+      this.showMessage(
+        `${AcApI18n.t('jig.layer.notFound')}: ${name}`,
+        'warning'
+      )
       return
     }
 
@@ -625,7 +631,10 @@ export class AcApLayerCmd extends AcEdCommand {
 
     const layer = context.doc.database.tables.layerTable.getAt(name)
     if (!layer) {
-      this.showMessage(`${AcApI18n.t('jig.layer.notFound')}: ${name}`, 'warning')
+      this.showMessage(
+        `${AcApI18n.t('jig.layer.notFound')}: ${name}`,
+        'warning'
+      )
       return
     }
 

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerDelCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerDelCmd.ts
@@ -297,12 +297,17 @@ export class AcApLayerDelCmd extends AcEdCommand {
     const layer = db.tables.layerTable.getAt(layerName)
 
     if (!layer) {
-      this.showMessage(`${AcApI18n.t('jig.laydel.layerNotFound')}: ${layerName}`)
+      this.showMessage(
+        `${AcApI18n.t('jig.laydel.layerNotFound')}: ${layerName}`
+      )
       return
     }
 
     if (layer.name === '0') {
-      this.showMessage(AcApI18n.t('jig.laydel.cannotDeleteZeroLayer'), 'warning')
+      this.showMessage(
+        AcApI18n.t('jig.laydel.cannotDeleteZeroLayer'),
+        'warning'
+      )
       return
     }
 
@@ -325,7 +330,10 @@ export class AcApLayerDelCmd extends AcEdCommand {
 
     context.view.selectionSet.clear()
     AcApDocManager.instance.regen()
-    this.showMessage(`${AcApI18n.t('jig.laydel.deleted')}: ${layer.name}`, 'success')
+    this.showMessage(
+      `${AcApI18n.t('jig.laydel.deleted')}: ${layer.name}`,
+      'success'
+    )
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerFreezeCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerFreezeCmd.ts
@@ -391,7 +391,10 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
 
     this.setLayerFrozen(layer, true)
     context.view.selectionSet.clear()
-    this.showMessage(`${AcApI18n.t('jig.layfrz.frozen')}: ${layer.name}`, 'success')
+    this.showMessage(
+      `${AcApI18n.t('jig.layfrz.frozen')}: ${layer.name}`,
+      'success'
+    )
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerLockCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerLockCmd.ts
@@ -105,6 +105,9 @@ export class AcApLayerLockCmd extends AcEdCommand {
 
     this.setLayerLocked(layer, true)
     context.view.selectionSet.clear()
-    this.showMessage(`${AcApI18n.t('jig.laylck.locked')}: ${layer.name}`, 'success')
+    this.showMessage(
+      `${AcApI18n.t('jig.laylck.locked')}: ${layer.name}`,
+      'success'
+    )
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerOnCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerOnCmd.ts
@@ -41,6 +41,9 @@ export class AcApLayerOnCmd extends AcEdCommand {
       return
     }
 
-    this.showMessage(`${AcApI18n.t('jig.layon.turnedOn')}: ${turnedOn}`, 'success')
+    this.showMessage(
+      `${AcApI18n.t('jig.layon.turnedOn')}: ${turnedOn}`,
+      'success'
+    )
   }
 }

--- a/packages/cad-simple-viewer/src/command/modify/AcApOffsetCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApOffsetCmd.ts
@@ -22,7 +22,8 @@ import {
   AcEdPromptState,
   AcEdPromptStateMachine,
   AcEdPromptStateStep,
-  AcEdPromptStatus} from '../../editor'
+  AcEdPromptStatus
+} from '../../editor'
 import { AcApI18n } from '../../i18n'
 
 /**
@@ -437,10 +438,7 @@ export class AcApOffsetCmd extends AcEdCommand {
           new AcGePoint3d(result.value)
         )
         if (offsetCurves.length === 0) {
-          showCommandMessage(
-            AcApI18n.t('jig.offset.offsetFailed'),
-            'warning'
-          )
+          showCommandMessage(AcApI18n.t('jig.offset.offsetFailed'), 'warning')
         } else {
           blockTable.modelSpace.appendEntity(offsetCurves)
         }

--- a/packages/cad-simple-viewer/src/command/modify/AcApUnisolateObjectsCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApUnisolateObjectsCmd.ts
@@ -21,9 +21,6 @@ export class AcApUnisolateObjectsCmd extends AcEdCommand {
       return
     }
 
-    this.showMessage(
-      AcApI18n.t('jig.hideobjects.nothingToRestore'),
-      'info'
-    )
+    this.showMessage(AcApI18n.t('jig.hideobjects.nothingToRestore'), 'info')
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/handler/AcEdInputHandler.ts
+++ b/packages/cad-simple-viewer/src/editor/input/handler/AcEdInputHandler.ts
@@ -31,8 +31,5 @@ export interface AcEdInputHandler<T> {
    *
    * Handlers that only accept a single value typically delegate to {@link parse}.
    */
-  parseCommandLine(
-    token: string,
-    context?: AcEdPointInputContext
-  ): T | null
+  parseCommandLine(token: string, context?: AcEdPointInputContext): T | null
 }

--- a/packages/cad-simple-viewer/src/editor/input/session/AcEdInputSession.ts
+++ b/packages/cad-simple-viewer/src/editor/input/session/AcEdInputSession.ts
@@ -9,7 +9,9 @@ export interface AcEdCommandLineSessionControl {
   handleEscape(): void
 }
 
-export abstract class AcEdInputSession<T> implements AcEdCommandLineSessionControl {
+export abstract class AcEdInputSession<
+  T
+> implements AcEdCommandLineSessionControl {
   protected resolve!: (value: T) => void
 
   start(): Promise<T> {

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
@@ -671,10 +671,7 @@ export class AcEdCommandLine {
           const handled = this.activeSession.handleEnter(this.getInputText())
           if (!handled) {
             this.showMessage(
-              this.localize(
-                'main.commandLine.invalidInput',
-                'Invalid input.'
-              ),
+              this.localize('main.commandLine.invalidInput', 'Invalid input.'),
               'warning'
             )
           }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -498,10 +498,9 @@ export class AcEdInputManager {
     return {
       promise: this._commandLine.getPromptInput(
         keywordOptions,
-        text =>
-          this.parseCommandLineInput(text, handler, inputCount, options),
+        text => this.parseCommandLineInput(text, handler, inputCount, options),
         {
-          mode: this.resolvePromptInputMode(handler, inputCount),
+          mode: this.resolvePromptInputMode(handler),
           allowNone,
           allowTyping
         }
@@ -514,14 +513,9 @@ export class AcEdInputManager {
    * Resolves command-line precedence rules for the active handler.
    */
   private resolvePromptInputMode(
-    handler: AcEdInputHandler<unknown>,
-    inputCount: AcEdFloatingInputBoxCount
+    handler: AcEdInputHandler<unknown>
   ): AcEdPromptInputMode {
-    if (handler instanceof AcEdStringHandler) return 'string'
-    if (inputCount === 2 || handler instanceof AcEdPointHandler) {
-      return 'geometric'
-    }
-    return 'geometric'
+    return handler instanceof AcEdStringHandler ? 'string' : 'geometric'
   }
 
   /**
@@ -1599,9 +1593,10 @@ export class AcEdInputManager {
     }
 
     const handler = new AcEdPointHandler(options)
-    const value = handler.parseCommandLine(token, {
-      referencePoint: this.resolvePointInputContext(options).referencePoint
-    })
+    const value = handler.parseCommandLine(
+      token,
+      this.resolvePointInputContext(options)
+    )
     if (value != null) {
       this.lastPoint = { x: value.x, y: value.y }
       return value
@@ -2016,7 +2011,11 @@ export class AcEdInputManager {
           case 'value':
             if (options.handler instanceof AcEdPointHandler) {
               const point = result.value as unknown as AcGePoint3dLike
-              if (point && Number.isFinite(point.x) && Number.isFinite(point.y)) {
+              if (
+                point &&
+                Number.isFinite(point.x) &&
+                Number.isFinite(point.y)
+              ) {
                 this.lastPoint = { x: point.x, y: point.y }
               }
             }

--- a/packages/cad-simple-viewer/src/view/AcTrEntityDisplayController.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrEntityDisplayController.ts
@@ -87,10 +87,8 @@ export class AcTrEntityDisplayController {
     blockTableRecord: AcDbBlockTableRecord,
     hasEntity: (objectId: AcDbObjectId) => boolean
   ): AcDbEntity[] {
-    return this.collectMissingEntities(
-      blockTableRecord,
-      hasEntity,
-      entity => this.shouldConvertForExport(entity)
+    return this.collectMissingEntities(blockTableRecord, hasEntity, entity =>
+      this.shouldConvertForExport(entity)
     )
   }
 

--- a/packages/cad-simple-viewer/src/view/AcTrProgressiveOpenFitController.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrProgressiveOpenFitController.ts
@@ -104,7 +104,10 @@ export class AcTrProgressiveOpenFitController {
    * paint converted geometry during document open.
    */
   async yieldForRender(entityIndex: number) {
-    if (!this.active || entityIndex % AcTrProgressiveOpenFitController.YIELD_EVERY !== 0) {
+    if (
+      !this.active ||
+      entityIndex % AcTrProgressiveOpenFitController.YIELD_EVERY !== 0
+    ) {
       return
     }
 
@@ -119,7 +122,10 @@ export class AcTrProgressiveOpenFitController {
     }
 
     const now = performance.now()
-    if (now - this.lastZoomAt < AcTrProgressiveOpenFitController.FIT_INTERVAL_MS) {
+    if (
+      now - this.lastZoomAt <
+      AcTrProgressiveOpenFitController.FIT_INTERVAL_MS
+    ) {
       return
     }
 

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -830,16 +830,11 @@ export class AcTrView2d extends AcEdBaseView {
     const waiter = new AcEdConditionWaiter(
       () => this._numOfEntitiesToProcess <= 0,
       () => {
-        if (
-          layoutBtrId &&
-          this._externallyFramedLayouts.delete(layoutBtrId)
-        ) {
+        if (layoutBtrId && this._externallyFramedLayouts.delete(layoutBtrId)) {
           this.endProgressiveOpenFit()
           return
         }
-        this._progressiveOpenFit.applyFinalFit(() =>
-          this.resolveLayoutFitBox()
-        )
+        this._progressiveOpenFit.applyFinalFit(() => this.resolveLayoutFitBox())
         this.endProgressiveOpenFit()
       },
       300, // check every 300 ms
@@ -1518,8 +1513,7 @@ export class AcTrView2d extends AcEdBaseView {
     })
 
     const stillLoading = this._numOfEntitiesToProcess > 0
-    const deferRenderWhileLoading =
-      stillLoading && !this._progressiveRendering
+    const deferRenderWhileLoading = stillLoading && !this._progressiveRendering
     if (!this._isDirty && !stillLoading) return
     if (deferRenderWhileLoading) return
 
@@ -1528,8 +1522,7 @@ export class AcTrView2d extends AcEdBaseView {
       this._css2dRenderer.render(this._scene.internalScene, this.internalCamera)
     }
     this._stats?.update()
-    this._isDirty =
-      (this._progressiveRendering && stillLoading) || needsRedraw
+    this._isDirty = (this._progressiveRendering && stillLoading) || needsRedraw
   }
 
   private startAnimationLoop() {
@@ -1765,7 +1758,10 @@ export class AcTrView2d extends AcEdBaseView {
    * to async workers; non-progressive mode uses synchronous drawing from
    * {@link drawEntity}(..., false).
    */
-  private async finishEntityGeometry(threeEntity: AcTrEntity, progressive: boolean) {
+  private async finishEntityGeometry(
+    threeEntity: AcTrEntity,
+    progressive: boolean
+  ) {
     if (progressive) {
       await threeEntity.draw()
       return
@@ -1778,8 +1774,10 @@ export class AcTrView2d extends AcEdBaseView {
 
   /** MTEXT/SHAPE entities expose syncDraw and render synchronously when delay=false. */
   private entityUsedSyncDraw(threeEntity: AcTrEntity) {
-    return typeof (threeEntity as { syncDraw?: () => unknown }).syncDraw ===
+    return (
+      typeof (threeEntity as { syncDraw?: () => unknown }).syncDraw ===
       'function'
+    )
   }
 
   /**
@@ -1855,7 +1853,10 @@ export class AcTrView2d extends AcEdBaseView {
           continue
         }
 
-        const threeEntity: AcTrEntity | null = this.drawEntity(entity, progressive)
+        const threeEntity: AcTrEntity | null = this.drawEntity(
+          entity,
+          progressive
+        )
         // Viewports may produce no border geometry (e.g. on a no-plot layer) while
         // still needing an AcTrViewportView for model content below.
         if (!threeEntity && !(entity instanceof AcDbViewport)) continue

--- a/packages/cad-simple-viewer/vite.config.ts
+++ b/packages/cad-simple-viewer/vite.config.ts
@@ -1,9 +1,7 @@
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
-import {
-  createLibEntryFileName
-} from '../vite-config/pluginRollupOutput'
+import { createLibEntryFileName } from '../vite-config/pluginRollupOutput'
 
 const packageId = 'cad-simple-viewer'
 

--- a/packages/cad-svg-plugin/tsconfig.json
+++ b/packages/cad-svg-plugin/tsconfig.json
@@ -5,7 +5,9 @@
     "outDir": "./lib",
     "baseUrl": "./src",
     "paths": {
-      "@mlightcad/cad-svg-plugin": ["./index.ts"]
+      "@mlightcad/cad-svg-plugin": [
+        "./index.ts"
+      ]
     }
   },
   "include": [

--- a/packages/cad-viewer-example/e2e/tests/main-thread-mtext.spec.ts
+++ b/packages/cad-viewer-example/e2e/tests/main-thread-mtext.spec.ts
@@ -21,7 +21,6 @@ async function installWorkerSpy(page: import('@playwright/test').Page) {
         super(scriptURL, options)
       }
     } as typeof Worker
-
     ;(
       window as Window & { __createdWorkerUrls?: string[] }
     ).__createdWorkerUrls = createdWorkerUrls

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -46,7 +46,11 @@
         <div class="settings-grid">
           <div class="setting-block setting-block--full">
             <h3 class="setting-label">Access mode</h3>
-            <div class="mode-segment" role="radiogroup" aria-label="Access mode">
+            <div
+              class="mode-segment"
+              role="radiogroup"
+              aria-label="Access mode"
+            >
               <button
                 v-for="mode in accessModes"
                 :key="mode.value"

--- a/packages/cad-viewer/vite.config.ts
+++ b/packages/cad-viewer/vite.config.ts
@@ -10,9 +10,7 @@ import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import vue from '@vitejs/plugin-vue'
 import dts from 'vite-plugin-dts'
 import { libInjectCss } from 'vite-plugin-lib-inject-css'
-import {
-  createLibEntryFileName
-} from '../vite-config/pluginRollupOutput'
+import { createLibEntryFileName } from '../vite-config/pluginRollupOutput'
 
 const packageId = 'cad-viewer'
 

--- a/packages/three-renderer/__tests__/AcTrBatchDrawPolicy.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchDrawPolicy.spec.ts
@@ -99,7 +99,9 @@ describe('AcTrBatchDrawPolicy', () => {
       { x: 30, y: 40, z: 50 }
     ]
     const box = new THREE.Box3()
-    points.forEach(point => box.expandByPoint(new THREE.Vector3(point.x, point.y, point.z)))
+    points.forEach(point =>
+      box.expandByPoint(new THREE.Vector3(point.x, point.y, point.z))
+    )
 
     expect(resolveAnchorFromBox(box)).toEqual(resolveAnchorFromPoints(points))
   })

--- a/packages/three-renderer/__tests__/AcTrBatchedBounds.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedBounds.spec.ts
@@ -33,14 +33,7 @@ function createLineSegments(
   geometry.setAttribute(
     'position',
     new THREE.Float32BufferAttribute(
-      [
-        start.x,
-        start.y,
-        start.z ?? 0,
-        end.x,
-        end.y,
-        end.z ?? 0
-      ],
+      [start.x, start.y, start.z ?? 0, end.x, end.y, end.z ?? 0],
       3
     )
   )
@@ -286,20 +279,18 @@ describe('AcTrBatchedGroup', () => {
     group.addEntity(createEntity('line-1', batchedLine))
     group.addEntity(createEntity('ray-1', unbatchedLine))
 
-    const batchedOnly = group.computeBoundingBox(
-      new THREE.Box3(),
-      { excludeObjectIds: new Set(['ray-1']) }
-    )
+    const batchedOnly = group.computeBoundingBox(new THREE.Box3(), {
+      excludeObjectIds: new Set(['ray-1'])
+    })
     expectBox3CloseTo(
       batchedOnly,
       { x: 1_000_000, y: 2_000_000, z: 0 },
       { x: 1_000_100, y: 2_000_050, z: 0 }
     )
 
-    const unbatchedOnly = group.computeBoundingBox(
-      new THREE.Box3(),
-      { excludeObjectIds: new Set(['line-1']) }
-    )
+    const unbatchedOnly = group.computeBoundingBox(new THREE.Box3(), {
+      excludeObjectIds: new Set(['line-1'])
+    })
     expectBox3CloseTo(
       unbatchedOnly,
       { x: 300_000, y: 400_000, z: 0 },
@@ -357,8 +348,8 @@ describe('AcTrBatchedGroup', () => {
     group.addEntity(entity)
 
     expect(group.stats.unbatched.count).toBe(0)
-    expect(
-      group.children.some(child => child instanceof AcTrBatchedMesh)
-    ).toBe(true)
+    expect(group.children.some(child => child instanceof AcTrBatchedMesh)).toBe(
+      true
+    )
   })
 })

--- a/packages/three-renderer/__tests__/AcTrBatchedGroupUnbatchedOps.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupUnbatchedOps.spec.ts
@@ -4,9 +4,15 @@ import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
 import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
 import { AcTrEntity } from '../src/object/AcTrEntity'
 import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
-import { getHighlightUserData, getSceneDrawableUserData } from '../src/util/AcTrObjectUserData'
+import {
+  getHighlightUserData,
+  getSceneDrawableUserData
+} from '../src/util/AcTrObjectUserData'
 
-function createEntity(objectId: string, ...drawables: THREE.Object3D[]): AcTrEntity {
+function createEntity(
+  objectId: string,
+  ...drawables: THREE.Object3D[]
+): AcTrEntity {
   const entity = new AcTrEntity(new AcTrRenderContext())
   entity.objectId = objectId
   entity.visible = true
@@ -171,9 +177,7 @@ describe('AcTrBatchedGroup unbatched operations', () => {
       new THREE.Vector3(0, 0, -1)
     )
 
-    expect(
-      raycaster.intersectObject(clonedRoot, true)
-    ).toHaveLength(0)
+    expect(raycaster.intersectObject(clonedRoot, true)).toHaveLength(0)
     expect(group.isIntersectWith('mtext-1', raycaster)).toBe(true)
   })
 
@@ -202,16 +206,10 @@ function createUnbatchedLine() {
   const geometry = new THREE.BufferGeometry()
   geometry.setAttribute(
     'position',
-    new THREE.Float32BufferAttribute(
-      [-10, 0, 0, 10, 0, 0],
-      3
-    )
+    new THREE.Float32BufferAttribute([-10, 0, 0, 10, 0, 0], 3)
   )
   geometry.setIndex([0, 1])
-  const line = new THREE.LineSegments(
-    geometry,
-    new THREE.LineBasicMaterial()
-  )
+  const line = new THREE.LineSegments(geometry, new THREE.LineBasicMaterial())
   line.position.set(RTE_REBASE_THRESHOLD + 500, 2_000_000, 0)
   getSceneDrawableUserData(line).noBatch = true
   line.updateMatrixWorld(true)

--- a/packages/three-renderer/__tests__/AcTrLine.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrLine.spec.ts
@@ -27,10 +27,7 @@ function findUnbatchedLineDrawable(group: AcTrBatchedGroup) {
     if (drawable) {
       return
     }
-    if (
-      child instanceof THREE.LineSegments ||
-      child instanceof LineSegments2
-    ) {
+    if (child instanceof THREE.LineSegments || child instanceof LineSegments2) {
       if (Math.abs(child.position.x) >= RTE_REBASE_THRESHOLD) {
         drawable = child
       }
@@ -123,7 +120,12 @@ describe('AcTrLine', () => {
       drawable instanceof THREE.LineSegments ||
         drawable instanceof LineSegments2
     ).toBe(true)
-    if (!(drawable instanceof THREE.LineSegments || drawable instanceof LineSegments2)) {
+    if (
+      !(
+        drawable instanceof THREE.LineSegments ||
+        drawable instanceof LineSegments2
+      )
+    ) {
       return
     }
 

--- a/packages/three-renderer/__tests__/AcTrLineSegments.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrLineSegments.spec.ts
@@ -16,10 +16,7 @@ function findUnbatchedLineDrawable(group: AcTrBatchedGroup) {
     if (drawable) {
       return
     }
-    if (
-      child instanceof THREE.LineSegments ||
-      child instanceof LineSegments2
-    ) {
+    if (child instanceof THREE.LineSegments || child instanceof LineSegments2) {
       if (Math.abs(child.position.x) >= RTE_REBASE_THRESHOLD) {
         drawable = child
       }
@@ -84,7 +81,12 @@ describe('AcTrLineSegments', () => {
       drawable instanceof THREE.LineSegments ||
         drawable instanceof LineSegments2
     ).toBe(true)
-    if (!(drawable instanceof THREE.LineSegments || drawable instanceof LineSegments2)) {
+    if (
+      !(
+        drawable instanceof THREE.LineSegments ||
+        drawable instanceof LineSegments2
+      )
+    ) {
       return
     }
 

--- a/packages/three-renderer/__tests__/AcTrMTextRenderer.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMTextRenderer.spec.ts
@@ -66,7 +66,9 @@ describe('AcTrMTextRenderer', () => {
     expect(mockUnifiedRenderer).toHaveBeenCalledWith('worker', {
       workerUrl: './assets/mtext-renderer-worker.js'
     })
-    expect(mockRendererInstances[0].setDefaultMode).toHaveBeenCalledWith('worker')
+    expect(mockRendererInstances[0].setDefaultMode).toHaveBeenCalledWith(
+      'worker'
+    )
   })
 
   it('destroys the previous unified renderer before re-initializing', () => {

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -300,10 +300,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     const unionBatchMap = (
       map: Map<
         number,
-        | AcTrBatchedLine
-        | AcTrBatchedLine2
-        | AcTrBatchedMesh
-        | AcTrBatchedPoint
+        AcTrBatchedLine | AcTrBatchedLine2 | AcTrBatchedMesh | AcTrBatchedPoint
       >
     ) => {
       map.forEach(batch => {
@@ -606,7 +603,9 @@ export class AcTrBatchedGroup extends THREE.Group {
     const unbatchedObjects = this._unbatchedEntities.get(objectId)
     if (unbatchedObjects) {
       for (let i = 0; i < unbatchedObjects.length; i++) {
-        if (this.isUnbatchedDrawableIntersecting(unbatchedObjects[i], raycaster)) {
+        if (
+          this.isUnbatchedDrawableIntersecting(unbatchedObjects[i], raycaster)
+        ) {
           return true
         }
       }
@@ -1086,7 +1085,8 @@ export class AcTrBatchedGroup extends THREE.Group {
       const clonedDrawable = getSceneDrawableUserData(cloned)
       clonedDrawable.styleMaterialId =
         sourceDrawable.styleMaterialId ?? this.getMaterialId(source.material)
-      clonedDrawable.bboxIntersectionCheck = sourceDrawable.bboxIntersectionCheck
+      clonedDrawable.bboxIntersectionCheck =
+        sourceDrawable.bboxIntersectionCheck
       clonedDrawable.bakedWorldMatrix = source.matrixWorld.toArray()
     }
     cloned.updateMatrix()
@@ -1312,7 +1312,11 @@ export class AcTrBatchedGroup extends THREE.Group {
       }
       _intersectBox.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld)
     } else {
-      this.unionUnbatchedObjectBounds(object, _intersectBox, _intersectScratchBox)
+      this.unionUnbatchedObjectBounds(
+        object,
+        _intersectBox,
+        _intersectScratchBox
+      )
       if (_intersectBox.isEmpty()) {
         return false
       }

--- a/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
@@ -808,9 +808,10 @@ export function createAcTrBatchedMixin<
         ) {
           continue
         }
-        const bounds = (
-          this as unknown as AcTrBatchBounds
-        ).getBoundingBoxAt(i, this._box)
+        const bounds = (this as unknown as AcTrBatchBounds).getBoundingBoxAt(
+          i,
+          this._box
+        )
         if (bounds) {
           // Per-slot boxes are in batch-local space; translate by batch origin.
           this._box.applyMatrix4(self.matrixWorld)

--- a/packages/three-renderer/src/object/AcTrImage.ts
+++ b/packages/three-renderer/src/object/AcTrImage.ts
@@ -6,11 +6,7 @@ import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
 import { AcTrEntity } from './AcTrEntity'
 
 export class AcTrImage extends AcTrEntity {
-  constructor(
-    blob: Blob,
-    style: AcGiImageStyle,
-    context: AcTrRenderContext
-  ) {
+  constructor(blob: Blob, style: AcGiImageStyle, context: AcTrRenderContext) {
     super(context)
     const blobUrl = URL.createObjectURL(blob)
     const textureLoader = new THREE.TextureLoader()

--- a/packages/three-renderer/src/object/AcTrLineSegments.ts
+++ b/packages/three-renderer/src/object/AcTrLineSegments.ts
@@ -24,9 +24,7 @@ export class AcTrLineSegments extends AcTrEntity {
     const box = new THREE.Box3()
 
     for (let i = 0; i < array.length; i += itemSize) {
-      box.expandByPoint(
-        _point.set(array[i], array[i + 1], array[i + 2] ?? 0)
-      )
+      box.expandByPoint(_point.set(array[i], array[i + 1], array[i + 2] ?? 0))
     }
 
     const localOrigin = box.getCenter(new THREE.Vector3())

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -349,11 +349,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    * @inheritdoc
    */
   area(area: AcGeArea2d) {
-    return new AcTrPolygon(
-      area,
-      this._subEntityTraits,
-      this._context
-    )
+    return new AcTrPolygon(area, this._subEntityTraits, this._context)
   }
 
   /**
@@ -398,12 +394,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
   }
 
   private linePoints(points: AcGePoint3dLike[]) {
-    return new AcTrLine(
-      points,
-      this._subEntityTraits,
-      this._context,
-      false
-    )
+    return new AcTrLine(points, this._subEntityTraits, this._context, false)
   }
 
   /**

--- a/packages/vite-config/pluginRollupOutput.ts
+++ b/packages/vite-config/pluginRollupOutput.ts
@@ -70,8 +70,7 @@ export function createLibEntryFileName(
   format: string,
   entryName = 'index'
 ): string {
-  const base =
-    entryName === 'register' ? `${packageId}-register` : packageId
+  const base = entryName === 'register' ? `${packageId}-register` : packageId
   return format === 'es' ? `${base}.js` : `${base}.umd.cjs`
 }
 


### PR DESCRIPTION
## Summary
- Apply Prettier formatting across viewer, three-renderer, plugin tsconfig, and vite config files
- Simplify esolvePromptInputMode by removing redundant branches and unused inputCount parameter
- Pass full esolvePointInputContext (including cursorPoint) in scripted point parsing so rubber-band distance entry works in scripted workflows