### PR TITLE
feat(html-export): add intersection object snap mode

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
@@ -186,6 +186,152 @@ describe('AcExOsnapIndex', () => {
     expect(snap).toEqual({ x: 0, y: 0, mode: 'endpoint' })
   })
 
+  it('snaps to line-line intersection from analytic primitives', () => {
+    const crossLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 0,
+            y0: 5,
+            x1: 10,
+            y1: 5
+          },
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 5,
+            y0: 0,
+            x1: 5,
+            y1: 10
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(crossLayout)
+    const snap = index.findSnap(5.1, 4.9, 1)
+    expect(snap).toEqual({ x: 5, y: 5, mode: 'intersection' })
+  })
+
+  it('prefers intersection over nearest at a crossing', () => {
+    const crossLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 0,
+            y0: 5,
+            x1: 10,
+            y1: 5
+          },
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 5,
+            y0: 0,
+            x1: 5,
+            y1: 10
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection', 'nearest'])
+    index.rebuild(crossLayout)
+    const snap = index.findSnap(5.05, 5.05, 1)
+    expect(snap?.mode).toBe('intersection')
+    expect(snap?.x).toBeCloseTo(5, 10)
+    expect(snap?.y).toBeCloseTo(5, 10)
+  })
+
+  it('hides intersection when either source layer is hidden', () => {
+    const crossLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: 'A',
+            x0: 0,
+            y0: 5,
+            x1: 10,
+            y1: 5
+          },
+          {
+            kind: 'line' as const,
+            layer: 'B',
+            x0: 5,
+            y0: 0,
+            x1: 5,
+            y1: 10
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(crossLayout)
+    expect(index.findSnap(5.1, 4.9, 1)?.mode).toBe('intersection')
+    index.setLayerHidden('A', true)
+    expect(index.findSnap(5.1, 4.9, 1)).toBeUndefined()
+    index.setLayerHidden('A', false)
+    index.setLayerHidden('B', true)
+    expect(index.findSnap(5.1, 4.9, 1)).toBeUndefined()
+  })
+
+  it('does not snap to parallel line intersections', () => {
+    const parallelLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 0,
+            y0: 0,
+            x1: 10,
+            y1: 0
+          },
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 0,
+            y0: 2,
+            x1: 10,
+            y1: 2
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(parallelLayout)
+    expect(index.findSnap(5, 1, 2)).toBeUndefined()
+  })
+
+  it('snaps to segment intersection in tessellated fallback layout', () => {
+    const crossLayout = {
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0] as [number, number, number],
+          positions: f32([0, 5, 0, 10, 5, 0, 5, 0, 0, 5, 10, 0])
+        }
+      ],
+      meshBatches: []
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(crossLayout)
+    const snap = index.findSnap(5.1, 4.9, 1)
+    expect(snap).toEqual({ x: 5, y: 5, mode: 'intersection' })
+  })
+
   it('rebuilds large tessellated layouts without blowing the call stack', () => {
     const positions = new Float32Array(200_000 * 6)
     for (let i = 0; i < 200_000; i++) {

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -742,6 +742,7 @@ export class AcExMeasureController {
     const previewGeometry = new THREE.BufferGeometry()
     this._previewLine = new THREE.Line(previewGeometry, previewMaterial)
     this._previewLine.visible = false
+    this._previewLine.frustumCulled = false
     this._previewLine.renderOrder = 15
     this._scene.add(this._previewLine)
   }
@@ -1183,6 +1184,7 @@ export class AcExMeasureController {
         existing.setXYZ(i, points[i]!.x, points[i]!.y, 0)
       }
       existing.needsUpdate = true
+      geometry.computeBoundingSphere()
     } else {
       const positions = new Float32Array(points.length * 3)
       for (let i = 0; i < points.length; i++) {
@@ -1192,6 +1194,7 @@ export class AcExMeasureController {
       geometry.dispose()
       const next = new THREE.BufferGeometry()
       next.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+      next.computeBoundingSphere()
       this._previewLine.geometry = next
     }
     this._previewLine.visible = true

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -8,6 +8,13 @@ import {
   distSq
 } from './AcExOsnapGeometry'
 import {
+  ACEX_MAX_INTERSECTION_SOURCES,
+  intersectionToleranceForExtent,
+  intersectLineSegments,
+  intersectPrimitivePair,
+  isIntersectionCapablePrimitive
+} from './AcExOsnapIntersections'
+import {
   type AcExOsnapAcGeCurve,
   primitiveToAcGeCurve
 } from './AcExOsnapPrimitiveToAcGe'
@@ -42,6 +49,7 @@ function modePriority(mode: AcExOsnapMode): number {
     case 'endpoint':
     case 'midpoint':
     case 'center':
+    case 'intersection':
       return 0
     case 'quadrant':
     case 'node':
@@ -472,13 +480,13 @@ interface AcExIndexedSnapPoint {
   layer: string
 }
 
-/** Source geometry for nearest snap queries. @internal */
+/** Source geometry for nearest snap and intersection queries. @internal */
 type AcExNearestSource =
   | {
       kind: 'primitive'
       index: number
       layer: string
-      geo: AcExOsnapAcGeCurve
+      geo?: AcExOsnapAcGeCurve
     }
   | { kind: 'segment'; index: number; layer: string }
 
@@ -644,12 +652,15 @@ export class AcExOsnapIndex {
 
     const discreteModes = new Set(this.modes)
     discreteModes.delete('nearest')
+    discreteModes.delete('intersection')
     const wantsNearest = this.modes.has('nearest')
+    const wantsIntersection = this.modes.has('intersection')
+    const wantsGeometryTree = wantsNearest || wantsIntersection
 
     for (let i = 0; i < this.primitives.length; i++) {
       const prim = this.primitives[i]!
       const geo = wantsNearest ? primitiveToAcGeCurve(prim) : undefined
-      if (wantsNearest && geo && geo.kind !== 'point') {
+      if (wantsGeometryTree && prim.kind !== 'point') {
         this.nearestSources.push({
           kind: 'primitive',
           index: i,
@@ -676,7 +687,7 @@ export class AcExOsnapIndex {
     for (let i = 0; i < this.segments.length; i++) {
       const seg = this.segments[i]!
       const layer = this.segmentLayers[i]!
-      if (wantsNearest) {
+      if (wantsGeometryTree) {
         this.nearestSources.push({ kind: 'segment', index: i, layer })
       }
       if (discreteModes.has('endpoint')) {
@@ -757,8 +768,15 @@ export class AcExOsnapIndex {
     }
 
     const discrete = this.findDiscreteSnap(px, py, threshold)
-    if (discrete) {
-      return discrete
+    const intersection = this.modes.has('intersection')
+      ? this.findIntersectionSnap(px, py, threshold)
+      : undefined
+    const bestDiscrete = this.pickBestSnapPoint(px, py, threshold, [
+      discrete,
+      intersection
+    ])
+    if (bestDiscrete) {
+      return bestDiscrete
     }
 
     if (!this.modes.has('nearest')) {
@@ -766,6 +784,131 @@ export class AcExOsnapIndex {
     }
 
     return this.findNearestSnap(px, py, threshold)
+  }
+
+  private pickBestSnapPoint(
+    px: number,
+    py: number,
+    threshold: number,
+    candidates: Array<AcExOsnapPoint | undefined>
+  ): AcExOsnapPoint | undefined {
+    const threshSq = threshold * threshold
+    let bestPriority = Number.MAX_VALUE
+    let bestDistSq = Number.MAX_VALUE
+    let best: AcExOsnapPoint | undefined
+
+    for (const candidate of candidates) {
+      if (!candidate) continue
+      const d2 = distSq(px, py, candidate.x, candidate.y)
+      if (d2 > threshSq) continue
+      const priority = modePriority(candidate.mode)
+      if (
+        priority < bestPriority ||
+        (priority === bestPriority && d2 < bestDistSq)
+      ) {
+        bestPriority = priority
+        bestDistSq = d2
+        best = candidate
+      }
+    }
+
+    return best
+  }
+
+  /**
+   * Finds an intersection snap near the cursor by testing pairs of geometry
+   * sources whose bounds overlap the osnap aperture (RBush-filtered).
+   */
+  private findIntersectionSnap(
+    px: number,
+    py: number,
+    threshold: number
+  ): AcExOsnapPoint | undefined {
+    if (this.nearestSources.length === 0) return undefined
+
+    const box = searchBox(px, py, threshold)
+    const hits = this.nearestTree.search(box)
+    if (hits.length === 0) return undefined
+
+    const threshSq = threshold * threshold
+    const extent = Math.max(box.maxX - box.minX, box.maxY - box.minY, 1)
+    const tol = intersectionToleranceForExtent(extent)
+
+    const primIndices: number[] = []
+    const segIndices: number[] = []
+    const primSeen = new Set<number>()
+    const segSeen = new Set<number>()
+
+    for (const hit of hits) {
+      const source = this.nearestSources[hit.index]!
+      if (this.hiddenLayers.has(source.layer)) continue
+
+      if (source.kind === 'primitive') {
+        const prim = this.primitives[source.index]!
+        if (!isIntersectionCapablePrimitive(prim)) continue
+        if (primSeen.has(source.index)) continue
+        if (primIndices.length >= ACEX_MAX_INTERSECTION_SOURCES) continue
+        primSeen.add(source.index)
+        primIndices.push(source.index)
+        continue
+      }
+
+      if (segSeen.has(source.index)) continue
+      if (segIndices.length >= ACEX_MAX_INTERSECTION_SOURCES) continue
+      segSeen.add(source.index)
+      segIndices.push(source.index)
+    }
+
+    let bestDistSq = threshSq
+    let best: AcExOsnapPoint | undefined
+
+    for (let i = 0; i < primIndices.length; i++) {
+      const indexA = primIndices[i]!
+      const primA = this.primitives[indexA]!
+      for (let j = i + 1; j < primIndices.length; j++) {
+        const indexB = primIndices[j]!
+        const primB = this.primitives[indexB]!
+        if (
+          this.hiddenLayers.has(primA.layer) ||
+          this.hiddenLayers.has(primB.layer)
+        ) {
+          continue
+        }
+        for (const point of intersectPrimitivePair(primA, primB, tol)) {
+          const d2 = distSq(px, py, point.x, point.y)
+          if (d2 <= bestDistSq) {
+            bestDistSq = d2
+            best = { x: point.x, y: point.y, mode: 'intersection' }
+          }
+        }
+      }
+    }
+
+    for (let i = 0; i < segIndices.length; i++) {
+      const indexA = segIndices[i]!
+      const segA = this.segments[indexA]!
+      const layerA = this.segmentLayers[indexA]!
+      for (let j = i + 1; j < segIndices.length; j++) {
+        const indexB = segIndices[j]!
+        const segB = this.segments[indexB]!
+        const layerB = this.segmentLayers[indexB]!
+        if (
+          this.hiddenLayers.has(layerA) ||
+          this.hiddenLayers.has(layerB)
+        ) {
+          continue
+        }
+        const point = intersectLineSegments(segA, segB, tol)
+        if (!point) continue
+        const d2 = distSq(px, py, point.x, point.y)
+        if (d2 <= bestDistSq) {
+          bestDistSq = d2
+          best = { x: point.x, y: point.y, mode: 'intersection' }
+        }
+      }
+    }
+
+    return best
   }
 
   private findDiscreteSnap(
@@ -828,11 +971,13 @@ export class AcExOsnapIndex {
       if (this.hiddenLayers.has(source.layer)) continue
 
       if (source.kind === 'primitive') {
+        const prim = this.primitives[source.index]!
+        const geo = source.geo ?? primitiveToAcGeCurve(prim)
         const nearest = collectPrimitiveNearestSnapCandidate(
-          this.primitives[source.index]!,
+          prim,
           px,
           py,
-          source.geo
+          geo
         )
         if (!nearest) continue
         const d2 = distSq(px, py, nearest.x, nearest.y)
@@ -884,7 +1029,7 @@ function segmentBounds(seg: AcExOsnapSegment): {
  */
 export function acExOsnapModeToMarkerType(
   mode: AcExOsnapMode
-): 'rect' | 'triangle' | 'x' | 'circle' | 'diamond' {
+): 'rect' | 'triangle' | 'x' | 'circle' | 'diamond' | 'intersection' {
   switch (mode) {
     case 'endpoint':
       return 'rect'
@@ -896,6 +1041,8 @@ export function acExOsnapModeToMarkerType(
       return 'diamond'
     case 'nearest':
       return 'x'
+    case 'intersection':
+      return 'intersection'
     case 'node':
     default:
       return 'rect'

--- a/packages/cad-html-plugin/src/AcExOsnapIntersections.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapIntersections.ts
@@ -1,0 +1,201 @@
+/**
+ * Curve intersection math for object snap in the offline HTML viewer.
+ *
+ * Intersections are evaluated on pointer query (not at layout load) so opening
+ * large HTML exports stays fast. {@link AcExOsnapIndex} uses its geometry RBush
+ * to limit pairwise tests to sources near the cursor.
+ *
+ * @packageDocumentation
+ */
+
+import { FLOAT_TOL, TAU } from '@mlightcad/data-model'
+
+import { normalizeArcDelta } from './AcExOsnapPrimitiveToAcGe'
+import type {
+  AcExOsnapArcPrimitive,
+  AcExOsnapCirclePrimitive,
+  AcExOsnapLinePrimitive,
+  AcExOsnapPrimitive
+} from './AcExOsnapPrimitiveTypes'
+
+/** Tessellated segment for intersection fallback. */
+export interface AcExOsnapSegmentLike {
+  x0: number
+  y0: number
+  x1: number
+  y1: number
+}
+
+type AcExCircArcLike = AcExOsnapCirclePrimitive | AcExOsnapArcPrimitive
+
+/** Max nearby geometry sources considered per intersection query. */
+export const ACEX_MAX_INTERSECTION_SOURCES = 48
+
+export function intersectionToleranceForExtent(extent: number): number {
+  return Math.max(FLOAT_TOL, Math.max(extent, 1) * 1e-9)
+}
+
+export function intersectLineSegments(
+  a: AcExOsnapSegmentLike,
+  b: AcExOsnapSegmentLike,
+  tol: number
+): { x: number; y: number } | undefined {
+  const d1x = a.x1 - a.x0
+  const d1y = a.y1 - a.y0
+  const d2x = b.x1 - b.x0
+  const d2y = b.y1 - b.y0
+  const denom = d1x * d2y - d1y * d2x
+  if (Math.abs(denom) < tol) return undefined
+
+  const dx = b.x0 - a.x0
+  const dy = b.y0 - a.y0
+  const t = (dx * d2y - dy * d2x) / denom
+  const u = (dx * d1y - dy * d1x) / denom
+  if (t < -tol || t > 1 + tol || u < -tol || u > 1 + tol) return undefined
+
+  return { x: a.x0 + t * d1x, y: a.y0 + t * d1y }
+}
+
+function isAngleInArcSweep(
+  angle: number,
+  prim: AcExOsnapArcPrimitive,
+  tol: number
+): boolean {
+  const delta = normalizeArcDelta(prim.startAngle, prim.endAngle)
+  let rel = angle - prim.startAngle
+  while (rel < 0) rel += TAU
+  while (rel >= TAU) rel -= TAU
+  const angleTol = Math.max(tol / Math.max(prim.r, 1), 1e-12)
+  return rel <= delta + angleTol
+}
+
+function isPointOnCircArc(
+  x: number,
+  y: number,
+  prim: AcExCircArcLike,
+  tol: number
+): boolean {
+  if (prim.kind === 'circle') {
+    return Math.abs(Math.hypot(x - prim.cx, y - prim.cy) - prim.r) <= tol
+  }
+  const dist = Math.hypot(x - prim.cx, y - prim.cy)
+  if (Math.abs(dist - prim.r) > tol) return false
+  const sx = prim.normalSign === -1 ? -1 : 1
+  if (Math.abs(prim.r) < tol) return false
+  const cosA = (x - prim.cx) / (sx * prim.r)
+  const sinA = (y - prim.cy) / prim.r
+  if (Math.abs(cosA * cosA + sinA * sinA - 1) > 1e-6) return false
+  const angle = Math.atan2(sinA, cosA)
+  return isAngleInArcSweep(angle, prim, tol)
+}
+
+function intersectLineCircle(
+  line: AcExOsnapLinePrimitive,
+  circ: AcExCircArcLike,
+  tol: number
+): Array<{ x: number; y: number }> {
+  const dx = line.x1 - line.x0
+  const dy = line.y1 - line.y0
+  const fx = line.x0 - circ.cx
+  const fy = line.y0 - circ.cy
+  const a = dx * dx + dy * dy
+  if (a < tol * tol) return []
+
+  const b = 2 * (fx * dx + fy * dy)
+  const c = fx * fx + fy * fy - circ.r * circ.r
+  const disc = b * b - 4 * a * c
+  if (disc < -tol) return []
+
+  const out: Array<{ x: number; y: number }> = []
+  const sqrtDisc = Math.sqrt(Math.max(0, disc))
+  for (const sign of [-1, 1] as const) {
+    const t = (-b + sign * sqrtDisc) / (2 * a)
+    if (t < -tol || t > 1 + tol) continue
+    const x = line.x0 + t * dx
+    const y = line.y0 + t * dy
+    if (isPointOnCircArc(x, y, circ, tol)) {
+      out.push({ x, y })
+    }
+  }
+  return out
+}
+
+function intersectCircles(
+  a: AcExCircArcLike,
+  b: AcExCircArcLike,
+  tol: number
+): Array<{ x: number; y: number }> {
+  const dx = b.cx - a.cx
+  const dy = b.cy - a.cy
+  const d = Math.hypot(dx, dy)
+  if (d < tol) return []
+
+  const rSum = a.r + b.r
+  const rDiff = Math.abs(a.r - b.r)
+  if (d > rSum + tol || d < rDiff - tol) return []
+
+  const aa = (a.r * a.r - b.r * b.r + d * d) / (2 * d)
+  const hSq = a.r * a.r - aa * aa
+  if (hSq < -tol) return []
+  const h = Math.sqrt(Math.max(0, hSq))
+  const mx = a.cx + (aa * dx) / d
+  const my = a.cy + (aa * dy) / d
+  const rx = (-dy * h) / d
+  const ry = (dx * h) / d
+
+  const points =
+    h <= tol
+      ? [{ x: mx, y: my }]
+      : [
+          { x: mx + rx, y: my + ry },
+          { x: mx - rx, y: my - ry }
+        ]
+
+  const out: Array<{ x: number; y: number }> = []
+  for (const p of points) {
+    if (isPointOnCircArc(p.x, p.y, a, tol) && isPointOnCircArc(p.x, p.y, b, tol)) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+/**
+ * Computes intersection points between two analytic snap primitives.
+ *
+ * Supports line/arc/circle pairs; ellipse and spline are skipped.
+ */
+export function intersectPrimitivePair(
+  a: AcExOsnapPrimitive,
+  b: AcExOsnapPrimitive,
+  tol: number
+): Array<{ x: number; y: number }> {
+  if (a.kind === 'line' && b.kind === 'line') {
+    const hit = intersectLineSegments(a, b, tol)
+    return hit ? [hit] : []
+  }
+  if (a.kind === 'line' && (b.kind === 'circle' || b.kind === 'arc')) {
+    return intersectLineCircle(a, b, tol)
+  }
+  if (b.kind === 'line' && (a.kind === 'circle' || a.kind === 'arc')) {
+    return intersectLineCircle(b, a, tol)
+  }
+  if (
+    (a.kind === 'circle' || a.kind === 'arc') &&
+    (b.kind === 'circle' || b.kind === 'arc')
+  ) {
+    return intersectCircles(a, b, tol)
+  }
+  return []
+}
+
+/** Whether a primitive can participate in intersection snap. */
+export function isIntersectionCapablePrimitive(
+  prim: AcExOsnapPrimitive
+): boolean {
+  return (
+    prim.kind === 'line' ||
+    prim.kind === 'circle' ||
+    prim.kind === 'arc'
+  )
+}

--- a/packages/cad-html-plugin/src/AcExOsnapMarker.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapMarker.ts
@@ -10,6 +10,7 @@ import { acExOsnapModeToMarkerType } from './AcExOsnap'
  * - `circle` — center
  * - `diamond` — quadrant
  * - `x` — nearest
+ * - `intersection` — curve intersection (square with X)
  */
 export type AcExOsnapMarkerShape =
   | 'rect'
@@ -17,6 +18,7 @@ export type AcExOsnapMarkerShape =
   | 'x'
   | 'circle'
   | 'diamond'
+  | 'intersection'
 
 /**
  * Screen-space object snap marker for the offline HTML viewer.
@@ -131,6 +133,26 @@ export class AcExOsnapMarker {
         transform: translate(-50%, -50%) rotate(45deg);
       }
       .mlcad-osnap-marker--x::after {
+        transform: translate(-50%, -50%) rotate(-45deg);
+      }
+      .mlcad-osnap-marker--intersection {
+        width: 12px; height: 12px;
+        border: 2px solid currentColor;
+        background: transparent;
+      }
+      .mlcad-osnap-marker--intersection::before,
+      .mlcad-osnap-marker--intersection::after {
+        content: '';
+        position: absolute;
+        top: 50%; left: 50%;
+        width: 70%; height: 2px;
+        background: currentColor;
+        transform-origin: center;
+      }
+      .mlcad-osnap-marker--intersection::before {
+        transform: translate(-50%, -50%) rotate(45deg);
+      }
+      .mlcad-osnap-marker--intersection::after {
         transform: translate(-50%, -50%) rotate(-45deg);
       }
     `

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
@@ -24,6 +24,7 @@
  * - `quadrant` — 0° / 90° / 180° / 270° on circles; arc-limited on arcs; axis crossings on closed ellipses.
  * - `nearest` — Closest point on the curve or segment to the pick point (not tessellated).
  * - `node` — Spline knot locations; also used for `AcDbPoint` entities.
+ * - `intersection` — Intersection of two nearby curves (computed on pointer query).
  *
  * Tangent snap is not implemented in the offline viewer.
  */
@@ -34,6 +35,7 @@ export type AcExOsnapMode =
   | 'quadrant'
   | 'nearest'
   | 'node'
+  | 'intersection'
 
 /**
  * A single object snap candidate returned to the measurement UI.
@@ -61,6 +63,7 @@ export const ACEX_DEFAULT_OSNAP_MODES: readonly AcExOsnapMode[] = [
   'midpoint',
   'center',
   'quadrant',
+  'intersection',
   'nearest'
 ] as const
 


### PR DESCRIPTION
## Summary
- Add `intersection` object snap mode to the offline HTML viewer, computing line/circle/arc intersections at pointer query time (RBush-filtered, capped at 48 nearby sources per query) so large HTML exports stay fast at open.
- Add intersection marker styling (square with X), include intersection in default osnap modes, and prefer intersection over nearest at crossings.
- Fix measurement preview line disappearing when geometry updates by disabling frustum culling and recomputing bounding spheres.

## Test plan
- [x] `pnpm test -- packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts` (16 tests pass)
- [ ] Open an HTML export with crossing lines and verify intersection snap appears at crossings
- [ ] Toggle layer visibility and confirm intersection snap hides when either source layer is hidden
- [ ] Verify measurement preview line remains visible while dragging