### PR TITLE
feat(three-renderer): split batches by world origin for large-coordinate precision

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -13,7 +13,11 @@ jest.mock('@mlightcad/three-renderer', () => ({
   isBatchGeometryVisible: (flags: number) => (flags & 3) === 3
 }))
 
+import { AcTrBatchedGroup } from '../../three-renderer/src/batch/AcTrBatchedGroup'
 import { AcTrBatchedLine } from '../../three-renderer/src/batch/AcTrBatchedLine'
+import { RTE_REBASE_THRESHOLD } from '../../three-renderer/src/draw/AcTrBatchDrawPolicy'
+import { AcTrEntity } from '../../three-renderer/src/object/AcTrEntity'
+import { AcTrRenderContext } from '../../three-renderer/src/renderer/AcTrRenderContext'
 import * as THREE from 'three'
 
 import { compactIndexedSlice, readBatchWorldOffset, toWcsCoord } from '../src/AcExBatchBuffers'
@@ -347,5 +351,81 @@ describe('collectBatchesFromObject3D rebase offsets', () => {
       1_800_045,
       0
     ])
+  })
+
+  it('exports multiple origin-split batched lines with reconstructable WCS', () => {
+    const group = new AcTrBatchedGroup()
+    const material = new THREE.LineBasicMaterial()
+    const farX = 100_000 + RTE_REBASE_THRESHOLD + 100
+
+    const createPositionedLine = (x: number, y: number) => {
+      const geometry = new THREE.BufferGeometry()
+      geometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute([0, 0, 0, 100, 50, 0], 3)
+      )
+      geometry.setIndex([0, 1])
+      const line = new THREE.LineSegments(geometry, material)
+      line.position.set(x, y, 0)
+      line.updateMatrixWorld(true)
+      return line
+    }
+
+    const createEntity = (objectId: string, ...drawables: THREE.Object3D[]) => {
+      const entity = new AcTrEntity(new AcTrRenderContext())
+      entity.objectId = objectId
+      entity.visible = true
+      for (const drawable of drawables) {
+        entity.add(drawable)
+      }
+      return entity
+    }
+
+    group.addEntity(
+      createEntity('line-near-a', createPositionedLine(100_000, 2_000_000))
+    )
+    group.addEntity(
+      createEntity('line-near-b', createPositionedLine(100_500, 2_000_050))
+    )
+    group.addEntity(createEntity('line-far', createPositionedLine(farX, 3_000_000)))
+
+    expect(
+      group.children.filter(child => child instanceof AcTrBatchedLine)
+    ).toHaveLength(2)
+
+    const { lineBatches } = collectBatchesFromObject3D(group)
+    expect(lineBatches).toHaveLength(2)
+
+    lineBatches.sort((a, b) => a.offset[0] - b.offset[0])
+    const nearExport = lineBatches[0]!
+    const farExport = lineBatches[1]!
+
+    expect(
+      toWcsCoord(nearExport.positions[0]!, nearExport.offset[0]!)
+    ).toBeCloseTo(100_000, 0)
+    expect(
+      toWcsCoord(nearExport.positions[1]!, nearExport.offset[1]!)
+    ).toBeCloseTo(2_000_000, 0)
+    expect(
+      toWcsCoord(nearExport.positions[3]!, nearExport.offset[0]!)
+    ).toBeCloseTo(100_100, 0)
+    expect(
+      toWcsCoord(nearExport.positions[4]!, nearExport.offset[1]!)
+    ).toBeCloseTo(2_000_050, 0)
+
+    expect(toWcsCoord(farExport.positions[0]!, farExport.offset[0]!)).toBeCloseTo(
+      farX,
+      0
+    )
+    expect(toWcsCoord(farExport.positions[1]!, farExport.offset[1]!)).toBeCloseTo(
+      3_000_000,
+      0
+    )
+
+    for (const batch of lineBatches) {
+      for (let i = 0; i < batch.positions.length; i++) {
+        expect(Math.abs(batch.positions[i]!)).toBeLessThan(RTE_REBASE_THRESHOLD)
+      }
+    }
   })
 })

--- a/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
+++ b/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
@@ -284,8 +284,8 @@ export function createViewerPointsMaterial(
 }
 
 /**
- * Re-aligns hatch pattern coordinates after unbatched geometry was baked
- * into world space during batch-group cloning.
+ * Re-aligns hatch pattern coordinates after hatch meshes were world-baked
+ * during batch-group cloning (pattern fills stay on the unbatched draw path).
  */
 export function transformHatchPatternToWorldSpace(
   pattern: AcExHatchPattern,

--- a/packages/three-renderer/__tests__/AcTrBatchDrawPolicy.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchDrawPolicy.spec.ts
@@ -3,7 +3,10 @@ import * as THREE from 'three'
 import {
   alwaysBatchDrawPolicy,
   alwaysUnbatchDrawPolicy,
+  canMergeIntoBatchOrigin,
+  batchOriginOffsetDistance,
   defaultBatchDrawPolicy,
+  exceedsBatchOriginOffset,
   isLargeWorldCoordinatePoint,
   resolveAnchorFromBox,
   resolveAnchorFromPoints,
@@ -104,5 +107,35 @@ describe('AcTrBatchDrawPolicy', () => {
     )
 
     expect(resolveAnchorFromBox(box)).toEqual(resolveAnchorFromPoints(points))
+  })
+
+  it('detects batch origin offsets that exceed the rebase threshold', () => {
+    const origin = new THREE.Vector3(100_000, 0, 0)
+    expect(
+      exceedsBatchOriginOffset(origin, new THREE.Vector3(100_500, 0, 0))
+    ).toBe(false)
+    expect(batchOriginOffsetDistance(origin, new THREE.Vector3(100_500, 0, 0))).toBe(
+      500
+    )
+    expect(
+      exceedsBatchOriginOffset(
+        origin,
+        new THREE.Vector3(100_000 + RTE_REBASE_THRESHOLD, 0, 0)
+      )
+    ).toBe(true)
+  })
+
+  it('allows merging into empty batches and rejects far offsets', () => {
+    const origin = new THREE.Vector3(100_000, 0, 0)
+    expect(canMergeIntoBatchOrigin(undefined, origin)).toBe(true)
+    expect(canMergeIntoBatchOrigin(origin, new THREE.Vector3(100_500, 0, 0))).toBe(
+      true
+    )
+    expect(
+      canMergeIntoBatchOrigin(
+        origin,
+        new THREE.Vector3(100_000 + RTE_REBASE_THRESHOLD, 0, 0)
+      )
+    ).toBe(false)
   })
 })

