### PR TITLE
fix(html-export): skip hidden/highlight drawables and align group bbox

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -15,7 +15,9 @@ jest.mock('@mlightcad/three-renderer', () => {
     getMaterialMetadata,
     isBatchGeometryActive,
     isBatchGeometryVisible,
-    isHighlightOverlayDescendant
+    isHighlightCloneDrawable,
+    isHighlightOverlayDescendant,
+    isObjectHierarchyVisible
   } = jest.requireActual('../../three-renderer/src')
 
   return {
@@ -26,7 +28,9 @@ jest.mock('@mlightcad/three-renderer', () => {
     getMaterialMetadata,
     isBatchGeometryActive,
     isBatchGeometryVisible,
-    isHighlightOverlayDescendant
+    isHighlightCloneDrawable,
+    isHighlightOverlayDescendant,
+    isObjectHierarchyVisible
   }
 })
 
@@ -53,6 +57,7 @@ import {
   exportActiveBatchedSlice,
   exportBufferGeometrySlice
 } from '../src/AcExSceneBatchCollector'
+import { getHighlightUserData } from '../../three-renderer/src/util/AcTrObjectUserData'
 
 const BATCH_SLOT_ACTIVE = 0b11
 const BATCH_SLOT_HIDDEN = 0b01
@@ -602,5 +607,94 @@ describe('collectBatchesFromObject3D rebase offsets', () => {
     const { lineBatches } = collectBatchesFromObject3D(group)
     expect(lineBatches).toHaveLength(1)
     expect(lineBatches[0]!.color).toBe(0xffffff)
+  })
+
+  it('skips highlight clone drawables even without overlay group markers', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 10, 0, 0], 3)
+    )
+    const source = new THREE.LineSegments(
+      geometry,
+      new THREE.LineBasicMaterial({ color: 0xffffff })
+    )
+    source.position.set(100, 200, 0)
+
+    const highlightClone = source.clone() as THREE.LineSegments
+    getHighlightUserData(highlightClone).objectId = 'line-1'
+
+    const root = new THREE.Group()
+    root.add(source)
+    root.add(highlightClone)
+
+    const { lineBatches } = collectBatchesFromObject3D(root)
+    expect(lineBatches).toHaveLength(1)
+    expect(lineBatches[0]!.color).toBe(0xffffff)
+  })
+
+  it('skips scene-hidden unbatched drawables during export', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 10, 0, 0], 3)
+    )
+    const visible = new THREE.LineSegments(
+      geometry,
+      new THREE.LineBasicMaterial({ color: 0xffffff })
+    )
+    const hidden = visible.clone() as THREE.LineSegments
+    hidden.visible = false
+
+    const root = new THREE.Group()
+    root.add(visible)
+    root.add(hidden)
+
+    const { lineBatches } = collectBatchesFromObject3D(root)
+    expect(lineBatches).toHaveLength(1)
+  })
+
+  it('skips drawables hidden by an invisible ancestor during export', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 10, 0, 0], 3)
+    )
+    const line = new THREE.LineSegments(
+      geometry,
+      new THREE.LineBasicMaterial({ color: 0xffffff })
+    )
+    const hiddenGroup = new THREE.Group()
+    hiddenGroup.visible = false
+    hiddenGroup.add(line)
+
+    const visible = new THREE.LineSegments(
+      geometry.clone(),
+      new THREE.LineBasicMaterial({ color: 0xffffff })
+    )
+
+    const root = new THREE.Group()
+    root.add(hiddenGroup)
+    root.add(visible)
+
+    const { lineBatches } = collectBatchesFromObject3D(root)
+    expect(lineBatches).toHaveLength(1)
+  })
+
+  it('exports only active LineSegments2 instanceCount segments', () => {
+    const geometry = new LineSegmentsGeometry()
+    geometry.setPositions(
+      new Float32Array([
+        0, 0, 0, 10, 0, 0, 0, 10, 0, 10, 10, 0, 99, 99, 99, 88, 88, 88
+      ])
+    )
+    ;(geometry as THREE.InstancedBufferGeometry).instanceCount = 2
+
+    const material = new LineMaterial({ color: 0xff0000, linewidth: 2.5 })
+    const line = new LineSegments2(geometry, material)
+
+    const { lineBatches } = collectBatchesFromObject3D(line)
+    expect(lineBatches).toHaveLength(1)
+    expect(lineBatches[0]!.positions.length).toBe(12)
   })
 })

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -6,7 +6,9 @@ import {
   getMaterialMetadata,
   isBatchGeometryActive,
   isBatchGeometryVisible,
-  isHighlightOverlayDescendant
+  isHighlightCloneDrawable,
+  isHighlightOverlayDescendant,
+  isObjectHierarchyVisible
 } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
