### PR TITLE
feat(example): add collapsible mobile file sidebar

### DIFF
--- a/packages/cad-simple-viewer-example/index.html
+++ b/packages/cad-simple-viewer-example/index.html
@@ -38,6 +38,10 @@
         overflow: auto;
       }
 
+      .file-sidebar-toggle {
+        display: none;
+      }
+
       .sidebar-title {
         font-size: 0.95rem;
         font-weight: 600;
@@ -172,23 +176,111 @@
           flex: 0 0 auto;
           max-width: none;
           min-width: 0;
-          height: 35%;
+          height: auto;
+          padding: 0;
+          overflow: visible;
           border-right: none;
           border-bottom: 1px solid #1f2937;
         }
 
+        .sidebar-title-desktop {
+          display: none;
+        }
+
+        .file-sidebar-toggle {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          width: 100%;
+          gap: 0.75rem;
+          padding: 0.65rem 0.85rem;
+          border: none;
+          background: #0f172a;
+          color: inherit;
+          cursor: pointer;
+          text-align: left;
+        }
+
+        .file-sidebar-toggle:hover {
+          background: #111827;
+        }
+
+        .file-sidebar-toggle-label {
+          display: flex;
+          flex-direction: column;
+          gap: 0.15rem;
+          min-width: 0;
+        }
+
+        .file-sidebar-toggle-subtitle {
+          font-size: 0.75rem;
+          font-weight: 400;
+          color: #9ca3af;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .file-sidebar-chevron {
+          flex: 0 0 auto;
+          font-size: 0.7rem;
+          color: #9ca3af;
+          transition: transform 0.2s ease;
+        }
+
+        .file-sidebar.expanded .file-sidebar-chevron {
+          transform: rotate(180deg);
+        }
+
+        .file-sidebar-body {
+          display: none;
+          flex-direction: column;
+          gap: 0.65rem;
+          padding: 0 0.85rem 0.75rem;
+          max-height: min(42vh, 320px);
+          overflow: auto;
+        }
+
+        .file-sidebar.expanded .file-sidebar-body {
+          display: flex;
+        }
+
         .viewer-pane {
-          height: 65%;
+          flex: 1;
+          min-height: 0;
+        }
+
+        .viewer-toolbar {
+          flex-wrap: wrap;
+          height: auto;
+          min-height: 48px;
+          padding: 0.45rem 0.75rem;
         }
       }
     </style>
   </head>
   <body>
     <div class="app-shell">
-      <aside class="file-sidebar">
-        <h2 class="sidebar-title">Predefined Files</h2>
-        <p class="sidebar-help">Select one file below or open a local DXF/DWG file.</p>
-        <div class="file-list" id="predefinedFileList">
+      <aside class="file-sidebar" id="fileSidebar">
+        <h2 class="sidebar-title sidebar-title-desktop">Predefined Files</h2>
+        <button
+          type="button"
+          class="file-sidebar-toggle"
+          id="fileSidebarToggle"
+          aria-expanded="false"
+          aria-controls="fileSidebarBody"
+        >
+          <span class="file-sidebar-toggle-label">
+            <span class="sidebar-title">Predefined Files</span>
+            <span class="file-sidebar-toggle-subtitle" id="fileSidebarSubtitle">
+              Tap to browse sample files
+            </span>
+          </span>
+          <span class="file-sidebar-chevron" aria-hidden="true">▼</span>
+        </button>
+        <div class="file-sidebar-body" id="fileSidebarBody">
+          <p class="sidebar-help">Select one file below or open a local DXF/DWG file.</p>
+          <div class="file-list" id="predefinedFileList">
           <button
             type="button"
             class="file-list-item"
@@ -238,6 +330,7 @@
           >
             patient-chairs.dwg
           </button>
+          </div>
         </div>
       </aside>
 

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -44,6 +44,9 @@ class CadViewerApp {
   private viewerPane: HTMLElement
   private emptyState: HTMLDivElement
   private predefinedButtons: NodeListOf<HTMLButtonElement>
+  private fileSidebar: HTMLElement
+  private fileSidebarToggle: HTMLButtonElement
+  private fileSidebarSubtitle: HTMLSpanElement
   private isInitialized: boolean = false
   private hasOpenedFile: boolean = false
   private hasLoadedDocument: boolean = false
@@ -85,10 +88,18 @@ class CadViewerApp {
     this.predefinedButtons = document.querySelectorAll(
       '#predefinedFileList .file-list-item'
     ) as NodeListOf<HTMLButtonElement>
+    this.fileSidebar = document.getElementById('fileSidebar') as HTMLElement
+    this.fileSidebarToggle = document.getElementById(
+      'fileSidebarToggle'
+    ) as HTMLButtonElement
+    this.fileSidebarSubtitle = document.getElementById(
+      'fileSidebarSubtitle'
+    ) as HTMLSpanElement
 
     this.setupFileHandling()
     this.setupToolbarActions()
     this.setupPredefinedFileActions()
+    this.setupMobileSidebar()
     this.updateEmptyStateVisibility()
     this.updateToolbarButtonsState()
   }
@@ -233,9 +244,51 @@ class CadViewerApp {
         this.updateEmptyStateVisibility()
         this.predefinedButtons.forEach(item => item.classList.remove('active'))
         button.classList.add('active')
+        this.updateFileSidebarSubtitle(button.textContent?.trim() || '')
+        this.setFileSidebarExpanded(false)
         void this.loadPredefinedFile(url)
       })
     })