--- a/packages/three-renderer/__tests__/AcTrBatchedBounds.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedBounds.spec.ts
@@ -352,4 +352,128 @@ describe('AcTrBatchedGroup', () => {
       true
     )
   })
+
+  it('splits mesh batches when geometry world offsets are too far apart', () => {
+    const group = new AcTrBatchedGroup()
+    const material = new THREE.MeshBasicMaterial()
+
+    const createPositionedGlyph = (x: number) => {
+      const mesh = createGlyphMesh(0)
+      mesh.material = material
+      mesh.position.set(x, 0, 0)
+      mesh.updateMatrixWorld(true)
+      return mesh
+    }
+
+    group.addEntity(
+      createEntity(
+        'glyph-near',
+        createPositionedGlyph(100_000),
+        createPositionedGlyph(100_500)
+      )
+    )
+    group.addEntity(
+      createEntity(
+        'glyph-far',
+        createPositionedGlyph(100_000 + RTE_REBASE_THRESHOLD + 100)
+      )
+    )
+
+    const batchedMeshes = group.children.filter(
+      child => child instanceof AcTrBatchedMesh
+    )
+    expect(batchedMeshes).toHaveLength(2)
+
+    for (const batch of batchedMeshes) {
+      const positions = batch.geometry.getAttribute('position')
+        .array as Float32Array
+      for (let i = 0; i < positions.length; i += 3) {
+        expect(Math.abs(positions[i])).toBeLessThan(RTE_REBASE_THRESHOLD)
+        expect(Math.abs(positions[i + 1])).toBeLessThan(RTE_REBASE_THRESHOLD)
+      }
+    }
+  })
+
+  it('splits line batches when geometry world offsets are too far apart', () => {
+    const group = new AcTrBatchedGroup()
+    const material = new THREE.LineBasicMaterial()
+
+    const createPositionedLine = (x: number) => {
+      const line = createLineSegments(
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 },
+        new THREE.Vector3(x, 0, 0)
+      )
+      line.material = material
+      return line
+    }
+
+    group.addEntity(
+      createEntity(
+        'line-near',
+        createPositionedLine(100_000),
+        createPositionedLine(100_500)
+      )
+    )
+    group.addEntity(
+      createEntity(
+        'line-far',
+        createPositionedLine(100_000 + RTE_REBASE_THRESHOLD + 100)
+      )
+    )
+
+    const batchedLines = group.children.filter(
+      child => child instanceof AcTrBatchedLine
+    )
+    expect(batchedLines).toHaveLength(2)
+
+    for (const batch of batchedLines) {
+      const positions = batch.geometry.getAttribute('position')
+        .array as Float32Array
+      for (let i = 0; i < positions.length; i += 3) {
+        expect(Math.abs(positions[i])).toBeLessThan(RTE_REBASE_THRESHOLD)
+      }
+    }
+  })
+
+  it('merges geometry into the nearest origin batch when multiple are eligible', () => {
+    const group = new AcTrBatchedGroup()
+    const material = new THREE.LineBasicMaterial()
+    const farX = 100_000 + RTE_REBASE_THRESHOLD + 100
+
+    const createPositionedLine = (x: number) => {
+      const line = createLineSegments(
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 },
+        new THREE.Vector3(x, 0, 0)
+      )
+      line.material = material
+      return line
+    }
+
+    group.addEntity(createEntity('line-near', createPositionedLine(100_000)))
+    group.addEntity(createEntity('line-far', createPositionedLine(farX)))
+
+    const batchedLines = group.children
+      .filter(child => child instanceof AcTrBatchedLine)
+      .sort((a, b) => a.position.x - b.position.x) as AcTrBatchedLine[]
+    expect(batchedLines).toHaveLength(2)
+    const nearBatch = batchedLines[0]
+    const farBatch = batchedLines[1]
+    expect(nearBatch.geometryCount).toBe(1)
+    expect(farBatch.geometryCount).toBe(1)
+
+    group.addEntity(
+      createEntity('line-between', createPositionedLine(farX - 50_000))
+    )
+
+    expect(nearBatch.geometryCount).toBe(1)
+    expect(farBatch.geometryCount).toBe(2)
+
+    const positions = farBatch.geometry.getAttribute('position')
+      .array as Float32Array
+    for (let i = 0; i < positions.length; i += 3) {
+      expect(Math.abs(positions[i])).toBeLessThan(RTE_REBASE_THRESHOLD)
+    }
+  })
 })

--- a/packages/three-renderer/__tests__/AcTrLine.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrLine.spec.ts
@@ -22,7 +22,7 @@ const batchPolicy: AcTrBatchDrawPolicy = {
   resolveDrawMode: () => 'batch'
 }
 