@@ -47,6 +49,15 @@ export interface AcExCollectedBatches {
   lineBatches: AcExLineBatch[]
   /** Mesh and point batches extracted from the subtree. */
   meshBatches: AcExMeshBatch[]
+}
+
+/** Per-slot geometry range metadata from {@link AcTrBatchedExportSource}. */
+type AcTrPackedGeometryInfo = {
+  flags: number
+  vertexStart: number
+  vertexCount: number
+  indexStart?: number
+  indexCount?: number
 }
 
 /**
@@ -131,19 +142,16 @@ export function exportBufferGeometrySlice(
   return { positions }
 }
 
-/** Per-slot geometry range metadata from {@link AcTrBatchedExportSource}. */
-type AcTrPackedGeometryInfo = {
-  flags: number
-  vertexStart: number
-  vertexCount: number
-  indexStart?: number
-  indexCount?: number
-}
-
 /** Batched object that exposes packed geometry slot metadata for HTML export. */
 type AcTrBatchedExportSource = {
   mappingStats: { count: number }
   getGeometryRangeAt(geometryId: number): AcTrPackedGeometryInfo
+}
+
+function shouldExportBatchedSlot(info: AcTrPackedGeometryInfo): boolean {
+  return (
+    isBatchGeometryActive(info.flags) && isBatchGeometryVisible(info.flags)
+  )
 }
 
 /**
@@ -184,11 +192,7 @@ export function exportActiveBatchedSlice(
       }
       const indexStart = info.indexStart ?? 0
       const indexCount = info.indexCount ?? 0
-      if (
-        !isBatchGeometryActive(info.flags) ||
-        !isBatchGeometryVisible(info.flags) ||
-        indexCount <= 0
-      ) {
+      if (!shouldExportBatchedSlot(info) || indexCount <= 0) {
         continue
       }
       for (let i = 0; i < indexCount; i++) {
@@ -211,11 +215,7 @@ export function exportActiveBatchedSlice(
     } catch {
       continue
     }
-    if (
-      !isBatchGeometryActive(info.flags) ||
-      !isBatchGeometryVisible(info.flags) ||
-      info.vertexCount <= 0
-    ) {
+    if (!shouldExportBatchedSlot(info) || info.vertexCount <= 0) {
       continue
     }
     const start = info.vertexStart * itemSize
@@ -270,11 +270,7 @@ export function exportActiveBatchedLine2Slice(
     } catch {
       continue
     }
-    if (
-      !isBatchGeometryActive(info.flags) ||
-      !isBatchGeometryVisible(info.flags) ||
-      info.vertexCount <= 0
-    ) {
+    if (!shouldExportBatchedSlot(info) || info.vertexCount <= 0) {
       continue
     }
     const segmentStart = info.vertexStart
@@ -286,6 +282,21 @@ export function exportActiveBatchedLine2Slice(
   }
 
   return { positions: new Float32Array(activeFloats) }
+}
+
+function resolveLineSegments2SegmentCount(
+  geometry: THREE.BufferGeometry,
+  segmentCapacity: number
+): number {
+  const instanced = geometry as THREE.InstancedBufferGeometry
+  const instanceCount = instanced.instanceCount
+  if (Number.isFinite(instanceCount) && instanceCount >= 0) {
+    return Math.min(Math.floor(instanceCount), segmentCapacity)
+  }
+
+  const drawRange = geometry.drawRange
+  const rangeStart = clampRangeStart(drawRange.start, segmentCapacity)
+  return resolveRangeCount(drawRange.count, segmentCapacity, rangeStart)
 }
 
 function exportLineSegments2Slice(
@@ -303,12 +314,24 @@ function exportLineSegments2Slice(
     return { positions: new Float32Array(0) }
   }
 
+  const segmentCount = resolveLineSegments2SegmentCount(
+    geometry,
+    startAttr.count
+  )
+  if (segmentCount <= 0) {
+    return { positions: new Float32Array(0) }
+  }
+
   const activeFloats: number[] = []
-  for (let segment = 0; segment < startAttr.count; segment++) {
+  for (let segment = 0; segment < segmentCount; segment++) {
     appendSegmentFromAttribute(activeFloats, startAttr, segment)
     appendSegmentFromAttribute(activeFloats, endAttr, segment)
   }
   return { positions: new Float32Array(activeFloats) }
+}
+
+function shouldExportPlainDrawable(object: THREE.Object3D): boolean {
+  return isObjectHierarchyVisible(object)
 }
 
 function readLineWidth(material: THREE.Material): number | undefined {
@@ -436,7 +459,9 @@ function exportBatchedLine2(
   }
 }
 
-function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
+function exportBatchedLine(
+  batch: AcTrBatchedLine
+): AcExLineBatch | undefined {
   const slice = exportActiveBatchedSlice(batch, batch.geometry)
   if (slice.positions.length === 0) {
     return undefined
@@ -457,7 +482,9 @@ function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
   }
 }
 
-function exportBatchedMesh(batch: AcTrBatchedMesh): AcExMeshBatch | undefined {
+function exportBatchedMesh(
+  batch: AcTrBatchedMesh
+): AcExMeshBatch | undefined {
   const slice = exportActiveBatchedSlice(batch, batch.geometry)
   if (slice.positions.length === 0) {
     return undefined
@@ -506,7 +533,10 @@ export function collectBatchesFromObject3D(
   const meshBatches: AcExMeshBatch[] = []
 
   root.traverse(child => {
-    if (isHighlightOverlayDescendant(child)) {
+    if (
+      isHighlightOverlayDescendant(child) ||
+      isHighlightCloneDrawable(child)
+    ) {
       return
     }
     if (child instanceof AcTrBatchedLine) {
@@ -530,6 +560,7 @@ export function collectBatchesFromObject3D(
       return
     }
     if (child instanceof LineSegments2) {
+      if (!shouldExportPlainDrawable(child)) return
       const rawSlice = exportLineSegments2Slice(child.geometry)
       if (rawSlice.positions.length === 0) return
       const material = child.material as THREE.Material
@@ -546,6 +577,7 @@ export function collectBatchesFromObject3D(
       child instanceof THREE.LineSegments &&
       !(child instanceof AcTrBatchedLine)
     ) {
+      if (!shouldExportPlainDrawable(child)) return
       const rawSlice = exportBufferGeometrySlice(child.geometry)
       if (rawSlice.positions.length === 0) return
       const material = child.material as THREE.Material
@@ -566,6 +598,7 @@ export function collectBatchesFromObject3D(
       child instanceof THREE.Mesh &&
       !(child instanceof AcTrBatchedMesh)
     ) {
+      if (!shouldExportPlainDrawable(child)) return
       const rawSlice = exportBufferGeometrySlice(child.geometry)
       if (rawSlice.positions.length === 0) return
       const material = child.material as THREE.Material

--- a/packages/three-renderer/__tests__/AcTrGroup.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrGroup.spec.ts
@@ -115,4 +115,28 @@ describe('AcTrGroup wcsBbox', () => {
       [union.max.x, union.max.y, 0]
     )
   })
+
+  it('keeps wcsBbox aligned with child-box union after rotated insert transform', () => {
+    const context = new AcTrRenderContext()
+    const lineA = createLine('line-a', { x: 0, y: 0 }, { x: 10, y: 0 }, context)
+    const lineB = createLine('line-b', { x: 0, y: 0 }, { x: 0, y: 10 }, context)
+    const group = new AcTrGroup([lineA, lineB], context)
+
+    group.applyMatrix(new AcGeMatrix3d().makeRotationZ(Math.PI / 4))
+
+    const union = new THREE.Box3()
+    for (const box of group.wcsChildBoxes) {
+      union.union(
+        new THREE.Box3(
+          new THREE.Vector3(box.minX, box.minY, 0),
+          new THREE.Vector3(box.maxX, box.maxY, 0)
+        )
+      )
+    }
+    expectWcsBboxCloseTo(
+      group.wcsBbox,
+      [union.min.x, union.min.y, 0],
+      [union.max.x, union.max.y, 0]
+    )
+  })
 })

--- a/packages/three-renderer/src/index.ts
+++ b/packages/three-renderer/src/index.ts
@@ -29,8 +29,10 @@ export {
 } from './style/AcTrHatchPatternShaders'
 export * from './util/AcTrMTextColorUtil'
 export {
+  isHighlightCloneDrawable,
   isHighlightOverlayDescendant,
   markHighlightOverlayGroup,
   type AcTrHighlightOverlayGroup,
   type AcTrHighlightOverlayGroupUserData
 } from './util/AcTrObjectUserData'
+export { isObjectHierarchyVisible } from './util/AcTrVisibility'

--- a/packages/three-renderer/src/object/AcTrGroup.ts
+++ b/packages/three-renderer/src/object/AcTrGroup.ts
@@ -83,6 +83,12 @@ export class AcTrGroup extends AcTrEntity {
     // hovering over one entity. For example, when hovering on one character in one
     // block reference, its bounding box is used to check intersection instead of its
     // real shape. After merging, there is no way to do this kind of check.
+
+    // wcsChildBoxes is the source of truth for spatial indexing. The aggregate
+    // wcsBbox union taken during construction (or Box3.applyMatrix4 after INSERT)
+    // can be slightly larger than the union of per-child boxes when transforms
+    // include rotation or when nested groups carry mismatched metadata.
+    this.syncWcsBboxFromChildBoxes()
   }
 
   get isOnTheSameLayer() {
@@ -103,6 +109,7 @@ export class AcTrGroup extends AcTrEntity {
       this.applyMatrixToEntityBox(box, threeMatrix)
     )
     super.applyMatrix(matrix)
+    this.syncWcsBboxFromChildBoxes()
   }
 
   /**
@@ -123,6 +130,23 @@ export class AcTrGroup extends AcTrEntity {
     cloned.copy(this, false)
     this.copyGeometry(this, cloned)
     return cloned
+  }
+
+  private syncWcsBboxFromChildBoxes() {
+    if (this._wcsChildBoxes.length === 0) {
+      return
+    }
+
+    const union = new THREE.Box3()
+    for (const box of this._wcsChildBoxes) {
+      union.union(
+        new THREE.Box3(
+          new THREE.Vector3(box.minX, box.minY, 0),
+          new THREE.Vector3(box.maxX, box.maxY, 0)
+        )
+      )
+    }
+    this.wcsBbox = union
   }
 
   private storeBoxes(object: THREE.Object3D) {

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -206,6 +206,27 @@ export function isHighlightOverlayDescendant(object: THREE.Object3D): boolean {
   return false
 }
 
+/**
+ * Returns whether `object` is a transient selection/hover highlight clone rather
+ * than source drawing geometry.
+ *
+ * Highlight clones receive `userData.objectId` in
+ * {@link AcTrBatchedGroup.highlight}; leaf drawables in the normal scene graph do
+ * not. Entity containers also carry `objectId`, but they are excluded here.
+ */
+export function isHighlightCloneDrawable(object: THREE.Object3D): boolean {
+  if (getHighlightUserData(object).objectId == null) {
+    return false
+  }
+
+  const userData = getObjectUserData(object)
+  if (userData.layerName != null && object.children.length > 0) {
+    return false
+  }
+
+  return true
+}
+
 export function getBatchedContainerUserData(
   object: THREE.Object3D
 ): AcTrBatchedContainerUserData {


### PR DESCRIPTION
## Summary

- HTML export skips transient highlight clones (via `isHighlightCloneDrawable`) in addition to overlay descendants, and ignores plain drawables that are hidden locally or by an invisible ancestor.
- LineSegments2 export now respects `instanceCount` / draw range so only active segments are baked into snapshots.
- `AcTrGroup` re-syncs `wcsBbox` from per-child boxes after construction and matrix transforms, keeping spatial indexing accurate for rotated INSERT transforms.

## Test plan

- [x] `pnpm jest packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts packages/three-renderer/__tests__/AcTrGroup.spec.ts`