+  }
+
+  private setupMobileSidebar() {
+    this.fileSidebarToggle.addEventListener('click', () => {
+      this.setFileSidebarExpanded(!this.fileSidebar.classList.contains('expanded'))
+    })
+
+    document.addEventListener('click', event => {
+      if (!this.isMobileLayout() || !this.fileSidebar.classList.contains('expanded')) {
+        return
+      }
+
+      const target = event.target
+      if (!(target instanceof Node)) {
+        return
+      }
+
+      if (!this.fileSidebar.contains(target)) {
+        this.setFileSidebarExpanded(false)
+      }
+    })
+
+    window.addEventListener('resize', () => {
+      if (!this.isMobileLayout()) {
+        this.setFileSidebarExpanded(false)
+      }
+    })
+  }
+
+  private isMobileLayout() {
+    return window.matchMedia('(max-width: 960px)').matches
+  }
+
+  private setFileSidebarExpanded(expanded: boolean) {
+    this.fileSidebar.classList.toggle('expanded', expanded)
+    this.fileSidebarToggle.setAttribute('aria-expanded', String(expanded))
+  }
+
+  private updateFileSidebarSubtitle(label: string) {
+    this.fileSidebarSubtitle.textContent = label || 'Tap to browse sample files'
   }
 
   private async loadLocalFile(file: File) {
@@ -269,6 +322,7 @@ class CadViewerApp {
       if (success) {
         this.onFileOpened()
         this.predefinedButtons.forEach(item => item.classList.remove('active'))
+        this.updateFileSidebarSubtitle('Tap to browse sample files')
         this.showMessage(`Successfully loaded: ${file.name}`, 'success')
       } else {
         this.showMessage(`Failed to load: ${file.name}`, 'error')

--- a/packages/three-renderer/__tests__/AcTrBufferGeometryUtil.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBufferGeometryUtil.spec.ts
@@ -10,6 +10,8 @@ describe('AcTrBufferGeometryUtil finite coordinate helpers', () => {
     expect(
       AcTrBufferGeometryUtil.isFinitePoint({ x: Number.NaN, y: 1, z: 0 })
     ).toBe(false)
+    expect(AcTrBufferGeometryUtil.isFinitePoint(null)).toBe(false)
+    expect(AcTrBufferGeometryUtil.isFinitePoint(undefined)).toBe(false)
   })
 
   it('avoids THREE.js NaN warnings in safeComputeBoundingBox', () => {

--- a/packages/three-renderer/src/util/AcTrBufferGeometryUtil.ts
+++ b/packages/three-renderer/src/util/AcTrBufferGeometryUtil.ts
@@ -287,8 +287,11 @@ export class AcTrBufferGeometryUtil {
   /**
    * Returns true when all coordinates of a 3D point are finite.
    */
-  static isFinitePoint(point: AcGePoint3dLike): boolean {
+  static isFinitePoint(
+    point: AcGePoint3dLike | null | undefined
+  ): boolean {
     return (
+      !!point &&
       Number.isFinite(point.x) &&
       Number.isFinite(point.y) &&
       Number.isFinite(point.z ?? 0)

--- a/packages/three-renderer/src/util/AcTrGeometrySanitizer.ts
+++ b/packages/three-renderer/src/util/AcTrGeometrySanitizer.ts
@@ -7,6 +7,8 @@ import {
   getOcsReferenceVector
 } from '@mlightcad/data-model'
 
+import { AcTrBufferGeometryUtil } from './AcTrBufferGeometryUtil'
+
 const FINITE_VECTOR_EPS = 1e-12
 const reportedIssues = new Set<string>()
 
@@ -23,12 +25,7 @@ export interface AcTrGeometrySanitizerContext {
  */
 export class AcTrGeometrySanitizer {
   static isFinitePoint(point: AcGePoint3dLike | null | undefined): boolean {
-    return (
-      !!point &&
-      Number.isFinite(point.x) &&
-      Number.isFinite(point.y) &&
-      Number.isFinite(point.z ?? 0)
-    )
+    return AcTrBufferGeometryUtil.isFinitePoint(point)
   }
 
   static filterFinitePoints(


### PR DESCRIPTION
## Summary

- Add a collapsible file sidebar for the cad-simple-viewer example on mobile (<=960px), with toggle button, selected-file subtitle, click-outside-to-close, and improved toolbar/layout.
- Consolidate `isFinitePoint` in `AcTrBufferGeometryUtil` with null/undefined guards; delegate from `AcTrGeometrySanitizer` and extend unit tests.

## Test plan

- [ ] Open cad-simple-viewer-example on a viewport <=960px and verify the file sidebar collapses/expands via the toggle
- [ ] Select a predefined file and confirm the subtitle updates and the sidebar auto-collapses
- [ ] Open a local DXF/DWG and confirm the subtitle resets
- [ ] Resize above 960px and confirm desktop sidebar layout is unchanged
- [ ] Run `pnpm test` in three-renderer and verify `AcTrBufferGeometryUtil` tests pass