### PR TITLE
fix(html-export): set default keywords on export prompts

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcApExportHtmlCmd.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcApExportHtmlCmd.spec.ts
@@ -1,0 +1,154 @@
+jest.mock('@mlightcad/cad-simple-viewer', () => {
+  class AcEdCommand {}
+
+  class MockKeywordCollection {
+    default: unknown
+    add(display: string, global: string, local: string) {
+      return { display, global, local, enabled: true, visible: true }
+    }
+  }
+
+  class AcEdPromptKeywordOptions {
+    allowNone = false
+    keywords = new MockKeywordCollection()
+
+    constructor(readonly message: string) {}
+  }
+
+  return {
+    AcApContext: {},
+    AcApDocManager: {
+      instance: {
+        editor: {
+          getKeywords: jest.fn()
+        }
+      }
+    },
+    AcApI18n: {
+      t: (key: string) => {
+        const globals: Record<string, string> = {
+          'jig.chtml.keywords.yes.global': 'Yes',
+          'jig.chtml.keywords.no.global': 'No',
+          'jig.chtml.keywords.extents.global': 'Extents',
+          'jig.chtml.keywords.current.global': 'Current'
+        }
+        return globals[key] ?? key
+      }
+    },
+    AcEdCommand,
+    AcEdPromptKeywordOptions,
+    AcEdPromptStatus: {
+      Cancel: -5002,
+      None: 0x1388,
+      OK: 0x13ec,
+      Keyword: -5005
+    }
+  }
+})
+
+jest.mock('../src/AcApHtmlConvertor', () => ({
+  AcApHtmlConvertor: jest.fn().mockImplementation(() => ({
+    convert: jest.fn(() => Promise.resolve())
+  }))
+}))
+
+import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { AcEdPromptStatus } from '@mlightcad/cad-simple-viewer'
+
+import { AcApExportHtmlCmd } from '../src/AcApExportHtmlCmd'
+import { AcApHtmlConvertor } from '../src/AcApHtmlConvertor'
+
+const getKeywords = AcApDocManager.instance.editor.getKeywords as jest.Mock
+const convert = () =>
+  (AcApHtmlConvertor as jest.MockedClass<typeof AcApHtmlConvertor>).mock
+    .results[0]?.value.convert as jest.Mock
+
+describe('AcApExportHtmlCmd prompt defaults', () => {
+  const cmd = new AcApExportHtmlCmd()
+  const context = {
+    doc: { fileName: 'drawing.dwg', docTitle: 'Drawing' },
+    view: {}
+  } as any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('accepts empty Enter (None) for both prompts and exports with defaults', async () => {
+    getKeywords
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+    await cmd.execute(context)
+
+    expect(getKeywords).toHaveBeenCalledTimes(2)
+    expect(getKeywords.mock.calls[0][0].allowNone).toBe(true)
+    expect(getKeywords.mock.calls[1][0].allowNone).toBe(true)
+    expect(convert()).toHaveBeenCalledWith(
+      'drawing.dwg',
+      {
+        exportInvisibleLayers: true,
+        initialView: 'fit'
+      },
+      context.view
+    )
+  })
+
+  test('accepts default keyword (OK) for both prompts and exports', async () => {
+    getKeywords
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.OK, stringResult: 'Yes' })
+      .mockResolvedValueOnce({
+        status: AcEdPromptStatus.OK,
+        stringResult: 'Extents'
+      })
+
+    await cmd.execute(context)
+
+    expect(convert()).toHaveBeenCalledWith(
+      'drawing.dwg',
+      {
+        exportInvisibleLayers: true,
+        initialView: 'fit'
+      },
+      context.view
+    )
+  })
+
+  test('cancels export when the first prompt is cancelled', async () => {
+    getKeywords.mockResolvedValueOnce({ status: AcEdPromptStatus.Cancel })
+
+    await cmd.execute(context)
+
+    expect(getKeywords).toHaveBeenCalledTimes(1)
+    expect(AcApHtmlConvertor).not.toHaveBeenCalled()
+  })
+
+  test('cancels export when the second prompt is cancelled', async () => {
+    getKeywords
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.Cancel })
+
+    await cmd.execute(context)
+
+    expect(getKeywords).toHaveBeenCalledTimes(2)
+    expect(AcApHtmlConvertor).not.toHaveBeenCalled()
+  })
+
+  test('registers default keywords on prompt options', async () => {
+    getKeywords
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+    await cmd.execute(context)
+
+    const invisibleLayersPrompt = getKeywords.mock.calls[0][0]
+    const initialViewPrompt = getKeywords.mock.calls[1][0]
+
+    expect(invisibleLayersPrompt.keywords.default).toEqual(
+      expect.objectContaining({ global: 'Yes' })
+    )
+    expect(initialViewPrompt.keywords.default).toEqual(
+      expect.objectContaining({ global: 'Extents' })
+    )
+  })
+})