-function findUnbatchedLineDrawable(group: AcTrBatchedGroup) {
+function findLargeCoordinateLineDrawable(group: AcTrBatchedGroup) {
   let drawable: THREE.Object3D | undefined
   group.traverse(child => {
     if (drawable) {
@@ -98,7 +98,7 @@ describe('AcTrLine', () => {
     expect(getSceneDrawableUserData(drawable).noBatch).toBeUndefined()
   })
 
-  it('keeps geometry local and visible in the unbatched group at large coordinates', () => {
+  it('keeps geometry local and visible in a rebased batch at large coordinates', () => {
     const context = new AcTrRenderContext()
     const lineEntity = new AcTrLine(
       [
@@ -111,12 +111,12 @@ describe('AcTrLine', () => {
     lineEntity.objectId = 'line-large'
     lineEntity.visible = true
 
-    expect(lineEntity.resolveDrawMode()).toBe('unbatch')
+    expect(lineEntity.resolveDrawMode()).toBe('batch')
 
     const group = new AcTrBatchedGroup()
     group.addEntity(lineEntity)
 
-    const drawable = findUnbatchedLineDrawable(group)
+    const drawable = findLargeCoordinateLineDrawable(group)
     expect(
       drawable instanceof THREE.LineSegments ||
         drawable instanceof LineSegments2

--- a/packages/three-renderer/__tests__/AcTrLineSegments.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrLineSegments.spec.ts
@@ -11,7 +11,7 @@ import { AcTrSubEntityTraitsUtil } from '../src/util'
 const defaultTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
 const largeX = RTE_REBASE_THRESHOLD + 500_000
 
-function findUnbatchedLineDrawable(group: AcTrBatchedGroup) {
+function findLargeCoordinateLineDrawable(group: AcTrBatchedGroup) {
   let drawable: THREE.Object3D | undefined
   group.traverse(child => {
     if (drawable) {
@@ -52,7 +52,7 @@ function getMaxAbsPositionComponent(geometry: THREE.BufferGeometry) {
 }
 
 describe('AcTrLineSegments', () => {
-  it('keeps geometry local and visible in the unbatched group at large coordinates', () => {
+  it('keeps geometry local and visible in a rebased batch at large coordinates', () => {
     const context = new AcTrRenderContext()
     const array = new Float32Array([
       largeX,
@@ -72,12 +72,12 @@ describe('AcTrLineSegments', () => {
     lineEntity.objectId = 'lineseg-large'
     lineEntity.visible = true
 
-    expect(lineEntity.resolveDrawMode()).toBe('unbatch')
+    expect(lineEntity.resolveDrawMode()).toBe('batch')
 
     const group = new AcTrBatchedGroup()
     group.addEntity(lineEntity)
 
-    const drawable = findUnbatchedLineDrawable(group)
+    const drawable = findLargeCoordinateLineDrawable(group)
     expect(
       drawable instanceof THREE.LineSegments ||
         drawable instanceof LineSegments2

--- a/packages/three-renderer/__tests__/AcTrPoint.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrPoint.spec.ts
@@ -32,7 +32,7 @@ function getMaxAbsPositionComponent(geometry: THREE.BufferGeometry) {
   return maxAbs
 }
 
-function findPointSymbolDrawable(group: AcTrBatchedGroup) {
+function findLargeCoordinatePointSymbolDrawable(group: AcTrBatchedGroup) {
   let drawable: THREE.LineSegments | undefined
   group.traverse(child => {
     if (drawable) {
@@ -110,7 +110,7 @@ describe('AcTrPoint large coordinates', () => {
     expect(point.wcsBbox.max.y).toBeGreaterThanOrEqual(2_000_000)
   })
 
-  it('renders large point symbols correctly in the unbatched group', () => {
+  it('renders large point symbols correctly in a rebased batch', () => {
     const pointEntity = new AcTrPoint(
       largePoint,
       defaultTraits,
@@ -120,12 +120,12 @@ describe('AcTrPoint large coordinates', () => {
     pointEntity.objectId = 'point-large'
     pointEntity.visible = true
 
-    expect(pointEntity.resolveDrawMode()).toBe('unbatch')
+    expect(pointEntity.resolveDrawMode()).toBe('batch')
 
     const group = new AcTrBatchedGroup()
     group.addEntity(pointEntity)
 
-    const drawable = findPointSymbolDrawable(group)
+    const drawable = findLargeCoordinatePointSymbolDrawable(group)
     expect(drawable).toBeDefined()
     expect(getMaxAbsPositionComponent(drawable!.geometry)).toBeLessThan(2)
     expect(drawable!.position.x).toBeCloseTo(largePoint.x, 6)

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -2,6 +2,10 @@ import * as THREE from 'three'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
+import {
+  batchOriginOffsetDistance,
+  canMergeIntoBatchOrigin
+} from '../draw/AcTrBatchDrawPolicy'
 import { AcTrPointSymbolCreator } from '../geometry/AcTrPointSymbolCreator'
 import { AcTrEntity } from '../object'
 import { getMaterialMetadata } from '../style/AcTrMaterialMetadata'
@@ -19,15 +23,77 @@ import { AcTrBatchedLine2 } from './AcTrBatchedLine2'
 import { AcTrBatchedMesh } from './AcTrBatchedMesh'
 import { AcTrBatchedPoint } from './AcTrBatchedPoint'
 
+/**
+ * Union of batch container classes resolved by {@link THREE.Object3D.getObjectById}
+ * when {@link AcTrBatchedGroup} performs entity-level operations.
+ *
+ * Covers line, wide-line, and mesh render paths. Each container packs many
+ * entity geometries into shared GPU buffers and exposes per-slot APIs such as
+ * {@link AcTrBatchedLine.setVisibleAt | setVisibleAt},
+ * {@link AcTrBatchedLine.deleteGeometry | deleteGeometry}, and
+ * {@link AcTrBatchedLine.intersectWith | intersectWith}.
+ *
+ * Point batches ({@link AcTrBatchedPoint}) use the same slot-addressing model but
+ * are typed separately where the group needs point-specific behavior.
+ *
+ * @see {@link AcTrOriginBatch} for the superset used in internal batch maps.
+ */
 export type AcTrBatchedObject =
   | AcTrBatchedLine
   | AcTrBatchedLine2
   | AcTrBatchedMesh
 
+/**
+ * Any batch container stored in an origin-split batch map inside
+ * {@link AcTrBatchedGroup}.
+ *
+ * Extends {@link AcTrBatchedObject} with {@link AcTrBatchedPoint}, which renders
+ * CAD point entities as `THREE.Points`. All variants share a stable world-space
+ * {@link AcTrBatchedLine.origin | origin} so vertex data can be rebased for
+ * float32 precision on large-coordinate drawings.
+ */
+type AcTrOriginBatch =
+  | AcTrBatchedLine
+  | AcTrBatchedLine2
+  | AcTrBatchedMesh
+  | AcTrBatchedPoint
+
+/**
+ * Material-keyed registry of batch containers that may be split by world origin.
+ *
+ * - **Key** — Three.js material id (`Material.id`). Geometries with the same
+ *   material are candidates for the same draw call.
+ * - **Value** — One or more batch containers for that material. When geometry
+ *   from distant world regions cannot safely share one rebasing origin, the group
+ *   creates additional containers via {@link AcTrBatchedGroup.resolveOriginBatch}.
+ *
+ * @typeParam T - Concrete batch container type (line, mesh, point, etc.).
+ */
+type AcTrOriginBatchMap<T extends AcTrOriginBatch> = Map<number, T[]>
+
+/**
+ * Reverse lookup from one logical CAD entity to a single geometry slot inside a
+ * batched container.
+ *
+ * A decomposed entity (for example an INSERT or multi-pass layer bucket) may
+ * occupy several slots; {@link AcTrBatchedGroup} stores an array of these entries
+ * per entity object id in `_entitiesMap`.
+ */
 export interface AcTrEntityInBatchedObject {
-  /** Three.js object id of the target batched container. */
+  /**
+   * Three.js object id (`Object3D.id`) of the batched container that owns the slot.
+   *
+   * Used with {@link THREE.Object3D.getObjectById} to retrieve the container
+   * before calling per-slot batch APIs.
+   */
   batchedObjectId: number
-  /** Geometry id inside that batched container. */
+  /**
+   * Stable geometry slot id assigned by the batch container when the entity
+   * geometry was appended.
+   *
+   * Identifies the sub-range inside the packed buffer for visibility toggles,
+   * deletion, raycast filtering, and highlight cloning.
+   */
   batchId: number
 }
 
@@ -88,8 +154,9 @@ export interface AcTrBatchedGroupStats {
  * layer/layout group.
  *
  * Entities are distributed into per-material batch containers (line/mesh/point
- * and wide-line variants), while unsupported render paths are stored in a
- * dedicated unbatched group.
+ * and wide-line variants). Multiple containers may share one material when their
+ * world-space origins are too far apart for safe float32 rebasing. Unsupported
+ * render paths are stored in a dedicated unbatched group.
  */
 export class AcTrBatchedGroup extends THREE.Group {
   private static readonly INITIAL_LINE_VERTEX_CAPACITY = 128
@@ -100,45 +167,45 @@ export class AcTrBatchedGroup extends THREE.Group {
   /**
    * Batched line map for line segments without vertex index.
    * - the key is material id
-   * - the value is one batched line
+   * - the value is one or more batched lines split by world origin
    */
-  private _lineBatches: Map<number, AcTrBatchedLine>
+  private _lineBatches: AcTrOriginBatchMap<AcTrBatchedLine>
   /**
    * Batched line map for lines with vertex index.
    * - the key is material id
-   * - the value is one batched map
+   * - the value is one or more batched lines split by world origin
    */
-  private _lineWithIndexBatches: Map<number, AcTrBatchedLine>
+  private _lineWithIndexBatches: AcTrOriginBatchMap<AcTrBatchedLine>
   /**
    * Batched line map for wide lines rendered as THREE.LineSegments2.
    * - the key is material id
-   * - the value is one batched line2
+   * - the value is one or more batched line2 containers split by world origin
    */
-  private _line2Batches: Map<number, AcTrBatchedLine2>
+  private _line2Batches: AcTrOriginBatchMap<AcTrBatchedLine2>
   /**
    * Batched mesh map for meshes without vertex index.
    * - the key is material id
-   * - the value is one batched map
+   * - the value is one or more batched meshes split by world origin
    */
-  private _meshBatches: Map<number, AcTrBatchedMesh>
+  private _meshBatches: AcTrOriginBatchMap<AcTrBatchedMesh>
   /**
    * Batched mesh map for meshes with vertex index.
    * - the key is material id
-   * - the value is one batched map
+   * - the value is one or more batched meshes split by world origin
    */
-  private _meshWithIndexBatches: Map<number, AcTrBatchedMesh>
+  private _meshWithIndexBatches: AcTrOriginBatchMap<AcTrBatchedMesh>
   /**
    * Batched mesh map for points rendered as THREE.Points
    * - the key is material id
-   * - the value is one batched map
+   * - the value is one or more batched point containers split by world origin
    */
-  private _pointBatches: Map<number, AcTrBatchedPoint>
+  private _pointBatches: AcTrOriginBatchMap<AcTrBatchedPoint>
   /**
    * Batched mesh map for points rendered as THREE.LineSegments
    * - the key is material id
-   * - the value is one batched map
+   * - the value is one or more batched lines split by world origin
    */
-  private _pointSymbolBatches: Map<number, AcTrBatchedLine>
+  private _pointSymbolBatches: AcTrOriginBatchMap<AcTrBatchedLine>
   /**
    * The group to store all of selected entities
    */
@@ -202,28 +269,30 @@ export class AcTrBatchedGroup extends THREE.Group {
       },
       mesh: {
         indexed: {
-          count: this._meshWithIndexBatches.size,
+          count: this.countBatchContainers(this._meshWithIndexBatches),
           geometrySize: this.getBatchedGeometrySize(this._meshWithIndexBatches),
           mappingSize: this.getBatchedGeometryMappingSize(
             this._meshWithIndexBatches
           )
         },
         nonIndexed: {
-          count: this._meshBatches.size,
+          count: this.countBatchContainers(this._meshBatches),
           geometrySize: this.getBatchedGeometrySize(this._meshBatches),
           mappingSize: this.getBatchedGeometryMappingSize(this._meshBatches)
         }
       },
       line: {
         indexed: {
-          count: this._lineWithIndexBatches.size,
+          count: this.countBatchContainers(this._lineWithIndexBatches),
           geometrySize: this.getBatchedGeometrySize(this._lineWithIndexBatches),
           mappingSize: this.getBatchedGeometryMappingSize(
             this._lineWithIndexBatches
           )
         },
         nonIndexed: {
-          count: this._lineBatches.size + this._line2Batches.size,
+          count:
+            this.countBatchContainers(this._lineBatches) +
+            this.countBatchContainers(this._line2Batches),
           geometrySize:
             this.getBatchedGeometrySize(this._lineBatches) +
             this.getBatchedGeometrySize(this._line2Batches),
@@ -234,14 +303,14 @@ export class AcTrBatchedGroup extends THREE.Group {
       },
       point: {
         indexed: {
-          count: this._pointSymbolBatches.size,
+          count: this.countBatchContainers(this._pointSymbolBatches),
           geometrySize: this.getBatchedGeometrySize(this._pointSymbolBatches),
           mappingSize: this.getBatchedGeometryMappingSize(
             this._pointSymbolBatches
           )
         },
         nonIndexed: {
-          count: this._pointBatches.size,
+          count: this.countBatchContainers(this._pointBatches),
           geometrySize: this.getBatchedGeometrySize(this._pointBatches),
           mappingSize: this.getBatchedGeometryMappingSize(this._pointBatches)
         }
@@ -274,14 +343,18 @@ export class AcTrBatchedGroup extends THREE.Group {
     const pointSymbol = creator.create(displayMode)
 
     if (pointSymbol.line) {
-      this._pointSymbolBatches.forEach(item => {
-        item.resetGeometry(displayMode)
+      this._pointSymbolBatches.forEach(batches => {
+        batches.forEach(item => {
+          item.resetGeometry(displayMode)
+        })
       })
     }
 
     const isShowPoint = pointSymbol.point != null
-    this._pointBatches.forEach(item => {
-      item.visible = isShowPoint
+    this._pointBatches.forEach(batches => {
+      batches.forEach(item => {
+        item.visible = isShowPoint
+      })
     })
   }
 
@@ -297,14 +370,11 @@ export class AcTrBatchedGroup extends THREE.Group {
     target.makeEmpty()
     const scratch = new THREE.Box3()
 
-    const unionBatchMap = (
-      map: Map<
-        number,
-        AcTrBatchedLine | AcTrBatchedLine2 | AcTrBatchedMesh | AcTrBatchedPoint
-      >
-    ) => {
-      map.forEach(batch => {
-        batch.unionActiveVisibleBoundingBoxInto(target, options)
+    const unionBatchMap = (map: AcTrOriginBatchMap<AcTrOriginBatch>) => {
+      map.forEach(batches => {
+        batches.forEach(batch => {
+          batch.unionActiveVisibleBoundingBoxInto(target, options)
+        })
       })
     }
 
@@ -334,9 +404,11 @@ export class AcTrBatchedGroup extends THREE.Group {
    */
   clear() {
     this.groups.forEach(group => {
-      group.forEach(value => {
-        value.dispose()
-        value.removeFromParent()
+      group.forEach(batches => {
+        batches.forEach(batch => {
+          batch.dispose()
+          batch.removeFromParent()
+        })
       })
       group.clear()
     })
@@ -357,14 +429,24 @@ export class AcTrBatchedGroup extends THREE.Group {
    * @param material - The new material associated with the batch object
    */
   updateMaterial(oldId: number, material: THREE.Material) {
-    this.groups.forEach(group => {
-      const batch = group.get(oldId)
-      if (batch) {
-        batch.material = material
-        // @ts-expect-error batch is from group and it must be type-safe.
-        group.set(material.id, batch)
+    for (const group of this.groups) {
+      const batches = group.get(oldId)
+      if (!batches) {
+        continue
       }
-    })
+      for (const batch of batches) {
+        batch.material = material
+      }
+      if (material.id !== oldId) {
+        group.delete(oldId)
+        const existing = group.get(material.id)
+        if (existing) {
+          existing.push(...batches)
+        } else {
+          group.set(material.id, batches)
+        }
+      }
+    }
     this._unbatchedObjects.traverse(object => {
       if (!('material' in object)) return
       const drawableUserData = getSceneDrawableUserData(object)
@@ -644,7 +726,7 @@ export class AcTrBatchedGroup extends THREE.Group {
   /**
    * Returns all batch maps managed by this group.
    */
-  protected get groups() {
+  protected get groups(): AcTrOriginBatchMap<AcTrOriginBatch>[] {
     return [
       this._lineBatches,
       this._lineWithIndexBatches,
@@ -764,24 +846,25 @@ export class AcTrBatchedGroup extends THREE.Group {
   ): AcTrEntityInBatchedObject {
     const material = object.material as THREE.Material
     const batches = this.getMatchedLineBatches(object)
-    let batchedLine = batches.get(material.id)
-    if (batchedLine == null) {
-      batchedLine = new AcTrBatchedLine(
-        AcTrBatchedGroup.INITIAL_LINE_VERTEX_CAPACITY,
-        AcTrBatchedGroup.INITIAL_LINE_INDEX_CAPACITY,
-        material
-      )
-      batches.set(material.id, batchedLine)
-      this.add(batchedLine)
-    }
+    const worldOffset = new THREE.Vector3().setFromMatrixPosition(
+      object.matrixWorld
+    )
+    const batchedLine = this.resolveOriginBatch(
+      batches,
+      material.id,
+      worldOffset,
+      () =>
+        new AcTrBatchedLine(
+          AcTrBatchedGroup.INITIAL_LINE_VERTEX_CAPACITY,
+          AcTrBatchedGroup.INITIAL_LINE_INDEX_CAPACITY,
+          material
+        )
+    )
 
     // Bake rotation/scale into geometry, but keep world translation as offset.
     // This preserves block reference transforms while avoiding large Float32 coords.
     const geometry = object.geometry.clone()
     const matrixNoTranslation = object.matrixWorld.clone()
-    const worldOffset = new THREE.Vector3().setFromMatrixPosition(
-      object.matrixWorld
-    )
     matrixNoTranslation.setPosition(0, 0, 0)
     geometry.applyMatrix4(matrixNoTranslation)
     const geometryId = batchedLine.addGeometry(geometry, -1, -1, worldOffset)
@@ -802,20 +885,21 @@ export class AcTrBatchedGroup extends THREE.Group {
     userData: AcTrBatchGeometryUserData
   ): AcTrEntityInBatchedObject {
     const material = object.material as THREE.Material
-    let batchedLine = this._line2Batches.get(material.id)
-    if (batchedLine == null) {
-      batchedLine = new AcTrBatchedLine2(
-        AcTrBatchedGroup.INITIAL_LINE_VERTEX_CAPACITY,
-        material
-      )
-      this._line2Batches.set(material.id, batchedLine)
-      this.add(batchedLine)
-    }
-
-    const matrixNoTranslation = object.matrixWorld.clone()
     const worldOffset = new THREE.Vector3().setFromMatrixPosition(
       object.matrixWorld
     )
+    const batchedLine = this.resolveOriginBatch(
+      this._line2Batches,
+      material.id,
+      worldOffset,
+      () =>
+        new AcTrBatchedLine2(
+          AcTrBatchedGroup.INITIAL_LINE_VERTEX_CAPACITY,
+          material
+        )
+    )
+
+    const matrixNoTranslation = object.matrixWorld.clone()
     matrixNoTranslation.setPosition(0, 0, 0)
     const geometry = this.cloneLineSegments2Geometry(
       object,
@@ -864,30 +948,33 @@ export class AcTrBatchedGroup extends THREE.Group {
     }
 
     const batches = this.getMatchedMeshBatches(object)
-    let batchedMesh = batches.get(material.id)
-    if (batchedMesh == null) {
-      const metadata = getMaterialMetadata(material)
-      const drawOrder = metadata.drawOrder ?? 0
-      batchedMesh = new AcTrBatchedMesh(
-        AcTrBatchedGroup.INITIAL_MESH_VERTEX_CAPACITY,
-        AcTrBatchedGroup.INITIAL_MESH_INDEX_CAPACITY,
-        material
-      )
-      // All CAD geometry lives on the same Z plane, so depth test alone
-      // cannot decide which primitive wins on a shared pixel. Use the
-      // material's explicit draw-order tier, derived from
-      // `AcGiSubEntityTraits.drawOrder`, so hatch fills sit below
-      // linework while wide polylines and text glyph meshes stay at the
-      // normal linework tier.
-      batchedMesh.renderOrder = drawOrder
-      batches.set(material.id, batchedMesh)
-      this.add(batchedMesh)
-    }
-    const geometry = object.geometry.clone()
-    const matrixNoTranslation = object.matrixWorld.clone()
     const worldOffset = new THREE.Vector3().setFromMatrixPosition(
       object.matrixWorld
     )
+    const batchedMesh = this.resolveOriginBatch(
+      batches,
+      material.id,
+      worldOffset,
+      () => {
+        const metadata = getMaterialMetadata(material)
+        const drawOrder = metadata.drawOrder ?? 0
+        const batch = new AcTrBatchedMesh(
+          AcTrBatchedGroup.INITIAL_MESH_VERTEX_CAPACITY,
+          AcTrBatchedGroup.INITIAL_MESH_INDEX_CAPACITY,
+          material
+        )
+        // All CAD geometry lives on the same Z plane, so depth test alone
+        // cannot decide which primitive wins on a shared pixel. Use the
+        // material's explicit draw-order tier, derived from
+        // `AcGiSubEntityTraits.drawOrder`, so hatch fills sit below
+        // linework while wide polylines and text glyph meshes stay at the
+        // normal linework tier.
+        batch.renderOrder = drawOrder
+        return batch
+      }
+    )
+    const geometry = object.geometry.clone()
+    const matrixNoTranslation = object.matrixWorld.clone()
     matrixNoTranslation.setPosition(0, 0, 0)
     geometry.applyMatrix4(matrixNoTranslation)
     const geometryId = batchedMesh.addGeometry(geometry, -1, -1, worldOffset)
@@ -908,21 +995,24 @@ export class AcTrBatchedGroup extends THREE.Group {
     userData: AcTrBatchGeometryUserData
   ): AcTrEntityInBatchedObject {
     const material = object.material as THREE.Material
-    let batchedPoint = this._pointBatches.get(material.id)
-    if (batchedPoint == null) {
-      batchedPoint = new AcTrBatchedPoint(
-        AcTrBatchedGroup.INITIAL_POINT_VERTEX_CAPACITY,
-        material
-      )
-      batchedPoint.visible = object.visible
-      this._pointBatches.set(material.id, batchedPoint)
-      this.add(batchedPoint)
-    }
-    const geometry = object.geometry.clone()
-    const matrixNoTranslation = object.matrixWorld.clone()
     const worldOffset = new THREE.Vector3().setFromMatrixPosition(
       object.matrixWorld
     )
+    const batchedPoint = this.resolveOriginBatch(
+      this._pointBatches,
+      material.id,
+      worldOffset,
+      () => {
+        const batch = new AcTrBatchedPoint(
+          AcTrBatchedGroup.INITIAL_POINT_VERTEX_CAPACITY,
+          material
+        )
+        batch.visible = object.visible
+        return batch
+      }
+    )
+    const geometry = object.geometry.clone()
+    const matrixNoTranslation = object.matrixWorld.clone()
     matrixNoTranslation.setPosition(0, 0, 0)
     geometry.applyMatrix4(matrixNoTranslation)
     const geometryId = batchedPoint.addGeometry(geometry, -1, worldOffset)
@@ -933,6 +1023,98 @@ export class AcTrBatchedGroup extends THREE.Group {
       batchedObjectId: batchedPoint.id,
       batchId: geometryId
     }
+  }
+
+  /**
+   * Resolves an existing batch container for one material and world offset, or
+   * creates a new container when every existing origin is too far away.
+   *
+   * When multiple containers are eligible, picks the one whose established
+   * origin is closest to `worldOffset` so rebased vertex magnitudes stay small.
+   */
+  private resolveOriginBatch<T extends AcTrOriginBatch>(
+    batches: AcTrOriginBatchMap<T>,
+    materialId: number,
+    worldOffset: THREE.Vector3,
+    create: () => T
+  ): T {
+    let list = batches.get(materialId)
+    if (list == null) {
+      list = []
+      batches.set(materialId, list)
+    }
+
+    let best: T | undefined
+    let bestDistance = Infinity
+
+    for (const batch of list) {
+      if (!canMergeIntoBatchOrigin(batch.origin, worldOffset)) {
+        continue
+      }
+
+      const origin = batch.origin
+      if (origin == null) {
+        return batch
+      }
+
+      const distance = batchOriginOffsetDistance(origin, worldOffset)
+      if (distance < bestDistance) {
+        bestDistance = distance
+        best = batch
+      }
+    }
+
+    if (best) {
+      return best
+    }
+
+    const batch = create()
+    list.push(batch)
+    this.add(batch)
+    return batch
+  }
+
+  /**
+   * Counts batch containers across all material keys in one batch map.
+   */
+  private countBatchContainers<T extends AcTrOriginBatch>(
+    map: AcTrOriginBatchMap<T>
+  ) {
+    let count = 0
+    map.forEach(batches => {
+      count += batches.length
+    })
+    return count
+  }
+
+  /**
+   * Estimates geometry memory size for all objects in one batch map.
+   */
+  private getBatchedGeometrySize<T extends AcTrOriginBatch>(
+    batch: AcTrOriginBatchMap<T>
+  ) {
+    let memory = 0
+    batch.forEach(batches => {
+      batches.forEach(value => {
+        memory += this.getGeometrySize(value)
+      })
+    })
+    return memory
+  }
+
+  /**
+   * Estimates mapping metadata memory size for all objects in one batch map.
+   */
+  private getBatchedGeometryMappingSize<T extends AcTrOriginBatch>(
+    batch: AcTrOriginBatchMap<T>
+  ) {
+    let memory = 0
+    batch.forEach(batches => {
+      batches.forEach(item => {
+        memory += item.mappingStats.size
+      })
+    })
+    return memory
   }
 
   /**
@@ -961,40 +1143,6 @@ export class AcTrBatchedGroup extends THREE.Group {
       batches = this._meshWithIndexBatches
     }
     return batches
-  }
-
-  /**
-   * Estimates geometry memory size for all objects in one batch map.
-   */
-  private getBatchedGeometrySize(
-    batch:
-      | Map<number, AcTrBatchedPoint>
-      | Map<number, AcTrBatchedLine>
-      | Map<number, AcTrBatchedLine2>
-      | Map<number, AcTrBatchedMesh>
-  ) {
-    let memory = 0
-    batch.forEach(value => {
-      memory += this.getGeometrySize(value)
-    })
-    return memory
-  }
-
-  /**
-   * Estimates mapping metadata memory size for all objects in one batch map.
-   */
-  private getBatchedGeometryMappingSize(
-    batch:
-      | Map<number, AcTrBatchedPoint>
-      | Map<number, AcTrBatchedLine>
-      | Map<number, AcTrBatchedLine2>
-      | Map<number, AcTrBatchedMesh>
-  ) {
-    let memory = 0
-    batch.forEach(item => {
-      memory += item.mappingStats.size
-    })
-    return memory
   }
 
   /**

--- a/packages/three-renderer/src/batch/AcTrBatchedLine.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine.ts
@@ -135,6 +135,11 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     return this._maxIndexCount - this._nextIndexStart
   }
 
+  /** World-space origin used when rebasing packed vertex data, if established. */
+  get origin() {
+    return this._origin
+  }
+
   /**
    * Allocates packed attribute/index buffers on first geometry insertion.
    *

--- a/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
@@ -76,6 +76,11 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     return this._maxSegmentCount - this._nextSegmentStart
   }
 
+  /** World-space origin used when rebasing packed segment data, if established. */
+  get origin() {
+    return this._origin
+  }
+
   private _initializeGeometry(reference: LineSegmentsGeometry) {
     if (this._geometryInitialized) {
       return

--- a/packages/three-renderer/src/batch/AcTrBatchedMesh.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMesh.ts
@@ -121,6 +121,11 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
     return this._maxIndexCount - this._nextIndexStart
   }
 
+  /** World-space origin used when rebasing packed vertex data, if established. */
+  get origin() {
+    return this._origin
+  }
+
   /**
    * Allocates packed attribute/index buffers on first geometry insertion.
    *

--- a/packages/three-renderer/src/batch/AcTrBatchedPoint.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedPoint.ts
@@ -118,6 +118,11 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
     return this._maxVertexCount - this._nextVertexStart
   }
 
+  /** World-space origin used when rebasing packed vertex data, if established. */
+  get origin() {
+    return this._origin
+  }
+
   /**
    * Allocates packed attribute buffers on first geometry insertion.
    *

--- a/packages/three-renderer/src/draw/AcTrBatchDrawPolicy.ts
+++ b/packages/three-renderer/src/draw/AcTrBatchDrawPolicy.ts
@@ -98,6 +98,51 @@ export function isLargeWorldCoordinatePoint(
 }
 
 /**
+ * Returns whether a world-space offset is too far from an established batch
+ * origin to keep float32 vertex precision when rebasing into shared buffers.
+ *
+ * @param origin - World-space origin already assigned to a batch container.
+ * @param worldOffset - World-space translation for the geometry being appended.
+ * @param threshold - Maximum allowed per-axis delta; defaults to
+ *   {@link RTE_REBASE_THRESHOLD}.
+ */
+/**
+ * Maximum per-axis absolute delta between a batch origin and a world offset.
+ */
+export function batchOriginOffsetDistance(
+  origin: THREE.Vector3,
+  worldOffset: THREE.Vector3
+): number {
+  return Math.max(
+    Math.abs(worldOffset.x - origin.x),
+    Math.abs(worldOffset.y - origin.y),
+    Math.abs(worldOffset.z - origin.z)
+  )
+}
+
+export function exceedsBatchOriginOffset(
+  origin: THREE.Vector3,
+  worldOffset: THREE.Vector3,
+  threshold = RTE_REBASE_THRESHOLD
+): boolean {
+  return batchOriginOffsetDistance(origin, worldOffset) >= threshold
+}
+
+/**
+ * Returns whether geometry with the given world offset can be merged into a
+ * batch that already has (or has not yet established) the supplied origin.
+ *
+ * Empty batches (`origin == null`) always accept the next geometry so it can
+ * define the origin from its bounding-box center.
+ */
+export function canMergeIntoBatchOrigin(
+  origin: THREE.Vector3 | undefined,
+  worldOffset: THREE.Vector3
+): boolean {
+  return origin == null || !exceedsBatchOriginOffset(origin, worldOffset)
+}
+
+/**
  * Computes a representative anchor point from a list of world-space vertices.
  *
  * The anchor is the center of the axis-aligned bounding box that contains all

--- a/packages/three-renderer/src/renderer/AcTrRenderContext.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderContext.ts
@@ -1,6 +1,6 @@
 import {
   AcTrBatchDrawPolicy,
-  defaultBatchDrawPolicy
+  alwaysBatchDrawPolicy
 } from '../draw/AcTrBatchDrawPolicy'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
 
@@ -9,6 +9,12 @@ import { AcTrStyleManager } from '../style/AcTrStyleManager'
  *
  * Bundles material/style access with scene-graph policies so entity instances
  * only hold one reference while each concern stays in its own module.
+ *
+ * Defaults to {@link alwaysBatchDrawPolicy} so entities merge in
+ * {@link AcTrBatchedGroup} whenever possible. Large-coordinate precision is
+ * handled at render time by relative-to-eye rebasing in {@link AcTrRenderer}.
+ * Inject {@link defaultBatchDrawPolicy} only when you need the legacy
+ * coordinate-threshold unbatch path for testing or compatibility.
  */
 export class AcTrRenderContext {
   readonly styleManager: AcTrStyleManager
@@ -16,7 +22,7 @@ export class AcTrRenderContext {
 
   constructor(
     styleManager: AcTrStyleManager = new AcTrStyleManager(),
-    batchDrawPolicy: AcTrBatchDrawPolicy = defaultBatchDrawPolicy
+    batchDrawPolicy: AcTrBatchDrawPolicy = alwaysBatchDrawPolicy
   ) {
     this.styleManager = styleManager
     this.batchDrawPolicy = batchDrawPolicy


### PR DESCRIPTION
## Summary

- Split per-material batch containers by world-space origin when geometry offsets exceed the RTE rebase threshold, keeping float32 vertex data within safe magnitudes for large-coordinate drawings.
- Add batch origin merge helpers (canMergeIntoBatchOrigin, exceedsBatchOriginOffset, batchOriginOffsetDistance) and route new geometry into the nearest eligible origin batch.
- Default AcTrRenderContext to alwaysBatchDrawPolicy so large-coordinate entities stay on the rebased batch path instead of the legacy unbatch fallback; update HTML export and renderer tests accordingly.

## Test plan

- [ ] Run three-renderer unit tests (AcTrBatchDrawPolicy, AcTrBatchedBounds, AcTrLine, AcTrLineSegments, AcTrPoint)
- [ ] Run cad-html-plugin AcExSceneBatchCollector tests for multi-origin batch export
- [ ] Open a large-coordinate DXF/DWG and verify linework, point symbols, and meshes render correctly
- [ ] Export HTML from a drawing with distant geometry regions and confirm WCS coordinates reconstruct correctly