### PR TITLE
feat(html-export): add export options for invisible layers and initial view

### DIFF
--- a/packages/cad-html-exporter-cli/README.md
+++ b/packages/cad-html-exporter-cli/README.md
@@ -37,6 +37,8 @@ pnpm exec cad-html-exporter drawing.dxf --locale zh -o drawing.html
 | `-o, --output <path>` | Output HTML file (default: input name with `.html`) |
 | `--locale <code>` | Embedded viewer locale (`en`, `zh`, …) |
 | `--title <text>` | Title in snapshot metadata / `<title>` |
+| `--no-export-invisible-layers` | Exclude off/frozen layer geometry (default: included) |
+| `--initial-view <fit\|current>` | Initial view when opening HTML (`fit` = zoom extents, default) |
 
 ## How it works
 

--- a/packages/cad-html-exporter-cli/runner/main.ts
+++ b/packages/cad-html-exporter-cli/runner/main.ts
@@ -1,7 +1,9 @@
 import {
   AcApHtmlConvertor,
   packHtml,
-  AcApHtmlSnapshotBuilder
+  AcApHtmlSnapshotBuilder,
+  captureAcApHtmlViewState,
+  resolveAcApHtmlExportOptions
 } from '@mlightcad/cad-html-plugin'
 import { AcApDocManager, AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
 
@@ -10,7 +12,12 @@ declare global {
     exportCadToHtml: (
       fileName: string,
       bytes: Uint8Array,
-      options?: { locale?: string; title?: string }
+      options?: {
+        locale?: string
+        title?: string
+        exportInvisibleLayers?: boolean
+        initialView?: 'fit' | 'current'
+      }
     ) => Promise<string>
   }
 }
@@ -57,16 +64,24 @@ window.exportCadToHtml = async (fileName, bytes, options = {}) => {
   await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
 
   const view = await new AcApHtmlConvertor().prepareAcTrView2dForHtmlExport(
-    docManager.curView
+    docManager.curView,
+    resolveAcApHtmlExportOptions(options)
   )
 
+  const resolved = resolveAcApHtmlExportOptions(options)
   const snapshot = await new AcApHtmlSnapshotBuilder().buildAsync(
     view.cadScene,
     docManager.curDocument.database,
     {
       title: options.title ?? fileName,
       background: view.backgroundColor,
-      locale: options.locale
+      locale: options.locale,
+      exportInvisibleLayers: resolved.exportInvisibleLayers,
+      initialView: resolved.initialView,
+      viewState:
+        resolved.initialView === 'current'
+          ? captureAcApHtmlViewState(view)
+          : undefined
     }
   )
 

--- a/packages/cad-html-exporter-cli/src/cli.ts
+++ b/packages/cad-html-exporter-cli/src/cli.ts
@@ -19,12 +19,26 @@ program
   )
   .option('--locale <code>', 'UI locale embedded in HTML (e.g. en, zh)', 'en')
   .option('--title <text>', 'Drawing title in exported metadata')
