### PR TITLE
fix(html-export): snap T-junction and L-corner intersection osnap points

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
@@ -3,6 +3,10 @@ import {
   extractLineBatchSnapSegments,
   mergeConnectedSegments
 } from '../src/AcExOsnap'
+import {
+  intersectLineSegmentPoints,
+  intersectionGeomToleranceForSnap
+} from '../src/AcExOsnapIntersections'
 
 describe('mergeConnectedSegments', () => {
   it('merges indexed polyline edges into one logical segment', () => {
@@ -21,6 +25,44 @@ function f32(values: number[]): Float32Array {
 function u32(values: number[]): Uint32Array {
   return Uint32Array.from(values)
 }
+
+describe('intersectLineSegmentPoints', () => {
+  it('finds T-junction when stem endpoint is slightly off crossbar', () => {
+    const geomTol = intersectionGeomToleranceForSnap(2, 1)
+    const paramTol = geomTol * 1e-6
+    const hits = intersectLineSegmentPoints(
+      { x0: 0, y0: 5, x1: 10, y1: 5 },
+      { x0: 5, y0: 5.001, x1: 5, y1: 10 },
+      paramTol,
+      geomTol
+    )
+    expect(hits).toEqual([{ x: 5, y: 5 }])
+  })
+
+  it('finds L-corner where one line ends where the other starts', () => {
+    const geomTol = intersectionGeomToleranceForSnap(2, 1)
+    const paramTol = geomTol * 1e-6
+    const hits = intersectLineSegmentPoints(
+      { x0: 0, y0: 0, x1: 10, y1: 0 },
+      { x0: 10, y0: 0, x1: 10, y1: 10 },
+      paramTol,
+      geomTol
+    )
+    expect(hits).toEqual([{ x: 10, y: 0 }])
+  })
+
+  it('finds L-corner when shared endpoints are slightly off', () => {
+    const geomTol = intersectionGeomToleranceForSnap(2, 1)
+    const paramTol = geomTol * 1e-6
+    const hits = intersectLineSegmentPoints(
+      { x0: 0, y0: 0, x1: 10, y1: 0 },
+      { x0: 10.001, y0: 0, x1: 10.001, y1: 10 },
+      paramTol,
+      geomTol
+    )
+    expect(hits).toEqual([{ x: 10.001, y: 0 }])
+  })
+})
 
 describe('AcExOsnapIndex', () => {
   const layout = {
@@ -186,6 +228,147 @@ describe('AcExOsnapIndex', () => {
     expect(snap).toEqual({ x: 0, y: 0, mode: 'endpoint' })
   })
 
+  it('snaps to T-junction where stem ends on crossbar interior', () => {
+    const tLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 0,
+            y0: 5,
+            x1: 10,
+            y1: 5
+          },
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 5,
+            y0: 0,
+            x1: 5,
+            y1: 5
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(tLayout)
+    const snap = index.findSnap(5.1, 4.9, 1)
+    expect(snap).toEqual({ x: 5, y: 5, mode: 'intersection' })
+  })
+
+  it('snaps to T-junction where stem starts on crossbar interior', () => {
+    const tLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 0,
+            y0: 5,
+            x1: 10,
+            y1: 5
+          },
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 5,
+            y0: 5,
+            x1: 5,
+            y1: 10
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(tLayout)
+    const snap = index.findSnap(5.1, 4.9, 1)
+    expect(snap).toEqual({ x: 5, y: 5, mode: 'intersection' })
+  })
+
+  it('snaps to T-junction when stem endpoint is slightly off crossbar', () => {
+    const tLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 0,
+            y0: 5,
+            x1: 10,
+            y1: 5
+          },
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 5,
+            y0: 5.001,
+            x1: 5,
+            y1: 10
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(tLayout)
+    const snap = index.findSnap(5.1, 4.9, 1)
+    expect(snap).toEqual({ x: 5, y: 5, mode: 'intersection' })
+  })
+
+  it('snaps to L-corner where two line endpoints meet', () => {
+    const cornerLayout = {
+      ...layout,
+      osnap: {
+        primitives: [
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 0,
+            y0: 0,
+            x1: 10,
+            y1: 0
+          },
+          {
+            kind: 'line' as const,
+            layer: '0',
+            x0: 10,
+            y0: 0,
+            x1: 10,
+            y1: 10
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(cornerLayout)
+    const snap = index.findSnap(9.9, 0.1, 1)
+    expect(snap).toEqual({ x: 10, y: 0, mode: 'intersection' })
+  })
+
+  it('snaps to L-corner in tessellated fallback layout', () => {
+    const cornerLayout = {
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0] as [number, number, number],
+          positions: f32([0, 0, 0, 10, 0, 0, 10, 0, 0, 10, 10, 0])
+        }
+      ],
+      meshBatches: []
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(cornerLayout)
+    const snap = index.findSnap(9.9, 0.1, 1)
+    expect(snap).toEqual({ x: 10, y: 0, mode: 'intersection' })
+  })
+
   it('snaps to line-line intersection from analytic primitives', () => {
     const crossLayout = {
       ...layout,
@@ -309,6 +492,27 @@ describe('AcExOsnapIndex', () => {
     const index = new AcExOsnapIndex(['intersection'])
     index.rebuild(parallelLayout)
     expect(index.findSnap(5, 1, 2)).toBeUndefined()
+  })
+
+  it('snaps to T-junction in tessellated fallback layout', () => {
+    const tLayout = {
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0] as [number, number, number],
+          positions: f32([0, 5, 0, 10, 5, 0, 5, 5, 0, 5, 10, 0])
+        }
+      ],
+      meshBatches: []
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(tLayout)
+    const snap = index.findSnap(5.1, 4.9, 1)
+    expect(snap).toEqual({ x: 5, y: 5, mode: 'intersection' })
   })
 
   it('snaps to segment intersection in tessellated fallback layout', () => {

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -9,8 +9,9 @@ import {
 } from './AcExOsnapGeometry'
 import {
   ACEX_MAX_INTERSECTION_SOURCES,
+  intersectionGeomToleranceForSnap,
   intersectionToleranceForExtent,
-  intersectLineSegments,
+  intersectLineSegmentPoints,
   intersectPrimitivePair,
   isIntersectionCapablePrimitive
 } from './AcExOsnapIntersections'
@@ -832,7 +833,8 @@ export class AcExOsnapIndex {
 
     const threshSq = threshold * threshold
     const extent = Math.max(box.maxX - box.minX, box.maxY - box.minY, 1)
-    const tol = intersectionToleranceForExtent(extent)
+    const paramTol = intersectionToleranceForExtent(extent)
+    const geomTol = intersectionGeomToleranceForSnap(extent, threshold)
 
     const primIndices: number[] = []
     const segIndices: number[] = []
@@ -874,7 +876,12 @@ export class AcExOsnapIndex {
         ) {
           continue
         }
-        for (const point of intersectPrimitivePair(primA, primB, tol)) {
+        for (const point of intersectPrimitivePair(
+          primA,
+          primB,
+          paramTol,
+          geomTol
+        )) {
           const d2 = distSq(px, py, point.x, point.y)
           if (d2 <= bestDistSq) {
             bestDistSq = d2
@@ -898,12 +905,17 @@ export class AcExOsnapIndex {
         ) {
           continue
         }
-        const point = intersectLineSegments(segA, segB, tol)
-        if (!point) continue
-        const d2 = distSq(px, py, point.x, point.y)
-        if (d2 <= bestDistSq) {
-          bestDistSq = d2
-          best = { x: point.x, y: point.y, mode: 'intersection' }
+        for (const point of intersectLineSegmentPoints(
+          segA,
+          segB,
+          paramTol,
+          geomTol
+        )) {
+          const d2 = distSq(px, py, point.x, point.y)
+          if (d2 <= bestDistSq) {
+            bestDistSq = d2
+            best = { x: point.x, y: point.y, mode: 'intersection' }
+          }
         }
       }
     }

--- a/packages/cad-html-plugin/src/AcExOsnapIntersections.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapIntersections.ts
@@ -35,25 +35,148 @@ export function intersectionToleranceForExtent(extent: number): number {
   return Math.max(FLOAT_TOL, Math.max(extent, 1) * 1e-9)
 }
 
-export function intersectLineSegments(
+/**
+ * Geometric tolerance for T-junction and near-miss intersection snap.
+ *
+ * Parametric segment intersection uses {@link intersectionToleranceForExtent};
+ * endpoint-on-segment checks also scale with the osnap aperture so stem endpoints
+ * that sit slightly off a crossbar still snap like AutoCAD.
+ */
+export function intersectionGeomToleranceForSnap(
+  extent: number,
+  threshold: number
+): number {
+  return (
+    Math.max(intersectionToleranceForExtent(extent), threshold * 1e-3) +
+    FLOAT_TOL
+  )
+}
+
+function withinGeomTolerance(distance: number, geomTol: number): boolean {
+  return distance <= geomTol
+}
+
+function closestPointOnSegmentLike(
+  px: number,
+  py: number,
+  seg: AcExOsnapSegmentLike
+): { x: number; y: number; t: number; dist: number } {
+  const dx = seg.x1 - seg.x0
+  const dy = seg.y1 - seg.y0
+  const lenSq = dx * dx + dy * dy
+  if (lenSq < 1e-18) {
+    const dist = Math.hypot(px - seg.x0, py - seg.y0)
+    return { x: seg.x0, y: seg.y0, t: 0, dist }
+  }
+  let t = ((px - seg.x0) * dx + (py - seg.y0) * dy) / lenSq
+  t = Math.max(0, Math.min(1, t))
+  const x = seg.x0 + t * dx
+  const y = seg.y0 + t * dy
+  return { x, y, t, dist: Math.hypot(px - x, py - y) }
+}
+
+function appendUniqueIntersectionPoint(
+  out: Array<{ x: number; y: number }>,
+  point: { x: number; y: number },
+  tol: number
+): void {
+  for (const existing of out) {
+    if (Math.hypot(existing.x - point.x, existing.y - point.y) <= tol) {
+      return
+    }
+  }
+  out.push(point)
+}
+
+function intersectLineSegmentsParametric(
   a: AcExOsnapSegmentLike,
   b: AcExOsnapSegmentLike,
-  tol: number
+  paramTol: number,
+  geomTol = paramTol
 ): { x: number; y: number } | undefined {
   const d1x = a.x1 - a.x0
   const d1y = a.y1 - a.y0
   const d2x = b.x1 - b.x0
   const d2y = b.y1 - b.y0
   const denom = d1x * d2y - d1y * d2x
-  if (Math.abs(denom) < tol) return undefined
+  if (Math.abs(denom) < paramTol) return undefined
 
   const dx = b.x0 - a.x0
   const dy = b.y0 - a.y0
   const t = (dx * d2y - dy * d2x) / denom
   const u = (dx * d1y - dy * d1x) / denom
-  if (t < -tol || t > 1 + tol || u < -tol || u > 1 + tol) return undefined
+  if (t < -geomTol || t > 1 + geomTol || u < -geomTol || u > 1 + geomTol) {
+    return undefined
+  }
 
   return { x: a.x0 + t * d1x, y: a.y0 + t * d1y }
+}
+
+/**
+ * T-junction snap: one segment endpoint lies on the interior (or boundary) of
+ * the other segment within `geomTol`, but parametric intersection can miss when
+ * the endpoint is only slightly off the host line.
+ */
+function intersectLineSegmentsEndpointJoin(
+  a: AcExOsnapSegmentLike,
+  b: AcExOsnapSegmentLike,
+  geomTol: number
+): Array<{ x: number; y: number }> {
+  const out: Array<{ x: number; y: number }> = []
+  const endpointsA = [
+    { x: a.x0, y: a.y0 },
+    { x: a.x1, y: a.y1 }
+  ]
+  const endpointsB = [
+    { x: b.x0, y: b.y0 },
+    { x: b.x1, y: b.y1 }
+  ]
+
+  for (const ep of endpointsA) {
+    const onB = closestPointOnSegmentLike(ep.x, ep.y, b)
+    if (withinGeomTolerance(onB.dist, geomTol)) {
+      appendUniqueIntersectionPoint(out, { x: onB.x, y: onB.y }, geomTol)
+    }
+  }
+  for (const ep of endpointsB) {
+    const onA = closestPointOnSegmentLike(ep.x, ep.y, a)
+    if (withinGeomTolerance(onA.dist, geomTol)) {
+      appendUniqueIntersectionPoint(out, { x: onA.x, y: onA.y }, geomTol)
+    }
+  }
+
+  return out
+}
+
+export function intersectLineSegments(
+  a: AcExOsnapSegmentLike,
+  b: AcExOsnapSegmentLike,
+  paramTol: number,
+  geomTol = paramTol
+): { x: number; y: number } | undefined {
+  const parametric = intersectLineSegmentsParametric(a, b, paramTol, geomTol)
+  if (parametric) return parametric
+
+  const endpointJoin = intersectLineSegmentsEndpointJoin(a, b, geomTol)
+  return endpointJoin[0]
+}
+
+/** All intersection points between two line segments (crossing and T-junction). */
+export function intersectLineSegmentPoints(
+  a: AcExOsnapSegmentLike,
+  b: AcExOsnapSegmentLike,
+  paramTol: number,
+  geomTol = paramTol
+): Array<{ x: number; y: number }> {
+  const out: Array<{ x: number; y: number }> = []
+  const parametric = intersectLineSegmentsParametric(a, b, paramTol, geomTol)
+  if (parametric) {
+    out.push(parametric)
+  }
+  for (const point of intersectLineSegmentsEndpointJoin(a, b, geomTol)) {
+    appendUniqueIntersectionPoint(out, point, geomTol)
+  }
+  return out
 }
 
 function isAngleInArcSweep(
@@ -89,33 +212,71 @@ function isPointOnCircArc(
   return isAngleInArcSweep(angle, prim, tol)
 }
 
+function lineEndpointsOnCircArc(
+  line: AcExOsnapLinePrimitive,
+  circ: AcExCircArcLike,
+  geomTol: number
+): Array<{ x: number; y: number }> {
+  const out: Array<{ x: number; y: number }> = []
+  for (const ep of [
+    { x: line.x0, y: line.y0 },
+    { x: line.x1, y: line.y1 }
+  ]) {
+    if (isPointOnCircArc(ep.x, ep.y, circ, geomTol)) {
+      appendUniqueIntersectionPoint(out, ep, geomTol)
+      continue
+    }
+    const dx = ep.x - circ.cx
+    const dy = ep.y - circ.cy
+    const dist = Math.hypot(dx, dy)
+    if (dist < geomTol) continue
+    const px = circ.cx + (dx / dist) * circ.r
+    const py = circ.cy + (dy / dist) * circ.r
+    if (
+      isPointOnCircArc(px, py, circ, geomTol) &&
+      withinGeomTolerance(Math.hypot(ep.x - px, ep.y - py), geomTol)
+    ) {
+      appendUniqueIntersectionPoint(out, { x: px, y: py }, geomTol)
+    }
+  }
+  return out
+}
+
 function intersectLineCircle(
   line: AcExOsnapLinePrimitive,
   circ: AcExCircArcLike,
-  tol: number
+  paramTol: number,
+  geomTol = paramTol
 ): Array<{ x: number; y: number }> {
   const dx = line.x1 - line.x0
   const dy = line.y1 - line.y0
   const fx = line.x0 - circ.cx
   const fy = line.y0 - circ.cy
   const a = dx * dx + dy * dy
-  if (a < tol * tol) return []
+  if (a < paramTol * paramTol) {
+    return lineEndpointsOnCircArc(line, circ, geomTol)
+  }
 
   const b = 2 * (fx * dx + fy * dy)
   const c = fx * fx + fy * fy - circ.r * circ.r
   const disc = b * b - 4 * a * c
-  if (disc < -tol) return []
+  if (disc < -paramTol) {
+    return lineEndpointsOnCircArc(line, circ, geomTol)
+  }
 
   const out: Array<{ x: number; y: number }> = []
   const sqrtDisc = Math.sqrt(Math.max(0, disc))
   for (const sign of [-1, 1] as const) {
     const t = (-b + sign * sqrtDisc) / (2 * a)
-    if (t < -tol || t > 1 + tol) continue
+    if (t < -paramTol || t > 1 + paramTol) continue
     const x = line.x0 + t * dx
     const y = line.y0 + t * dy
-    if (isPointOnCircArc(x, y, circ, tol)) {
-      out.push({ x, y })
+    if (isPointOnCircArc(x, y, circ, geomTol)) {
+      appendUniqueIntersectionPoint(out, { x, y }, geomTol)
     }
+  }
+  for (const point of lineEndpointsOnCircArc(line, circ, geomTol)) {
+    appendUniqueIntersectionPoint(out, point, geomTol)
   }
   return out
 }
@@ -168,23 +329,23 @@ function intersectCircles(
 export function intersectPrimitivePair(
   a: AcExOsnapPrimitive,
   b: AcExOsnapPrimitive,
-  tol: number
+  paramTol: number,
+  geomTol = paramTol
 ): Array<{ x: number; y: number }> {
   if (a.kind === 'line' && b.kind === 'line') {
-    const hit = intersectLineSegments(a, b, tol)
-    return hit ? [hit] : []
+    return intersectLineSegmentPoints(a, b, paramTol, geomTol)
   }
   if (a.kind === 'line' && (b.kind === 'circle' || b.kind === 'arc')) {
-    return intersectLineCircle(a, b, tol)
+    return intersectLineCircle(a, b, paramTol, geomTol)
   }
   if (b.kind === 'line' && (a.kind === 'circle' || a.kind === 'arc')) {
-    return intersectLineCircle(b, a, tol)
+    return intersectLineCircle(b, a, paramTol, geomTol)
   }
   if (
     (a.kind === 'circle' || a.kind === 'arc') &&
     (b.kind === 'circle' || b.kind === 'arc')
   ) {
-    return intersectCircles(a, b, tol)
+    return intersectCircles(a, b, paramTol)
   }
   return []
 }


### PR DESCRIPTION
## Summary
- Add aperture-scaled geometric tolerance (`intersectionGeomToleranceForSnap`) for intersection osnap, separate from the existing extent-based parametric tolerance.
- Detect T-junction and L-corner snaps via endpoint-on-segment projection, in addition to classic parametric line-line intersection.
- Extend line–circle/arc intersection with endpoint-on-arc fallback for degenerate or near-miss cases.
- Add unit and integration tests for T-junctions, L-corners, and tessellated fallback layouts.

## Test plan
- [x] `pnpm jest packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts` (25 tests pass)
- [ ] Manual: open an HTML export, enable intersection osnap, verify T-junction and L-corner snapping near line endpoints
