### PR TITLE
refactor(viewer): centralize command prompt colon formatting in command line UI

### DIFF
--- a/packages/cad-simple-viewer/src/command/AcApSysVarCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApSysVarCmd.ts
@@ -31,14 +31,8 @@ export class AcApSysVarCmd extends AcEdCommand {
       context.doc.database
     )
     const basePrompt = AcApI18n.t('jig.sysvar.prompt').trim()
-    const match = basePrompt.match(/([：:])\s*$/)
-    // Preserve the existing trailing colon style (Chinese or ASCII) if present.
-    const colon = match?.[1] ?? ':'
-    const promptCore = match
-      ? basePrompt.slice(0, match.index).trimEnd()
-      : basePrompt
     const suffix = currentValue == null ? '' : ` <${String(currentValue)}>`
-    const promptMessage = `${promptCore}${suffix}${colon}`
+    const promptMessage = `${basePrompt}${suffix}`
     const prompt = new AcEdPromptStringOptions(promptMessage)
     const result = await AcApDocManager.instance.editor.getString(prompt)
     if (result.status !== AcEdPromptStatus.OK || !result.stringResult) return

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
@@ -87,9 +87,10 @@ export class AcEdCommandLine {
 
   setPrompt(message?: string) {
     this.isPromptActive = true
-    this.promptEl.innerHTML = message ?? ''
+    const promptCore = message?.trim().replace(/[：:]\s*$/, '') ?? ''
+    this.promptEl.innerHTML = promptCore ? `${promptCore}: ` : ''
     this.textInput.placeholder = ''
-    this.recordRecentMessage(message)
+    this.recordRecentMessage(promptCore ? `${promptCore}:` : message)
   }
 
   clear() {
@@ -821,7 +822,8 @@ export class AcEdCommandLine {
     this.textInput.placeholder = ''
 
     if (options.message) {
-      this.promptEl.append(options.message.trim() + ' ')
+      const promptCore = options.message.trim().replace(/[：:]\s*$/, '')
+      this.promptEl.append(promptCore + ' ')
     }
 
     const promptFormat = options.getKeywordPromptFormat()

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -2,16 +2,16 @@ export default {
   arc: {
     startPointOrCenter: 'Specify start point of arc or',
     secondPointOrOptions: 'Specify second point of arc or',
-    secondPoint: 'Specify second point of arc:',
-    startPoint: 'Specify start point of arc:',
-    centerPoint: 'Specify center point of arc:',
-    endPoint: 'Specify end point of arc:',
+    secondPoint: 'Specify second point of arc',
+    startPoint: 'Specify start point of arc',
+    centerPoint: 'Specify center point of arc',
+    endPoint: 'Specify end point of arc',
     endPointOrOptions: 'Specify end point of arc or',
     centerPointOrOptions: 'Specify center point of arc',
-    includedAngle: 'Specify included angle:',
-    chordLength: 'Specify chord length:',
-    tangentDirection: 'Specify tangent direction for start point of arc:',
-    radius: 'Specify radius of arc:',
+    includedAngle: 'Specify included angle',
+    chordLength: 'Specify chord length',
+    tangentDirection: 'Specify tangent direction for start point of arc',
+    radius: 'Specify radius of arc',
     keywords: {
       center: {
         display: 'Center(C)',
@@ -60,16 +60,16 @@ export default {
     }
   },
   circle: {
-    center: 'Specify the center of circle:',
+    center: 'Specify the center of circle',
     centerOrOptions: 'Specify center point of circle or',
-    radius: 'Specify the radius of circle:',
+    radius: 'Specify the radius of circle',
     radiusOrDiameter: 'Specify radius of circle or',
-    diameter: 'Specify diameter of circle:',
-    twoPointFirst: 'Specify first endpoint of circle diameter:',
-    twoPointSecond: 'Specify second endpoint of circle diameter:',
-    threePointFirst: 'Specify first point on circle:',
-    threePointSecond: 'Specify second point on circle:',
-    threePointThird: 'Specify third point on circle:',
+    diameter: 'Specify diameter of circle',
+    twoPointFirst: 'Specify first endpoint of circle diameter',
+    twoPointSecond: 'Specify second endpoint of circle diameter',
+    threePointFirst: 'Specify first point on circle',
+    threePointSecond: 'Specify second point on circle',
+    threePointThird: 'Specify third point on circle',
     keywords: {
       threeP: {
         display: '3P(3P)',
@@ -94,9 +94,9 @@ export default {
     secondPointOrArray: 'Specify second point or',
     modePrompt: 'Enter copy mode option',
     arrayItemCount:
-      'Enter the number of items in the array including the original:',
+      'Enter the number of items in the array including the original',
     arraySecondPointOrFit: 'Specify second point or',
-    arrayFitSecondPoint: 'Specify second point:',
+    arrayFitSecondPoint: 'Specify second point',
     keywords: {
       displacement: {
         display: 'Displacement(D)',
@@ -131,20 +131,20 @@ export default {
     }
   },
   dimlinear: {
-    xLine1Point: 'Specify the first extension line origin:',
-    xLine2Point: 'Specify the second extension line origin:',
-    dimLinePoint: 'Specify dimension line location:'
+    xLine1Point: 'Specify the first extension line origin',
+    xLine2Point: 'Specify the second extension line origin',
+    dimLinePoint: 'Specify dimension line location'
   },
   ellipse: {
     axisEndpointOrOptions: 'Specify axis endpoint of ellipse or',
     arcAxisEndpointOrCenter: 'Specify axis endpoint of elliptical arc or',
-    center: 'Specify center of ellipse:',
-    firstAxisEndpoint: 'Specify endpoint of axis:',
-    secondAxisEndpoint: 'Specify other endpoint of axis:',
+    center: 'Specify center of ellipse',
+    firstAxisEndpoint: 'Specify endpoint of axis',
+    secondAxisEndpoint: 'Specify other endpoint of axis',
     otherAxisOrRotation: 'Specify distance to other axis or',
-    rotationAngle: 'Specify rotation angle around major axis:',
-    arcStartAngle: 'Specify start angle of elliptical arc:',
-    arcEndAngle: 'Specify end angle of elliptical arc:',
+    rotationAngle: 'Specify rotation angle around major axis',
+    arcStartAngle: 'Specify start angle of elliptical arc',
+    arcEndAngle: 'Specify end angle of elliptical arc',
     keywords: {
       arc: {
         display: 'Arc(A)',
@@ -171,11 +171,11 @@ export default {
   },
   hatch: {
     prompt: 'Select boundary object or',
-    pickPoint: 'Specify internal point (or press Enter to finish):',
-    select: 'Select objects to hatch:',
-    patternName: 'Enter hatch pattern name:',
-    scale: 'Specify hatch pattern scale:',
-    angle: 'Specify hatch pattern angle:',
+    pickPoint: 'Specify internal point (or press Enter to finish)',
+    select: 'Select objects to hatch',
+    patternName: 'Enter hatch pattern name',
+    scale: 'Specify hatch pattern scale',
+    angle: 'Specify hatch pattern angle',
     style: 'Enter hatch style',
     associative: 'Specify associativity',
     invalidBoundary: 'Selected objects do not form a closed boundary.',
@@ -256,21 +256,21 @@ export default {
     main: 'Enter option',
     listSummary: 'Layer list was printed to browser console',
     emptyInput: 'No layer name was entered.',
-    newPrompt: 'Enter name for new layer(s):',
-    makePrompt: 'Enter name of layer to make current:',
-    setPrompt: 'Enter name of layer to set current:',
-    onPrompt: 'Enter layer name(s) to turn on:',
-    offPrompt: 'Enter layer name(s) to turn off:',
-    freezePrompt: 'Enter layer name(s) to freeze:',
-    thawPrompt: 'Enter layer name(s) to thaw:',
-    lockPrompt: 'Enter layer name(s) to lock:',
-    unlockPrompt: 'Enter layer name(s) to unlock:',
-    colorLayerPrompt: 'Enter layer name(s) to change color:',
+    newPrompt: 'Enter name for new layer(s)',
+    makePrompt: 'Enter name of layer to make current',
+    setPrompt: 'Enter name of layer to set current',
+    onPrompt: 'Enter layer name(s) to turn on',
+    offPrompt: 'Enter layer name(s) to turn off',
+    freezePrompt: 'Enter layer name(s) to freeze',
+    thawPrompt: 'Enter layer name(s) to thaw',
+    lockPrompt: 'Enter layer name(s) to lock',
+    unlockPrompt: 'Enter layer name(s) to unlock',
+    colorLayerPrompt: 'Enter layer name(s) to change color',
     colorValuePrompt:
-      'Enter color (ACI 1-255, RGB like 255,0,0, or CSS color name):',
+      'Enter color (ACI 1-255, RGB like 255,0,0, or CSS color name)',
     invalidColor: 'Invalid color input.',
-    descriptionLayerPrompt: 'Enter layer name to edit description:',
-    descriptionValuePrompt: 'Enter new layer description:',
+    descriptionLayerPrompt: 'Enter layer name to edit description',
+    descriptionValuePrompt: 'Enter new layer description',
     created: 'Created layer count',
     alreadyExists: 'Layer already exists',
     notFound: 'Layer not found',
@@ -541,9 +541,9 @@ export default {
     noPreviousState: 'There is no previous layer state to restore.'
   },
   line: {
-    firstPoint: 'Specify the first point:',
+    firstPoint: 'Specify the first point',
     firstPointOrContinue: 'Specify first point or',
-    nextPoint: 'Specify the next point:',
+    nextPoint: 'Specify the next point',
     nextPointWithOptions: 'Specify next point or',
     keywords: {
       continue: {
@@ -565,9 +565,9 @@ export default {
   },
   xline: {
     firstPointOrOptions: 'Specify a point or',
-    secondPoint: 'Specify second point:',
-    throughPoint: 'Specify through point:',
-    angle: 'Enter angle of xline:',
+    secondPoint: 'Specify second point',
+    throughPoint: 'Specify through point',
+    angle: 'Enter angle of xline',
     invalidDirection: 'Invalid direction for XLINE.',
     keywords: {
       hor: {
@@ -588,17 +588,17 @@ export default {
     }
   },
   ray: {
-    startPoint: 'Specify start point:',
-    throughPoint: 'Specify through point:'
+    startPoint: 'Specify start point',
+    throughPoint: 'Specify through point'
   },
   mline: {
     startPointWithOptions: 'Specify start point or',
     nextPointWithOptions: 'Specify next point or',
     justificationPrompt: 'Enter justification type',
-    scalePrompt: 'Specify mline scale:',
-    stylePrompt: 'Enter mline style name or [?] for list:',
+    scalePrompt: 'Specify mline scale',
+    stylePrompt: 'Enter mline style name or [?] for list',
     styleNotFound: 'Mline style not found',
-    styleListHeader: 'Loaded mline styles:',
+    styleListHeader: 'Loaded mline styles',
     styleListEmpty: 'No mline style is loaded in current drawing.',
     keywords: {
       justification: {
@@ -644,27 +644,27 @@ export default {
     }
   },
   measureAngle: {
-    vertex: 'Specify vertex point:',
-    arm1: 'Specify point on first arm:',
-    arm2: 'Specify point on second arm:'
+    vertex: 'Specify vertex point',
+    arm1: 'Specify point on first arm',
+    arm2: 'Specify point on second arm'
   },
   measureArc: {
-    startPoint: 'Specify arc start point:',
-    throughPoint: 'Specify a point on the arc:',
-    endPoint: 'Specify arc end point:'
+    startPoint: 'Specify arc start point',
+    throughPoint: 'Specify a point on the arc',
+    endPoint: 'Specify arc end point'
   },
   measureArea: {
-    firstPoint: 'Specify first point:',
-    nextPoint: 'Specify next point (or press Enter to finish):'
+    firstPoint: 'Specify first point',
+    nextPoint: 'Specify next point (or press Enter to finish)'
   },
   measureDistance: {
-    firstPoint: 'Specify first point:',
-    secondPoint: 'Specify second point:'
+    firstPoint: 'Specify first point',
+    secondPoint: 'Specify second point'
   },
   move: {
     basePointOrDisplacement: 'Specify base point or',
     secondPointOrDisplacement: 'Specify second point or',
-    displacement: 'Specify displacement:',
+    displacement: 'Specify displacement',
     keywords: {
       displacement: {
         display: 'Displacement(D)',
@@ -674,15 +674,15 @@ export default {
     }
   },
   offset: {
-    distance: 'Specify offset distance:',
-    selectObject: 'Select object to offset or press Enter to finish:',
-    sidePoint: 'Specify point on side to offset:',
+    distance: 'Specify offset distance',
+    selectObject: 'Select object to offset or press Enter to finish',
+    sidePoint: 'Specify point on side to offset',
     invalidDistance: 'Offset distance must be greater than 0.',
     invalidSelection: 'Selected object cannot be offset.',
     offsetFailed: 'Unable to create an offset curve for the specified side.'
   },
   mtext: {
-    point: 'Specify mtext insertion point:'
+    point: 'Specify mtext insertion point'
   },
   pngout: {
     boundsFirstCorner: 'Specify first corner of bounds',
@@ -693,11 +693,11 @@ export default {
     point: 'Specify a point'
   },
   polygon: {
-    numberOfSides: 'Enter number of sides:',
+    numberOfSides: 'Enter number of sides',
     centerOrEdge: 'Specify center of polygon or',
     radiusOrType: 'Enter options',
-    edgeStart: 'Specify first endpoint of edge:',
-    edgeEnd: 'Specify second endpoint of edge:',
+    edgeStart: 'Specify first endpoint of edge',
+    edgeEnd: 'Specify second endpoint of edge',
     keywords: {
       edge: {
         display: 'Edge(E)',
@@ -722,8 +722,8 @@ export default {
     }
   },
   polyline: {
-    firstPoint: 'Specify the first point:',
-    nextPoint: 'Specify the next point (or press Enter to finish):',
+    firstPoint: 'Specify the first point',
+    nextPoint: 'Specify the next point (or press Enter to finish)',
     nextPointWithOptions: 'Specify next point or',
     nextPointWithArcOptions: 'Specify next point or',
     keywords: {
@@ -768,29 +768,29 @@ export default {
         global: 'Radius'
       }
     },
-    arcAngle: 'Specify arc angle:',
-    arcCenter: 'Specify center point:',
-    arcSecondPoint: 'Specify second point on arc:',
-    arcEndPoint: 'Specify arc end point:',
-    arcRadius: 'Specify arc radius:'
+    arcAngle: 'Specify arc angle',
+    arcCenter: 'Specify center point',
+    arcSecondPoint: 'Specify second point on arc',
+    arcEndPoint: 'Specify arc end point',
+    arcRadius: 'Specify arc radius'
   },
   rect: {
-    firstPoint: 'Specify first corner point:',
-    nextPoint: 'Specify other corner point:',
+    firstPoint: 'Specify first corner point',
+    nextPoint: 'Specify other corner point',
     firstPointWithOptions: 'Specify first corner point or',
     otherCornerWithOptions: 'Specify other corner point or',
-    chamferFirst: 'Specify first chamfer distance:',
-    chamferSecond: 'Specify second chamfer distance:',
-    filletRadius: 'Specify fillet radius:',
-    segmentWidth: 'Specify rectangle line width:',
-    elevationValue: 'Specify elevation:',
-    thicknessValue: 'Specify thickness:',
-    rotationAngle: 'Specify rectangle rotation angle:',
-    dimensionLength: 'Specify rectangle length:',
-    dimensionWidth: 'Specify rectangle width:',
-    areaValue: 'Specify rectangle area:',
+    chamferFirst: 'Specify first chamfer distance',
+    chamferSecond: 'Specify second chamfer distance',
+    filletRadius: 'Specify fillet radius',
+    segmentWidth: 'Specify rectangle line width',
+    elevationValue: 'Specify elevation',
+    thicknessValue: 'Specify thickness',
+    rotationAngle: 'Specify rectangle rotation angle',
+    dimensionLength: 'Specify rectangle length',
+    dimensionWidth: 'Specify rectangle width',
+    areaValue: 'Specify rectangle area',
     areaLengthOrWidth: 'Specify rectangle length',
-    areaSpecifyWidth: 'Specify rectangle width:',
+    areaSpecifyWidth: 'Specify rectangle width',
     invalidPositive: 'Invalid input. Please enter a value greater than 0.',
     invalidRect:
       'Unable to create rectangle. Please specify valid corners or dimensions.',
@@ -850,12 +850,12 @@ export default {
     }
   },
   rotate: {
-    basePoint: 'Specify base point:',
+    basePoint: 'Specify base point',
     rotationAngleOrOptions: 'Specify rotation angle or',
     referenceAngleOrPoints: 'Specify reference angle or',
-    firstReferencePoint: 'Specify first point of reference angle:',
-    secondReferencePoint: 'Specify second point:',
-    newAngle: 'Specify new angle:',
+    firstReferencePoint: 'Specify first point of reference angle',
+    secondReferencePoint: 'Specify second point',
+    newAngle: 'Specify new angle',
     keywords: {
       copy: {
         display: 'Copy(C)',
@@ -878,18 +878,18 @@ export default {
     }
   },
   sketch: {
-    firstPoint: 'Specify the first point:',
-    nextPoint: 'Specify the end point:'
+    firstPoint: 'Specify the first point',
+    nextPoint: 'Specify the end point'
   },
   spline: {
-    firstPoint: 'Specify the first point:',
-    nextPoint: 'Specify the next point (or press Enter to finish):',
+    firstPoint: 'Specify the first point',
+    nextPoint: 'Specify the next point (or press Enter to finish)',
     firstPointWithOptions: 'Specify first point or',
     nextPointWithFitOptions: 'Specify next point or',
     nextPointWithCvOptions: 'Specify next control vertex or',
     methodPrompt: 'Enter spline creation method',
     knotsPrompt: 'Enter knot parameterization',
-    degreePrompt: 'Specify spline degree:',
+    degreePrompt: 'Specify spline degree',
     keywords: {
       method: {
         display: 'Method(M)',
@@ -944,15 +944,15 @@ export default {
     }
   },
   sysvar: {
-    prompt: 'Please input new value:'
+    prompt: 'Please input new value'
   },
   zoom: {
     mainPrompt: 'Specify corner of window or',
-    firstCorner: 'Specify first corner:',
-    secondCorner: 'Specify opposite corner:',
-    centerPoint: 'Specify center point:',
-    heightOrScale: 'Enter height or scale factor (nX or nXP):',
-    scaleFactor: 'Enter scale factor (nX or nXP):',
+    firstCorner: 'Specify first corner',
+    secondCorner: 'Specify opposite corner',
+    centerPoint: 'Specify center point',
+    heightOrScale: 'Enter height or scale factor (nX or nXP)',
+    scaleFactor: 'Enter scale factor (nX or nXP)',
     keywords: {
       all: {
         display: 'All(A)',

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -2,16 +2,16 @@ export default {
   arc: {
     startPointOrCenter: '指定圆弧的起点或',
     secondPointOrOptions: '指定圆弧上的第二点或',
-    secondPoint: '指定圆弧上的第二点：',
-    startPoint: '指定圆弧的起点：',
-    centerPoint: '指定圆弧的圆心：',
-    endPoint: '指定圆弧的端点：',
+    secondPoint: '指定圆弧上的第二点',
+    startPoint: '指定圆弧的起点',
+    centerPoint: '指定圆弧的圆心',
+    endPoint: '指定圆弧的端点',
     endPointOrOptions: '指定圆弧的端点或',
     centerPointOrOptions: '指定圆弧的圆心或',
-    includedAngle: '指定圆弧的夹角：',
-    chordLength: '指定圆弧的弦长：',
-    tangentDirection: '指定圆弧起点的切线方向：',
-    radius: '指定圆弧的半径：',
+    includedAngle: '指定圆弧的夹角',
+    chordLength: '指定圆弧的弦长',
+    tangentDirection: '指定圆弧起点的切线方向',
+    radius: '指定圆弧的半径',
     keywords: {
       center: {
         display: '圆心(C)',
@@ -54,16 +54,16 @@ export default {
     }
   },
   circle: {
-    center: '指定圆的圆心：',
+    center: '指定圆的圆心',
     centerOrOptions: '指定圆的圆心或',
-    radius: '指定圆的半径：',
+    radius: '指定圆的半径',
     radiusOrDiameter: '指定圆的半径或',
-    diameter: '指定圆的直径：',
-    twoPointFirst: '指定圆直径的第一个端点：',
-    twoPointSecond: '指定圆直径的第二个端点：',
-    threePointFirst: '指定圆上的第一个点：',
-    threePointSecond: '指定圆上的第二个点：',
-    threePointThird: '指定圆上的第三个点：',
+    diameter: '指定圆的直径',
+    twoPointFirst: '指定圆直径的第一个端点',
+    twoPointSecond: '指定圆直径的第二个端点',
+    threePointFirst: '指定圆上的第一个点',
+    threePointSecond: '指定圆上的第二个点',
+    threePointThird: '指定圆上的第三个点',
     keywords: {
       threeP: {
         display: '三点(3P)',
@@ -87,9 +87,9 @@ export default {
     displacementOrArray: '指定位移或',
     secondPointOrArray: '指定第二个点或',
     modePrompt: '输入复制模式选项',
-    arrayItemCount: '输入阵列中的项目数（包括原对象）：',
+    arrayItemCount: '输入阵列中的项目数（包括原对象）',
     arraySecondPointOrFit: '指定第二个点或',
-    arrayFitSecondPoint: '指定第二个点：',
+    arrayFitSecondPoint: '指定第二个点',
     keywords: {
       displacement: {
         display: '位移(D)',
@@ -124,20 +124,20 @@ export default {
     }
   },
   dimlinear: {
-    xLine1Point: '指定第一条尺寸界限原点：',
-    xLine2Point: '指定第二条尺寸界限原点：',
-    dimLinePoint: '指定尺寸线位置：'
+    xLine1Point: '指定第一条尺寸界限原点',
+    xLine2Point: '指定第二条尺寸界限原点',
+    dimLinePoint: '指定尺寸线位置'
   },
   ellipse: {
     axisEndpointOrOptions: '指定椭圆的轴端点或',
     arcAxisEndpointOrCenter: '指定椭圆弧的轴端点或',
-    center: '指定椭圆中心点：',
-    firstAxisEndpoint: '指定轴的端点：',
-    secondAxisEndpoint: '指定轴的另一个端点：',
+    center: '指定椭圆中心点',
+    firstAxisEndpoint: '指定轴的端点',
+    secondAxisEndpoint: '指定轴的另一个端点',
     otherAxisOrRotation: '指定到另一轴的距离或',
-    rotationAngle: '指定绕长轴的旋转角度：',
-    arcStartAngle: '指定椭圆弧起始角：',
-    arcEndAngle: '指定椭圆弧终止角：',
+    rotationAngle: '指定绕长轴的旋转角度',
+    arcStartAngle: '指定椭圆弧起始角',
+    arcEndAngle: '指定椭圆弧终止角',
     keywords: {
       arc: {
         display: '圆弧(A)',
@@ -163,11 +163,11 @@ export default {
   },
   hatch: {
     prompt: '选择边界对象或',
-    pickPoint: '指定内部点（或按 Enter 结束）：',
-    select: '选择要填充的对象：',
-    patternName: '输入填充图案名称：',
-    scale: '指定填充图案比例：',
-    angle: '指定填充图案角度：',
+    pickPoint: '指定内部点（或按 Enter 结束）',
+    select: '选择要填充的对象',
+    patternName: '输入填充图案名称',
+    scale: '指定填充图案比例',
+    angle: '指定填充图案角度',
     style: '输入填充样式',
     associative: '指定关联性',
     invalidBoundary: '所选对象无法构成闭合边界。',
@@ -248,20 +248,20 @@ export default {
     main: '输入选项',
     listSummary: '图层列表已输出到浏览器控制台',
     emptyInput: '未输入图层名。',
-    newPrompt: '输入新建图层名称（可用逗号分隔多个）：',
-    makePrompt: '输入要创建并设为当前的图层名：',
-    setPrompt: '输入要设为当前的图层名：',
-    onPrompt: '输入要打开的图层名：',
-    offPrompt: '输入要关闭的图层名：',
-    freezePrompt: '输入要冻结的图层名：',
-    thawPrompt: '输入要解冻的图层名：',
-    lockPrompt: '输入要锁定的图层名：',
-    unlockPrompt: '输入要解锁的图层名：',
-    colorLayerPrompt: '输入要修改颜色的图层名：',
-    colorValuePrompt: '输入颜色（ACI 1-255、RGB 如 255,0,0 或颜色名）：',
+    newPrompt: '输入新建图层名称（可用逗号分隔多个）',
+    makePrompt: '输入要创建并设为当前的图层名',
+    setPrompt: '输入要设为当前的图层名',
+    onPrompt: '输入要打开的图层名',
+    offPrompt: '输入要关闭的图层名',
+    freezePrompt: '输入要冻结的图层名',
+    thawPrompt: '输入要解冻的图层名',
+    lockPrompt: '输入要锁定的图层名',
+    unlockPrompt: '输入要解锁的图层名',
+    colorLayerPrompt: '输入要修改颜色的图层名',
+    colorValuePrompt: '输入颜色（ACI 1-255、RGB 如 255,0,0 或颜色名）',
     invalidColor: '颜色输入无效。',
-    descriptionLayerPrompt: '输入要修改说明的图层名：',
-    descriptionValuePrompt: '输入新的图层说明：',
+    descriptionLayerPrompt: '输入要修改说明的图层名',
+    descriptionValuePrompt: '输入新的图层说明',
     created: '已创建图层数量',
     alreadyExists: '图层已存在',
     notFound: '未找到图层',
@@ -531,9 +531,9 @@ export default {
     noPreviousState: '没有可恢复的先前图层状态。'
   },
   line: {
-    firstPoint: '指定第一个点：',
+    firstPoint: '指定第一个点',
     firstPointOrContinue: '请指定第一个点或',
-    nextPoint: '指定下一个点：',
+    nextPoint: '指定下一个点',
     nextPointWithOptions: '请指定下一个点或',
     keywords: {
       continue: {
@@ -555,9 +555,9 @@ export default {
   },
   xline: {
     firstPointOrOptions: '指定点或',
-    secondPoint: '指定第二个点：',
-    throughPoint: '指定穿过点：',
-    angle: '输入构造线角度：',
+    secondPoint: '指定第二个点',
+    throughPoint: '指定穿过点',
+    angle: '输入构造线角度',
     invalidDirection: 'XLINE 的方向无效。',
     keywords: {
       hor: {
@@ -578,17 +578,17 @@ export default {
     }
   },
   ray: {
-    startPoint: '指定起点：',
-    throughPoint: '指定通过点：'
+    startPoint: '指定起点',
+    throughPoint: '指定通过点'
   },
   mline: {
     startPointWithOptions: '指定起点或',
     nextPointWithOptions: '指定下一点或',
     justificationPrompt: '输入对正方式',
-    scalePrompt: '指定多线比例：',
-    stylePrompt: '输入多线样式名或 [?] 列出样式：',
+    scalePrompt: '指定多线比例',
+    stylePrompt: '输入多线样式名或 [?] 列出样式',
     styleNotFound: '未找到多线样式',
-    styleListHeader: '已加载的多线样式：',
+    styleListHeader: '已加载的多线样式',
     styleListEmpty: '当前图纸没有已加载的多线样式。',
     keywords: {
       justification: {
@@ -634,27 +634,27 @@ export default {
     }
   },
   measureArc: {
-    startPoint: '指定弧的起点：',
-    throughPoint: '指定弧上的一个点：',
-    endPoint: '指定弧的终点：'
+    startPoint: '指定弧的起点',
+    throughPoint: '指定弧上的一个点',
+    endPoint: '指定弧的终点'
   },
   measureAngle: {
-    vertex: '指定顶点：',
-    arm1: '指定第一条边上的点：',
-    arm2: '指定第二条边上的点：'
+    vertex: '指定顶点',
+    arm1: '指定第一条边上的点',
+    arm2: '指定第二条边上的点'
   },
   measureArea: {
-    firstPoint: '指定第一个点：',
-    nextPoint: '指定下一个点（或按 Enter 完成）：'
+    firstPoint: '指定第一个点',
+    nextPoint: '指定下一个点（或按 Enter 完成）'
   },
   measureDistance: {
-    firstPoint: '指定第一个点：',
-    secondPoint: '指定第二个点：'
+    firstPoint: '指定第一个点',
+    secondPoint: '指定第二个点'
   },
   move: {
     basePointOrDisplacement: '指定基点或',
     secondPointOrDisplacement: '指定第二个点或',
-    displacement: '指定位移：',
+    displacement: '指定位移',
     keywords: {
       displacement: {
         display: '位移(D)',
@@ -664,15 +664,15 @@ export default {
     }
   },
   offset: {
-    distance: '指定偏移距离：',
-    selectObject: '选择要偏移的对象，或按 Enter 结束：',
-    sidePoint: '指定要偏移到的那一侧的点：',
+    distance: '指定偏移距离',
+    selectObject: '选择要偏移的对象，或按 Enter 结束',
+    sidePoint: '指定要偏移到的那一侧的点',
     invalidDistance: '偏移距离必须大于 0。',
     invalidSelection: '所选对象不能偏移。',
     offsetFailed: '无法在指定侧创建偏移曲线。'
   },
   mtext: {
-    point: '指定多行文本插入点：'
+    point: '指定多行文本插入点'
   },
   pngout: {
     boundsFirstCorner: '指定边界的第一个角点',
@@ -683,11 +683,11 @@ export default {
     point: '指定点'
   },
   polygon: {
-    numberOfSides: '输入边数：',
+    numberOfSides: '输入边数',
     centerOrEdge: '指定多边形中心点或',
     radiusOrType: '输入选项',
-    edgeStart: '指定边的第一个端点：',
-    edgeEnd: '指定边的第二个端点：',
+    edgeStart: '指定边的第一个端点',
+    edgeEnd: '指定边的第二个端点',
     keywords: {
       edge: {
         display: '边(E)',
@@ -712,8 +712,8 @@ export default {
     }
   },
   polyline: {
-    firstPoint: '指定第一个点：',
-    nextPoint: '指定下一个点（或按 Enter 完成）：',
+    firstPoint: '指定第一个点',
+    nextPoint: '指定下一个点（或按 Enter 完成）',
     nextPointWithOptions: '请指定下一个点或',
     nextPointWithArcOptions: '请指定下一个点或',
     keywords: {
@@ -758,19 +758,19 @@ export default {
         global: 'Radius'
       }
     },
-    arcAngle: '指定弧角度：',
-    arcCenter: '指定圆心：',
-    arcSecondPoint: '指定弧上的第二点：',
-    arcEndPoint: '指定弧的终点：',
-    arcRadius: '指定弧半径：'
+    arcAngle: '指定弧角度',
+    arcCenter: '指定圆心',
+    arcSecondPoint: '指定弧上的第二点',
+    arcEndPoint: '指定弧的终点',
+    arcRadius: '指定弧半径'
   },
   rotate: {
-    basePoint: '指定基点：',
+    basePoint: '指定基点',
     rotationAngleOrOptions: '指定旋转角度或',
     referenceAngleOrPoints: '指定参考角或',
-    firstReferencePoint: '指定参考角的第一点：',
-    secondReferencePoint: '指定第二点：',
-    newAngle: '指定新角度：',
+    firstReferencePoint: '指定参考角的第一点',
+    secondReferencePoint: '指定第二点',
+    newAngle: '指定新角度',
     keywords: {
       copy: {
         display: '复制(C)',
@@ -793,22 +793,22 @@ export default {
     }
   },
   rect: {
-    firstPoint: '指定第一个角点：',
-    nextPoint: '指定另一个角点：',
+    firstPoint: '指定第一个角点',
+    nextPoint: '指定另一个角点',
     firstPointWithOptions: '指定第一个角点或者',
     otherCornerWithOptions: '指定另一个角点或者',
-    chamferFirst: '指定第一个倒角距离：',
-    chamferSecond: '指定第二个倒角距离：',
-    filletRadius: '指定圆角半径：',
-    segmentWidth: '指定矩形线宽：',
-    elevationValue: '指定标高：',
-    thicknessValue: '指定厚度：',
-    rotationAngle: '指定矩形旋转角度：',
-    dimensionLength: '指定矩形长度：',
-    dimensionWidth: '指定矩形宽度：',
-    areaValue: '指定矩形面积：',
+    chamferFirst: '指定第一个倒角距离',
+    chamferSecond: '指定第二个倒角距离',
+    filletRadius: '指定圆角半径',
+    segmentWidth: '指定矩形线宽',
+    elevationValue: '指定标高',
+    thicknessValue: '指定厚度',
+    rotationAngle: '指定矩形旋转角度',
+    dimensionLength: '指定矩形长度',
+    dimensionWidth: '指定矩形宽度',
+    areaValue: '指定矩形面积',
     areaLengthOrWidth: '指定矩形长度',
-    areaSpecifyWidth: '指定矩形宽度：',
+    areaSpecifyWidth: '指定矩形宽度',
     invalidPositive: '输入无效：请输入大于 0 的数值。',
     invalidRect: '无法创建矩形：请输入有效的角点或尺寸。',
     thicknessNotSupported:
@@ -867,18 +867,18 @@ export default {
     }
   },
   sketch: {
-    firstPoint: '指定第一个点：',
-    nextPoint: '指定结束点：'
+    firstPoint: '指定第一个点',
+    nextPoint: '指定结束点'
   },
   spline: {
-    firstPoint: '指定第一个点：',
-    nextPoint: '指定下一个点（或按 Enter 完成）：',
+    firstPoint: '指定第一个点',
+    nextPoint: '指定下一个点（或按 Enter 完成）',
     firstPointWithOptions: '指定第一个点或',
     nextPointWithFitOptions: '指定下一个点或',
     nextPointWithCvOptions: '指定下一个控制顶点或',
     methodPrompt: '输入样条创建方式',
     knotsPrompt: '输入节点参数化方式',
-    degreePrompt: '指定样条次数：',
+    degreePrompt: '指定样条次数',
     keywords: {
       method: {
         display: '方法(M)',
@@ -933,15 +933,15 @@ export default {
     }
   },
   sysvar: {
-    prompt: '请输入新的值：'
+    prompt: '请输入新的值'
   },
   zoom: {
     mainPrompt: '指定窗口角点或',
-    firstCorner: '指定第一个角点：',
-    secondCorner: '指定对角点：',
-    centerPoint: '指定缩放中心点：',
-    heightOrScale: '输入高度或比例因子（nX 或 nXP）：',
-    scaleFactor: '输入比例因子（nX 或 nXP）：',
+    firstCorner: '指定第一个角点',
+    secondCorner: '指定对角点',
+    centerPoint: '指定缩放中心点',
+    heightOrScale: '输入高度或比例因子（nX 或 nXP）',
+    scaleFactor: '输入比例因子（nX 或 nXP）',
     keywords: {
       all: {
         display: '全部(A)',


### PR DESCRIPTION
## Summary
- Remove trailing colons from English and Chinese jig prompt strings so message text stays locale-neutral.
- Render prompt colons centrally in `AcEdCommandLine` (`setPrompt` and keyword prompts) for consistent formatting.
- Simplify `AcApSysVarCmd` by dropping duplicate colon parsing now handled by the command line UI.

## Test plan
- [ ] Run drawing commands (LINE, CIRCLE, LAYER, SYSVAR) in English and Chinese locales.
- [ ] Confirm command-line prompts show a single trailing colon with correct spacing.
- [ ] Verify keyword prompts (e.g. `Specify first point or [Close(C)]`) still append options correctly.
- [ ] Check SYSVAR prompt displays current value suffix (`<value>`) before the colon.