--- a/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
+++ b/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
@@ -66,16 +66,17 @@ export class AcApExportHtmlCmd extends AcEdCommand {
       `${AcApI18n.t('jig.chtml.exportInvisibleLayers')} <${current}>`
     )
     prompt.allowNone = true
-    prompt.keywords.add(
+    const yes = prompt.keywords.add(
       AcApI18n.t('jig.chtml.keywords.yes.display'),
       AcApI18n.t('jig.chtml.keywords.yes.global'),
       AcApI18n.t('jig.chtml.keywords.yes.local')
     )
-    prompt.keywords.add(
+    const no = prompt.keywords.add(
       AcApI18n.t('jig.chtml.keywords.no.display'),
       AcApI18n.t('jig.chtml.keywords.no.global'),
       AcApI18n.t('jig.chtml.keywords.no.local')
     )
+    prompt.keywords.default = defaults.exportInvisibleLayers ? yes : no
 
     const result = await AcApDocManager.instance.editor.getKeywords(prompt)
     if (result.status === AcEdPromptStatus.Cancel) {
@@ -108,16 +109,18 @@ export class AcApExportHtmlCmd extends AcEdCommand {
       `${AcApI18n.t('jig.chtml.initialView')} <${current}>`
     )
     prompt.allowNone = true
-    prompt.keywords.add(
+    const extents = prompt.keywords.add(
       AcApI18n.t('jig.chtml.keywords.extents.display'),
       AcApI18n.t('jig.chtml.keywords.extents.global'),
       AcApI18n.t('jig.chtml.keywords.extents.local')
     )
-    prompt.keywords.add(
+    const currentView = prompt.keywords.add(
       AcApI18n.t('jig.chtml.keywords.current.display'),
       AcApI18n.t('jig.chtml.keywords.current.global'),
       AcApI18n.t('jig.chtml.keywords.current.local')
     )
+    prompt.keywords.default =
+      defaults.initialView === 'current' ? currentView : extents
 
     const result = await AcApDocManager.instance.editor.getKeywords(prompt)
     if (result.status === AcEdPromptStatus.Cancel) {

--- a/packages/cad-simple-viewer/__tests__/AcEdKeywordSession.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdKeywordSession.spec.ts
@@ -43,15 +43,17 @@ describe('KeywordSession Enter behavior', () => {
     expect(resolved).toEqual([''])
   })
 
-  test('Enter with no default and allowNone=false is invalid', () => {
-    const options = new AcEdPromptKeywordOptions('pick')
-    options.keywords.add('First', 'First', 'First')
-    options.allowNone = false
+  test('Enter with default keyword takes precedence over allowNone', () => {
+    const options = new AcEdPromptKeywordOptions('export invisible layers <Yes>')
+    const yes = options.keywords.add('Yes(Y)', 'Yes', 'Yes')
+    options.keywords.add('No(N)', 'No', 'No')
+    options.keywords.default = yes
+    options.allowNone = true
 
     const { session, resolved } = createSession(options)
     const handled = session.handleEnter('')
 
-    expect(handled).toBe(false)
-    expect(resolved).toEqual([])
+    expect(handled).toBe(true)
+    expect(resolved).toEqual(['Yes'])
   })
 })

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -1031,15 +1031,16 @@ export class AcEdInputManager {
   async getKeywords(
     options: AcEdPromptKeywordOptions
   ): Promise<AcEdPromptResult> {
-    const scriptedValue = this.tryGetScriptedValue(
-      new AcEdKeywordHandler(options)
-    )
-    if (scriptedValue != null) {
-      return new AcEdPromptResult(AcEdPromptStatus.OK, scriptedValue)
-    }
-
     return this.executePrompt(
       async () => {
+        const scriptedValue = this.tryGetScriptedValue(
+          new AcEdKeywordHandler(options),
+          options
+        )
+        if (scriptedValue != null) {
+          return scriptedValue
+        }
+
         const result = await this._commandLine.getKeywords(options, true)
         if (!result) {
           if (options.allowNone) {


### PR DESCRIPTION
## Summary
- Set `keywords.default` on HTML export invisible-layers and initial-view prompts so Enter accepts the bracketed default (AutoCAD-style) instead of ambiguous empty input.
- Move `getKeywords` scripted-input handling inside `executePrompt` and pass prompt options for consistent `allowNone` behavior.
- Add `AcApExportHtmlCmd` unit tests and update keyword session Enter precedence test.

## Test plan
- [x] `pnpm test -- packages/cad-simple-viewer/__tests__/AcEdKeywordSession.spec.ts packages/cad-html-plugin/__tests__/AcApExportHtmlCmd.spec.ts`
- [ ] Run CHtml export command and press Enter at both prompts; verify defaults are applied
- [ ] Verify typing `N` / `Current` still overrides defaults