### PR TITLE
refactor: route layer and entity edits through open-for-write transactions

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApLayerCurCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerCurCmd.spec.ts
@@ -54,7 +54,6 @@ import { AcEdPromptStatus } from '../src/editor'
 
 interface TestEntity {
   layer: string
-  triggerModifiedEvent: jest.Mock
 }
 
 interface TestLayer {
@@ -62,8 +61,7 @@ interface TestLayer {
 }
 
 const createEntity = (layer: string): TestEntity => ({
-  layer,
-  triggerModifiedEvent: jest.fn()
+  layer
 })
 
 const createContext = (
@@ -73,13 +71,18 @@ const createContext = (
   currentLayer = 'Current'
 ) => {
   const clear = jest.fn()
+  const openEntityForWrite = jest.fn((objectId: string) =>
+    entities.get(objectId)
+  )
 
   return {
     clear,
+    openEntityForWrite,
     context: {
       doc: {
         database: {
           clayer: currentLayer,
+          openEntityForWrite,
           tables: {
             blockTable: {
               getEntityById: jest.fn((objectId: string) =>
@@ -111,7 +114,7 @@ describe('AcApLayerCurCmd', () => {
   test('changes preselected objects to the current layer', async () => {
     const line = createEntity('Old')
     const alreadyCurrent = createEntity('Current')
-    const { clear, context } = createContext(
+    const { clear, openEntityForWrite, context } = createContext(
       new Map([
         ['line', line],
         ['already-current', alreadyCurrent]
@@ -125,8 +128,8 @@ describe('AcApLayerCurCmd', () => {
 
     expect(AcApDocManager.instance.editor.getSelection).not.toHaveBeenCalled()
     expect(line.layer).toBe('Current')
-    expect(line.triggerModifiedEvent).toHaveBeenCalledTimes(1)
-    expect(alreadyCurrent.triggerModifiedEvent).not.toHaveBeenCalled()
+    expect(openEntityForWrite).toHaveBeenCalledTimes(1)
+    expect(openEntityForWrite).toHaveBeenCalledWith('line')
     expect(clear).toHaveBeenCalledTimes(1)
     expect(AcApDocManager.instance.regen).toHaveBeenCalledTimes(1)
     expect(AcApDocManager.instance.editor.showMessage).toHaveBeenCalledWith(
@@ -137,7 +140,7 @@ describe('AcApLayerCurCmd', () => {
 
   test('prompts for selection when no objects are preselected', async () => {
     const line = createEntity('Old')
-    const { context } = createContext(
+    const { openEntityForWrite, context } = createContext(
       new Map([['line', line]]),
       new Map([['Current', { name: 'Current' }]])
     )
@@ -155,13 +158,13 @@ describe('AcApLayerCurCmd', () => {
     const prompt = getSelection.mock.calls[0][0]
     expect(prompt.message).toBe('jig.laycur.prompt')
     expect(line.layer).toBe('Current')
-    expect(line.triggerModifiedEvent).toHaveBeenCalledTimes(1)
+    expect(openEntityForWrite).toHaveBeenCalledTimes(1)
     expect(AcApDocManager.instance.regen).toHaveBeenCalledTimes(1)
   })
 
   test('does not modify objects when the current layer cannot be resolved', async () => {
     const line = createEntity('Old')
-    const { clear, context } = createContext(
+    const { clear, openEntityForWrite, context } = createContext(
       new Map([['line', line]]),
       new Map(),
       ['line']
@@ -171,7 +174,7 @@ describe('AcApLayerCurCmd', () => {
     await cmd.execute(context as never)
 
     expect(line.layer).toBe('Old')
-    expect(line.triggerModifiedEvent).not.toHaveBeenCalled()
+    expect(openEntityForWrite).not.toHaveBeenCalled()
     expect(clear).not.toHaveBeenCalled()
     expect(AcApDocManager.instance.regen).not.toHaveBeenCalled()
     expect(AcApDocManager.instance.editor.showMessage).toHaveBeenCalledWith(
@@ -182,7 +185,7 @@ describe('AcApLayerCurCmd', () => {
 
   test('reports when selected objects are already on the current layer', async () => {
     const line = createEntity('Current')
-    const { clear, context } = createContext(
+    const { clear, openEntityForWrite, context } = createContext(
       new Map([['line', line]]),
       new Map([['Current', { name: 'Current' }]]),
       ['line']
@@ -191,7 +194,7 @@ describe('AcApLayerCurCmd', () => {
     const cmd = new AcApLayerCurCmd()
     await cmd.execute(context as never)
 
-    expect(line.triggerModifiedEvent).not.toHaveBeenCalled()
+    expect(openEntityForWrite).not.toHaveBeenCalled()
     expect(clear).not.toHaveBeenCalled()
     expect(AcApDocManager.instance.regen).not.toHaveBeenCalled()
     expect(AcApDocManager.instance.editor.showMessage).toHaveBeenCalledWith(

--- a/packages/cad-simple-viewer/__tests__/AcApLayerFreezeCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerFreezeCmd.spec.ts
@@ -78,6 +78,7 @@ import { AcEdPromptStatus } from '../src/editor'
 
 interface TestLayer {
   name: string
+  objectId: string
   standardFlags?: number
   isFrozen: boolean
 }
@@ -87,6 +88,7 @@ const lockedFlag = 0x04
 
 const createLayer = (name: string, standardFlags?: number): TestLayer => ({
   name,
+  objectId: `layer:${name}`,
   standardFlags,
   get isFrozen() {
     return !!((this.standardFlags ?? 0) & frozenFlag)
@@ -100,13 +102,19 @@ const createContext = (
 ) => {
   const clear = jest.fn()
   const layersByName = new Map(layers.map(layer => [layer.name, layer]))
+  const layersById = new Map(layers.map(layer => [layer.objectId, layer]))
+  const openObjectForWrite = jest.fn((objectId: string) =>
+    layersById.get(objectId)
+  )
 
   return {
     clear,
+    openObjectForWrite,
     context: {
       doc: {
         database: {
           clayer: currentLayer,
+          openObjectForWrite,
           tables: {
             blockTable: {
               getEntityById: (objectId: string) => entitiesById[objectId]

--- a/packages/cad-simple-viewer/__tests__/AcApLayerIsoCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerIsoCmd.spec.ts
@@ -74,6 +74,7 @@ import { AcEdPromptStatus } from '../src/editor'
 
 interface TestLayer {
   name: string
+  objectId: string
   isOff: boolean
   standardFlags?: number
   isFrozen: boolean
@@ -89,6 +90,7 @@ const createLayer = (
   standardFlags?: number
 ): TestLayer => ({
   name,
+  objectId: `layer:${name}`,
   isOff,
   standardFlags,
   get isFrozen() {
@@ -121,8 +123,13 @@ const createContext = (
 ) => {
   const clear = jest.fn()
   const layersByName = new Map(layers.map(layer => [layer.name, layer]))
+  const layersById = new Map(layers.map(layer => [layer.objectId, layer]))
+  const openObjectForWrite = jest.fn((objectId: string) =>
+    layersById.get(objectId)
+  )
   const db = {
     clayer: currentLayer,
+    openObjectForWrite,
     tables: {
       blockTable: {
         getEntityById: jest.fn((objectId: string) => entitiesById[objectId])

--- a/packages/cad-simple-viewer/__tests__/AcApLayerLockCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerLockCmd.spec.ts
@@ -62,6 +62,7 @@ import { AcEdPromptStatus } from '../src/editor'
 
 interface TestLayer {
   name: string
+  objectId: string
   standardFlags?: number
   isLocked: boolean
 }
@@ -71,6 +72,7 @@ const lockedFlag = 0x04
 
 const createLayer = (name: string, standardFlags?: number): TestLayer => ({
   name,
+  objectId: `layer:${name}`,
   standardFlags,
   get isLocked() {
     return !!((this.standardFlags ?? 0) & lockedFlag)
@@ -79,12 +81,20 @@ const createLayer = (name: string, standardFlags?: number): TestLayer => ({
 
 const createContext = (layers: Map<string, TestLayer>) => {
   const clear = jest.fn()
+  const layersById = new Map(
+    [...layers.values()].map(layer => [layer.objectId, layer])
+  )
+  const openObjectForWrite = jest.fn((objectId: string) =>
+    layersById.get(objectId)
+  )
 
   return {
     clear,
+    openObjectForWrite,
     context: {
       doc: {
         database: {
+          openObjectForWrite,
           tables: {
             blockTable: {
               getEntityById: jest.fn((objectId: string) =>

--- a/packages/cad-simple-viewer/__tests__/AcApLayerThawCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerThawCmd.spec.ts
@@ -41,6 +41,7 @@ import { AcApDocManager } from '../src/app'
 import { AcApLayerThawCmd } from '../src/command/layer/AcApLayerThawCmd'
 
 interface TestLayer {
+  objectId: string
   standardFlags?: number
   isFrozen: boolean
 }
@@ -48,7 +49,11 @@ interface TestLayer {
 const frozenFlag = 0x01
 const lockedFlag = 0x04
 
-const createLayer = (standardFlags?: number): TestLayer => ({
+const createLayer = (
+  objectId: string,
+  standardFlags?: number
+): TestLayer => ({
+  objectId,
   standardFlags,
   get isFrozen() {
     return !!((this.standardFlags ?? 0) & frozenFlag)
@@ -57,12 +62,18 @@ const createLayer = (standardFlags?: number): TestLayer => ({
 
 const createContext = (layers: TestLayer[]) => {
   const clear = jest.fn()
+  const layersById = new Map(layers.map(layer => [layer.objectId, layer]))
+  const openObjectForWrite = jest.fn((objectId: string) =>
+    layersById.get(objectId)
+  )
 
   return {
     clear,
+    openObjectForWrite,
     context: {
       doc: {
         database: {
+          openObjectForWrite,
           tables: {
             layerTable: {
               newIterator: () => layers
@@ -86,9 +97,9 @@ describe('AcApLayerThawCmd', () => {
 
   test('thaws frozen layers and preserves other layer flags', async () => {
     const layers = [
-      createLayer(frozenFlag | lockedFlag),
-      createLayer(frozenFlag),
-      createLayer(lockedFlag)
+      createLayer('layer-0', frozenFlag | lockedFlag),
+      createLayer('layer-1', frozenFlag),
+      createLayer('layer-2', lockedFlag)
     ]
     const { clear, context } = createContext(layers)
     const cmd = new AcApLayerThawCmd()
@@ -107,8 +118,8 @@ describe('AcApLayerThawCmd', () => {
 
   test('reports when every layer is already thawed', async () => {
     const { clear, context } = createContext([
-      createLayer(0),
-      createLayer(lockedFlag)
+      createLayer('layer-0', 0),
+      createLayer('layer-1', lockedFlag)
     ])
     const cmd = new AcApLayerThawCmd()
 

--- a/packages/cad-simple-viewer/__tests__/AcApLayerUnisoCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerUnisoCmd.spec.ts
@@ -73,6 +73,7 @@ import { AcApLayerUnisoCmd } from '../src/command/layer/AcApLayerUnisoCmd'
 
 interface TestLayer {
   name: string
+  objectId: string
   isOff: boolean
   standardFlags?: number
   isFrozen: boolean
@@ -88,6 +89,7 @@ const createLayer = (
   standardFlags?: number
 ): TestLayer => ({
   name,
+  objectId: `layer:${name}`,
   isOff,
   standardFlags,
   get isFrozen() {
@@ -106,8 +108,13 @@ const createContext = (
 ) => {
   const clear = jest.fn()
   const layersByName = new Map(layers.map(layer => [layer.name, layer]))
+  const layersById = new Map(layers.map(layer => [layer.objectId, layer]))
+  const openObjectForWrite = jest.fn((objectId: string) =>
+    layersById.get(objectId)
+  )
   const database = {
     clayer: currentLayer,
+    openObjectForWrite,
     tables: {
       blockTable: {
         getEntityById: (objectId: string) => entitiesById[objectId]

--- a/packages/cad-simple-viewer/__tests__/AcApLayerUnlockCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerUnlockCmd.spec.ts
@@ -62,6 +62,7 @@ import { AcEdPromptStatus } from '../src/editor'
 
 interface TestLayer {
   name: string
+  objectId: string
   standardFlags?: number
   isLocked: boolean
 }
@@ -71,6 +72,7 @@ const lockedFlag = 0x04
 
 const createLayer = (name: string, standardFlags?: number): TestLayer => ({
   name,
+  objectId: `layer:${name}`,
   standardFlags,
   get isLocked() {
     return !!((this.standardFlags ?? 0) & lockedFlag)
@@ -79,12 +81,20 @@ const createLayer = (name: string, standardFlags?: number): TestLayer => ({
 
 const createContext = (layers: Map<string, TestLayer>) => {
   const clear = jest.fn()
+  const layersById = new Map(
+    [...layers.values()].map(layer => [layer.objectId, layer])
+  )
+  const openObjectForWrite = jest.fn((objectId: string) =>
+    layersById.get(objectId)
+  )
 
   return {
     clear,
+    openObjectForWrite,
     context: {
       doc: {
         database: {
+          openObjectForWrite,
           tables: {
             blockTable: {
               getEntityById: jest.fn((objectId: string) =>

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerCmd.ts
@@ -13,6 +13,11 @@ import {
   AcEdPromptStringOptions
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import {
+  openLayerForWrite,
+  setLayerFrozenState,
+  setLayerLockedState
+} from './AcApLayerEdit'
 
 /**
  * Top-level keywords accepted by the `-LAYER` command main prompt.
@@ -236,34 +241,6 @@ export class AcApLayerCmd extends AcEdCommand {
   }
 
   /**
-   * Sets or clears the frozen bit in `standardFlags`.
-   *
-   * The explicit bit operation is used to ensure both freeze and thaw are
-   * applied deterministically.
-   *
-   * @param layer - Target layer table record.
-   * @param frozen - `true` to freeze, `false` to thaw.
-   */
-  private setLayerFrozen(layer: AcDbLayerTableRecord, frozen: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = frozen ? flags | 0x01 : flags & ~0x01
-  }
-
-  /**
-   * Sets or clears the locked bit in `standardFlags`.
-   *
-   * The explicit bit operation is used to ensure both lock and unlock are
-   * applied deterministically.
-   *
-   * @param layer - Target layer table record.
-   * @param locked - `true` to lock, `false` to unlock.
-   */
-  private setLayerLocked(layer: AcDbLayerTableRecord, locked: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = locked ? flags | 0x04 : flags & ~0x04
-  }
-
-  /**
    * Prompts for one or more layer names and parses them into a list.
    *
    * This helper powers batch operations such as on/off/freeze/thaw/lock/unlock
@@ -384,9 +361,12 @@ export class AcApLayerCmd extends AcEdCommand {
       return
     }
 
-    layer.isOff = false
-    this.setLayerFrozen(layer, false)
-    context.doc.database.clayer = layer.name
+    const opened = openLayerForWrite(context.doc.database, layer)
+    if (!opened) return
+
+    opened.isOff = false
+    setLayerFrozenState(opened, false)
+    context.doc.database.clayer = opened.name
   }
 
   /**
@@ -417,9 +397,12 @@ export class AcApLayerCmd extends AcEdCommand {
       table.add(layer)
     }
 
-    layer.isOff = false
-    this.setLayerFrozen(layer, false)
-    context.doc.database.clayer = layer.name
+    const opened = openLayerForWrite(context.doc.database, layer)
+    if (!opened) return
+
+    opened.isOff = false
+    setLayerFrozenState(opened, false)
+    context.doc.database.clayer = opened.name
   }
 
   /**
@@ -456,7 +439,9 @@ export class AcApLayerCmd extends AcEdCommand {
         skippedCurrent.push(layer.name)
         return
       }
-      layer.isOff = off
+      const opened = openLayerForWrite(db, layer)
+      if (!opened) return
+      opened.isOff = off
     })
 
     if (skippedCurrent.length > 0) {
@@ -498,7 +483,9 @@ export class AcApLayerCmd extends AcEdCommand {
         skippedCurrent.push(layer.name)
         return
       }
-      this.setLayerFrozen(layer, freeze)
+      const opened = openLayerForWrite(db, layer)
+      if (!opened) return
+      setLayerFrozenState(opened, freeze)
     })
 
     if (skippedCurrent.length > 0) {
@@ -531,7 +518,11 @@ export class AcApLayerCmd extends AcEdCommand {
         'warning'
       )
     }
-    layers.forEach(layer => this.setLayerLocked(layer, lock))
+    layers.forEach(layer => {
+      const opened = openLayerForWrite(context.doc.database, layer)
+      if (!opened) return
+      setLayerLockedState(opened, lock)
+    })
   }
 
   /**
@@ -610,7 +601,9 @@ export class AcApLayerCmd extends AcEdCommand {
     }
 
     layers.forEach(layer => {
-      layer.color = color.clone()
+      const opened = openLayerForWrite(context.doc.database, layer)
+      if (!opened) return
+      opened.color = color.clone()
     })
   }
 
@@ -646,6 +639,9 @@ export class AcApLayerCmd extends AcEdCommand {
     const result = await AcApDocManager.instance.editor.getString(descPrompt)
     if (result.status !== AcEdPromptStatus.OK) return
 
-    layer.description = result.stringResult ?? ''
+    const opened = openLayerForWrite(context.doc.database, layer)
+    if (!opened) return
+
+    opened.description = result.stringResult ?? ''
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerCurCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerCurCmd.ts
@@ -1,4 +1,4 @@
-import { AcDbEntity, AcDbObjectId } from '@mlightcad/data-model'
+import { AcDbObjectId } from '@mlightcad/data-model'
 
 import { AcApContext, AcApDocManager } from '../../app'
 import {
@@ -76,7 +76,7 @@ export class AcApLayerCurCmd extends AcEdCommand {
       return
     }
 
-    const changedEntities: AcDbEntity[] = []
+    let changedCount = 0
     let alreadyCurrent = 0
     let missing = 0
 
@@ -92,11 +92,17 @@ export class AcApLayerCurCmd extends AcEdCommand {
         return
       }
 
-      entity.layer = currentLayer.name
-      changedEntities.push(entity)
+      const opened = db.openEntityForWrite(objectId)
+      if (!opened) {
+        missing++
+        return
+      }
+
+      opened.layer = currentLayer.name
+      changedCount++
     })
 
-    if (changedEntities.length === 0) {
+    if (changedCount === 0) {
       this.showMessage(
         alreadyCurrent > 0
           ? AcApI18n.t('jig.laycur.alreadyCurrent')
@@ -106,12 +112,11 @@ export class AcApLayerCurCmd extends AcEdCommand {
       return
     }
 
-    changedEntities.forEach(entity => entity.triggerModifiedEvent())
     context.view.selectionSet.clear()
     // Layer changes move entities between render buckets, so rebuild the view.
     AcApDocManager.instance.regen()
     this.showMessage(
-      `${AcApI18n.t('jig.laycur.changed')}: ${changedEntities.length} (${currentLayer.name})`,
+      `${AcApI18n.t('jig.laycur.changed')}: ${changedCount} (${currentLayer.name})`,
       'success'
     )
   }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerEdit.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerEdit.ts
@@ -1,0 +1,76 @@
+import { AcDbDatabase, AcDbLayerTableRecord } from '@mlightcad/data-model'
+
+/** Bit mask for the global frozen flag in {@link AcDbLayerTableRecord.standardFlags}. */
+export const LAYER_FROZEN_FLAG = 0x01
+
+/** Bit mask for the locked flag in {@link AcDbLayerTableRecord.standardFlags}. */
+export const LAYER_LOCKED_FLAG = 0x04
+
+/**
+ * Opens an existing layer table record for write through the active transaction.
+ *
+ * Symbol table records follow ObjectARX semantics: callers must open a record
+ * with {@link AcDbDatabase.openObjectForWrite} before mutating it while a
+ * transaction is recording changes.
+ *
+ * @param db - Database that owns the layer table.
+ * @param layerOrName - Layer record or layer name to open.
+ * @returns The opened layer record, or `undefined` when the layer does not exist.
+ */
+export function openLayerForWrite(
+  db: AcDbDatabase,
+  layerOrName: AcDbLayerTableRecord | string
+): AcDbLayerTableRecord | undefined {
+  const layer =
+    typeof layerOrName === 'string'
+      ? db.tables.layerTable.getAt(layerOrName)
+      : layerOrName
+  if (!layer) return undefined
+  return db.openObjectForWrite<AcDbLayerTableRecord>(layer.objectId)
+}
+
+/**
+ * Sets or clears the frozen bit in a layer's {@link AcDbLayerTableRecord.standardFlags}.
+ *
+ * Other standard flags on the record are preserved.
+ *
+ * @param layer - Layer record that is already open for write.
+ * @param frozen - `true` to freeze the layer, `false` to thaw it.
+ */
+export function setLayerFrozenState(
+  layer: AcDbLayerTableRecord,
+  frozen: boolean
+) {
+  const flags = layer.standardFlags ?? 0
+  layer.standardFlags = frozen
+    ? flags | LAYER_FROZEN_FLAG
+    : flags & ~LAYER_FROZEN_FLAG
+}
+
+/**
+ * Sets or clears the locked bit in a layer's {@link AcDbLayerTableRecord.standardFlags}.
+ *
+ * Other standard flags on the record are preserved.
+ *
+ * @param layer - Layer record that is already open for write.
+ * @param locked - `true` to lock the layer, `false` to unlock it.
+ */
+export function setLayerLockedState(
+  layer: AcDbLayerTableRecord,
+  locked: boolean
+) {
+  const flags = layer.standardFlags ?? 0
+  layer.standardFlags = locked
+    ? flags | LAYER_LOCKED_FLAG
+    : flags & ~LAYER_LOCKED_FLAG
+}
+
+/**
+ * Returns whether a layer is locked according to its standard flags.
+ *
+ * @param layer - Layer record to inspect.
+ * @returns `true` when the locked bit is set in {@link AcDbLayerTableRecord.standardFlags}.
+ */
+export function isLayerLocked(layer: AcDbLayerTableRecord): boolean {
+  return ((layer.standardFlags ?? 0) & LAYER_LOCKED_FLAG) !== 0
+}

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerFreezeCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerFreezeCmd.ts
@@ -1,4 +1,4 @@
-import { AcDbLayerTableRecord, AcDbObjectId } from '@mlightcad/data-model'
+import { AcDbObjectId } from '@mlightcad/data-model'
 
 import { AcApContext, AcApDocManager } from '../../app'
 import {
@@ -9,6 +9,7 @@ import {
   AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { openLayerForWrite, setLayerFrozenState } from './AcApLayerEdit'
 
 /**
  * Top-level keywords supported by the `LAYFRZ` entity selection prompt.
@@ -325,17 +326,6 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
   }
 
   /**
-   * Toggles the frozen flag on a layer table record.
-   *
-   * @param layer - Layer record to update.
-   * @param frozen - Whether the layer should be marked frozen.
-   */
-  private setLayerFrozen(layer: AcDbLayerTableRecord, frozen: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = frozen ? flags | 0x01 : flags & ~0x01
-  }
-
-  /**
    * Resolves the picked entity's layer and freezes it when allowed.
    *
    * The method validates the selection, prevents freezing the current layer,
@@ -389,7 +379,10 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
       wasFrozen: layer.isFrozen
     })
 
-    this.setLayerFrozen(layer, true)
+    const opened = openLayerForWrite(db, layer)
+    if (!opened) return
+
+    setLayerFrozenState(opened, true)
     context.view.selectionSet.clear()
     this.showMessage(
       `${AcApI18n.t('jig.layfrz.frozen')}: ${layer.name}`,
@@ -420,7 +413,10 @@ export class AcApLayerFreezeCmd extends AcEdCommand {
       return
     }
 
-    this.setLayerFrozen(layer, history.wasFrozen)
+    const opened = openLayerForWrite(context.doc.database, layer)
+    if (!opened) return
+
+    setLayerFrozenState(opened, history.wasFrozen)
     context.view.selectionSet.clear()
     this.showMessage(
       `${AcApI18n.t('jig.layfrz.restored')}: ${layer.name}`,

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerIsoCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerIsoCmd.ts
@@ -1,4 +1,4 @@
-import { AcDbLayerTableRecord, AcDbObjectId } from '@mlightcad/data-model'
+import { AcDbObjectId } from '@mlightcad/data-model'
 
 import { AcApContext, AcApDocManager } from '../../app'
 import {
@@ -9,6 +9,11 @@ import {
   AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import {
+  openLayerForWrite,
+  setLayerFrozenState,
+  setLayerLockedState
+} from './AcApLayerEdit'
 import {
   AcApLayerIsoLayerSnapshot,
   AcApLayerIsoLayerState,
@@ -265,28 +270,6 @@ export class AcApLayerIsoCmd extends AcEdCommand {
   }
 
   /**
-   * Sets or clears the frozen bit while preserving other layer flags.
-   *
-   * @param layer - Target layer table record.
-   * @param frozen - Whether the layer should be marked frozen.
-   */
-  private setLayerFrozen(layer: AcDbLayerTableRecord, frozen: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = frozen ? flags | 0x01 : flags & ~0x01
-  }
-
-  /**
-   * Sets or clears the locked bit while preserving other layer flags.
-   *
-   * @param layer - Target layer table record.
-   * @param locked - Whether the layer should be marked locked.
-   */
-  private setLayerLocked(layer: AcDbLayerTableRecord, locked: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = locked ? flags | 0x04 : flags & ~0x04
-  }
-
-  /**
    * Resolves selected entities to layer names and applies isolation.
    *
    * @param context - Active application context containing database and view.
@@ -320,33 +303,36 @@ export class AcApLayerIsoCmd extends AcEdCommand {
     const affectedLayerNames = new Set<string>()
 
     for (const layer of table.newIterator()) {
-      if (targetNames.has(layer.name)) {
-        if (layer.isOff) {
-          layer.isOff = false
-          affectedLayerNames.add(layer.name)
+      const opened = openLayerForWrite(db, layer)
+      if (!opened) continue
+
+      if (targetNames.has(opened.name)) {
+        if (opened.isOff) {
+          opened.isOff = false
+          affectedLayerNames.add(opened.name)
         }
-        if (layer.isFrozen) {
-          this.setLayerFrozen(layer, false)
-          affectedLayerNames.add(layer.name)
+        if (opened.isFrozen) {
+          setLayerFrozenState(opened, false)
+          affectedLayerNames.add(opened.name)
         }
-        if (layer.isLocked) {
-          this.setLayerLocked(layer, false)
-          affectedLayerNames.add(layer.name)
+        if (opened.isLocked) {
+          setLayerLockedState(opened, false)
+          affectedLayerNames.add(opened.name)
         }
         continue
       }
 
       if (AcApLayerIsoCmd._settings.isolationMode === 'Off') {
-        if (!layer.isOff) {
-          layer.isOff = true
-          affectedLayerNames.add(layer.name)
+        if (!opened.isOff) {
+          opened.isOff = true
+          affectedLayerNames.add(opened.name)
         }
         continue
       }
 
-      if (!layer.isLocked) {
-        this.setLayerLocked(layer, true)
-        affectedLayerNames.add(layer.name)
+      if (!opened.isLocked) {
+        setLayerLockedState(opened, true)
+        affectedLayerNames.add(opened.name)
       }
     }
 

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerLockCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerLockCmd.ts
@@ -1,4 +1,4 @@
-import { AcDbLayerTableRecord, AcDbObjectId } from '@mlightcad/data-model'
+import { AcDbObjectId } from '@mlightcad/data-model'
 
 import { AcApContext, AcApDocManager } from '../../app'
 import {
@@ -8,6 +8,7 @@ import {
   AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { openLayerForWrite, setLayerLockedState } from './AcApLayerEdit'
 
 /**
  * AutoCAD-like `LAYLCK` command.
@@ -60,17 +61,6 @@ export class AcApLayerLockCmd extends AcEdCommand {
   }
 
   /**
-   * Sets or clears the locked bit in `standardFlags`.
-   *
-   * @param layer - Target layer table record.
-   * @param locked - `true` to lock, `false` to unlock.
-   */
-  private setLayerLocked(layer: AcDbLayerTableRecord, locked: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = locked ? flags | 0x04 : flags & ~0x04
-  }
-
-  /**
    * Resolves the picked entity's layer and locks it when needed.
    *
    * @param context - Active application context containing the current database and view.
@@ -103,7 +93,10 @@ export class AcApLayerLockCmd extends AcEdCommand {
       return
     }
 
-    this.setLayerLocked(layer, true)
+    const opened = openLayerForWrite(db, layer)
+    if (!opened) return
+
+    setLayerLockedState(opened, true)
     context.view.selectionSet.clear()
     this.showMessage(
       `${AcApI18n.t('jig.laylck.locked')}: ${layer.name}`,

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerOffCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerOffCmd.ts
@@ -9,6 +9,7 @@ import {
   AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { openLayerForWrite } from './AcApLayerEdit'
 
 /**
  * Top-level keywords supported by the `LAYOFF` entity selection prompt.
@@ -375,7 +376,10 @@ export class AcApLayoffCmd extends AcEdCommand {
       wasOff: layer.isOff
     })
 
-    layer.isOff = true
+    const opened = openLayerForWrite(db, layer)
+    if (!opened) return
+
+    opened.isOff = true
     context.view.selectionSet.clear()
     this.showMessage(
       `${AcApI18n.t('jig.layoff.turnedOff')}: ${layer.name}`,
@@ -406,7 +410,10 @@ export class AcApLayoffCmd extends AcEdCommand {
       return
     }
 
-    layer.isOff = history.wasOff
+    const opened = openLayerForWrite(context.doc.database, layer)
+    if (!opened) return
+
+    opened.isOff = history.wasOff
     context.view.selectionSet.clear()
     this.showMessage(
       `${AcApI18n.t('jig.layoff.restored')}: ${layer.name}`,

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerOnCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerOnCmd.ts
@@ -1,6 +1,7 @@
 import { AcApContext } from '../../app'
 import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { openLayerForWrite } from './AcApLayerEdit'
 
 /**
  * AutoCAD-like `LAYON` command.
@@ -25,12 +26,15 @@ export class AcApLayerOnCmd extends AcEdCommand {
    * @returns Resolves when all layer states have been processed.
    */
   async execute(context: AcApContext) {
-    const layers = [...context.doc.database.tables.layerTable.newIterator()]
+    const db = context.doc.database
+    const layers = [...db.tables.layerTable.newIterator()]
     let turnedOn = 0
 
     layers.forEach(layer => {
       if (!layer.isOff) return
-      layer.isOff = false
+      const opened = openLayerForWrite(db, layer)
+      if (!opened) return
+      opened.isOff = false
       turnedOn++
     })
 

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerPCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerPCmd.ts
@@ -1,8 +1,12 @@
-import { AcDbLayerTableRecord } from '@mlightcad/data-model'
-
 import { AcApContext } from '../../app'
 import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import {
+  isLayerLocked,
+  openLayerForWrite,
+  setLayerFrozenState,
+  setLayerLockedState
+} from './AcApLayerEdit'
 
 /**
  * Snapshot of the layer state at a specific point in time.
@@ -37,7 +41,7 @@ class AcApLayerPreviousStateManager {
         name: layer.name,
         isOn: !layer.isOff,
         isFrozen: layer.isFrozen,
-        isLocked: this.isLayerLocked(layer)
+        isLocked: isLayerLocked(layer)
       }))
     }
   }
@@ -57,19 +61,18 @@ class AcApLayerPreviousStateManager {
 
     // Apply layer state changes
     snapshot.states.forEach(state => {
-      const layer = db.tables.layerTable.getAt(state.name)
+      const layer = openLayerForWrite(db, state.name)
       if (!layer) return
 
       layer.isOff = !state.isOn
-      this.setLayerFrozen(layer, state.isFrozen)
-      this.setLayerLocked(layer, state.isLocked)
+      setLayerFrozenState(layer, state.isFrozen)
+      setLayerLockedState(layer, state.isLocked)
     })
 
-    // Restore current layer
-    const currentLayer = db.tables.layerTable.getAt(snapshot.clayer)
+    const currentLayer = openLayerForWrite(db, snapshot.clayer)
     if (currentLayer) {
       currentLayer.isOff = false
-      this.setLayerFrozen(currentLayer, false)
+      setLayerFrozenState(currentLayer, false)
       db.clayer = currentLayer.name
       return true
     }
@@ -82,34 +85,6 @@ class AcApLayerPreviousStateManager {
    */
   clearPreviousState(): void {
     this.previousSnapshot = null
-  }
-
-  /**
-   * Checks if a layer is locked.
-   * @param layer - Layer table record
-   */
-  private isLayerLocked(layer: AcDbLayerTableRecord): boolean {
-    return ((layer.standardFlags ?? 0) & 0x04) !== 0
-  }
-
-  /**
-   * Sets or clears the locked bit in layer flags.
-   * @param layer - Layer table record
-   * @param locked - Whether the layer should be locked
-   */
-  private setLayerLocked(layer: AcDbLayerTableRecord, locked: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = locked ? flags | 0x04 : flags & ~0x04
-  }
-
-  /**
-   * Sets or clears the frozen bit in layer flags.
-   * @param layer - Layer table record
-   * @param frozen - Whether the layer should be frozen
-   */
-  private setLayerFrozen(layer: AcDbLayerTableRecord, frozen: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = frozen ? flags | 0x01 : flags & ~0x01
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerThawCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerThawCmd.ts
@@ -1,8 +1,7 @@
-import { AcDbLayerTableRecord } from '@mlightcad/data-model'
-
 import { AcApContext } from '../../app'
 import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { openLayerForWrite, setLayerFrozenState } from './AcApLayerEdit'
 
 /**
  * AutoCAD-like `LAYTHW` command.
@@ -27,12 +26,15 @@ export class AcApLayerThawCmd extends AcEdCommand {
    * @returns Resolves when all layer states have been processed.
    */
   async execute(context: AcApContext) {
-    const layers = [...context.doc.database.tables.layerTable.newIterator()]
+    const db = context.doc.database
+    const layers = [...db.tables.layerTable.newIterator()]
     let thawed = 0
 
     layers.forEach(layer => {
       if (!layer.isFrozen) return
-      this.setLayerFrozen(layer, false)
+      const opened = openLayerForWrite(db, layer)
+      if (!opened) return
+      setLayerFrozenState(opened, false)
       thawed++
     })
 
@@ -44,16 +46,5 @@ export class AcApLayerThawCmd extends AcEdCommand {
     }
 
     this.showMessage(`${AcApI18n.t('jig.laythw.thawed')}: ${thawed}`, 'success')
-  }
-
-  /**
-   * Clears or sets the frozen bit while preserving other layer flags.
-   *
-   * @param layer - Target layer table record.
-   * @param frozen - Whether the layer should be marked frozen.
-   */
-  private setLayerFrozen(layer: AcDbLayerTableRecord, frozen: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = frozen ? flags | 0x01 : flags & ~0x01
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerUnisoCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerUnisoCmd.ts
@@ -1,8 +1,11 @@
-import { AcDbLayerTableRecord } from '@mlightcad/data-model'
-
 import { AcApContext } from '../../app'
 import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import {
+  openLayerForWrite,
+  setLayerFrozenState,
+  setLayerLockedState
+} from './AcApLayerEdit'
 import {
   AcApLayerIsoLayerSnapshot,
   AcApLayerIsoState
@@ -42,8 +45,7 @@ export class AcApLayerUnisoCmd extends AcEdCommand {
     let restoredLayers = 0
 
     for (const entry of snapshot.layers) {
-      const layer = table.getAt(entry.name)
-      if (!layer) {
+      if (!table.getAt(entry.name)) {
         this.showMessage(
           `${AcApI18n.t('jig.layuniso.layerNotFound')}: ${entry.name}`,
           'warning'
@@ -51,7 +53,7 @@ export class AcApLayerUnisoCmd extends AcEdCommand {
         continue
       }
 
-      if (this.restoreLayerIfUnchanged(layer, entry)) {
+      if (this.restoreLayerIfUnchanged(db, entry)) {
         restoredLayers++
       }
     }
@@ -85,57 +87,41 @@ export class AcApLayerUnisoCmd extends AcEdCommand {
    * @returns `true` if any tracked flag was restored.
    */
   private restoreLayerIfUnchanged(
-    layer: AcDbLayerTableRecord,
+    db: AcApContext['doc']['database'],
     snapshot: AcApLayerIsoLayerSnapshot
   ) {
+    const layer = db.tables.layerTable.getAt(snapshot.name)
+    if (!layer) return false
+
+    const opened = openLayerForWrite(db, layer)
+    if (!opened) return false
+
     let restored = false
 
     if (
-      layer.isOff === snapshot.isolated.isOff &&
-      layer.isOff !== snapshot.before.isOff
+      opened.isOff === snapshot.isolated.isOff &&
+      opened.isOff !== snapshot.before.isOff
     ) {
-      layer.isOff = snapshot.before.isOff
+      opened.isOff = snapshot.before.isOff
       restored = true
     }
 
     if (
-      layer.isFrozen === snapshot.isolated.isFrozen &&
-      layer.isFrozen !== snapshot.before.isFrozen
+      opened.isFrozen === snapshot.isolated.isFrozen &&
+      opened.isFrozen !== snapshot.before.isFrozen
     ) {
-      this.setLayerFrozen(layer, snapshot.before.isFrozen)
+      setLayerFrozenState(opened, snapshot.before.isFrozen)
       restored = true
     }
 
     if (
-      layer.isLocked === snapshot.isolated.isLocked &&
-      layer.isLocked !== snapshot.before.isLocked
+      opened.isLocked === snapshot.isolated.isLocked &&
+      opened.isLocked !== snapshot.before.isLocked
     ) {
-      this.setLayerLocked(layer, snapshot.before.isLocked)
+      setLayerLockedState(opened, snapshot.before.isLocked)
       restored = true
     }
 
     return restored
-  }
-
-  /**
-   * Sets or clears the frozen bit while preserving other layer flags.
-   *
-   * @param layer - Target layer table record.
-   * @param frozen - Whether the layer should be marked frozen.
-   */
-  private setLayerFrozen(layer: AcDbLayerTableRecord, frozen: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = frozen ? flags | 0x01 : flags & ~0x01
-  }
-
-  /**
-   * Sets or clears the locked bit while preserving other layer flags.
-   *
-   * @param layer - Target layer table record.
-   * @param locked - Whether the layer should be marked locked.
-   */
-  private setLayerLocked(layer: AcDbLayerTableRecord, locked: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = locked ? flags | 0x04 : flags & ~0x04
   }
 }

--- a/packages/cad-simple-viewer/src/command/layer/AcApLayerUnlockCmd.ts
+++ b/packages/cad-simple-viewer/src/command/layer/AcApLayerUnlockCmd.ts
@@ -1,4 +1,4 @@
-import { AcDbLayerTableRecord, AcDbObjectId } from '@mlightcad/data-model'
+import { AcDbObjectId } from '@mlightcad/data-model'
 
 import { AcApContext, AcApDocManager } from '../../app'
 import {
@@ -8,6 +8,7 @@ import {
   AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { openLayerForWrite, setLayerLockedState } from './AcApLayerEdit'
 
 /**
  * AutoCAD-like `LAYULK` command.
@@ -60,17 +61,6 @@ export class AcApLayerUnlockCmd extends AcEdCommand {
   }
 
   /**
-   * Sets or clears the locked bit in `standardFlags`.
-   *
-   * @param layer - Target layer table record.
-   * @param locked - `true` to lock, `false` to unlock.
-   */
-  private setLayerLocked(layer: AcDbLayerTableRecord, locked: boolean) {
-    const flags = layer.standardFlags ?? 0
-    layer.standardFlags = locked ? flags | 0x04 : flags & ~0x04
-  }
-
-  /**
    * Resolves the picked entity's layer and unlocks it when needed.
    *
    * @param context - Active application context containing the current database and view.
@@ -103,7 +93,10 @@ export class AcApLayerUnlockCmd extends AcEdCommand {
       return
     }
 
-    this.setLayerLocked(layer, false)
+    const opened = openLayerForWrite(db, layer)
+    if (!opened) return
+
+    setLayerLockedState(opened, false)
     context.view.selectionSet.clear()
     this.showMessage(
       `${AcApI18n.t('jig.layulk.unlocked')}: ${layer.name}`,

--- a/packages/cad-simple-viewer/src/command/modify/AcApMoveCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApMoveCmd.ts
@@ -218,7 +218,6 @@ export class AcApMoveCmd extends AcEdCommand {
       const opened = context.doc.database.openEntityForWrite(entity)
       if (!opened) return
       opened.transformBy(matrix)
-      opened.triggerModifiedEvent()
     })
     selectionSet.clear()
   }

--- a/packages/cad-simple-viewer/src/command/modify/AcApRotateCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApRotateCmd.ts
@@ -344,7 +344,6 @@ export class AcApRotateCmd extends AcEdCommand {
         const opened = context.doc.database.openEntityForWrite(entity)
         if (!opened) return
         opened.transformBy(matrix)
-        opened.triggerModifiedEvent()
       })
     }
 

--- a/packages/cad-simple-viewer/src/editor/grip/AcEdGripEditSession.ts
+++ b/packages/cad-simple-viewer/src/editor/grip/AcEdGripEditSession.ts
@@ -69,7 +69,6 @@ export class AcEdGripEditSession {
       const entity = db.openEntityForWrite(this._entity)
       if (!entity) return
       entity.subMoveGripPointsAt([this._target.gripIndex], offset)
-      entity.triggerModifiedEvent()
     })
     this.finish()
   }

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -60,6 +60,7 @@ import {
 import { isEffectiveSpatialQueryHit } from '../editor/view/AcEdSpatialQueryResult'
 import type { AcTrSpatialSearchOptions } from '../spatialIndex/AcTrSpatialIndex'
 import { AcTrGeometryUtil } from '../util'
+import { acapRunDatabaseEdit } from '../util/AcApDatabaseEdit'
 import { AcEdViewKeyHandler } from './AcEdViewKeyHandler'
 import { AcTrEntityDisplayController } from './AcTrEntityDisplayController'
 import {
@@ -895,9 +896,14 @@ export class AcTrView2d extends AcEdBaseView {
   }
 
   private async editMTextEntity(mtext: AcDbMText) {
+    const db = mtext.database
+
     if (mtext.lineSpacingFactor !== AcEdMTextEditor.defaultLineSpacingFactor) {
-      mtext.lineSpacingFactor = AcEdMTextEditor.defaultLineSpacingFactor
-      mtext.triggerModifiedEvent()
+      acapRunDatabaseEdit(db, 'Edit MText', () => {
+        const opened = db.openEntityForWrite(mtext)
+        if (!(opened instanceof AcDbMText)) return
+        opened.lineSpacingFactor = AcEdMTextEditor.defaultLineSpacingFactor
+      })
     }
 
     // Hide the in-scene MTEXT while the inline editor renders its own copy; otherwise
@@ -919,13 +925,16 @@ export class AcTrView2d extends AcEdBaseView {
       })
       if (!result) return
 
-      mtext.location = result.location
-      mtext.contents = result.contents
-      mtext.width = result.width
-      mtext.height = result.height
-      mtext.lineSpacingFactor = result.lineSpacingFactor
-      mtext.attachmentPoint = result.attachmentPoint
-      mtext.triggerModifiedEvent()
+      acapRunDatabaseEdit(db, 'Edit MText', () => {
+        const opened = db.openEntityForWrite(mtext)
+        if (!(opened instanceof AcDbMText)) return
+        opened.location = result.location
+        opened.contents = result.contents
+        opened.width = result.width
+        opened.height = result.height
+        opened.lineSpacingFactor = result.lineSpacingFactor
+        opened.attachmentPoint = result.attachmentPoint
+      })
       applied = true
     } finally {
       if (!applied) {
@@ -1155,28 +1164,31 @@ export class AcTrView2d extends AcEdBaseView {
     changes: Partial<AcDbLayerTableRecordAttrs>
   ) {
     const updatedLayers = this._scene.updateLayer(this.toLayerInfo(layer))
-    const traits: Record<string, unknown> = {}
-    if (changes.color) {
-      traits.color = changes.color.clone()
-    }
-    if (changes.lineStyle) {
-      traits.lineType = layer.lineStyle
-    }
-    if (changes.lineWeight !== undefined) {
-      traits.lineWeight = changes.lineWeight
-    }
-    if (changes.transparency !== undefined) {
-      traits.transparency = changes.transparency
-    }
-    traits.layer = layer.name // always present
 
-    const materials = this._renderer.updateLayerMaterial(layer.name, traits)
-    updatedLayers.forEach(layer => {
-      for (const id in materials) {
-        const material = materials[id]
-        layer.updateMaterial(Number(id), material)
+    if (this.layerStyleMayHaveChanged(changes)) {
+      const traits: Record<string, unknown> = {}
+      if (changes.color) {
+        traits.color = changes.color.clone()
       }
-    })
+      if (changes.linetype != null) {
+        traits.lineType = layer.lineStyle
+      }
+      if (changes.lineWeight !== undefined) {
+        traits.lineWeight = changes.lineWeight
+      }
+      if (changes.transparency !== undefined) {
+        traits.transparency = changes.transparency
+      }
+      traits.layer = layer.name // always present
+
+      const materials = this._renderer.updateLayerMaterial(layer.name, traits)
+      updatedLayers.forEach(layer => {
+        for (const id in materials) {
+          const material = materials[id]
+          layer.updateMaterial(Number(id), material)
+        }
+      })
+    }
 
     if (
       this._entityDisplay.layerVisibilityMayHaveChanged(changes) &&
@@ -1770,6 +1782,17 @@ export class AcTrView2d extends AcEdBaseView {
     } else {
       stats.dom.style.display = 'none' // Hide the stats
     }
+  }
+
+  private layerStyleMayHaveChanged(
+    changes: Partial<AcDbLayerTableRecordAttrs>
+  ): boolean {
+    return (
+      changes.color != null ||
+      changes.linetype != null ||
+      changes.lineWeight !== undefined ||
+      changes.transparency != null
+    )
   }
 
   private toLayerInfo(layer: AcDbLayerTableRecord) {

--- a/packages/cad-viewer/__tests__/AcApHatchRibbonCmd.spec.ts
+++ b/packages/cad-viewer/__tests__/AcApHatchRibbonCmd.spec.ts
@@ -48,6 +48,9 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
     AcApI18n: {
       t: (key: string) => key
     },
+    acapRunDatabaseEdit: (_db: unknown, _label: string, fn: () => void) => {
+      fn()
+    },
     AcEdPromptEntityOptions,
     AcEdPromptStatus: {
       OK: 'OK',

--- a/packages/cad-viewer/src/command/AcApHatchRibbonCmd.ts
+++ b/packages/cad-viewer/src/command/AcApHatchRibbonCmd.ts
@@ -3,6 +3,7 @@ import {
   AcApDocManager,
   AcApHatchCmd,
   AcApI18n,
+  acapRunDatabaseEdit,
   AcEdPromptEntityOptions,
   AcEdPromptStatus,
   type HatchSettings
@@ -394,13 +395,23 @@ export class AcApHatchRibbonCmd extends AcApHatchCmd {
   }
 
   private applyStateToSelectedHatches() {
+    const docManager = AcApDocManager.instance
+    const db = docManager.curDocument?.database
+    if (!db) return
+
     const hatches = this.getSelectedHatches()
     if (hatches.length === 0) return
 
-    hatches.forEach(hatch => this.applyStateToHatch(hatch, true))
+    acapRunDatabaseEdit(db, 'Hatch Properties', () => {
+      hatches.forEach(hatch => {
+        const opened = db.openEntityForWrite(hatch)
+        if (!opened || !(opened instanceof AcDbHatch)) return
+        this.applyStateToHatch(opened)
+      })
+    })
   }
 
-  private applyStateToHatch(hatch: AcDbHatch, triggerModified: boolean) {
+  private applyStateToHatch(hatch: AcDbHatch) {
     const fillColor = this.toAcCmColor(this._state.fillColor)
     const opacity = Math.max(0, Math.min(90, this._state.opacity))
 
@@ -437,10 +448,6 @@ export class AcApHatchRibbonCmd extends AcApHatchCmd {
         ? this.toAcCmColor(this._state.backgroundColor)
         : undefined
     hatch.transparency = this.createTransparency(opacity)
-
-    if (triggerModified) {
-      hatch.triggerModifiedEvent()
-    }
   }
 
   setPatternName(value: string) {
@@ -622,7 +629,7 @@ export class AcApHatchRibbonCmd extends AcApHatchCmd {
   }
 
   protected override configureHatch(hatch: AcDbHatch) {
-    this.applyStateToHatch(hatch, false)
+    this.applyStateToHatch(hatch)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-viewer/src/component/dialog/MlReplacementDlg.vue
+++ b/packages/cad-viewer/src/component/dialog/MlReplacementDlg.vue
@@ -213,6 +213,7 @@ import {
   AcApCacheFontCmd,
   AcApDocManager,
   AcApFontUtil,
+  acapRunDatabaseEdit,
   AcApSettingManager,
   eventBus
 } from '@mlightcad/cad-simple-viewer'
@@ -322,17 +323,17 @@ const handleConfirm = async () => {
   const docManager = AcApDocManager.instance
   const db = docManager.curDocument.database
   let replacedImage = false
-  imageTableData.forEach(item => {
-    if (item.file) {
-      item.ids.forEach(id => {
-        const image = db.tables.blockTable.modelSpace.getIdAt(
-          id
-        ) as AcDbRasterImage
-        image.image = item.file
-        image.triggerModifiedEvent()
-        replacedImage = true
-      })
-    }
+  acapRunDatabaseEdit(db, 'Replace Image', () => {
+    imageTableData.forEach(item => {
+      if (item.file) {
+        item.ids.forEach(id => {
+          const image = db.openEntityForWrite(id) as AcDbRasterImage | undefined
+          if (!image) return
+          image.image = item.file
+          replacedImage = true
+        })
+      }
+    })
   })
 
   const settingManager = AcApSettingManager.instance

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -456,7 +456,6 @@ const applyToSelectedEntities = (mutator: (entity: AcDbEntity) => void) => {
     const entity = db.openEntityForWrite(id)
     if (!entity) return
     mutator(entity)
-    entity.triggerModifiedEvent()
   })
 }
 

--- a/packages/cad-viewer/src/composable/useLayers.ts
+++ b/packages/cad-viewer/src/composable/useLayers.ts
@@ -1,7 +1,7 @@
 import {
   AcApDocManager,
-  AcDbDocumentEventArgs
-} from '@mlightcad/cad-simple-viewer'
+  acapRunDatabaseEdit,
+  AcDbDocumentEventArgs} from '@mlightcad/cad-simple-viewer'
 import {
   AcCmColor,
   AcDbDatabase,
@@ -40,6 +40,7 @@ export interface LayerStateSnapshot {
 export function useLayers(editor: AcApDocManager) {
   const layerFrozenFlag = 0x01
   const layerLockedFlag = 0x04
+  const layerEditLabel = 'Layer'
   const reactiveLayers = reactive<LayerInfo[]>([])
   const currentLayerNameState = ref('')
   let observedDatabase: AcDbDatabase | undefined
@@ -47,6 +48,27 @@ export function useLayers(editor: AcApDocManager) {
   const getCurrentDatabase = () => editor.curDocument?.database
   const syncCurrentLayerName = (db = getCurrentDatabase()) => {
     currentLayerNameState.value = db?.clayer || ''
+  }
+
+  const openLayerForWrite = (
+    db: AcDbDatabase,
+    layerName: string
+  ): AcDbLayerTableRecord | undefined => {
+    const layer = db.tables.layerTable.getAt(layerName)
+    if (!layer) return undefined
+    return db.openObjectForWrite<AcDbLayerTableRecord>(layer.objectId)
+  }
+
+  const runLayerEdit = (
+    db: AcDbDatabase | undefined,
+    fn: () => boolean
+  ): boolean => {
+    if (!db) return false
+    let result = false
+    acapRunDatabaseEdit(db, layerEditLabel, () => {
+      result = fn()
+    })
+    return result
   }
 
   const setLayerFrozenState = (
@@ -176,20 +198,24 @@ export function useLayers(editor: AcApDocManager) {
   ) {
     if (db.clayer !== targetLayerName) return true
 
-    let fallbackLayer: AcDbLayerTableRecord | undefined
-    let preferredLayer: AcDbLayerTableRecord | undefined
+    let fallbackLayerName: string | undefined
+    let preferredLayerName: string | undefined
 
     for (const layer of db.tables.layerTable.newIterator()) {
       if (layer.name === targetLayerName) continue
-      fallbackLayer ??= layer
+      fallbackLayerName ??= layer.name
       if (!layer.isOff && !layer.isFrozen) {
-        preferredLayer = layer
+        preferredLayerName = layer.name
         break
       }
     }
 
-    const nextCurrentLayer = preferredLayer ?? fallbackLayer
+    const nextLayerName = preferredLayerName ?? fallbackLayerName
+    if (!nextLayerName) return false
+
+    const nextCurrentLayer = openLayerForWrite(db, nextLayerName)
     if (!nextCurrentLayer) return false
+
     nextCurrentLayer.isOff = false
     setLayerFrozenState(nextCurrentLayer, false)
     db.clayer = nextCurrentLayer.name
@@ -200,27 +226,34 @@ export function useLayers(editor: AcApDocManager) {
   function setCurrentLayer(layerName: string) {
     const db = getCurrentDatabase()
     if (!db || !layerName) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
 
-    const layer = db.tables.layerTable.getAt(layerName)
-    if (!layer) return false
+    return runLayerEdit(db, () => {
+      const layer = openLayerForWrite(db, layerName)
+      if (!layer) return false
 
-    layer.isOff = false
-    setLayerFrozenState(layer, false)
-    db.clayer = layer.name
-    syncCurrentLayerName(db)
-    return true
+      layer.isOff = false
+      setLayerFrozenState(layer, false)
+      db.clayer = layer.name
+      syncCurrentLayerName(db)
+      return true
+    })
   }
 
   function setLayerOn(layerName: string, isOn: boolean) {
     const db = getCurrentDatabase()
     if (!db || !layerName) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
 
-    const layer = db.tables.layerTable.getAt(layerName)
-    if (!layer) return false
+    return runLayerEdit(db, () => {
+      if (!isOn && !switchCurrentLayerIfNeeded(db, layerName)) return false
 
-    if (!isOn && !switchCurrentLayerIfNeeded(db, layer.name)) return false
-    layer.isOff = !isOn
-    return true
+      const layer = openLayerForWrite(db, layerName)
+      if (!layer) return false
+
+      layer.isOff = !isOn
+      return true
+    })
   }
 
   function toggleLayerOn(layerName: string) {
@@ -234,13 +267,17 @@ export function useLayers(editor: AcApDocManager) {
   function setLayerFrozen(layerName: string, isFrozen: boolean) {
     const db = getCurrentDatabase()
     if (!db || !layerName) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
 
-    const layer = db.tables.layerTable.getAt(layerName)
-    if (!layer) return false
+    return runLayerEdit(db, () => {
+      if (isFrozen && !switchCurrentLayerIfNeeded(db, layerName)) return false
 
-    if (isFrozen && !switchCurrentLayerIfNeeded(db, layer.name)) return false
-    setLayerFrozenState(layer, isFrozen)
-    return true
+      const layer = openLayerForWrite(db, layerName)
+      if (!layer) return false
+
+      setLayerFrozenState(layer, isFrozen)
+      return true
+    })
   }
 
   function toggleLayerFrozen(layerName: string) {
@@ -254,12 +291,15 @@ export function useLayers(editor: AcApDocManager) {
   function setLayerLocked(layerName: string, isLocked: boolean) {
     const db = getCurrentDatabase()
     if (!db || !layerName) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
 
-    const layer = db.tables.layerTable.getAt(layerName)
-    if (!layer) return false
+    return runLayerEdit(db, () => {
+      const layer = openLayerForWrite(db, layerName)
+      if (!layer) return false
 
-    setLayerLockedState(layer, isLocked)
-    return true
+      setLayerLockedState(layer, isLocked)
+      return true
+    })
   }
 
   function toggleLayerLocked(layerName: string) {
@@ -286,57 +326,72 @@ export function useLayers(editor: AcApDocManager) {
   function isolateLayer(layerName: string) {
     const db = getCurrentDatabase()
     if (!db || !layerName) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
 
-    const targetLayer = db.tables.layerTable.getAt(layerName)
-    if (!targetLayer) return false
+    return runLayerEdit(db, () => {
+      for (const layer of db.tables.layerTable.newIterator()) {
+        const keepVisible = layer.name === layerName
+        const opened = openLayerForWrite(db, layer.name)
+        if (!opened) continue
 
-    for (const layer of db.tables.layerTable.newIterator()) {
-      const keepVisible = layer.name === targetLayer.name
-      layer.isOff = !keepVisible
-      if (keepVisible) {
-        setLayerFrozenState(layer, false)
+        opened.isOff = !keepVisible
+        if (keepVisible) {
+          setLayerFrozenState(opened, false)
+        }
       }
-    }
 
-    db.clayer = targetLayer.name
-    syncCurrentLayerName(db)
-    return true
+      db.clayer = layerName
+      syncCurrentLayerName(db)
+      return true
+    })
   }
 
   function setAllLayersOn() {
     const db = getCurrentDatabase()
     if (!db) return false
 
-    let changed = false
-    for (const layer of db.tables.layerTable.newIterator()) {
-      if (!layer.isOff) continue
-      layer.isOff = false
-      changed = true
-    }
+    return runLayerEdit(db, () => {
+      let changed = false
+      for (const layer of db.tables.layerTable.newIterator()) {
+        if (!layer.isOff) continue
 
-    return changed
+        const opened = openLayerForWrite(db, layer.name)
+        if (!opened) continue
+
+        opened.isOff = false
+        changed = true
+      }
+
+      return changed
+    })
   }
 
   function setLayerColor(layerName: string, color: AcCmColor) {
     const db = getCurrentDatabase()
     if (!db) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
 
-    const dbLayer = db.tables.layerTable.getAt(layerName)
-    if (!dbLayer) return false
+    return runLayerEdit(db, () => {
+      const layer = openLayerForWrite(db, layerName)
+      if (!layer) return false
 
-    dbLayer.color = color
-    return true
+      layer.color = color
+      return true
+    })
   }
 
   function setLayerLineWeight(layerName: string, lineWeight: number) {
     const db = getCurrentDatabase()
     if (!db) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
 
-    const dbLayer = db.tables.layerTable.getAt(layerName)
-    if (!dbLayer) return false
+    return runLayerEdit(db, () => {
+      const layer = openLayerForWrite(db, layerName)
+      if (!layer) return false
 
-    dbLayer.lineWeight = lineWeight
-    return true
+      layer.lineWeight = lineWeight
+      return true
+    })
   }
 
   function captureLayerSnapshot(
@@ -355,25 +410,28 @@ export function useLayers(editor: AcApDocManager) {
   ) {
     if (!db) return false
 
-    snapshot.states.forEach(state => {
-      const layer = db.tables.layerTable.getAt(state.name)
-      if (!layer) return
-      layer.isOff = !state.isOn
-      setLayerFrozenState(layer, state.isFrozen)
-      setLayerLockedState(layer, state.isLocked)
-    })
+    return runLayerEdit(db, () => {
+      snapshot.states.forEach(state => {
+        const layer = openLayerForWrite(db, state.name)
+        if (!layer) return
 
-    const currentLayer = db.tables.layerTable.getAt(snapshot.clayer)
-    if (currentLayer) {
-      currentLayer.isOff = false
-      setLayerFrozenState(currentLayer, false)
-      db.clayer = currentLayer.name
+        layer.isOff = !state.isOn
+        setLayerFrozenState(layer, state.isFrozen)
+        setLayerLockedState(layer, state.isLocked)
+      })
+
+      const currentLayer = openLayerForWrite(db, snapshot.clayer)
+      if (currentLayer) {
+        currentLayer.isOff = false
+        setLayerFrozenState(currentLayer, false)
+        db.clayer = currentLayer.name
+        syncCurrentLayerName(db)
+        return true
+      }
+
       syncCurrentLayerName(db)
-      return true
-    }
-
-    syncCurrentLayerName(db)
-    return false
+      return false
+    })
   }
 
   editor.events.documentActivated.addEventListener(handleDocumentActivated)

--- a/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
@@ -9,6 +9,26 @@ import { AcTrStyleManager } from '../src/style/AcTrStyleManager'
 import { AcTrSubEntityTraitsUtil } from '../src/util/AcTrEntityTraitsUtil'
 
 describe('AcTrStyleManager', () => {
+  it('preserves entity color when updateLayerMaterial receives layer name only', () => {
+    const styleManager = new AcTrStyleManager()
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.layer = 'ROAD'
+    traits.color.setRGB(255, 0, 0)
+
+    const original = styleManager.getLineMaterial(
+      traits
+    ) as THREE.LineBasicMaterial
+    expect(original.color.getHex()).toBe(0xff0000)
+
+    const updates = styleManager.updateLayerMaterial('ROAD', {
+      layer: 'ROAD'
+    })
+    const updated = updates[original.id] as THREE.LineBasicMaterial
+
+    expect(updated).toBeDefined()
+    expect(updated.color.getHex()).toBe(0xff0000)
+  })
+
   it('binds inherited materials onto the effective layer for later layer updates', () => {
     const styleManager = new AcTrStyleManager()
     const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()

--- a/packages/three-renderer/src/style/AcTrMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrMaterialManager.ts
@@ -69,7 +69,10 @@ export abstract class AcTrMaterialManager<T> {
 
     // cache original traits
     if (!this.keyToTraits[key]) {
-      this.keyToTraits[key] = { ...deepClone(traits), ...options }
+      this.keyToTraits[key] = this.cloneTraits({
+        ...traits,
+        ...options
+      } as AcGiSubEntityTraits & T)
     }
 
     // hit cache
@@ -121,7 +124,7 @@ export abstract class AcTrMaterialManager<T> {
       )
 
       // Step 1: merged traits (only mutate traits that are actually ByLayer)
-      const mergedTraits = deepClone(oldTraits)
+      const mergedTraits = this.cloneTraits(oldTraits)
       this.applyInheritedLayerTraits(mergedTraits, newTraits, byLayerBindings)
       if (newTraits.layer != null) {
         mergedTraits.layer = newTraits.layer
@@ -255,7 +258,7 @@ export abstract class AcTrMaterialManager<T> {
     }
 
     const remappedTraits: AcGiSubEntityTraits & T = {
-      ...deepClone(traits),
+      ...this.cloneTraits(traits),
       layer: layerName
     }
     const byLayerBindings = this.resolveByLayerBindings(traits, material)
@@ -273,6 +276,26 @@ export abstract class AcTrMaterialManager<T> {
       remappedTraits,
       byLayerBindings
     )
+  }
+
+  /**
+   * Clones render traits while preserving class-based color/transparency values.
+   *
+   * {@link deepClone} only copies enumerable fields, so `AcCmColor` /
+   * `AcCmTransparency` instances would degrade into plain objects and later
+   * resolve to white during material rebuilds.
+   */
+  protected cloneTraits<U extends AcGiSubEntityTraits & Partial<T>>(
+    traits: U
+  ): U {
+    const cloned = deepClone(traits) as U
+    if (traits.color?.clone) {
+      cloned.color = traits.color.clone()
+    }
+    if (traits.transparency?.clone) {
+      cloned.transparency = traits.transparency.clone()
+    }
+    return cloned
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.9.14
-  '@mlightcad/dxf-json-converter': ^1.9.14
-  '@mlightcad/libredwg-converter': ^3.7.14
+  '@mlightcad/data-model': ^1.10.0
+  '@mlightcad/dxf-json-converter': ^1.10.0
+  '@mlightcad/libredwg-converter': ^3.10.0
   '@mlightcad/mtext-input-box': ^0.2.19
   '@mlightcad/mtext-renderer': ^0.11.5
   '@mlightcad/ribbon': ^0.1.10
@@ -116,14 +116,14 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       '@mlightcad/dxf-json-converter':
-        specifier: ^1.9.14
-        version: 1.9.14(@mlightcad/data-model@1.9.14)
+        specifier: ^1.10.0
+        version: 1.10.0(@mlightcad/data-model@1.10.0)
       '@mlightcad/libredwg-converter':
-        specifier: ^3.7.14
-        version: 3.7.14(@mlightcad/data-model@1.9.14)
+        specifier: ^3.10.0
+        version: 3.10.0(@mlightcad/data-model@1.10.0)
       '@mlightcad/mtext-renderer':
         specifier: ^0.11.5
         version: 0.11.5(three@0.172.0)
@@ -153,8 +153,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -186,8 +186,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1
@@ -201,14 +201,14 @@ importers:
   packages/cad-simple-viewer:
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       '@mlightcad/dxf-json-converter':
-        specifier: ^1.9.14
-        version: 1.9.14(@mlightcad/data-model@1.9.14)
+        specifier: ^1.10.0
+        version: 1.10.0(@mlightcad/data-model@1.10.0)
       '@mlightcad/libredwg-converter':
-        specifier: ^3.7.14
-        version: 3.7.14(@mlightcad/data-model@1.9.14)
+        specifier: ^3.10.0
+        version: 3.10.0(@mlightcad/data-model@1.10.0)
       '@mlightcad/mtext-input-box':
         specifier: ^0.2.19
         version: 0.2.19(@mlightcad/mtext-renderer@0.11.5(three@0.172.0))(three@0.172.0)
@@ -258,8 +258,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -273,8 +273,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       '@mlightcad/mtext-parser':
         specifier: ^1.4.1
         version: 1.4.1
@@ -300,8 +300,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       '@mlightcad/ribbon':
         specifier: ^0.1.10
         version: 0.1.10(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
@@ -372,8 +372,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -437,8 +437,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.9.14
-        version: 1.9.14
+        specifier: ^1.10.0
+        version: 1.10.0
       '@mlightcad/mtext-renderer':
         specifier: ^0.11.5
         version: 0.11.5(three@0.172.0)
@@ -1535,35 +1535,35 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.6.14':
-    resolution: {integrity: sha512-tbMJ1L1WqKA1g+aDe5GarfhQhvKZ3bZ38eysCBnmHpWZQXgSyT05XNk1AU2VNjvDVt6F/PgWGaAyWYAXNTvqPg==}
+  '@mlightcad/common@1.10.0':
+    resolution: {integrity: sha512-InIkqNXMfGUBmIIAjlFM1lZljrImDUeLPT5XeNXtZZktnnxvswGxuMTrBgLb048ey7VuJTbJxMsxINxA63t57A==}
 
-  '@mlightcad/data-model@1.9.14':
-    resolution: {integrity: sha512-lcje19R7EUmBT8yF11LQfPAuQTX49lyVgEJ5E+5TWn234z1WA8BhhX/pDx8SnfhU9tzyrcAc6mIy9QDaM8Q22A==}
+  '@mlightcad/data-model@1.10.0':
+    resolution: {integrity: sha512-Fx2r3YC8uanxDukFdjz3+HT0R7GEfPgXWNQ+4Us2S0bn6tVjahksdL5cfYntEuEcysss+YdwKvqzoa5rXFYyFg==}
 
-  '@mlightcad/dxf-json-converter@1.9.14':
-    resolution: {integrity: sha512-JG7mItkujW1F37kmdzMczQ6ybwC+RRfLXg6xN3PiQXgILJwIqyQD9TQC3ieKT8BDcjFELJOg2TFLJF/Te+iHQg==}
+  '@mlightcad/dxf-json-converter@1.10.0':
+    resolution: {integrity: sha512-7BGbJDdagmJc24FEpPjGw6y+gXBDHNpjTulhkvuzsqTuLk7IFs81CWu6FSH53FX4LFABysh06HkzsP7o57IbBw==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.9.14
+      '@mlightcad/data-model': ^1.10.0
 
   '@mlightcad/dxf-json@1.2.5':
     resolution: {integrity: sha512-yUwYrRP321Pzjun4h69KFz5YnGoqA7iKZvP+Y93F4yMe2avko5yd/iaNxAZxCdrO6JeOsi3rcEaYBtg6UDiK8Q==}
 
-  '@mlightcad/geometry-engine@3.4.14':
-    resolution: {integrity: sha512-WPfpXRqpuISARl0wr6TChs0baS1gTiuHGLBXJVKKukr1jwxA7DfIxlhkk8uUtwhnP0hYHVASJqEr9gXuH46FQA==}
+  '@mlightcad/geometry-engine@3.10.0':
+    resolution: {integrity: sha512-9kONy5bOmZIAV2iUATpti7YntuQtx7kKjo3YHJJ1qr5Vq4ZbsdCcSMv04hMr1y1p+/67OYyHTB59PN0oACj6yA==}
     peerDependencies:
-      '@mlightcad/common': 1.6.14
+      '@mlightcad/common': 1.10.0
 
-  '@mlightcad/graphic-interface@3.5.14':
-    resolution: {integrity: sha512-KBIAnsuOPGVl3zgum73EdtHVKTJgbGtaFCqjSJ4uT+VV4HtT5wtdQH40NXx71HVTBOpWqEZrn3m6/2Pf8H1nSg==}
+  '@mlightcad/graphic-interface@3.10.0':
+    resolution: {integrity: sha512-CUM1sccROs+YJOrxJryCFdFMk/IRkwbtZAsCSj0Oo4OWBwvCO+f9sAikdHSfldm+gcjgucLAWJPsq0q31UZsug==}
     peerDependencies:
-      '@mlightcad/common': 1.6.14
-      '@mlightcad/geometry-engine': 3.4.14
+      '@mlightcad/common': 1.10.0
+      '@mlightcad/geometry-engine': 3.10.0
 
-  '@mlightcad/libredwg-converter@3.7.14':
-    resolution: {integrity: sha512-UcOkfsy1rxhl9raOhKwTKzthCQgSanm8JGn3MEm8JjaAlu3TlVH5t6eMIyoFNWS/lORtHszGx2W0i657n2YoeQ==}
+  '@mlightcad/libredwg-converter@3.10.0':
+    resolution: {integrity: sha512-Voghcyuo3ojFJTCqt4gq/BMKhpOqq6YZHwRywpAdHoAp0GASjz+BMSWZnqfp9O+rf/J6l3Ur9wZIWNnFqWErRQ==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.9.14
+      '@mlightcad/data-model': ^1.10.0
 
   '@mlightcad/libredwg-web@0.7.7':
     resolution: {integrity: sha512-JnEug2IVXafUecM9/WCQgH8mJRliaEq0Uxu3Mxt0Zk82n1MrSd25iA0Boo7e7t9qVwRPxQLGFxWoyPIrAeTy4w==}
@@ -6642,39 +6642,39 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mlightcad/common@1.6.14':
+  '@mlightcad/common@1.10.0':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.9.14':
+  '@mlightcad/data-model@1.10.0':
     dependencies:
-      '@mlightcad/common': 1.6.14
-      '@mlightcad/geometry-engine': 3.4.14(@mlightcad/common@1.6.14)
-      '@mlightcad/graphic-interface': 3.5.14(@mlightcad/common@1.6.14)(@mlightcad/geometry-engine@3.4.14(@mlightcad/common@1.6.14))
+      '@mlightcad/common': 1.10.0
+      '@mlightcad/geometry-engine': 3.10.0(@mlightcad/common@1.10.0)
+      '@mlightcad/graphic-interface': 3.10.0(@mlightcad/common@1.10.0)(@mlightcad/geometry-engine@3.10.0(@mlightcad/common@1.10.0))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
-  '@mlightcad/dxf-json-converter@1.9.14(@mlightcad/data-model@1.9.14)':
+  '@mlightcad/dxf-json-converter@1.10.0(@mlightcad/data-model@1.10.0)':
     dependencies:
-      '@mlightcad/data-model': 1.9.14
+      '@mlightcad/data-model': 1.10.0
       '@mlightcad/dxf-json': 1.2.5
 
   '@mlightcad/dxf-json@1.2.5':
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.4.14(@mlightcad/common@1.6.14)':
+  '@mlightcad/geometry-engine@3.10.0(@mlightcad/common@1.10.0)':
     dependencies:
-      '@mlightcad/common': 1.6.14
+      '@mlightcad/common': 1.10.0
 
-  '@mlightcad/graphic-interface@3.5.14(@mlightcad/common@1.6.14)(@mlightcad/geometry-engine@3.4.14(@mlightcad/common@1.6.14))':
+  '@mlightcad/graphic-interface@3.10.0(@mlightcad/common@1.10.0)(@mlightcad/geometry-engine@3.10.0(@mlightcad/common@1.10.0))':
     dependencies:
-      '@mlightcad/common': 1.6.14
-      '@mlightcad/geometry-engine': 3.4.14(@mlightcad/common@1.6.14)
+      '@mlightcad/common': 1.10.0
+      '@mlightcad/geometry-engine': 3.10.0(@mlightcad/common@1.10.0)
 
-  '@mlightcad/libredwg-converter@3.7.14(@mlightcad/data-model@1.9.14)':
+  '@mlightcad/libredwg-converter@3.10.0(@mlightcad/data-model@1.10.0)':
     dependencies:
-      '@mlightcad/data-model': 1.9.14
+      '@mlightcad/data-model': 1.10.0
       '@mlightcad/libredwg-web': 0.7.7
 
   '@mlightcad/libredwg-web@0.7.7': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,9 +8,9 @@ allowBuilds:
   unrs-resolver: true
   vue-demi: true
 overrides:
-  '@mlightcad/data-model': '^1.9.14'
-  '@mlightcad/dxf-json-converter': '^1.9.14'
-  '@mlightcad/libredwg-converter': '^3.7.14'
+  '@mlightcad/data-model': '^1.10.0'
+  '@mlightcad/dxf-json-converter': '^1.10.0'
+  '@mlightcad/libredwg-converter': '^3.10.0'
   '@mlightcad/mtext-input-box': '^0.2.19'
   '@mlightcad/mtext-renderer': '^0.11.5'
   '@mlightcad/ribbon': '^0.1.10'


### PR DESCRIPTION
## Summary

- Introduce shared layer edit helpers (`AcApLayerEdit.ts`) and update all layer commands plus the `useLayers` composable to open records for write via `openObjectForWrite` / `openEntityForWrite` inside `acapRunDatabaseEdit` transactions.
- Remove manual `triggerModifiedEvent()` calls from move/rotate, grip edit, ribbon property edits, hatch ribbon, and image replacement flows; the transaction system now records changes.
- Bump `@mlightcad/data-model` to ^1.10.0 (and related converter packages) and fix `AcTrMaterialManager` trait cloning so `AcCmColor` / `AcCmTransparency` instances are preserved during layer material rebuilds.
- Skip layer material updates in `AcTrView2d` when only visibility/lock/freeze flags change, avoiding spurious color resets.

## Test plan

- [ ] Toggle layer on/off, freeze/thaw, lock/unlock from the layer panel and verify visibility updates correctly
- [ ] Run LAYCUR, LAYISO, LAYUNISO, LAYP and confirm layer state changes are undoable
- [ ] Move/rotate entities and edit via grips; confirm geometry updates without console errors
- [ ] Edit hatch properties from the ribbon on selected hatches
- [ ] Replace raster images via the replacement dialog
- [ ] Edit MTEXT inline and confirm content/position persist
- [ ] Run `pnpm test` for cad-simple-viewer, cad-viewer, and three-renderer packages
