### PR TITLE
fix(three-renderer): refresh AcTrGroup WCS bounds after deferred geometry

### DIFF
--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -1794,10 +1794,7 @@ export class AcTrView2d extends AcEdBaseView {
    */
   private async ensureGroupDrawableGeometry(group: AcTrGroup) {
     const pending: Promise<void>[] = []
-    group.traverse(child => {
-      if (!(child instanceof AcTrEntity)) {
-        return
-      }
+    const finalizeDeferredEntity = (child: AcTrEntity) => {
       if (this.entityUsedSyncDraw(child)) {
         return
       }
@@ -1808,6 +1805,17 @@ export class AcTrView2d extends AcEdBaseView {
         return
       }
       pending.push(Promise.resolve(drawable.syncDraw()))
+    }
+
+    group.getSourceEntities().forEach(finalizeDeferredEntity)
+    group.traverse(child => {
+      if (!(child instanceof AcTrEntity)) {
+        return
+      }
+      if (group.getSourceEntities().includes(child)) {
+        return
+      }
+      finalizeDeferredEntity(child)
     })
     await Promise.all(pending)
   }
@@ -1920,7 +1928,13 @@ export class AcTrView2d extends AcEdBaseView {
               entity instanceof AcDbRay || entity instanceof AcDbXline
             )
 
+            if (threeEntity instanceof AcTrGroup) {
+              await this.ensureGroupDrawableGeometry(threeEntity as AcTrGroup)
+            }
             await this.finishEntityGeometry(threeEntity, progressive)
+            if (threeEntity instanceof AcTrGroup) {
+              ;(threeEntity as AcTrGroup).refreshWcsChildBoxesFromChildren()
+            }
             this._scene.addEntity(threeEntity, isExtendBbox)
             this.applySessionHiddenObjectState(entity.objectId)
             // Release memory occupied by this entity
@@ -1969,6 +1983,7 @@ export class AcTrView2d extends AcEdBaseView {
 
   private async handleGroup(group: AcTrGroup) {
     await this.ensureGroupDrawableGeometry(group)
+    group.refreshWcsChildBoxesFromChildren()
 
     const children = group.children
     const objectsGroupByLayer: Map<string, THREE.Object3D[]> = new Map()

--- a/packages/three-renderer/__tests__/AcTrGroup.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrGroup.spec.ts
@@ -2,6 +2,7 @@ import { AcGeMatrix3d } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
 import { expectWcsBboxCloseTo } from './helpers/expectWcsBbox'
+import { AcTrEntity } from '../src/object/AcTrEntity'
 import { AcTrGroup } from '../src/object/AcTrGroup'
 import { AcTrLine } from '../src/object/AcTrLine'
 import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
@@ -163,5 +164,127 @@ describe('AcTrGroup wcsBbox', () => {
       [union.min.x, union.min.y, 0],
       [union.max.x, union.max.y, 0]
     )
+  })
+
+  it('rebuilds WCS child boxes after deferred geometry is attached', () => {
+    const context = new AcTrRenderContext()
+    const line = createLine('line-a', { x: 0, y: 0 }, { x: 10, y: 0 }, context, 'L2')
+    const deferred = createLine(
+      'line-deferred',
+      { x: 5, y: 5 },
+      { x: 15, y: 10 },
+      context,
+      'L3'
+    )
+    deferred.wcsBbox.makeEmpty()
+
+    const group = new AcTrGroup([line, deferred], context)
+    group.applyMatrix(new AcGeMatrix3d().makeTranslation(100, 200, 0))
+
+    expect(group.wcsChildBoxes).toHaveLength(1)
+
+    deferred.wcsBbox.set(
+      new THREE.Vector3(5, 5, 0),
+      new THREE.Vector3(15, 10, 0)
+    )
+    group.refreshWcsChildBoxesFromChildren()
+
+    expect(group.wcsChildBoxes).toHaveLength(2)
+    expect(group.wcsChildBoxes[1]).toMatchObject({
+      minX: 105,
+      minY: 205,
+      maxX: 115,
+      maxY: 210,
+      id: 'line-deferred'
+    })
+    expectWcsBboxCloseTo(group.wcsBbox, [100, 200, 0], [115, 210, 0])
+  })
+
+  it('skips invalid child boxes when applying insert transform', () => {
+    const context = new AcTrRenderContext()
+    const line = createLine('line-a', { x: 0, y: 0 }, { x: 10, y: 0 }, context, 'L2')
+    const group = new AcTrGroup([line], context)
+    group.wcsChildBoxes.push({
+      minX: Number.POSITIVE_INFINITY,
+      minY: Number.POSITIVE_INFINITY,
+      maxX: Number.NEGATIVE_INFINITY,
+      maxY: Number.NEGATIVE_INFINITY,
+      id: 'deferred-text'
+    })
+
+    group.applyMatrix(new AcGeMatrix3d().makeTranslation(50, 25, 0))
+
+    expect(group.wcsChildBoxes[0]).toMatchObject({
+      minX: 50,
+      minY: 25,
+      maxX: 60,
+      maxY: 25,
+      id: 'line-a'
+    })
+    expect(Number.isFinite(group.wcsChildBoxes[1].minX)).toBe(false)
+    expectWcsBboxCloseTo(group.wcsBbox, [50, 25, 0], [60, 25, 0])
+  })
+})
+
+describe('AcTrGroup dispose', () => {
+  it('clears detached source entities and disposes flattened render children', () => {
+    const context = new AcTrRenderContext()
+    const line = createLine('line-a', { x: 0, y: 0 }, { x: 10, y: 0 }, context)
+    const group = new AcTrGroup([line], context)
+
+    expect(group.getSourceEntities()).toHaveLength(1)
+    expect(group.getSourceEntities()[0]).toBe(line)
+    expect(group.children).toHaveLength(1)
+
+    const meshChild = group.children[0] as THREE.Object3D & {
+      geometry: THREE.BufferGeometry
+    }
+    const geometryDispose = jest.spyOn(meshChild.geometry, 'dispose')
+
+    group.dispose()
+
+    expect(group.getSourceEntities()).toHaveLength(0)
+    expect(geometryDispose).toHaveBeenCalledTimes(1)
+    expect(group.children).toHaveLength(0)
+  })
+
+  it('does not double-dispose attributes still attached as children', () => {
+    const context = new AcTrRenderContext()
+    const line0 = createLine(
+      'line-0',
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      context,
+      '0'
+    )
+    const group = new AcTrGroup([line0], context)
+    const attribute = createLine(
+      'attrib-1',
+      { x: 1, y: 1 },
+      { x: 5, y: 1 },
+      context,
+      'CARTOUCHE'
+    )
+    group.addChild(attribute)
+
+    expect(group.getSourceEntities()).toContain(attribute)
+
+    const disposeObjectSpy = jest.spyOn(AcTrEntity, 'disposeObject')
+
+    group.dispose()
+
+    const attributeShellCalls = disposeObjectSpy.mock.calls.filter(
+      ([target, removeFromParent]) =>
+        target === attribute && removeFromParent === false
+    )
+    const attributeCalls = disposeObjectSpy.mock.calls.filter(
+      ([target]) => target === attribute
+    )
+
+    expect(attributeShellCalls).toHaveLength(0)
+    expect(attributeCalls.length).toBeLessThanOrEqual(1)
+    expect(group.getSourceEntities()).toHaveLength(0)
+
+    disposeObjectSpy.mockRestore()
   })
 })

--- a/packages/three-renderer/src/object/AcTrEntity.ts
+++ b/packages/three-renderer/src/object/AcTrEntity.ts
@@ -344,7 +344,9 @@ export class AcTrEntity extends AcTrObject implements AcGiEntity {
     const threeMatrix = AcTrMatrixUtil.createMatrix4(matrix)
     this.applyMatrix4(threeMatrix)
     this.updateMatrixWorld(true)
-    this._wcsBbox.applyMatrix4(threeMatrix)
+    if (!this._wcsBbox.isEmpty()) {
+      this._wcsBbox.applyMatrix4(threeMatrix)
+    }
   }
 
   /**

--- a/packages/three-renderer/src/object/AcTrGroup.ts
+++ b/packages/three-renderer/src/object/AcTrGroup.ts
@@ -20,6 +20,39 @@ export class AcTrGroup extends AcTrEntity {
   private _isOnTheSameLayer: boolean
   private _wcsChildBoxes: AcTrEntityBox[] = []
 
+  /**
+   * Leaf {@link AcTrEntity} instances that contributed geometry to this group
+   * before {@link flatten} hoisted render meshes and removed intermediate
+   * containers from the scene graph.
+   *
+   * {@link AcTrGroup} construction follows this order:
+   *
+   * 1. Add each block-definition entity and call {@link registerSourceEntities}
+   * 2. Snapshot initial bounds via {@link storeBoxes}
+   * 3. Call {@link flatten}, which reparents drawable leaves directly under
+   *    this group and detaches the original {@link AcTrEntity} wrappers
+   *
+   * After step 3, `group.children` no longer contains the source entities,
+   * yet their `wcsBbox` values remain the authoritative block-local extents
+   * once deferred drawing (MText/Shape `syncDraw`) completes.
+   *
+   * This list is also extended by {@link addChild} when
+   * {@link AcDbRenderingCache.draw} appends block-reference attributes after
+   * the INSERT transform is applied. Those attributes stay attached to the
+   * group and are tracked here for both deferred drawing and spatial-index
+   * refresh.
+   *
+   * Consumers such as {@link getSourceEntities},
+   * {@link refreshWcsChildBoxesFromChildren}, and
+   * `AcTrView2d.ensureGroupDrawableGeometry` rely on this list because a
+   * post-flatten {@link THREE.Object3D.traverse} walk cannot recover the
+   * detached entity containers.
+   *
+   * Entries are deep-cloned in {@link copy} so rendering-cache block instances
+   * keep independent geometry state.
+   */
+  private _sourceEntities: AcTrEntity[] = []
+
   constructor(entities: AcTrEntity[], context: AcTrRenderContext) {
     super(context)
     entities.forEach(entity => {
@@ -30,6 +63,7 @@ export class AcTrGroup extends AcTrEntity {
         this.wcsBbox.union(subGroup.wcsBbox)
       } else {
         this.add(entity)
+        this.registerSourceEntities(entity)
         this.wcsBbox.union(entity.wcsBbox)
       }
       this.storeBoxes(entity)
@@ -101,6 +135,70 @@ export class AcTrGroup extends AcTrEntity {
   }
 
   /**
+   * Returns the entities captured in {@link _sourceEntities}.
+   *
+   * The returned array is the live backing store (not a defensive copy).
+   * Treat it as read-only unless you are extending {@link AcTrGroup} itself.
+   *
+   * @returns Block-definition entities and post-construction attributes that
+   *   remain addressable after {@link flatten}, in registration order.
+   */
+  getSourceEntities(): readonly AcTrEntity[] {
+    return this._sourceEntities
+  }
+
+  /**
+   * Rebuilds {@link wcsChildBoxes} and the aggregate {@link wcsBbox} from
+   * current entity geometry.
+   *
+   * Block-reference conversion through {@link AcDbRenderingCache.draw} may
+   * call {@link applyMatrix} while MText/Shape bounds are still empty. An empty
+   * {@link THREE.Box3} contains `±Infinity` corners; transforming those values
+   * yields `NaN` and breaks spatial-index consistency checks in
+   * `AcTrView2d.handleGroup`.
+   *
+   * This method is intended to run **after** deferred geometry is finished
+   * (see `AcTrView2d.ensureGroupDrawableGeometry`). It:
+   *
+   * 1. Clears {@link _wcsChildBoxes}
+   * 2. Recomputes one WCS axis-aligned box per tracked source entity via
+   *    {@link appendSourceEntityWcsChildBox}
+   * 3. Adds boxes for any {@link AcTrEntity} children still present in the
+   *    flattened tree (for example attributes not represented in
+   *    {@link _sourceEntities}) via {@link appendTreeEntityWcsChildBox}
+   * 4. Re-synchronizes the aggregate {@link wcsBbox} through
+   *    {@link syncWcsBboxFromChildBoxes}
+   *
+   * Coordinate rules:
+   *
+   * - **Insert not baked** (`matrixWorld` is not identity): source-entity
+   *   `wcsBbox` values are in block-local space; they are transformed by this
+   *   group's `matrixWorld`.
+   * - **Insert baked** (`bakeTransformToChildren` reset the group to
+   *   identity): each source entity's local `matrix` carries the baked INSERT
+   *   transform and is applied instead.
+   * - **Tree-resident entities** (attributes): already expressed relative to
+   *   the current scene graph; their full `matrixWorld` is used.
+   */
+  refreshWcsChildBoxesFromChildren() {
+    this._wcsChildBoxes.length = 0
+    this.updateMatrixWorld(true)
+    const scratch = new THREE.Box3()
+    for (const entity of this._sourceEntities) {
+      this.appendSourceEntityWcsChildBox(entity, scratch)
+    }
+    this.children.forEach(child => {
+      if (
+        child instanceof AcTrEntity &&
+        !this._sourceEntities.includes(child)
+      ) {
+        this.appendTreeEntityWcsChildBox(child, scratch)
+      }
+    })
+    this.syncWcsBboxFromChildBoxes()
+  }
+
+  /**
    * Block-reference attributes are appended after the group is constructed
    * (see AcDbRenderingCache.draw). Register their bounds for spatial indexing.
    */
@@ -116,6 +214,7 @@ export class AcTrGroup extends AcTrEntity {
       // including attributes on their own layers such as title-block CARTOUCHE.
       this._isOnTheSameLayer = false
     }
+    this.registerSourceEntities(entity)
     this.storeBoxes(entity)
     if (!entity.wcsBbox.isEmpty()) {
       this.wcsBbox.union(entity.wcsBbox)
@@ -128,9 +227,11 @@ export class AcTrGroup extends AcTrEntity {
    */
   applyMatrix(matrix: AcGeMatrix3d) {
     const threeMatrix = AcTrMatrixUtil.createMatrix4(matrix)
-    this._wcsChildBoxes.forEach(box =>
-      this.applyMatrixToEntityBox(box, threeMatrix)
-    )
+    this._wcsChildBoxes.forEach(box => {
+      if (AcTrGroup.isFiniteEntityBox(box)) {
+        this.applyMatrixToEntityBox(box, threeMatrix)
+      }
+    })
     super.applyMatrix(matrix)
     this.syncWcsBboxFromChildBoxes()
   }
@@ -142,6 +243,9 @@ export class AcTrGroup extends AcTrEntity {
     this._isOnTheSameLayer = object._isOnTheSameLayer
     this._wcsChildBoxes = []
     object.wcsChildBoxes.forEach(box => this._wcsChildBoxes.push({ ...box }))
+    this._sourceEntities = object._sourceEntities.map(
+      entity => entity.fastDeepClone() as AcTrEntity
+    )
     return super.copy(object, recursive)
   }
 
@@ -155,6 +259,47 @@ export class AcTrGroup extends AcTrEntity {
     return cloned
   }
 
+  /**
+   * Releases render resources owned by this group and its tracked source entities.
+   *
+   * {@link flatten} reparents drawable leaves onto {@link children} and detaches
+   * the original {@link AcTrEntity} wrappers listed in {@link _sourceEntities}.
+   * The base {@link AcTrEntity.dispose} walk only reaches `children`, so this
+   * override first disposes detached source shells (without removing live
+   * children) and then delegates to `super.dispose()` for the flattened mesh
+   * tree.
+   *
+   * Entities still present in `children` (for example block-reference
+   * attributes appended via {@link addChild}) are intentionally skipped here so
+   * they are not released twice.
+   */
+  dispose() {
+    const liveChildren = new Set(this.children)
+    for (const entity of this._sourceEntities) {
+      if (!liveChildren.has(entity)) {
+        AcTrEntity.disposeObject(entity, false)
+      }
+    }
+    this._sourceEntities.length = 0
+    super.dispose()
+  }
+
+  /**
+   * Recomputes the aggregate {@link wcsBbox} as the union of {@link _wcsChildBoxes}.
+   *
+   * {@link _wcsChildBoxes} is the source of truth for per-child spatial-index
+   * bounds. The union taken during construction or via
+   * {@link AcTrEntity.wcsBbox.union} can diverge slightly after rotated INSERT
+   * transforms or when nested groups contribute mismatched metadata; this
+   * method keeps the aggregate box aligned with the child-box list.
+   *
+   * No-op when {@link _wcsChildBoxes} is empty so an absent child list does
+   * not overwrite an existing {@link wcsBbox}.
+   *
+   * Called from the constructor, {@link addChild}, {@link applyMatrix},
+   * {@link refreshWcsChildBoxesFromChildren}, and whenever
+   * {@link storeBoxes} ingests new entries.
+   */
   private syncWcsBboxFromChildBoxes() {
     if (this._wcsChildBoxes.length === 0) {
       return
@@ -172,21 +317,234 @@ export class AcTrGroup extends AcTrEntity {
     this.wcsBbox = union
   }
 
+  /**
+   * Snapshots one block child's axis-aligned bounds into {@link _wcsChildBoxes}.
+   *
+   * Invoked while assembling a group from block-definition entities (before
+   * {@link flatten}) and again when {@link addChild} registers block-reference
+   * attributes. Each stored entry pairs an {@link AcDbObjectId} with a 2D WCS
+   * or block-local rectangle derived from the child's {@link wcsBbox}.
+   *
+   * Ingestion rules:
+   *
+   * - **Nested {@link AcTrGroup}**: copies the inner group's existing
+   *   {@link _wcsChildBoxes} entries instead of re-walking geometry, because
+   *   the inner list is already normalized to leaf entities.
+   * - **Leaf {@link AcTrEntity}**: reads `wcsBbox` min/max corners directly.
+   * - **Empty or non-finite boxes**: skipped via {@link isFiniteEntityBox} so
+   *   deferred MText/Shape geometry cannot seed `±Infinity` values that later
+   *   become `NaN` during {@link applyMatrix}.
+   *
+   * @param object - Block-definition entity or nested group whose bounds
+   *   should be recorded for spatial indexing.
+   */
   private storeBoxes(object: THREE.Object3D) {
     if (object instanceof AcTrGroup) {
-      object._wcsChildBoxes.forEach(box => this._wcsChildBoxes.push(box))
+      object._wcsChildBoxes.forEach(box => {
+        if (AcTrGroup.isFiniteEntityBox(box)) {
+          this._wcsChildBoxes.push(box)
+        }
+      })
     } else if (object instanceof AcTrEntity) {
-      // only leaf entities should contribute to _wcsChildBoxes
-      this._wcsChildBoxes.push({
+      if (object.wcsBbox.isEmpty()) {
+        return
+      }
+      const box = {
         minX: object.wcsBbox.min.x,
         minY: object.wcsBbox.min.y,
         maxX: object.wcsBbox.max.x,
         maxY: object.wcsBbox.max.y,
         id: object.objectId
-      })
+      }
+      if (!AcTrGroup.isFiniteEntityBox(box)) {
+        return
+      }
+      // only leaf entities should contribute to _wcsChildBoxes
+      this._wcsChildBoxes.push(box)
     }
   }
 
+  /**
+   * Records leaf entities from a newly added block child into
+   * {@link _sourceEntities}.
+   *
+   * Called from the constructor (before {@link flatten}) and from
+   * {@link addChild} when {@link AcDbRenderingCache.draw} attaches attributes.
+   *
+   * Nested {@link AcTrGroup} instances are flattened into their own
+   * {@link _sourceEntities} at construction time; this method copies that
+   * inner list rather than storing the nested group wrapper, so outer groups
+   * always track drawable leaves only.
+   *
+   * @param object - Block-definition entity or nested group being registered.
+   */
+  private registerSourceEntities(object: THREE.Object3D) {
+    if (object instanceof AcTrGroup) {
+      object.getSourceEntities().forEach(entity => {
+        this._sourceEntities.push(entity)
+      })
+      return
+    }
+    if (object instanceof AcTrEntity) {
+      this._sourceEntities.push(object)
+    }
+  }
+
+  /**
+   * Appends one WCS child box derived from a {@link _sourceEntities} entry.
+   *
+   * Used for entities detached from the scene graph by {@link flatten}. Their
+   * {@link wcsBbox} remains in block-local coordinates until an INSERT
+   * transform is applied.
+   *
+   * Transform selection mirrors the block-reference pipeline:
+   *
+   * - When this group's `matrixWorld` is identity (INSERT transform baked into
+   *   children), the source entity's local {@link THREE.Object3D.matrix} is
+   *   applied.
+   * - Otherwise the group's `matrixWorld` (the active INSERT transform) is
+   *   applied to the block-local box.
+   *
+   * Entries with an empty or non-finite resulting box are skipped so
+   * {@link _wcsChildBoxes} never receives `NaN` extents.
+   *
+   * @param entity - Tracked source entity whose `wcsBbox` should be converted
+   *   to WCS.
+   * @param scratch - Reusable {@link THREE.Box3} used to avoid per-entity
+   *   allocations during refresh.
+   */
+  private appendSourceEntityWcsChildBox(entity: AcTrEntity, scratch: THREE.Box3) {
+    if (entity.wcsBbox.isEmpty()) {
+      return
+    }
+
+    scratch.copy(entity.wcsBbox)
+    entity.updateMatrixWorld(true)
+    const transform = AcTrGroup.isWorldMatrixIdentity(this.matrixWorld)
+      ? entity.matrix
+      : this.matrixWorld
+    scratch.applyMatrix4(transform)
+    if (!Number.isFinite(scratch.min.x) || !Number.isFinite(scratch.max.x)) {
+      return
+    }
+
+    this._wcsChildBoxes.push({
+      minX: scratch.min.x,
+      minY: scratch.min.y,
+      maxX: scratch.max.x,
+      maxY: scratch.max.y,
+      id: entity.objectId
+    })
+  }
+
+  /**
+   * Appends one WCS child box for an {@link AcTrEntity} still present in this
+   * group's flattened `children` list.
+   *
+   * Block-reference **attributes** added through {@link addChild} after
+   * {@link AcDbRenderingCache.draw} are not removed by {@link flatten} and are
+   * typically already authored in WCS. For those entities the full
+   * `matrixWorld` transform is applied to `wcsBbox`.
+   *
+   * This path is only used when the child is **not** already listed in
+   * {@link _sourceEntities}, preventing duplicate spatial-index entries.
+   *
+   * @param entity - Entity still attached under this group.
+   * @param scratch - Reusable {@link THREE.Box3} used to avoid per-entity
+   *   allocations during refresh.
+   */
+  private appendTreeEntityWcsChildBox(entity: AcTrEntity, scratch: THREE.Box3) {
+    if (entity.wcsBbox.isEmpty()) {
+      return
+    }
+
+    entity.updateMatrixWorld(true)
+    scratch.copy(entity.wcsBbox)
+    scratch.applyMatrix4(entity.matrixWorld)
+    if (!Number.isFinite(scratch.min.x) || !Number.isFinite(scratch.max.x)) {
+      return
+    }
+
+    this._wcsChildBoxes.push({
+      minX: scratch.min.x,
+      minY: scratch.min.y,
+      maxX: scratch.max.x,
+      maxY: scratch.max.y,
+      id: entity.objectId
+    })
+  }
+
+  /**
+   * Tests whether a world matrix is effectively identity.
+   *
+   * {@link AcDbRenderingCache.draw} calls {@link bakeTransformToChildren}
+   * when a block reference carries attributes. That path resets the group's
+   * transform to identity while baking the INSERT matrix into each child.
+   * {@link refreshWcsChildBoxesFromChildren} uses this helper to decide
+   * whether to apply the group `matrixWorld` or each source entity's local
+   * `matrix` when rebuilding {@link _wcsChildBoxes}.
+   *
+   * Comparison uses a fixed epsilon (`1e-6`) on all 16 matrix elements.
+   *
+   * @param matrix - World matrix to test, typically `this.matrixWorld`.
+   * @returns `true` when the matrix matches identity within tolerance.
+   */
+  private static isWorldMatrixIdentity(matrix: THREE.Matrix4) {
+    const identity = new THREE.Matrix4()
+    for (let i = 0; i < 16; ++i) {
+      if (Math.abs(matrix.elements[i] - identity.elements[i]) > 1e-6) {
+        return false
+      }
+    }
+    return true
+  }
+
+  /**
+   * Tests whether a spatial-index child box contains only finite coordinates.
+   *
+   * Empty or deferred geometry snapshots produce `±Infinity` corners in
+   * {@link THREE.Box3}. {@link applyMatrix} and
+   * {@link applyMatrixToEntityBox} must ignore those entries; otherwise
+   * INSERT transforms propagate `NaN` into {@link _wcsChildBoxes} and the
+   * aggregate {@link wcsBbox}.
+   *
+   * Also used by {@link storeBoxes} and {@link applyMatrix} to filter invalid
+   * boxes at ingestion time.
+   *
+   * @param box - Axis-aligned 2D bounds candidate in WCS or block-local space.
+   * @returns `true` when all four corners are finite numbers.
+   */
+  private static isFiniteEntityBox(box: {
+    minX: number
+    minY: number
+    maxX: number
+    maxY: number
+  }) {
+    return (
+      Number.isFinite(box.minX) &&
+      Number.isFinite(box.minY) &&
+      Number.isFinite(box.maxX) &&
+      Number.isFinite(box.maxY)
+    )
+  }
+
+  /**
+   * Transforms one {@link _wcsChildBoxes} entry by a 3×3 INSERT matrix and
+   * writes back a new axis-aligned rectangle.
+   *
+   * Unlike {@link THREE.Box3.applyMatrix4}, which can expand an AABB after
+   * rotation, this helper transforms all four XY corners explicitly and
+   * recomputes the tight axis-aligned bounds — matching how block-reference
+   * child boxes are expected to behave in the spatial index.
+   *
+   * The input box is mutated in place. Callers must guard with
+   * {@link isFiniteEntityBox} before invoking so invalid snapshots are not
+   * propagated.
+   *
+   * @param box - Child spatial-index rectangle to transform; updated in place.
+   * @param matrix - INSERT transform as a {@link THREE.Matrix4}, typically
+   *   derived from {@link AcGeMatrix3d} via {@link AcTrMatrixUtil.createMatrix4}.
+   */
   private applyMatrixToEntityBox(box: AcTrEntityBox, matrix: THREE.Matrix4) {
     const points = [
       new THREE.Vector3(box.minX, box.minY, 0),


### PR DESCRIPTION
## Summary

- Track flattened block source entities in `AcTrGroup` so deferred `MText/Shape` geometry can rebuild spatial-index child boxes after `syncDraw` completes
- Skip applying transforms to empty or non-finite bounding boxes to prevent `NaN` extents during INSERT transforms
- Refresh group WCS bounds in `AcTrView2d` after progressive entity loading and group handling
- Add unit tests for deferred geometry refresh, invalid box filtering, and group dispose behavior

## Test plan

- [x] pm test -- --testPathPatterns=AcTrGroup.spec (10 tests passed)
- [ ] Open a DXF/DWG with block references containing MText/Shape and verify spatial indexing / selection bounds are correct after load completes