### PR TITLE
fix(html-export): world-bake plain drawables and skip highlight overlays

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
@@ -48,6 +48,25 @@ function cloneUnbatchedHatchMesh(source: THREE.Mesh): THREE.Mesh {
   return cloned
 }
 
+function cloneUnbatchedHatchMeshFromGroup(source: THREE.Mesh): THREE.Mesh {
+  const cloned = source.clone() as THREE.Mesh
+  cloned.geometry = source.geometry.clone()
+  cloned.material = source.material
+  source.updateMatrixWorld(true)
+  source.matrixWorld.decompose(_position, _quaternion, _scale)
+  cloned.position.copy(_position)
+  cloned.quaternion.copy(_quaternion)
+  cloned.scale.copy(_scale)
+  getSceneDrawableUserData(cloned).bakedWorldMatrix =
+    source.matrixWorld.toArray()
+  cloned.updateMatrix()
+  return cloned
+}
+
+const _position = /*@__PURE__*/ new THREE.Vector3()
+const _quaternion = /*@__PURE__*/ new THREE.Quaternion()
+const _scale = /*@__PURE__*/ new THREE.Vector3()
+
 describe('patterned hatch HTML export', () => {
   it('collects hatch pattern data from unbatched world-baked meshes', () => {
     const styleManager = new AcTrStyleManager()
@@ -135,5 +154,36 @@ describe('patterned hatch HTML export', () => {
 
     const viewerMaterial = createViewerMeshMaterial(decodedBatch)
     expect(viewerMaterial).toBeInstanceOf(THREE.ShaderMaterial)
+  })
+
+  it('world-bakes patterned hatch clones that keep local geometry under object transforms', () => {
+    const styleManager = new AcTrStyleManager()
+    const material = createPatternedHatchMaterial(styleManager)
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(
+        new Float32Array([0, 0, 0, 10, 0, 0, 0, 10, 0]),
+        3
+      )
+    )
+
+    const source = new THREE.Mesh(geometry, material)
+    source.position.set(100, 200, 0)
+    source.rotation.z = Math.PI / 6
+    source.updateMatrixWorld(true)
+
+    const root = new THREE.Group()
+    root.add(cloneUnbatchedHatchMeshFromGroup(source))
+
+    const { meshBatches } = collectBatchesFromObject3D(root)
+    expect(meshBatches).toHaveLength(1)
+
+    const exported = meshBatches[0]!
+    expect(exported.offset).toEqual([0, 0, 0])
+    expect(exported.hatchPattern?.patternLines.length).toBeGreaterThan(0)
+    expect(exported.positions[0]).toBeCloseTo(100, 3)
+    expect(exported.positions[1]).toBeCloseTo(200, 3)
+    expect(createViewerMeshMaterial(exported).type).toBe('ShaderMaterial')
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -14,7 +14,8 @@ jest.mock('@mlightcad/three-renderer', () => {
   const {
     getMaterialMetadata,
     isBatchGeometryActive,
-    isBatchGeometryVisible
+    isBatchGeometryVisible,
+    isHighlightOverlayDescendant
   } = jest.requireActual('../../three-renderer/src')
 
   return {
@@ -24,7 +25,8 @@ jest.mock('@mlightcad/three-renderer', () => {
     AcTrBatchedPoint,
     getMaterialMetadata,
     isBatchGeometryActive,
-    isBatchGeometryVisible
+    isBatchGeometryVisible,
+    isHighlightOverlayDescendant
   }
 })
 
@@ -34,6 +36,7 @@ import { AcTrBatchedLine2 } from '../../three-renderer/src/batch/AcTrBatchedLine
 import { RTE_REBASE_THRESHOLD } from '../../three-renderer/src/draw/AcTrBatchDrawPolicy'
 import { AcTrEntity } from '../../three-renderer/src/object/AcTrEntity'
 import { AcTrRenderContext } from '../../three-renderer/src/renderer/AcTrRenderContext'
+import { getSceneDrawableUserData } from '../../three-renderer/src/util/AcTrObjectUserData'
 import * as THREE from 'three'
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
@@ -567,5 +570,31 @@ describe('collectBatchesFromObject3D rebase offsets', () => {
     expect(lineBatches).toHaveLength(1)
     expect(lineBatches[0]!.lineWidth).toBe(2.5)
     expect(lineBatches[0]!.color).toBe(0xff0000)
+  })
+
+  it('skips selection and hover highlight overlays during export', () => {
+    const group = new AcTrBatchedGroup()
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 10, 0, 0], 3)
+    )
+    const line = new THREE.LineSegments(
+      geometry,
+      new THREE.LineBasicMaterial({ color: 0xffffff })
+    )
+    line.position.set(100, 200, 0)
+    getSceneDrawableUserData(line).noBatch = true
+
+    const entity = new AcTrEntity(new AcTrRenderContext())
+    entity.objectId = 'line-1'
+    entity.visible = true
+    entity.add(line)
+    group.addEntity(entity)
+    group.select('line-1')
+
+    const { lineBatches } = collectBatchesFromObject3D(group)
+    expect(lineBatches).toHaveLength(1)
+    expect(lineBatches[0]!.color).toBe(0xffffff)
   })
 })

--- a/packages/cad-html-plugin/src/AcExBatchBuffers.ts
+++ b/packages/cad-html-plugin/src/AcExBatchBuffers.ts
@@ -104,3 +104,115 @@ export function readBatchWorldOffset(
   _worldOffset.z = position[14]!
   return [_worldOffset.x, _worldOffset.y, _worldOffset.z]
 }
+
+/** Minimal geometry slice used while rebasing plain drawables for HTML export. */
+export interface AcExPlainDrawableSlice {
+  positions: Float32Array
+  indices?: Uint32Array
+}
+
+/**
+ * Applies a world matrix to every vertex in a geometry slice using double precision.
+ */
+export function bakePlainDrawableSlice(
+  slice: AcExPlainDrawableSlice,
+  matrix: THREE.Matrix4
+): AcExPlainDrawableSlice {
+  const elements = matrix.elements
+  const source = slice.positions
+  if (source.length === 0) {
+    return { positions: new Float32Array(0), indices: slice.indices }
+  }
+
+  const transformed = new Float32Array(source.length)
+  for (let i = 0; i < source.length; i += 3) {
+    const x = source[i]!
+    const y = source[i + 1]!
+    const z = source[i + 2]!
+    transformed[i] =
+      elements[0]! * x + elements[4]! * y + elements[8]! * z + elements[12]!
+    transformed[i + 1] =
+      elements[1]! * x + elements[5]! * y + elements[9]! * z + elements[13]!
+    transformed[i + 2] =
+      elements[2]! * x + elements[6]! * y + elements[10]! * z + elements[14]!
+  }
+
+  return {
+    positions: transformed,
+    indices: slice.indices ? new Uint32Array(slice.indices) : undefined
+  }
+}
+
+/**
+ * Rebases a world-space slice around its axis-aligned center so HTML playback can
+ * keep float32-friendly local vertices with a separate float64 origin.
+ */
+export function rebasePlainDrawableSliceAroundCentroid(
+  slice: AcExPlainDrawableSlice
+): { slice: AcExPlainDrawableSlice; offset: [number, number, number] } {
+  const source = slice.positions
+  if (source.length < 3) {
+    return { slice, offset: [0, 0, 0] }
+  }
+
+  let minX = Infinity
+  let minY = Infinity
+  let minZ = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let maxZ = -Infinity
+
+  for (let i = 0; i < source.length; i += 3) {
+    const x = source[i]!
+    const y = source[i + 1]!
+    const z = source[i + 2]!
+    minX = Math.min(minX, x)
+    minY = Math.min(minY, y)
+    minZ = Math.min(minZ, z)
+    maxX = Math.max(maxX, x)
+    maxY = Math.max(maxY, y)
+    maxZ = Math.max(maxZ, z)
+  }
+
+  const offset: [number, number, number] = [
+    (minX + maxX) / 2,
+    (minY + maxY) / 2,
+    (minZ + maxZ) / 2
+  ]
+  const rebased = new Float32Array(source.length)
+  for (let i = 0; i < source.length; i += 3) {
+    rebased[i] = source[i]! - offset[0]
+    rebased[i + 1] = source[i + 1]! - offset[1]
+    rebased[i + 2] = source[i + 2]! - offset[2]
+  }
+
+  return {
+    slice: {
+      positions: rebased,
+      indices: slice.indices ? new Uint32Array(slice.indices) : undefined
+    },
+    offset
+  }
+}
+
+/**
+ * Converts one plain scene-graph drawable into the local+offset representation
+ * expected by the offline HTML viewer.
+ *
+ * Pattern-fill meshes stay world-baked with a zero offset so their hatch pattern
+ * metadata (transformed via `bakedWorldMatrix`) stays aligned with the fill boundary.
+ */
+export function exportPlainDrawableSlice(
+  object: THREE.Object3D,
+  slice: AcExPlainDrawableSlice,
+  options: { preserveWorldSpaceForPatternFill?: boolean } = {}
+): { slice: AcExPlainDrawableSlice; offset: [number, number, number] } {
+  object.updateMatrixWorld(true)
+  const worldSlice = bakePlainDrawableSlice(slice, object.matrixWorld)
+
+  if (options.preserveWorldSpaceForPatternFill) {
+    return { slice: worldSlice, offset: [0, 0, 0] }
+  }
+
+  return rebasePlainDrawableSliceAroundCentroid(worldSlice)
+}

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -5,7 +5,8 @@ import {
   AcTrBatchedPoint,
   getMaterialMetadata,
   isBatchGeometryActive,
-  isBatchGeometryVisible
+  isBatchGeometryVisible,
+  isHighlightOverlayDescendant
 } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
@@ -15,11 +16,11 @@ import {
   compactIndexedSlice,
   copyFloat32Range,
   copyUint32Range,
+  exportPlainDrawableSlice,
   readBatchWorldOffset
 } from './AcExBatchBuffers'
 import {
   computeLineDistancesForSegments,
-  exportLineDistanceSlice,
   exportVertexAttributeSlice,
   extractGradientFill,
   extractHatchPattern,
@@ -377,11 +378,24 @@ function readWorldOffset(object: THREE.Object3D): [number, number, number] {
   return readBatchWorldOffset(object)
 }
 
+function exportSceneDrawableSlice(
+  object: THREE.Object3D,
+  slice: AcExBufferGeometrySlice,
+  options: { preserveWorldSpaceForPatternFill?: boolean } = {}
+): AcExBufferGeometrySlice & { offset: [number, number, number] } {
+  const exported = exportPlainDrawableSlice(object, slice, options)
+  return {
+    ...exported.slice,
+    offset: exported.offset
+  }
+}
+
 function buildMeshBatch(
   geometry: THREE.BufferGeometry,
   material: THREE.Material,
   object: THREE.Object3D,
-  slice: AcExBufferGeometrySlice
+  slice: AcExBufferGeometrySlice,
+  offset: [number, number, number]
 ): AcExMeshBatch {
   const style = readMaterialStyle(material)
   const hatchPattern = resolveExportedHatchPattern(object, style.hatchPattern)
@@ -391,7 +405,7 @@ function buildMeshBatch(
   return {
     layer: style.layer,
     color: style.color,
-    offset: readWorldOffset(object),
+    offset,
     hatchPattern,
     gradientFill: style.gradientFill,
     gradientPositions,
@@ -448,7 +462,8 @@ function exportBatchedMesh(batch: AcTrBatchedMesh): AcExMeshBatch | undefined {
     batch.geometry,
     batch.material as THREE.Material,
     batch,
-    slice
+    slice,
+    readWorldOffset(batch)
   )
 }
 
@@ -465,7 +480,8 @@ function exportBatchedPoint(
       batch.geometry,
       batch.material as THREE.Material,
       batch,
-      slice
+      slice,
+      readWorldOffset(batch)
     )
   }
 }
@@ -486,6 +502,9 @@ export function collectBatchesFromObject3D(
   const meshBatches: AcExMeshBatch[] = []
 
   root.traverse(child => {
+    if (isHighlightOverlayDescendant(child)) {
+      return
+    }
     if (child instanceof AcTrBatchedLine) {
       const batch = exportBatchedLine(child)
       if (batch) lineBatches.push(batch)
@@ -507,14 +526,15 @@ export function collectBatchesFromObject3D(
       return
     }
     if (child instanceof LineSegments2) {
-      const slice = exportLineSegments2Slice(child.geometry)
-      if (slice.positions.length === 0) return
+      const rawSlice = exportLineSegments2Slice(child.geometry)
+      if (rawSlice.positions.length === 0) return
       const material = child.material as THREE.Material
       const { color, layer } = readMaterialStyle(material)
+      const { offset, ...slice } = exportSceneDrawableSlice(child, rawSlice)
       lineBatches.push({
         layer,
         color,
-        offset: readWorldOffset(child),
+        offset,
         lineWidth: readLineWidth(material),
         ...slice
       })
@@ -522,18 +542,18 @@ export function collectBatchesFromObject3D(
       child instanceof THREE.LineSegments &&
       !(child instanceof AcTrBatchedLine)
     ) {
-      const slice = exportBufferGeometrySlice(child.geometry)
-      if (slice.positions.length === 0) return
+      const rawSlice = exportBufferGeometrySlice(child.geometry)
+      if (rawSlice.positions.length === 0) return
       const material = child.material as THREE.Material
       const { color, layer, linePattern } = readMaterialStyle(material)
+      const { offset, ...slice } = exportSceneDrawableSlice(child, rawSlice)
       const lineDistances = linePattern
-        ? (exportLineDistanceSlice(child.geometry) ??
-          computeLineDistancesForSegments(slice.positions))
+        ? computeLineDistancesForSegments(slice.positions)
         : undefined
       lineBatches.push({
         layer,
         color,
-        offset: readWorldOffset(child),
+        offset,
         linePattern,
         lineDistances,
         ...slice
@@ -542,14 +562,20 @@ export function collectBatchesFromObject3D(
       child instanceof THREE.Mesh &&
       !(child instanceof AcTrBatchedMesh)
     ) {
-      const slice = exportBufferGeometrySlice(child.geometry)
-      if (slice.positions.length === 0) return
+      const rawSlice = exportBufferGeometrySlice(child.geometry)
+      if (rawSlice.positions.length === 0) return
+      const material = child.material as THREE.Material
+      const style = readMaterialStyle(material)
+      const { offset, ...slice } = exportSceneDrawableSlice(child, rawSlice, {
+        preserveWorldSpaceForPatternFill: !!style.hatchPattern
+      })
       meshBatches.push(
         buildMeshBatch(
           child.geometry,
-          child.material as THREE.Material,
+          material,
           child,
-          slice
+          slice,
+          offset
         )
       )
     }

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -12,9 +12,11 @@ import { getMaterialMetadata } from '../style/AcTrMaterialMetadata'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
 import { AcTrBufferGeometryUtil, AcTrMaterialUtil } from '../util'
 import {
+  type AcTrHighlightOverlayGroup,
   copyHighlightObjectFlags,
   getHighlightUserData,
-  getSceneDrawableUserData
+  getSceneDrawableUserData,
+  markHighlightOverlayGroup
 } from '../util/AcTrObjectUserData'
 import { isObjectHierarchyVisible } from '../util/AcTrVisibility'
 import { AcTrBatchGeometryUserData } from './AcTrBatchedGeometryInfo'
@@ -209,11 +211,11 @@ export class AcTrBatchedGroup extends THREE.Group {
   /**
    * The group to store all of selected entities
    */
-  private _selectedObjects: THREE.Group
+  private _selectedObjects: AcTrHighlightOverlayGroup
   /**
    * The group to store all of entities hovering on them
    */
-  private _hoverObjects: THREE.Group
+  private _hoverObjects: AcTrHighlightOverlayGroup
   /**
    * Non-batched objects (for render paths that cannot be merged, e.g. fat lines).
    */
@@ -242,8 +244,8 @@ export class AcTrBatchedGroup extends THREE.Group {
     this._entitiesMap = new Map()
     this._unbatchedEntities = new Map()
     this._unbatchedObjects = new THREE.Group()
-    this._selectedObjects = new THREE.Group()
-    this._hoverObjects = new THREE.Group()
+    this._selectedObjects = markHighlightOverlayGroup(new THREE.Group())
+    this._hoverObjects = markHighlightOverlayGroup(new THREE.Group())
     this.add(this._unbatchedObjects)
     this.add(this._selectedObjects)
     this.add(this._hoverObjects)

--- a/packages/three-renderer/src/index.ts
+++ b/packages/three-renderer/src/index.ts
@@ -28,3 +28,9 @@ export {
   type AcTrPatternLine
 } from './style/AcTrHatchPatternShaders'
 export * from './util/AcTrMTextColorUtil'
+export {
+  isHighlightOverlayDescendant,
+  markHighlightOverlayGroup,
+  type AcTrHighlightOverlayGroup,
+  type AcTrHighlightOverlayGroupUserData
+} from './util/AcTrObjectUserData'

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -90,6 +90,21 @@ export interface AcTrHighlightUserData {
 }
 
 /**
+ * Marks a {@link THREE.Group} that holds transient selection/hover highlight
+ * clones instead of source drawing geometry.
+ */
+export interface AcTrHighlightOverlayGroupUserData {
+  highlightOverlayGroup?: true
+}
+
+/**
+ * Selection or hover overlay container inside {@link AcTrBatchedGroup}.
+ */
+export type AcTrHighlightOverlayGroup = THREE.Group & {
+  userData: AcTrHighlightOverlayGroupUserData
+}
+
+/**
  * Temporary highlight clones attached to hover/selection overlay groups.
  */
 export type AcTrHighlightObjectUserData = AcTrHighlightUserData &
@@ -113,7 +128,8 @@ export interface AcTrObjectUserDataFields
     AcTrStyledDrawableUserData,
     AcTrRteObjectUserData,
     AcTrNoBatchUserData,
-    AcTrHighlightUserData {
+    AcTrHighlightUserData,
+    AcTrHighlightOverlayGroupUserData {
   originalMaterial?: THREE.Material | THREE.Material[]
 }
 
@@ -157,6 +173,37 @@ export function getHighlightUserData(
   object: THREE.Object3D
 ): AcTrHighlightObjectUserData {
   return getObjectUserData(object) as AcTrHighlightObjectUserData
+}
+
+export function getHighlightOverlayGroupUserData(
+  object: THREE.Object3D
+): AcTrHighlightOverlayGroupUserData {
+  return getObjectUserData(object) as AcTrHighlightOverlayGroupUserData
+}
+
+/**
+ * Tags one group as a selection/hover highlight overlay container.
+ */
+export function markHighlightOverlayGroup(
+  group: THREE.Group
+): AcTrHighlightOverlayGroup {
+  const overlay = group as AcTrHighlightOverlayGroup
+  overlay.userData.highlightOverlayGroup = true
+  return overlay
+}
+
+/**
+ * Returns whether `object` or any ancestor is a highlight overlay container.
+ */
+export function isHighlightOverlayDescendant(object: THREE.Object3D): boolean {
+  let node: THREE.Object3D | null = object
+  while (node) {
+    if (getHighlightOverlayGroupUserData(node).highlightOverlayGroup) {
+      return true
+    }
+    node = node.parent
+  }
+  return false
 }
 
 export function getBatchedContainerUserData(


### PR DESCRIPTION
## Summary
- World-bake unbatched LineSegments, LineSegments2, and Mesh nodes via matrixWorld during HTML export so object transforms are preserved
- Rebase exported vertices around centroid for float32-friendly local coordinates with separate float64 offset
- Skip selection/hover highlight overlay clones using typed highlightOverlayGroup markers on AcTrBatchedGroup
- Add tests for transformed hatch export and overlay exclusion

## Test plan
- [x] jest packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
- [x] jest packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
- [x] nx run @mlightcad/three-renderer:build
- [x] nx run @mlightcad/cad-html-plugin:build
- [ ] Manual: export HTML from drawing with selected entities and verify no duplicate highlight geometry
- [ ] Manual: export drawing with rotated/translated unbatched hatches and verify pattern alignment

Made with [Cursor](https://cursor.com)