### PR TITLE
fix(three-renderer): keep point symbol geometry local for large coordinates

### DIFF
--- a/packages/three-renderer/__tests__/AcTrPoint.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrPoint.spec.ts
@@ -1,3 +1,7 @@
+import * as THREE from 'three'
+
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
 import { expectWcsBboxCloseTo } from './helpers/expectWcsBbox'
 import { AcTrPoint } from '../src/object/AcTrPoint'
 import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
@@ -6,6 +10,43 @@ import { AcTrSubEntityTraitsUtil } from '../src/util'
 const defaultTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
 const dotStyle = { displayMode: 0, displaySize: 0 }
 const crossStyle = { displayMode: 2, displaySize: 0 }
+const circleCrossStyle = { displayMode: 35, displaySize: 0 }
+const largeX = RTE_REBASE_THRESHOLD + 500_000
+const largePoint = {
+  x: 3_134_356.509824163,
+  y: 1_394_770.78992697,
+  z: 0
+}
+
+function getMaxAbsPositionComponent(geometry: THREE.BufferGeometry) {
+  const position = geometry.getAttribute('position')
+  if (!position) {
+    return 0
+  }
+  let maxAbs = 0
+  for (let i = 0; i < position.count; i++) {
+    maxAbs = Math.max(maxAbs, Math.abs(position.getX(i)))
+    maxAbs = Math.max(maxAbs, Math.abs(position.getY(i)))
+    maxAbs = Math.max(maxAbs, Math.abs(position.getZ(i)))
+  }
+  return maxAbs
+}
+
+function findPointSymbolDrawable(group: AcTrBatchedGroup) {
+  let drawable: THREE.LineSegments | undefined
+  group.traverse(child => {
+    if (drawable) {
+      return
+    }
+    if (
+      child instanceof THREE.LineSegments &&
+      Math.abs(child.position.x) >= RTE_REBASE_THRESHOLD
+    ) {
+      drawable = child
+    }
+  })
+  return drawable
+}
 
 describe('AcTrPoint wcsBbox', () => {
   it('stores the point location in wcsBbox for dot display mode', () => {
@@ -32,5 +73,63 @@ describe('AcTrPoint wcsBbox', () => {
     expect(point.wcsBbox.max.x).toBeGreaterThanOrEqual(100)
     expect(point.wcsBbox.min.y).toBeLessThanOrEqual(200)
     expect(point.wcsBbox.max.y).toBeGreaterThanOrEqual(200)
+  })
+})
+
+describe('AcTrPoint large coordinates', () => {
+  it('keeps point symbol geometry local and stores world placement on position', () => {
+    const point = new AcTrPoint(
+      largePoint,
+      defaultTraits,
+      circleCrossStyle,
+      new AcTrRenderContext()
+    )
+
+    const symbol = point.children.find(
+      child => child instanceof THREE.LineSegments
+    ) as THREE.LineSegments | undefined
+
+    expect(symbol).toBeDefined()
+    expect(getMaxAbsPositionComponent(symbol!.geometry)).toBeLessThan(2)
+    expect(symbol!.position.x).toBeCloseTo(largePoint.x, 6)
+    expect(symbol!.position.y).toBeCloseTo(largePoint.y, 6)
+  })
+
+  it('keeps wcsBbox in world coordinates when geometry is rebased locally', () => {
+    const point = new AcTrPoint(
+      { x: largeX, y: 2_000_000, z: 0 },
+      defaultTraits,
+      circleCrossStyle,
+      new AcTrRenderContext()
+    )
+
+    expect(point.wcsBbox.isEmpty()).toBe(false)
+    expect(point.wcsBbox.min.x).toBeLessThanOrEqual(largeX)
+    expect(point.wcsBbox.max.x).toBeGreaterThanOrEqual(largeX)
+    expect(point.wcsBbox.min.y).toBeLessThanOrEqual(2_000_000)
+    expect(point.wcsBbox.max.y).toBeGreaterThanOrEqual(2_000_000)
+  })
+
+  it('renders large point symbols correctly in the unbatched group', () => {
+    const pointEntity = new AcTrPoint(
+      largePoint,
+      defaultTraits,
+      circleCrossStyle,
+      new AcTrRenderContext()
+    )
+    pointEntity.objectId = 'point-large'
+    pointEntity.visible = true
+
+    expect(pointEntity.resolveDrawMode()).toBe('unbatch')
+
+    const group = new AcTrBatchedGroup()
+    group.addEntity(pointEntity)
+
+    const drawable = findPointSymbolDrawable(group)
+    expect(drawable).toBeDefined()
+    expect(getMaxAbsPositionComponent(drawable!.geometry)).toBeLessThan(2)
+    expect(drawable!.position.x).toBeCloseTo(largePoint.x, 6)
+    expect(drawable!.position.y).toBeCloseTo(largePoint.y, 6)
+    expect(drawable!.frustumCulled).toBe(false)
   })
 })

--- a/packages/three-renderer/src/batch/AcTrBatchedLine.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine.ts
@@ -261,9 +261,19 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     const creator = AcTrPointSymbolCreator.instance
     userData.forEach(item => {
       if (item.position) {
-        const geometry = creator.create(displayMode, item.position)
+        const geometry = creator.create(displayMode)
         if (geometry.line) {
-          const geometryId = this.addGeometry(geometry.line)
+          const worldOffset = new THREE.Vector3(
+            item.position.x,
+            item.position.y,
+            item.position.z ?? 0
+          )
+          const geometryId = this.addGeometry(
+            geometry.line,
+            -1,
+            -1,
+            worldOffset
+          )
           this.setGeometryInfo(geometryId, item)
         }
       }

--- a/packages/three-renderer/src/geometry/AcTrPointSymbolCreator.ts
+++ b/packages/three-renderer/src/geometry/AcTrPointSymbolCreator.ts
@@ -452,12 +452,11 @@ export class AcTrPointSymbolCreator {
 
   create(
     displayMode: number | null = null,
-    point: AcGePoint3dLike = { x: 0, y: 0, z: 0 }
+    _point: AcGePoint3dLike = { x: 0, y: 0, z: 0 }
   ): AcTrPointSymbolGeometry {
     const result: AcTrPointSymbolGeometry = {}
     if (displayMode == null || displayMode == 0) {
-      _vector3.copy(point)
-      result.point = new THREE.BufferGeometry().setFromPoints([_vector3])
+      result.point = new THREE.BufferGeometry().setFromPoints([_originPoint])
     } else if (displayMode == 1) {
       // Display nothing if the pdmode is equal to 1
     } else {
@@ -467,13 +466,11 @@ export class AcTrPointSymbolCreator {
           `[AcTrPointSymbolCreator] Invalid point type value: '${displayMode}'!`
         )
       } else {
-        _vector3.copy(point)
-        _matrix.identity().makeTranslation(_vector3)
-        result.line = pointSymbolGeometry.clone().applyMatrix4(_matrix)
+        result.line = pointSymbolGeometry.clone()
 
         // For those display mode, there is one point at the center of point symbol
         if (displayMode == 32 || displayMode == 64 || displayMode == 96) {
-          result.point = new THREE.BufferGeometry().setFromPoints([_vector3])
+          result.point = new THREE.BufferGeometry().setFromPoints([_originPoint])
         }
       }
     }
@@ -495,5 +492,4 @@ export class AcTrPointSymbolCreator {
   }
 }
 
-const _matrix = /*@__PURE__*/ new THREE.Matrix4()
-const _vector3 = /*@__PURE__*/ new THREE.Vector3()
+const _originPoint = /*@__PURE__*/ new THREE.Vector3(0, 0, 0)

--- a/packages/three-renderer/src/object/AcTrPoint.ts
+++ b/packages/three-renderer/src/object/AcTrPoint.ts
@@ -30,8 +30,7 @@ export class AcTrPoint extends AcTrEntity {
     super(context)
     this._point = point
     const pointSymbol = AcTrPointSymbolCreator.instance.create(
-      style.displayMode,
-      point
+      style.displayMode
     )
 
     this.isShowPoint = pointSymbol.point != null
@@ -39,11 +38,11 @@ export class AcTrPoint extends AcTrEntity {
     // Always create one THREE.Points object. If 'isShowPoint' is true, show it. Otherwise, hide it.
     const geometry =
       pointSymbol.point ??
-      new THREE.BufferGeometry().setFromPoints([_vector3.copy(point)])
-    AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
-    if (geometry.boundingBox) this.wcsBbox.union(geometry.boundingBox)
+      new THREE.BufferGeometry().setFromPoints([_vector3.set(0, 0, 0)])
+    this.unionWorldBoundingBox(geometry, point)
     const material = this.styleManager.getPointsMaterial(traits)
     const pointObj = new THREE.Points(geometry, material)
+    pointObj.position.set(point.x, point.y, point.z ?? 0)
     // Add the flag to check intersection using bounding box of the mesh
     getSceneDrawableUserData(pointObj).bboxIntersectionCheck = true
     pointObj.visible = this.isShowPoint
@@ -51,10 +50,10 @@ export class AcTrPoint extends AcTrEntity {
 
     if (pointSymbol.line) {
       const geometry = pointSymbol.line
-      AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
-      if (geometry.boundingBox) this.wcsBbox.union(geometry.boundingBox)
+      this.unionWorldBoundingBox(geometry, point)
       const material = this.styleManager.getLineMaterial(traits, true)
       const lineSegmentsObj = new THREE.LineSegments(geometry, material)
+      lineSegmentsObj.position.set(point.x, point.y, point.z ?? 0)
       const lineDrawable = getSceneDrawableUserData(lineSegmentsObj)
       // Add the flag to check intersection using bounding box of the mesh
       lineDrawable.bboxIntersectionCheck = true
@@ -70,5 +69,20 @@ export class AcTrPoint extends AcTrEntity {
     return this.batchDrawPolicy.resolveDrawMode({
       position: this._point
     })
+  }
+
+  private unionWorldBoundingBox(
+    geometry: THREE.BufferGeometry,
+    worldOrigin: AcGePoint3dLike
+  ) {
+    const boundingBox = AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+    if (!boundingBox) {
+      return
+    }
+    const worldBox = boundingBox.clone()
+    worldBox.translate(
+      _vector3.set(worldOrigin.x, worldOrigin.y, worldOrigin.z ?? 0)
+    )
+    this.wcsBbox.union(worldBox)
   }
 }


### PR DESCRIPTION
## Summary

- Point symbols (dot and line-based display modes) now create geometry at the origin instead of baking world coordinates into vertex data
- World placement is applied via object position on THREE.Points and THREE.LineSegments, consistent with the RTE batch draw policy
- Batched point symbols pass world offset through addGeometry so large-coordinate drawings render correctly
- wcsBbox is computed by translating local geometry bounds to world space
- Added tests covering large-coordinate point symbols in direct and unbatched draw paths

## Test plan

- [ ] Open a drawing with points at large world coordinates (e.g. UTM/Easting values) and verify point symbols render at the correct locations
- [ ] Verify point selection and spatial indexing still work for large-coordinate points
- [ ] Run three-renderer tests: `pnpm nx test three-renderer --testPathPattern=AcTrPoint`