### PR TITLE
fix(html-export): read world offset from matrixWorld for nested drawables

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExRebase.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExRebase.spec.ts
@@ -1,4 +1,6 @@
-import { toWcsCoord } from '../src/AcExBatchBuffers'
+import * as THREE from 'three'
+
+import { readBatchWorldOffset, toWcsCoord } from '../src/AcExBatchBuffers'
 import { AcExOsnapIndex } from '../src/AcExOsnap'
 
 describe('rebase and measurement precision', () => {
@@ -59,5 +61,26 @@ describe('rebase and measurement precision', () => {
     index.rebuild(layout)
     const snap = index.findSnap(origin + 0.1, origin + 0.1, 1)
     expect(snap).toEqual({ x: origin, y: origin, mode: 'endpoint' })
+  })
+
+  it('reads nested drawable offsets from matrixWorld instead of local position', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(new Float32Array([-50, -25, 0, 50, 25, 0]), 3)
+    )
+    const line = new THREE.LineSegments(geometry, new THREE.LineBasicMaterial())
+    line.position.set(100_060, 200_045, 0)
+
+    const parent = new THREE.Group()
+    parent.position.set(900_000, 1_800_000, 0)
+    parent.add(line)
+    parent.updateMatrixWorld(true)
+
+    expect(readBatchWorldOffset(line)).toEqual([
+      1_000_060,
+      2_000_045,
+      0
+    ])
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -13,10 +13,12 @@ jest.mock('@mlightcad/three-renderer', () => ({
   isBatchGeometryVisible: (flags: number) => (flags & 3) === 3
 }))
 
+import { AcTrBatchedLine } from '../../three-renderer/src/batch/AcTrBatchedLine'
 import * as THREE from 'three'
 
-import { compactIndexedSlice } from '../src/AcExBatchBuffers'
+import { compactIndexedSlice, readBatchWorldOffset, toWcsCoord } from '../src/AcExBatchBuffers'
 import {
+  collectBatchesFromObject3D,
   exportActiveBatchedSlice,
   exportBufferGeometrySlice
 } from '../src/AcExSceneBatchCollector'
@@ -234,5 +236,115 @@ describe('compactIndexedSlice', () => {
 
     expect(Array.from(compact.positions)).toEqual([0, 0, 0, 1, 0, 0, 2, 0, 0])
     expect(Array.from(compact.indices)).toEqual([0, 1, 2])
+  })
+})
+
+function createRebasedLineSegments(
+  wcsStart: [number, number, number],
+  wcsEnd: [number, number, number]
+): THREE.LineSegments {
+  const cx = (wcsStart[0] + wcsEnd[0]) / 2
+  const cy = (wcsStart[1] + wcsEnd[1]) / 2
+  const cz = ((wcsStart[2] ?? 0) + (wcsEnd[2] ?? 0)) / 2
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.BufferAttribute(
+      new Float32Array([
+        wcsStart[0] - cx,
+        wcsStart[1] - cy,
+        (wcsStart[2] ?? 0) - cz,
+        wcsEnd[0] - cx,
+        wcsEnd[1] - cy,
+        (wcsEnd[2] ?? 0) - cz
+      ]),
+      3
+    )
+  )
+  const line = new THREE.LineSegments(geometry, new THREE.LineBasicMaterial())
+  line.position.set(cx, cy, cz)
+  return line
+}
+
+describe('collectBatchesFromObject3D rebase offsets', () => {
+  it('exports batched line geometry with the batch origin offset', () => {
+    const worldOffset = new THREE.Vector3(1_000_000, 2_000_000, 0)
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 100, 50, 0], 3)
+    )
+    geometry.setIndex([0, 1])
+
+    const batch = new AcTrBatchedLine()
+    const geometryId = batch.addGeometry(geometry, -1, -1, worldOffset)
+    batch.setGeometryInfo(geometryId, { objectId: 'line-1' })
+
+    const root = new THREE.Group()
+    root.add(batch)
+    root.updateMatrixWorld(true)
+
+    const { lineBatches } = collectBatchesFromObject3D(root)
+    expect(lineBatches).toHaveLength(1)
+
+    const exported = lineBatches[0]!
+    expect(exported.offset[0]).toBeCloseTo(1_000_000, 3)
+    expect(exported.offset[1]).toBeCloseTo(2_000_000, 3)
+    expect(
+      toWcsCoord(exported.positions[0]!, exported.offset[0]!)
+    ).toBeCloseTo(1_000_000, 3)
+    expect(
+      toWcsCoord(exported.positions[1]!, exported.offset[1]!)
+    ).toBeCloseTo(2_000_000, 3)
+    expect(
+      toWcsCoord(exported.positions[3]!, exported.offset[0]!)
+    ).toBeCloseTo(1_000_100, 3)
+    expect(
+      toWcsCoord(exported.positions[4]!, exported.offset[1]!)
+    ).toBeCloseTo(2_000_050, 3)
+  })
+
+  it('uses matrixWorld translation for rebased lines nested under a parent', () => {
+    const line = createRebasedLineSegments(
+      [1_000_010, 2_000_020, 0],
+      [1_000_110, 2_000_070, 0]
+    )
+    const parent = new THREE.Group()
+    parent.position.set(900_000, 1_800_000, 0)
+    parent.add(line)
+    parent.updateMatrixWorld(true)
+
+    const { lineBatches } = collectBatchesFromObject3D(parent)
+    expect(lineBatches).toHaveLength(1)
+
+    const exported = lineBatches[0]!
+    expect(exported.offset[0]).toBeCloseTo(1_000_060, 3)
+    expect(exported.offset[1]).toBeCloseTo(2_000_045, 3)
+    expect(
+      toWcsCoord(exported.positions[0]!, exported.offset[0]!)
+    ).toBeCloseTo(1_000_010, 3)
+    expect(
+      toWcsCoord(exported.positions[1]!, exported.offset[1]!)
+    ).toBeCloseTo(2_000_020, 3)
+    expect(
+      toWcsCoord(exported.positions[3]!, exported.offset[0]!)
+    ).toBeCloseTo(1_000_110, 3)
+    expect(
+      toWcsCoord(exported.positions[4]!, exported.offset[1]!)
+    ).toBeCloseTo(2_000_070, 3)
+  })
+
+  it('reads world offset from matrixWorld for nested drawables', () => {
+    const line = createRebasedLineSegments([10, 20, 0], [110, 70, 0])
+    const parent = new THREE.Group()
+    parent.position.set(900_000, 1_800_000, 0)
+    parent.add(line)
+    parent.updateMatrixWorld(true)
+
+    expect(readBatchWorldOffset(line)).toEqual([
+      900_060,
+      1_800_045,
+      0
+    ])
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -288,8 +288,9 @@ describe('collectBatchesFromObject3D rebase offsets', () => {
     expect(lineBatches).toHaveLength(1)
 
     const exported = lineBatches[0]!
-    expect(exported.offset[0]).toBeCloseTo(1_000_000, 3)
-    expect(exported.offset[1]).toBeCloseTo(2_000_000, 3)
+    // Batch origin is the first geometry bbox center plus worldOffset.
+    expect(exported.offset[0]).toBeCloseTo(1_000_050, 3)
+    expect(exported.offset[1]).toBeCloseTo(2_000_025, 3)
     expect(
       toWcsCoord(exported.positions[0]!, exported.offset[0]!)
     ).toBeCloseTo(1_000_000, 3)
@@ -306,8 +307,8 @@ describe('collectBatchesFromObject3D rebase offsets', () => {
 
   it('uses matrixWorld translation for rebased lines nested under a parent', () => {
     const line = createRebasedLineSegments(
-      [1_000_010, 2_000_020, 0],
-      [1_000_110, 2_000_070, 0]
+      [100_010, 200_020, 0],
+      [100_110, 200_070, 0]
     )
     const parent = new THREE.Group()
     parent.position.set(900_000, 1_800_000, 0)

--- a/packages/cad-html-plugin/src/AcExBatchBuffers.ts
+++ b/packages/cad-html-plugin/src/AcExBatchBuffers.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three'
+
 /**
  * Copies a contiguous span from an array-like source into a {@link Float32Array}.
  *
@@ -80,4 +82,25 @@ export function compactIndexedSlice(
  */
 export function toWcsCoord(local: number, origin: number): number {
   return local + origin
+}
+
+const _worldOffset = /*@__PURE__*/ { x: 0, y: 0, z: 0 }
+
+/**
+ * Reads the world-space translation stored separately from rebased vertex data.
+ *
+ * Renderer drawables keep float32-friendly local geometry and place the entity in
+ * WCS via the object transform (or batch {@link AcTrBatchedLine.position}).
+ * Nested no-batch subtrees (MTEXT, block-like placement roots) carry insertion
+ * on ancestors, so the translation must come from {@link THREE.Object3D.matrixWorld}.
+ */
+export function readBatchWorldOffset(
+  object: THREE.Object3D
+): [number, number, number] {
+  object.updateMatrixWorld(true)
+  const position = object.matrixWorld.elements
+  _worldOffset.x = position[12]!
+  _worldOffset.y = position[13]!
+  _worldOffset.z = position[14]!
+  return [_worldOffset.x, _worldOffset.y, _worldOffset.z]
 }

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -11,7 +11,8 @@ import * as THREE from 'three'
 import {
   compactIndexedSlice,
   copyFloat32Range,
-  copyUint32Range
+  copyUint32Range,
+  readBatchWorldOffset
 } from './AcExBatchBuffers'
 import {
   computeLineDistancesForSegments,
@@ -284,9 +285,7 @@ function resolveExportedHatchPattern(
 }
 
 function readWorldOffset(object: THREE.Object3D): [number, number, number] {
-  // Batched geometry is rebased: vertices are local and object.position is the origin.
-  const p = object.position
-  return [p.x, p.y, p.z]
+  return readBatchWorldOffset(object)
 }
 
 function buildMeshBatch(


### PR DESCRIPTION
## Summary

- Fix HTML export batch collector to read world-space translation from matrixWorld instead of local object.position, so rebased geometry nested under parent groups (e.g. MTEXT, block placement roots) exports with correct WCS coordinates.
- Add eadBatchWorldOffset helper in AcExBatchBuffers and use it in AcExSceneBatchCollector.
- Add unit tests covering nested drawable offsets, batched line origins, and collectBatchesFromObject3D\ rebase behavior.

## Test plan

- [ ] Run cad-html-plugin unit tests for AcExRebase and AcExSceneBatchCollector
- [ ] Open a drawing with large coordinates and export to HTML; verify line/entity positions match the viewer
- [ ] Verify HTML export for drawings with nested block-like or MTEXT subtrees still aligns with WCS