### PR TITLE
fix(cad-simple-viewer): align Enter key behavior with AutoCAD allowNone semantics

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcEdPromptOptionsBehavior.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdPromptOptionsBehavior.spec.ts
@@ -98,6 +98,37 @@ describe('FloatingInputBoxes Enter priority', () => {
     expect(boxes.onNone).not.toHaveBeenCalled()
     expect(boxes.xInput.markInvalid).toHaveBeenCalledTimes(1)
   })
+
+  test('dynamic preview coordinates are not committed when user did not type', () => {
+    const boxes = createBoxes({
+      userTyped: false,
+      useDefaultValue: false,
+      allowNone: true
+    })
+    boxes.xInput.value = '123.45'
+    boxes.yInput = {
+      userTyped: false,
+      value: '67.89',
+      focused: false,
+      markValid: jest.fn(),
+      markInvalid: jest.fn(),
+      focus: jest.fn(),
+      select: jest.fn(),
+      isEventTarget: () => false
+    } as any
+    boxes.twoInputs = true
+    boxes.validateFn = jest.fn(() => ({
+      isValid: true,
+      value: { x: 123.45, y: 67.89, z: 0 }
+    }))
+    const e = createEnterEvent()
+
+    ;(boxes as any).handleKeyDown(e)
+
+    expect(boxes.onNone).toHaveBeenCalledTimes(1)
+    expect(boxes.onCommit).not.toHaveBeenCalled()
+    expect(boxes.validateFn).not.toHaveBeenCalled()
+  })
 })
 
 describe('Prompt option classes behavior matrix', () => {

--- a/packages/cad-simple-viewer/src/command/draw/AcApLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApLineCmd.ts
@@ -194,6 +194,8 @@ export class AcApLineCmd extends AcEdCommand {
           prompt.basePoint = new AcGePoint3d(basePoint)
           prompt.jig = new AcApLineJig(context.view, basePoint)
         }
+        // AutoCAD LINE: Enter at "next point" ends the command without adding a segment.
+        prompt.allowNone = true
         return prompt
       }
 

--- a/packages/cad-simple-viewer/src/command/draw/AcApMLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApMLineCmd.ts
@@ -306,6 +306,8 @@ export class AcApMLineCmd extends AcEdCommand {
           styleName,
           elementOffsets: resolveStyleElementOffsets()
         }))
+        // AutoCAD MLINE: Enter at "next point" ends the command without adding a vertex.
+        prompt.allowNone = true
         return prompt
       }
 

--- a/packages/cad-simple-viewer/src/command/draw/AcApPolylineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApPolylineCmd.ts
@@ -597,6 +597,8 @@ export class AcApPolylineCmd extends AcEdCommand {
           prompt.basePoint = new AcGePoint3d(basePoint)
         }
         prompt.jig = createPreviewJig(undefined)
+        // AutoCAD PLINE: Enter at "next point" ends the command without adding a vertex.
+        prompt.allowNone = true
         return prompt
       }
 
@@ -676,6 +678,7 @@ export class AcApPolylineCmd extends AcEdCommand {
         prompt.jig = createPreviewJig(undefined, end =>
           applyArcDirection(computeDefaultArcBulge(end))
         )
+        prompt.allowNone = true
         return prompt
       }
 

--- a/packages/cad-simple-viewer/src/command/draw/AcApSplineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApSplineCmd.ts
@@ -297,6 +297,8 @@ export class AcApSplineCmd extends AcEdCommand {
         prompt.basePoint = new AcGePoint3d(basePoint)
       }
       prompt.jig = createPreviewJig()
