### PR TITLE
feat(example): opt in to local data-model linking during dev

### DIFF
--- a/packages/cad-viewer-example/package.json
+++ b/packages/cad-viewer-example/package.json
@@ -13,6 +13,7 @@
     "build": "vue-tsc && vite build",
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",
     "dev": "vite",
+    "dev:local-data-model": "vite --mode local-data-model",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",

--- a/packages/cad-viewer-example/vite.config.ts
+++ b/packages/cad-viewer-example/vite.config.ts
@@ -10,6 +10,19 @@ import { exampleRollupOutput } from '../vite-config/pluginRollupOutput'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const VIEWER_RUNTIME_SRC = '../cad-html-plugin/dist/viewer-runtime.iife.js'
+const LOCAL_DATA_MODEL_LIB = resolve(
+  __dirname,
+  '../../../realdwg-web/packages/data-model/lib'
+)
+const LOCAL_DATA_MODEL_ENTRY = resolve(LOCAL_DATA_MODEL_LIB, 'index.js')
+
+function useLocalDataModel(mode: string): boolean {
+  if (mode === 'local-data-model') {
+    return true
+  }
+  const flag = process.env.CAD_VIEWER_USE_LOCAL_DATA_MODEL
+  return flag === '1' || flag?.toLowerCase() === 'true'
+}
 
 export default defineConfig(({ command, mode }) => {
   if (!existsSync(resolve(__dirname, VIEWER_RUNTIME_SRC))) {
@@ -24,23 +37,25 @@ export default defineConfig(({ command, mode }) => {
     'cad-simple-viewer',
     'cad-viewer'
   ]
-  const realdwgDataModelEntry = resolve(
-    __dirname,
-    '../../../realdwg-web/packages/data-model/lib/index.js'
-  )
+  const linkLocalDataModel =
+    command === 'serve' &&
+    useLocalDataModel(mode) &&
+    existsSync(LOCAL_DATA_MODEL_ENTRY)
   if (command === 'serve') {
     aliases.push({
       find: /^@mlightcad\/(cad-svg-plugin|three-renderer|cad-simple-viewer|cad-viewer)$/,
       replacement: resolve(__dirname, '../$1/src')
     })
-    if (existsSync(realdwgDataModelEntry)) {
+    if (linkLocalDataModel) {
       aliases.push({
         find: '@mlightcad/data-model',
-        replacement: resolve(
-          __dirname,
-          '../../../realdwg-web/packages/data-model/lib'
-        )
+        replacement: LOCAL_DATA_MODEL_LIB
       })
+    } else if (useLocalDataModel(mode) && !existsSync(LOCAL_DATA_MODEL_ENTRY)) {
+      console.warn(
+        '[cad-viewer-example] Local data-model alias requested but not found at:',
+        LOCAL_DATA_MODEL_ENTRY
+      )
     }
   }
 
@@ -77,9 +92,7 @@ export default defineConfig(({ command, mode }) => {
         command === 'serve'
           ? [
               ...devSourcePackages.map(name => `@mlightcad/${name}`),
-              ...(existsSync(realdwgDataModelEntry)
-                ? ['@mlightcad/data-model']
-                : [])
+              ...(linkLocalDataModel ? ['@mlightcad/data-model'] : [])
             ]
           : []
     },


### PR DESCRIPTION
## Summary
- Add `dev:local-data-model` script to run cad-viewer-example with `vite --mode local-data-model`
- Gate the `@mlightcad/data-model` Vite alias behind an explicit opt-in (`local-data-model` mode or `CAD_VIEWER_USE_LOCAL_DATA_MODEL=1/true`) instead of auto-linking whenever the sibling `realdwg-web` checkout exists
- Log a warning when local data-model linking is requested but the expected path is missing

## Test plan
- [ ] Run `pnpm --filter @mlightcad/cad-viewer-example dev` without a local r`ealdwg-web` checkout and confirm the app uses the published `@mlightcad/data-model` package
- [ ] Run `pnpm --filter @mlightcad/cad-viewer-example dev:local-data-model` with `realdwg-web/packages/data-model/lib` present and confirm the alias resolves to the local build
- [ ] Set `CAD_VIEWER_USE_LOCAL_DATA_MODEL=1` and run `dev` to confirm the env flag enables the same alias behavior
- [ ] Run `dev:local-data-model` without the local path and confirm the warning is printed