+  .option(
+    '--no-export-invisible-layers',
+    'Exclude off/frozen layer geometry from the exported HTML'
+  )
+  .option(
+    '--initial-view <mode>',
+    'Initial view when opening HTML: fit (zoom extents) or current',
+    'fit'
+  )
   .action(async (input: string, opts) => {
     try {
+      const initialView =
+        opts.initialView === 'current' ? 'current' : ('fit' as const)
       const outputPath = await exportToHtml(path.resolve(input), {
         outputPath: opts.output ? path.resolve(opts.output) : undefined,
         locale: opts.locale,
-        title: opts.title
+        title: opts.title,
+        exportInvisibleLayers:
+          opts.exportInvisibleLayers === false ? false : undefined,
+        initialView
       })
       console.log(`Wrote ${outputPath}`)
     } catch (error) {

--- a/packages/cad-html-exporter-cli/src/exportToHtml.ts
+++ b/packages/cad-html-exporter-cli/src/exportToHtml.ts
@@ -11,7 +11,12 @@ declare global {
     exportCadToHtml: (
       fileName: string,
       bytes: Uint8Array,
-      options?: { locale?: string; title?: string }
+      options?: {
+        locale?: string
+        title?: string
+        exportInvisibleLayers?: boolean
+        initialView?: 'fit' | 'current'
+      }
     ) => Promise<string>
   }
 }
@@ -20,6 +25,8 @@ export interface ExportToHtmlOptions {
   outputPath?: string
   locale?: string
   title?: string
+  exportInvisibleLayers?: boolean
+  initialView?: 'fit' | 'current'
 }
 
 function runnerDistDir(): string {
@@ -127,19 +134,26 @@ export async function exportToHtml(
     await page.goto(`${server.url}/index.html`, { waitUntil: 'networkidle' })
 
     const html = await page.evaluate(
-      async ({ name, data, locale, title }) => {
+      async ({ name, data, locale, title, exportInvisibleLayers, initialView }) => {
         const binary = atob(data)
         const bytes = new Uint8Array(binary.length)
         for (let i = 0; i < binary.length; i++) {
           bytes[i] = binary.charCodeAt(i)
         }
-        return window.exportCadToHtml(name, bytes, { locale, title })
+        return window.exportCadToHtml(name, bytes, {
+          locale,
+          title,
+          exportInvisibleLayers,
+          initialView
+        })
       },
       {
         name: fileName,
         data: base64,
         locale: options.locale,
-        title: options.title ?? fileName
+        title: options.title ?? fileName,
+        exportInvisibleLayers: options.exportInvisibleLayers,
+        initialView: options.initialView
       }
     )
 

--- a/packages/cad-html-plugin/__tests__/AcApHtmlConvertor.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcApHtmlConvertor.spec.ts
@@ -46,6 +46,9 @@ describe('AcApHtmlConvertor', () => {
 
       expect(prepared).toBe(view)
       expect(ensureEntitiesConvertedForExport).toHaveBeenCalledTimes(1)
+      expect(ensureEntitiesConvertedForExport).toHaveBeenCalledWith({
+        includeInvisibleLayers: true
+      })
     })
   })
 })

--- a/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
+++ b/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
@@ -1,26 +1,140 @@
-import { AcApContext, AcEdCommand } from '@mlightcad/cad-simple-viewer'
+import {
+  AcApContext,
+  AcApDocManager,
+  AcApI18n,
+  AcEdCommand,
+  AcEdPromptKeywordOptions,
+  AcEdPromptStatus
+} from '@mlightcad/cad-simple-viewer'
 
 import { AcApHtmlConvertor } from './AcApHtmlConvertor'
+import {
+  type AcApHtmlExportOptions,
+  resolveAcApHtmlExportOptions
+} from './AcApHtmlExportOptions'
 
 /**
  * Editor command that exports the active drawing as a self-contained HTML file.
  *
  * The command delegates to {@link AcApHtmlConvertor}, which serializes the
  * current Three.js scene into an {@link AcExSnapshot} HTML snapshot,
- * bundles the offline viewer runtime, and triggers a browser download. No
- * prompts are shown; the output filename is derived from the document name.
+ * bundles the offline viewer runtime, and triggers a browser download.
  */
 export class AcApExportHtmlCmd extends AcEdCommand {
   /**
    * Runs the HTML export workflow for the drawing in `context`.
    *
-   * @param context - Active application context; only `context.doc.fileName` is
-   *   used today to suggest the downloaded file name.
+   * @param context - Active application context used for prompts and export.
    * @returns Resolves when the HTML file has been generated and the download
    *   has been initiated, or rejects if runtime loading or packaging fails.
    */
   async execute(context: AcApContext) {
+    const options = await this.promptOptions()
+    if (!options) {
+      return
+    }
+
     const converter = new AcApHtmlConvertor()
-    await converter.convert(context.doc.fileName || context.doc.docTitle)
+    await converter.convert(
+      context.doc.fileName || context.doc.docTitle,
+      options,
+      context.view
+    )
+  }
+
+  private async promptOptions(): Promise<AcApHtmlExportOptions | undefined> {
+    const exportInvisibleLayers = await this.promptExportInvisibleLayers()
+    if (exportInvisibleLayers === undefined) {
+      return undefined
+    }
+
+    const initialView = await this.promptInitialView()
+    if (initialView === undefined) {
+      return undefined
+    }
+
+    return resolveAcApHtmlExportOptions({
+      exportInvisibleLayers,
+      initialView
+    })
+  }
+
+  private async promptExportInvisibleLayers(): Promise<boolean | undefined> {
+    const defaults = resolveAcApHtmlExportOptions()
+    const current = defaults.exportInvisibleLayers ? 'Yes' : 'No'
+    const prompt = new AcEdPromptKeywordOptions(
+      `${AcApI18n.t('jig.chtml.exportInvisibleLayers')} <${current}>`
+    )
+    prompt.allowNone = true
+    prompt.keywords.add(
+      AcApI18n.t('jig.chtml.keywords.yes.display'),
+      AcApI18n.t('jig.chtml.keywords.yes.global'),
+      AcApI18n.t('jig.chtml.keywords.yes.local')
+    )
+    prompt.keywords.add(
+      AcApI18n.t('jig.chtml.keywords.no.display'),
+      AcApI18n.t('jig.chtml.keywords.no.global'),
+      AcApI18n.t('jig.chtml.keywords.no.local')
+    )
+
+    const result = await AcApDocManager.instance.editor.getKeywords(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) {
+      return undefined
+    }
+    if (result.status === AcEdPromptStatus.None) {
+      return defaults.exportInvisibleLayers
+    }
+    if (
+      result.status === AcEdPromptStatus.OK ||
+      result.status === AcEdPromptStatus.Keyword
+    ) {
+      if (!result.stringResult) {
+        return defaults.exportInvisibleLayers
+      }
+      return result.stringResult === 'Yes'
+    }
+    return undefined
+  }
+
+  private async promptInitialView(): Promise<
+    AcApHtmlExportOptions['initialView'] | undefined
+  > {
+    const defaults = resolveAcApHtmlExportOptions()
+    const current =
+      defaults.initialView === 'current'
+        ? AcApI18n.t('jig.chtml.keywords.current.global')
+        : AcApI18n.t('jig.chtml.keywords.extents.global')
+    const prompt = new AcEdPromptKeywordOptions(
+      `${AcApI18n.t('jig.chtml.initialView')} <${current}>`
+    )
+    prompt.allowNone = true
+    prompt.keywords.add(
+      AcApI18n.t('jig.chtml.keywords.extents.display'),
+      AcApI18n.t('jig.chtml.keywords.extents.global'),
+      AcApI18n.t('jig.chtml.keywords.extents.local')
+    )
+    prompt.keywords.add(
+      AcApI18n.t('jig.chtml.keywords.current.display'),
+      AcApI18n.t('jig.chtml.keywords.current.global'),
+      AcApI18n.t('jig.chtml.keywords.current.local')
+    )
+
+    const result = await AcApDocManager.instance.editor.getKeywords(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) {
+      return undefined
+    }
+    if (result.status === AcEdPromptStatus.None) {
+      return defaults.initialView
+    }
+    if (
+      result.status === AcEdPromptStatus.OK ||
+      result.status === AcEdPromptStatus.Keyword
+    ) {
+      if (!result.stringResult) {
+        return defaults.initialView
+      }
+      return result.stringResult === 'Current' ? 'current' : 'fit'
+    }
+    return undefined
   }
 }

--- a/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
@@ -7,6 +7,11 @@ import {
   yieldToMain
 } from '@mlightcad/cad-simple-viewer'
 
+import {
+  type AcApHtmlExportOptions,
+  captureAcApHtmlViewState,
+  resolveAcApHtmlExportOptions
+} from './AcApHtmlExportOptions'
 import { AcApHtmlSnapshotBuilder } from './AcApHtmlSnapshotBuilder'
 import { packHtml } from './AcExHtmlPackager'
 import type { AcExSnapshot } from './AcExSnapshotTypes'
@@ -40,7 +45,8 @@ export class AcApHtmlConvertor {
    * live scene after export completes.
    */
   async prepareAcTrView2dForHtmlExport(
-    view: AcEdBaseView | null | undefined
+    view: AcEdBaseView | null | undefined,
+    options: Pick<AcApHtmlExportOptions, 'exportInvisibleLayers'> = {}
   ): Promise<AcTrView2d> {
     if (!view || !('cadScene' in view) || !view.cadScene) {
       throw new Error(
@@ -52,7 +58,10 @@ export class AcApHtmlConvertor {
         'HTML export requires a 2D CAD view. Open a drawing before exporting.'
       )
     }
-    await view.ensureEntitiesConvertedForExport()
+    const resolved = resolveAcApHtmlExportOptions(options)
+    await view.ensureEntitiesConvertedForExport({
+      includeInvisibleLayers: resolved.exportInvisibleLayers
+    })
     await yieldToMain()
     return view
   }
@@ -63,25 +72,41 @@ export class AcApHtmlConvertor {
    * @param fileName - Optional base name for the download (without extension).
    *   When omitted, the active document's `fileName` is used. A `.html` suffix
    *   is always applied; `.dwg` / `.dxf` suffixes on the input are stripped.
+   * @param options - Export options such as invisible-layer inclusion and initial view.
+   * @param view - Optional view to export from. Defaults to the active view.
    * @returns Resolves when packaging and download complete.
    */
-  async convert(fileName?: string) {
+  async convert(
+    fileName?: string,
+    options: AcApHtmlExportOptions = {},
+    view?: AcEdBaseView | null
+  ) {
     const docManager = AcApDocManager.instance
+    const resolved = resolveAcApHtmlExportOptions(options)
     docManager.showBusyIndicator()
 
     try {
       await yieldToMain()
 
       const document = docManager.curDocument
-      const view = await this.prepareAcTrView2dForHtmlExport(docManager.curView)
+      const exportView = await this.prepareAcTrView2dForHtmlExport(
+        view ?? docManager.curView,
+        resolved
+      )
 
       const sourceName = fileName || document.fileName || document.docTitle
       const snapshot = await this._snapshotBuilder.buildAsync(
-        view.cadScene,
+        exportView.cadScene,
         document.database,
         {
           title: getDrawingExportBaseName(sourceName),
-          background: view.backgroundColor
+          background: exportView.backgroundColor,
+          exportInvisibleLayers: resolved.exportInvisibleLayers,
+          initialView: resolved.initialView,
+          viewState:
+            resolved.initialView === 'current'
+              ? captureAcApHtmlViewState(exportView)
+              : undefined
         }
       )
 

--- a/packages/cad-html-plugin/src/AcApHtmlExportOptions.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlExportOptions.ts
@@ -1,0 +1,54 @@
+import type { AcTrView2d } from '@mlightcad/cad-simple-viewer'
+
+import type {
+  AcExInitialViewMode,
+  AcExViewState
+} from './AcExSnapshotTypes'
+
+/** Matches the offline HTML viewer orthographic half-height in world units. */
+const HTML_VIEWER_CAMERA_FRUSTUM = 400
+
+/**
+ * User-configurable options for HTML export (`chtml` and CLI).
+ */
+export interface AcApHtmlExportOptions {
+  /**
+   * When `true`, off/frozen layers are converted and written into the snapshot.
+   * Defaults to `true` for backward compatibility with pre-option HTML export.
+   */
+  exportInvisibleLayers?: boolean
+  /**
+   * Initial framing when the exported HTML is opened. Defaults to `'fit'`.
+   */
+  initialView?: AcExInitialViewMode
+}
+
+/**
+ * Resolves export options with package defaults.
+ */
+export function resolveAcApHtmlExportOptions(
+  options: AcApHtmlExportOptions = {}
+): Required<AcApHtmlExportOptions> {
+  return {
+    exportInvisibleLayers: options.exportInvisibleLayers !== false,
+    initialView: options.initialView ?? 'fit'
+  }
+}
+
+/**
+ * Captures the active 2D view as camera state understood by the offline viewer.
+ */
+export function captureAcApHtmlViewState(view: AcTrView2d): AcExViewState {
+  const layoutView = view.activeLayoutView
+  const center = layoutView.center
+  const zoomMain = layoutView.trCamera.zoom
+  const height = Math.max(layoutView.height, 1)
+  const zoom =
+    (zoomMain * (2 * HTML_VIEWER_CAMERA_FRUSTUM)) / height
+
+  return {
+    centerX: center.x,
+    centerY: center.y,
+    zoom
+  }
+}

--- a/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
@@ -10,11 +10,13 @@ import { buildOsnapCatalog } from './AcExOsnapPrimitiveBuilder'
 import { collectBatchesFromObject3D } from './AcExSceneBatchCollector'
 import {
   ACEX_SNAPSHOT_VERSION,
+  type AcExInitialViewMode,
   type AcExLayerSnapshot,
   type AcExLayoutSnapshot,
   type AcExLineBatch,
   type AcExMeshBatch,
-  type AcExSnapshot
+  type AcExSnapshot,
+  type AcExViewState
 } from './AcExSnapshotTypes'
 import { buildViewerMetadata } from './AcExViewerMetadata'
 
@@ -37,6 +39,20 @@ export interface AcApHtmlSnapshotBuilderOptions {
    * Defaults to {@link AcApI18n.currentLocale} when omitted.
    */
   locale?: string
+  /**
+   * When `false`, geometry and layer-table entries for off/frozen layers are
+   * omitted from the snapshot. Defaults to `true`.
+   */
+  exportInvisibleLayers?: boolean
+  /**
+   * Initial framing when the exported HTML is opened. Defaults to `'fit'`.
+   */
+  initialView?: AcExInitialViewMode
+  /**
+   * Saved view center and zoom when {@link AcApHtmlSnapshotBuilderOptions.initialView}
+   * is `'current'`.
+   */
+  viewState?: AcExViewState
 }
 
 /**
@@ -83,6 +99,11 @@ export class AcApHtmlSnapshotBuilder {
   ): Promise<AcExSnapshot> {
     await yieldToMain()
 
+    const exportInvisibleLayers = options.exportInvisibleLayers !== false
+    const includeLayer = exportInvisibleLayers
+      ? undefined
+      : (layerName: string) =>
+          shouldExportLayer(scene, layerName, exportInvisibleLayers)
     const meta = buildViewerMetadata(database, {
       title: options.title,
       background: options.background
@@ -90,6 +111,9 @@ export class AcApHtmlSnapshotBuilder {
 
     const layers: AcExLayerSnapshot[] = []
     scene.layers.forEach(layer => {
+      if (!shouldExportLayer(scene, layer.name, exportInvisibleLayers)) {
+        return
+      }
       layers.push({
         name: layer.name,
         color: layer.color.RGB ?? 0xffffff,
@@ -102,6 +126,9 @@ export class AcApHtmlSnapshotBuilder {
       const lineBatches: AcExLineBatch[] = []
       const meshBatches: AcExMeshBatch[] = []
       for (const [, layer] of layout.layers) {
+        if (!shouldExportLayer(scene, layer.name, exportInvisibleLayers)) {
+          continue
+        }
         const collected = collectBatchesFromObject3D(layer.internalObject)
         lineBatches.push(...collected.lineBatches)
         meshBatches.push(...collected.meshBatches)
@@ -113,7 +140,7 @@ export class AcApHtmlSnapshotBuilder {
         isModelSpace: btrId === scene.modelSpaceBtrId,
         lineBatches,
         meshBatches,
-        osnap: buildOsnapCatalog(database, btrId)
+        osnap: buildOsnapCatalog(database, btrId, { includeLayer })
       })
       await yieldToMain()
     }
@@ -145,6 +172,11 @@ export class AcApHtmlSnapshotBuilder {
     database: AcDbDatabase,
     options: AcApHtmlSnapshotBuilderOptions
   ): AcExSnapshot {
+    const exportInvisibleLayers = options.exportInvisibleLayers !== false
+    const includeLayer = exportInvisibleLayers
+      ? undefined
+      : (layerName: string) =>
+          shouldExportLayer(scene, layerName, exportInvisibleLayers)
     const meta = buildViewerMetadata(database, {
       title: options.title,
       background: options.background
@@ -152,6 +184,9 @@ export class AcApHtmlSnapshotBuilder {
 
     const layers: AcExLayerSnapshot[] = []
     scene.layers.forEach(layer => {
+      if (!shouldExportLayer(scene, layer.name, exportInvisibleLayers)) {
+        return
+      }
       layers.push({
         name: layer.name,
         color: layer.color.RGB ?? 0xffffff,
@@ -161,16 +196,23 @@ export class AcApHtmlSnapshotBuilder {
 
     const layouts: AcExLayoutSnapshot[] = []
     scene.layouts.forEach((layout, btrId) => {
-      const { lineBatches, meshBatches } = collectBatchesFromObject3D(
-        layout.internalObject
-      )
+      const lineBatches: AcExLineBatch[] = []
+      const meshBatches: AcExMeshBatch[] = []
+      for (const [, layer] of layout.layers) {
+        if (!shouldExportLayer(scene, layer.name, exportInvisibleLayers)) {
+          continue
+        }
+        const collected = collectBatchesFromObject3D(layer.internalObject)
+        lineBatches.push(...collected.lineBatches)
+        meshBatches.push(...collected.meshBatches)
+      }
       layouts.push({
         btrId,
         name: resolveLayoutName(database, btrId),
         isModelSpace: btrId === scene.modelSpaceBtrId,
         lineBatches,
         meshBatches,
-        osnap: buildOsnapCatalog(database, btrId)
+        osnap: buildOsnapCatalog(database, btrId, { includeLayer })
       })
     })
 
@@ -209,6 +251,7 @@ function buildSnapshotMeta(
   const viewExtents = activeLayout
     ? computeLayoutExtents(activeLayout.lineBatches, activeLayout.meshBatches)
     : null
+  const initialView = options.initialView ?? 'fit'
 
   return {
     title: meta.title,
@@ -217,8 +260,27 @@ function buildSnapshotMeta(
     viewExtents: viewExtents ?? undefined,
     units: meta.units,
     background: meta.background,
-    locale: options.locale ?? AcApI18n.currentLocale
+    locale: options.locale ?? AcApI18n.currentLocale,
+    initialView,
+    viewState: initialView === 'current' ? options.viewState : undefined
   }
+}
+
+function shouldExportLayer(
+  scene: AcTrScene,
+  layerName: string,
+  exportInvisibleLayers: boolean
+): boolean {
+  if (exportInvisibleLayers) {
+    return true
+  }
+
+  const layer = scene.layers.get(layerName)
+  if (!layer) {
+    return true
+  }
+
+  return !layer.isOff && !layer.isFrozen
 }
 
 /**

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -387,7 +387,13 @@ function startViewer(): void {
   })
 
   resize()
-  fit()
+  if (snapshot.meta.initialView === 'current' && snapshot.meta.viewState) {
+    const { centerX, centerY, zoom } = snapshot.meta.viewState
+    flyTo(centerX, centerY, zoom)
+    render()
+  } else {
+    fit()
+  }
   releaseLayerGroupsGeometryCpuArrays(layerGroups)
   measure.refreshIdleStatus()
   hideLoading()

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
@@ -1025,14 +1025,18 @@ function visitTableEntity(
   insertLayer: string,
   out: AcExOsnapPrimitive[],
   blockStack: Set<AcDbObjectId>,
-  database: AcDbDatabase
+  database: AcDbDatabase,
+  includeLayer?: (layerName: string) => boolean
 ) {
   const layer = effectiveLayer(entity.layer, insertLayer)
+  if (includeLayer && !includeLayer(layer)) {
+    return
+  }
   const block = resolveTableBlock(entity, database)
   if (block && !blockStack.has(block.objectId) && blockHasEntities(block)) {
     blockStack.add(block.objectId)
     const nested = composeTransforms(matrix, blockInsertTransform(entity))
-    visitBlock(block, nested, layer, out, blockStack, database)
+    visitBlock(block, nested, layer, out, blockStack, database, includeLayer)
     blockStack.delete(block.objectId)
     return
   }
@@ -1101,14 +1105,26 @@ function visitEntity(
   insertLayer: string,
   out: AcExOsnapPrimitive[],
   blockStack: Set<AcDbObjectId>,
-  database: AcDbDatabase
+  database: AcDbDatabase,
+  includeLayer?: (layerName: string) => boolean
 ) {
   if (!entity.visibility) return
 
   const layer = effectiveLayer(entity.layer, insertLayer)
+  if (includeLayer && !includeLayer(layer)) {
+    return
+  }
 
   if (entity instanceof AcDbTable) {
-    visitTableEntity(entity, matrix, insertLayer, out, blockStack, database)
+    visitTableEntity(
+      entity,
+      matrix,
+      insertLayer,
+      out,
+      blockStack,
+      database,
+      includeLayer
+    )
     return
   }
 
@@ -1118,7 +1134,15 @@ function visitEntity(
     blockStack.add(block.objectId)
     const nested = composeTransforms(matrix, entity.getFullInsertionTransform())
     const blockInsertLayer = effectiveLayer(entity.layer, insertLayer)
-    visitBlock(block, nested, blockInsertLayer, out, blockStack, database)
+    visitBlock(
+      block,
+      nested,
+      blockInsertLayer,
+      out,
+      blockStack,
+      database,
+      includeLayer
+    )
     blockStack.delete(block.objectId)
     return
   }
@@ -1132,7 +1156,7 @@ function visitEntity(
       matrix,
       dimension.getFullDimBlockTransform()
     )
-    visitBlock(block, nested, layer, out, blockStack, database)
+    visitBlock(block, nested, layer, out, blockStack, database, includeLayer)
     blockStack.delete(block.objectId)
     return
   }
@@ -1285,10 +1309,19 @@ function visitBlock(
   insertLayer: string,
   out: AcExOsnapPrimitive[],
   blockStack: Set<AcDbObjectId>,
-  database: AcDbDatabase
+  database: AcDbDatabase,
+  includeLayer?: (layerName: string) => boolean
 ) {
   for (const entity of block.newIterator()) {
-    visitEntity(entity, matrix, insertLayer, out, blockStack, database)
+    visitEntity(
+      entity,
+      matrix,
+      insertLayer,
+      out,
+      blockStack,
+      database,
+      includeLayer
+    )
   }
 }
 
@@ -1344,9 +1377,15 @@ function ellipseFromArc(entity: AcDbArc): AcDbEllipse {
  * layoutSnapshot.osnap = osnap
  * ```
  */
+export interface AcExOsnapCatalogOptions {
+  /** When set, only entities on layers for which this returns `true` are exported. */
+  includeLayer?: (layerName: string) => boolean
+}
+
 export function buildOsnapCatalog(
   database: AcDbDatabase,
-  layoutBtrId: string
+  layoutBtrId: string,
+  options: AcExOsnapCatalogOptions = {}
 ): AcExOsnapCatalog {
   const block = resolveLayoutBlock(database, layoutBtrId)
   if (!block) {
@@ -1355,6 +1394,14 @@ export function buildOsnapCatalog(
 
   const primitives: AcExOsnapPrimitive[] = []
   const identity = new THREE.Matrix4()
-  visitBlock(block, identity, '0', primitives, new Set(), database)
+  visitBlock(
+    block,
+    identity,
+    '0',
+    primitives,
+    new Set(),
+    database,
+    options.includeLayer
+  )
   return { primitives }
 }

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -220,6 +220,19 @@ export interface AcExLayoutSnapshot {
   osnap?: AcExOsnapCatalog
 }
 
+/** Camera state for restoring the export-time view in the offline HTML viewer. */
+export interface AcExViewState {
+  /** View center X in world coordinates. */
+  centerX: number
+  /** View center Y in world coordinates. */
+  centerY: number
+  /** Orthographic zoom scaled for the offline viewer frustum. */
+  zoom: number
+}
+
+/** How the offline HTML viewer frames the drawing on first open. */
+export type AcExInitialViewMode = 'fit' | 'current'
+
 /**
  * Display-only snapshot embedded in exported HTML.
  * Does not contain DXF/DWG bytes, `AcDb` entity records, or editable drawing state.
@@ -250,6 +263,16 @@ export interface AcExSnapshot {
     background: number
     /** Export-time UI locale from the CAD app (informational; runtime uses browser language). */
     locale?: string
+    /**
+     * Initial framing when the HTML file opens. Defaults to `'fit'` when omitted
+     * for snapshots produced before this option existed.
+     */
+    initialView?: AcExInitialViewMode
+    /**
+     * Saved view center and zoom when {@link AcExSnapshot.meta.initialView} is
+     * `'current'`.
+     */
+    viewState?: AcExViewState
   }
   /** Layer table used by the layer drawer (visibility toggles, swatches). */
   layers: AcExLayerSnapshot[]

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -54,6 +54,11 @@ export const HTML_VIEWER_RUNTIME_FILE = 'viewer-runtime.iife.js'
 export { AcApExportHtmlCmd } from './AcApExportHtmlCmd'
 export { AcApHtmlConvertor } from './AcApHtmlConvertor'
 export {
+  type AcApHtmlExportOptions,
+  captureAcApHtmlViewState,
+  resolveAcApHtmlExportOptions
+} from './AcApHtmlExportOptions'
+export {
   AcApHtmlSnapshotBuilder,
   type AcApHtmlSnapshotBuilderOptions
 } from './AcApHtmlSnapshotBuilder'

--- a/packages/cad-simple-viewer/__tests__/AcTrEntityDisplayController.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrEntityDisplayController.spec.ts
@@ -189,4 +189,35 @@ describe('AcTrEntityDisplayController', () => {
 
     expect(pending.map(entity => entity.objectId)).toEqual(['line-off'])
   })
+
+  it('collectMissingEntitiesForExport skips off-layer entities when invisible layers are excluded', () => {
+    const offLayer = {
+      name: 'off',
+      isOff: true,
+      isFrozen: false,
+      color: new AcCmColor()
+    }
+    const onLayer = {
+      name: '0',
+      isOff: false,
+      isFrozen: false,
+      color: new AcCmColor()
+    }
+    const controller = new AcTrEntityDisplayController(name =>
+      name === 'off' ? offLayer : onLayer
+    )
+    const blockTableRecord = createBlockTableRecord([
+      createDbEntity('line-off', 'off'),
+      createDbEntity('line-visible', '0')
+    ])
+    const rendered = new Set<string>()
+
+    const pending = controller.collectMissingEntitiesForExport(
+      blockTableRecord,
+      objectId => rendered.has(objectId),
+      false
+    )
+
+    expect(pending.map(entity => entity.objectId)).toEqual(['line-visible'])
+  })
 })

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -985,5 +985,31 @@ export default {
         global: 'Window'
       }
     }
+  },
+  chtml: {
+    exportInvisibleLayers: 'Export invisible layers',
+    initialView: 'Initial view when opening HTML',
+    keywords: {
+      yes: {
+        display: 'Yes(Y)',
+        local: 'Yes',
+        global: 'Yes'
+      },
+      no: {
+        display: 'No(N)',
+        local: 'No',
+        global: 'No'
+      },
+      extents: {
+        display: 'Extents(E)',
+        local: 'Extents',
+        global: 'Extents'
+      },
+      current: {
+        display: 'Current(C)',
+        local: 'Current',
+        global: 'Current'
+      }
+    }
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -974,5 +974,31 @@ export default {
         global: 'Window'
       }
     }
+  },
+  chtml: {
+    exportInvisibleLayers: '是否导出不可见图层',
+    initialView: '打开 HTML 时的初始视图',
+    keywords: {
+      yes: {
+        display: '是(Y)',
+        local: '是',
+        global: 'Yes'
+      },
+      no: {
+        display: '否(N)',
+        local: '否',
+        global: 'No'
+      },
+      extents: {
+        display: '范围(E)',
+        local: '范围',
+        global: 'Extents'
+      },
+      current: {
+        display: '当前(C)',
+        local: '当前',
+        global: 'Current'
+      }
+    }
   }
 }

--- a/packages/cad-simple-viewer/src/view/AcTrEntityDisplayController.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrEntityDisplayController.ts
@@ -50,8 +50,24 @@ export class AcTrEntityDisplayController {
    * Export snapshots carry layer on/off state separately; geometry for off layers
    * must still be present so the HTML layer panel can toggle visibility.
    */
-  shouldConvertForExport(entity: AcTrEntityDisplayCandidate): boolean {
-    return entity.visibility
+  shouldConvertForExport(
+    entity: AcTrEntityDisplayCandidate,
+    includeInvisibleLayers = true
+  ): boolean {
+    if (!entity.visibility) {
+      return false
+    }
+
+    if (includeInvisibleLayers) {
+      return true
+    }
+
+    const layer = this.getLayerInfo(entity.layer)
+    if (!layer) {
+      return true
+    }
+
+    return AcTrLayer.isLayerVisible(layer)
   }
 
   /**
@@ -85,10 +101,11 @@ export class AcTrEntityDisplayController {
    */
   collectMissingEntitiesForExport(
     blockTableRecord: AcDbBlockTableRecord,
-    hasEntity: (objectId: AcDbObjectId) => boolean
+    hasEntity: (objectId: AcDbObjectId) => boolean,
+    includeInvisibleLayers = true
   ): AcDbEntity[] {
     return this.collectMissingEntities(blockTableRecord, hasEntity, entity =>
-      this.shouldConvertForExport(entity)
+      this.shouldConvertForExport(entity, includeInvisibleLayers)
     )
   }
 

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -724,7 +724,10 @@ export class AcTrView2d extends AcEdBaseView {
    *
    * Converted geometry remains in the live scene after this call completes.
    */
-  async ensureEntitiesConvertedForExport() {
+  async ensureEntitiesConvertedForExport(options?: {
+    includeInvisibleLayers?: boolean
+  }) {
+    const includeInvisibleLayers = options?.includeInvisibleLayers !== false
     const db = AcApDocManager.instance.curDocument.database
     const pending: AcDbEntity[] = []
 
@@ -736,7 +739,8 @@ export class AcTrView2d extends AcEdBaseView {
       pending.push(
         ...this._entityDisplay.collectMissingEntitiesForExport(
           blockTableRecord,
-          objectId => this.hasEntity(objectId)
+          objectId => this.hasEntity(objectId),
+          includeInvisibleLayers
         )
       )
     }


### PR DESCRIPTION
## Summary

- Add `chtml` interactive prompts and CLI flags for excluding off/frozen layer geometry and choosing initial view (`fit` vs `current`).
- Capture export-time camera state and restore it in the offline HTML viewer when `initialView` is `current`.
- Filter OSNAP catalog consistently when invisible layers are excluded.
- Treat Enter as accept-default on export keyword prompts; fix Commander negated flag handling for `--no-export-invisible-layers`.

## Test plan

- [x] `pnpm test -- packages/cad-html-plugin/__tests__/AcApHtmlConvertor.spec.ts packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts packages/cad-simple-viewer/__tests__/AcTrEntityDisplayController.spec.ts`
- [ ] Run `chtml` and confirm prompts accept Enter for defaults
- [ ] Export with `--no-export-invisible-layers` and verify geometry + OSNAP omit off/frozen layers
- [ ] Export with `--initial-view current` and verify offline viewer opens at export-time view