+      // AutoCAD SPLINE: Enter at "next point" ends the command without adding a fit/CV point.
+      prompt.allowNone = true
     }
 
     /**

--- a/packages/cad-simple-viewer/src/command/modify/AcApCopyCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApCopyCmd.ts
@@ -307,7 +307,8 @@ export class AcApCopyCmd extends AcEdCommand {
       pointPrompt.useBasePoint = true
       pointPrompt.useDashedLine = true
       pointPrompt.basePoint = basePoint
-      pointPrompt.allowNone = copyMode === 'Multiple'
+      // AutoCAD COPY: Enter at placement prompt ends without adding another copy.
+      pointPrompt.allowNone = true
       pointPrompt.jig = new AcApCopyPreviewJig(
         context.view,
         sourceEntities,

--- a/packages/cad-simple-viewer/src/command/modify/AcApMoveCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApMoveCmd.ts
@@ -96,6 +96,8 @@ export class AcApMoveCmd extends AcEdCommand {
           AcApI18n.t('jig.move.basePointOrDisplacement')
         )
         createDisplacementKeyword(prompt)
+        // AutoCAD MOVE: Enter at base point switches to displacement from origin.
+        prompt.allowNone = true
         return prompt
       }
 
@@ -103,6 +105,11 @@ export class AcApMoveCmd extends AcEdCommand {
         if (result.status === AcEdPromptStatus.OK) {
           basePoint = new AcGePoint3d(result.value!)
           this.machine.setState(new SecondPointState(this.machine))
+          return 'continue'
+        }
+
+        if (result.status === AcEdPromptStatus.None) {
+          this.machine.setState(new DisplacementState())
           return 'continue'
         }
 
@@ -136,6 +143,8 @@ export class AcApMoveCmd extends AcEdCommand {
             basePoint
           )
         }
+        // AutoCAD MOVE: Enter at second point ends without applying a move.
+        prompt.allowNone = true
         return prompt
       }
 
@@ -175,6 +184,8 @@ export class AcApMoveCmd extends AcEdCommand {
           sourceEntities,
           prompt.basePoint
         )
+        // AutoCAD MOVE: Enter at displacement prompt ends without applying a move.
+        prompt.allowNone = true
         return prompt
       }
 

--- a/packages/cad-simple-viewer/src/command/modify/AcApRotateCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApRotateCmd.ts
@@ -197,6 +197,8 @@ export class AcApRotateCmd extends AcEdCommand {
       prompt.basePoint = basePoint
       prompt.allowNegative = true
       prompt.allowZero = true
+      // AutoCAD ROTATE: Enter at angle prompt ends without rotating.
+      prompt.allowNone = true
       prompt.jig = new AcApRotatePreviewJig(
         context.view,
         sourceEntities,
@@ -236,6 +238,7 @@ export class AcApRotateCmd extends AcEdCommand {
       newAnglePrompt.basePoint = basePoint
       newAnglePrompt.allowNegative = true
       newAnglePrompt.allowZero = true
+      newAnglePrompt.allowNone = true
       newAnglePrompt.jig = new AcApRotatePreviewJig(
         context.view,
         sourceEntities,
@@ -303,6 +306,8 @@ export class AcApRotateCmd extends AcEdCommand {
       context.view,
       sourceEntities
     )
+    // AutoCAD ROTATE: Enter at base point cancels without rotating.
+    basePointPrompt.allowNone = true
     const basePointResult =
       await AcApDocManager.instance.editor.getPoint(basePointPrompt)
     if (basePointResult.status !== AcEdPromptStatus.OK) {

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptAngleOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptAngleOptions.ts
@@ -18,6 +18,7 @@ export class AcEdPromptAngleOptions extends AcEdPromptOptions<number> {
   private _useDefaultValue: boolean = false
   private _allowZero: boolean = true
   private _allowNegative: boolean = false
+  private _allowNone: boolean = false
 
   /**
    * Constructs a new `AcEdPromptAngleOptions` with a given prompt message.
@@ -150,6 +151,19 @@ export class AcEdPromptAngleOptions extends AcEdPromptOptions<number> {
   set allowNegative(flag: boolean) {
     if (!this.isReadOnly) {
       this._allowNegative = flag
+    }
+  }
+
+  /**
+   * Gets or sets whether pressing ENTER alone (no input) is accepted.
+   * Corresponds to `PromptAngleOptions.AllowNone` in AutoCAD .NET API.
+   */
+  get allowNone(): boolean {
+    return this._allowNone
+  }
+  set allowNone(flag: boolean) {
+    if (!this.isReadOnly) {
+      this._allowNone = flag
     }
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBox.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBox.ts
@@ -60,7 +60,12 @@ export class AcEdFloatingInputBox {
 
   /** Set value */
   set value(v: string) {
-    if (v !== undefined) this.input.value = v
+    if (v === undefined) return
+    const preserveSelection = this.focused && !this.userTyped
+    this.input.value = v
+    if (preserveSelection) {
+      this.input.select()
+    }
   }
 
   /** Read current text */
@@ -76,6 +81,9 @@ export class AcEdFloatingInputBox {
   /** Forwards focus() to the underlying element. */
   focus() {
     this.input.focus()
+    if (!this.userTyped) {
+      this.input.select()
+    }
   }
 
   /** Forwards blur() to the underlying element. */

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBoxes.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBoxes.ts
@@ -244,10 +244,14 @@ export class AcEdFloatingInputBoxes<T> {
         return
       }
 
-      // When allowNone is set and the user has not manually typed coordinates,
-      // treat Enter as PromptStatus.None so commands can finish naturally.
-      if (this.allowNone && !this.userTyped) {
-        this.onNone?.()
+      // Dynamic preview fills the inputs via setValue(); only manually typed
+      // coordinates should be committed on Enter.
+      if (!this.userTyped) {
+        if (this.allowNone) {
+          this.onNone?.()
+        } else {
+          currentInput.markInvalid()
+        }
       } else {
         const state = this.validate()
         if (state.isValid && state.value != null) {


### PR DESCRIPTION
## Summary

- Fix floating input boxes so dynamic preview coordinates are not committed when the user presses Enter without typing; Enter with `allowNone` now correctly returns `PromptStatus.None`.
- Preserve text selection in floating inputs during dynamic preview updates so typed-over preview values remain easy to replace.
- Add `allowNone` to `AcEdPromptAngleOptions` and enable it on LINE, PLINE, MLINE, SPLINE, COPY, MOVE, and ROTATE prompts to match AutoCAD behavior (Enter ends the command or cancels the current step without adding a point or applying a transform).

## Test plan

- [ ] Draw LINE / PLINE / MLINE / SPLINE: after placing the first point, press Enter at the next-point prompt — command should end without adding another vertex.
- [ ] COPY (multiple mode): press Enter at the placement prompt — command should end without placing another copy.
- [ ] MOVE: press Enter at base point — should switch to displacement mode; press Enter at second point or displacement prompt — should cancel without moving.
- [ ] ROTATE: press Enter at base point or angle prompt — should cancel without rotating.
- [ ] With dynamic coordinate preview visible and no manual typing, press Enter — should not commit preview coordinates (verify via new unit test).
- [ ] Run `AcEdPromptOptionsBehavior.spec.ts` tests.
