### PR TITLE
feat: add cad-simple-ui-plugin for framework-agnostic viewer UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,47 @@ pnpm preview:simple
 - **Zoom**: Pinch with two fingers
 - **Pan**: Single-finger drag
 
+## Plugin System
+
+CAD-Viewer is built around a modular **plugin system** in [`@mlightcad/cad-simple-viewer`](packages/cad-simple-viewer). Plugins implement the `AcApPlugin` interface and hook into viewer lifecycle via `onLoad` / `onUnload`—typically to register commands, add UI, or wire export/import pipelines.
+
+Load plugins through `AcApDocManager.instance.pluginManager` (`loadPlugin`, `registerLazyPlugin`, or `plugins.fromConfig` when creating the document manager). Export-oriented plugins support **lazy loading**: register a small stub up front and download the heavy bundle only when the user runs the related command (for example `chtml`).
+
+The monorepo ships several first-party plugins. Each focuses on one concern; combine them as needed. **Installation, registration, and API details live in each package’s README**—see the links below.
+
+### Official plugins
+
+| Package | Role | Commands / capabilities |
+|---------|------|-------------------------|
+| [`@mlightcad/cad-simple-ui-plugin`](packages/cad-simple-ui-plugin) | **Toolbar & layer manager UI** for `cad-simple-viewer` (plain DOM, no Vue/React) | `layer`, default toolbar (view, measure, export, review, theme, locale) |
+| [`@mlightcad/cad-html-plugin`](packages/cad-html-plugin) | Export drawings to **self-contained offline HTML** | `chtml` |
+| [`@mlightcad/cad-pdf-plugin`](packages/cad-pdf-plugin) | **PDF export and import** (vector pipeline) | `cpdf`, `ipdf` |
+| [`@mlightcad/cad-svg-plugin`](packages/cad-svg-plugin) | **SVG export** and shared vector renderer (also used by PDF export) | `csvg` |
+
+### `@mlightcad/cad-simple-ui-plugin` — UI chrome for the simple viewer
+
+[`cad-simple-viewer`](packages/cad-simple-viewer) deliberately ships **no application UI**—only the canvas and CAD core. If you embed the simple viewer in your own web app and want ready-made chrome without adopting the full Vue-based [`cad-viewer`](packages/cad-viewer) shell, **`cad-simple-ui-plugin` is the intended UI layer**.
+
+It provides:
+
+- A **configurable toolbar** (placement on any edge, default CAD commands, nested menus, custom items)
+- A **floating layer manager** (layer on/off, ACI color picker, zoom-to-layer on double-click)
+- **Theme sync** with the `COLORTHEME` sysvar and `--ml-ui-*` CSS tokens on your host element
+- **Locale sync** with `AcApI18n` (English / Chinese)
+
+All widgets are framework-agnostic (plain DOM). The full Vue [`cad-viewer`](packages/cad-viewer) app has its own Element Plus UI and does not require this plugin; use `cad-simple-ui-plugin` when you build on `cad-simple-viewer` directly.
+
+→ **Quick start, toolbar customization, and options:** [packages/cad-simple-ui-plugin/README.md](packages/cad-simple-ui-plugin/README.md)
+
+### Export plugins (HTML / PDF / SVG)
+
+These plugins add export (and PDF import) commands to the same plugin manager. They are **lazy-loaded** so initial page weight stays small. The [`cad-simple-viewer-example`](packages/cad-simple-viewer-example) demo registers all three export plugins plus `cad-simple-ui-plugin`; the full [`cad-viewer`](packages/cad-viewer) app registers the export plugins in its bootstrap.
+
+- **HTML** — one-file offline viewer for sharing and archiving: [packages/cad-html-plugin/README.md](packages/cad-html-plugin/README.md)  
+  (Headless CLI using the same pipeline: [packages/cad-html-exporter-cli/README.md](packages/cad-html-exporter-cli/README.md))
+- **PDF** — vector PDF export and PDF-to-CAD import: [packages/cad-pdf-plugin/README.md](packages/cad-pdf-plugin/README.md)
+- **SVG** — vector SVG export: [packages/cad-svg-plugin/README.md](packages/cad-svg-plugin/README.md)
+
 ## Performance
 
 CAD-Viewer is engineered for **exceptional performance** and can handle very large DXF/DWG files while maintaining high frame rates. It employs multiple advanced rendering technologies to optimize performance:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,6 +83,47 @@ pnpm preview:simple
 - **缩放**：双指捏合放大/缩小
 - **平移**：双指拖动移动视图
 
+## 插件系统（Plugin System）
+
+CAD-Viewer 在 [`@mlightcad/cad-simple-viewer`](packages/cad-simple-viewer) 中提供可扩展的**插件系统**。插件实现 `AcApPlugin` 接口，通过 `onLoad` / `onUnload` 接入查看器生命周期，常见用途包括注册命令、挂载 UI、或接入导出/导入流程。
+
+通过 `AcApDocManager.instance.pluginManager` 加载插件（`loadPlugin`、`registerLazyPlugin`，或在创建文档管理器时使用 `plugins.fromConfig`）。面向导出的插件支持**懒加载**：应用启动时只注册轻量 stub，用户首次执行相关命令（例如 `chtml`）时才下载完整 bundle。
+
+本 monorepo 内置多个官方插件，各司其职，可按需组合。**各插件的安装、注册方式与 API 说明请直接阅读对应包的 README**（见下方链接）。
+
+### 官方插件一览
+
+| 包名 | 作用 | 命令 / 能力 |
+|------|------|-------------|
+| [`@mlightcad/cad-simple-ui-plugin`](packages/cad-simple-ui-plugin) | 为 `cad-simple-viewer` 提供**工具栏与图层管理器 UI**（纯 DOM，不依赖 Vue/React） | `layer`、默认工具栏（视图、测量、导出、审阅、主题、语言） |
+| [`@mlightcad/cad-html-plugin`](packages/cad-html-plugin) | 导出为**自包含离线 HTML** | `chtml` |
+| [`@mlightcad/cad-pdf-plugin`](packages/cad-pdf-plugin) | **PDF 导出与导入**（矢量管线） | `cpdf`、`ipdf` |
+| [`@mlightcad/cad-svg-plugin`](packages/cad-svg-plugin) | **SVG 导出**及共享矢量渲染器（PDF 导出也会用到） | `csvg` |
+
+### `@mlightcad/cad-simple-ui-plugin` — 简易查看器的 UI 层
+
+[`cad-simple-viewer`](packages/cad-simple-viewer) 有意只提供 **CAD 核心与画布**，不包含应用级界面。若你在自有 Web 应用中嵌入简易查看器，又不想引入完整 Vue 版 [`cad-viewer`](packages/cad-viewer) 外壳，**`cad-simple-ui-plugin` 即推荐的 UI 插件**。
+
+主要能力：
+
+- **可配置工具栏**（四边任意放置、内置 CAD 命令、嵌套菜单、自定义按钮）
+- **浮动图层管理器**（图层开关、ACI 颜色选择、双击缩放至图层）
+- **主题同步**：跟随 `COLORTHEME` 系统变量及 host 上的 `--ml-ui-*` CSS 变量
+- **语言同步**：跟随 `AcApI18n`（中/英）
+
+全部 UI 为框架无关的纯 DOM 实现。完整 Vue 版 [`cad-viewer`](packages/cad-viewer) 自带 Element Plus 界面，**不需要**此插件；仅在直接基于 `cad-simple-viewer` 集成时使用 `cad-simple-ui-plugin`。
+
+→ **快速开始、工具栏定制与配置项：** [packages/cad-simple-ui-plugin/README.md](packages/cad-simple-ui-plugin/README.md)
+
+### 导出类插件（HTML / PDF / SVG）
+
+以下插件向同一插件管理器注册导出（及 PDF 导入）命令，并采用**懒加载**以控制首屏体积。[`cad-simple-viewer-example`](packages/cad-simple-viewer-example) 示例会注册全部三个导出插件以及 `cad-simple-ui-plugin`；完整 [`cad-viewer`](packages/cad-viewer) 应用在启动时注册导出类插件。
+
+- **HTML** — 单文件离线查看器，便于分享与归档：[packages/cad-html-plugin/README.md](packages/cad-html-plugin/README.md)  
+  （相同管线的无头 CLI：[packages/cad-html-exporter-cli/README.md](packages/cad-html-exporter-cli/README.md))
+- **PDF** — 矢量 PDF 导出与 PDF 导入 CAD：[packages/cad-pdf-plugin/README.md](packages/cad-pdf-plugin/README.md)
+- **SVG** — 矢量 SVG 导出：[packages/cad-svg-plugin/README.md](packages/cad-svg-plugin/README.md)
+
 ## 性能优化
 
 CAD-Viewer 针对复杂图纸渲染进行了多项优化，可在保持高帧率的同时处理大规模 DXF/DWG 文件：

--- a/packages/cad-html-plugin/src/AcApHtmlPlugin.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlPlugin.ts
@@ -4,6 +4,7 @@ import {
   AcEdCommandStack
 } from '@mlightcad/cad-simple-viewer'
 
+import packageJson from '../package.json'
 import { AcApExportHtmlCmd } from './AcApExportHtmlCmd'
 
 /**
@@ -16,7 +17,7 @@ export class AcApHtmlPlugin implements AcApPlugin {
   /** @inheritdoc */
   name = 'HtmlPlugin'
   /** @inheritdoc */
-  version = '1.0.0'
+  version = packageJson.version
   /** @inheritdoc */
   description = 'HTML export (chtml) command'
 

--- a/packages/cad-html-plugin/tsconfig.json
+++ b/packages/cad-html-plugin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "resolveJsonModule": true,
     "rootDir": "./src",
     "outDir": "./lib",
     "paths": {

--- a/packages/cad-html-plugin/vite.config.ts
+++ b/packages/cad-html-plugin/vite.config.ts
@@ -2,8 +2,8 @@ import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
 import {
-  createPluginEntryFileName,
-  createPluginLibRollupOutput
+  createLibEntryFileName,
+  createLibRollupOutput
 } from '../vite-config/pluginRollupOutput'
 
 const packageName = '@mlightcad/cad-html-plugin'
@@ -20,12 +20,12 @@ export default defineConfig({
       },
       name: pluginId,
       fileName: (format, entryName) =>
-        createPluginEntryFileName(pluginId, format, entryName)
+        createLibEntryFileName(pluginId, format, entryName)
     },
     minify: true,
     rollupOptions: {
       external: [packageName],
-      output: createPluginLibRollupOutput(pluginId)
+      output: createLibRollupOutput(pluginId)
     }
   },
   plugins: [peerDepsExternal() as PluginOption]

--- a/packages/cad-pdf-plugin/src/AcApPdfPlugin.ts
+++ b/packages/cad-pdf-plugin/src/AcApPdfPlugin.ts
@@ -4,6 +4,7 @@ import {
   AcEdCommandStack
 } from '@mlightcad/cad-simple-viewer'
 
+import packageJson from '../package.json'
 import { AcApConvertToPdfCmd } from './AcApConvertToPdfCmd'
 import { AcApImportPdfCmd } from './AcApImportPdfCmd'
 
@@ -17,7 +18,7 @@ export class AcApPdfPlugin implements AcApPlugin {
   /** @inheritdoc */
   name = 'PdfPlugin'
   /** @inheritdoc */
-  version = '1.0.0'
+  version = packageJson.version
   /** @inheritdoc */
   description = 'PDF export (cpdf) and import (ipdf) commands'
 

--- a/packages/cad-pdf-plugin/tsconfig.json
+++ b/packages/cad-pdf-plugin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "resolveJsonModule": true,
     "rootDir": "./src",
     "outDir": "./lib",
     "paths": {

--- a/packages/cad-simple-ui-plugin/README.md
+++ b/packages/cad-simple-ui-plugin/README.md
@@ -1,0 +1,407 @@
+# @mlightcad/cad-simple-ui-plugin
+
+Framework-agnostic toolbar and layer manager UI for [`@mlightcad/cad-simple-viewer`](https://github.com/mlightcad/cad-viewer).
+
+This plugin provides ready-to-use CAD viewer chrome without Vue, React, or Element Plus. All UI uses plain DOM and respects the cad-simple-viewer `--ml-ui-*` theme tokens.
+
+## Features
+
+- Configurable toolbar with predefined CAD commands, separators, and preset references
+- Nested toolbar menus with submenu arrows
+- Toolbar placement: `top`, `bottom`, `left`, `right`
+- Default toolbar includes view/review tools, export submenu, toolbar placement, theme and locale toggles
+- UI theme follows `COLORTHEME` sysvar and `--ml-ui-*` tokens on `host` automatically
+- Locale follows `AcApI18n.currentLocale` automatically
+- Floating layer manager (name, visibility, color)
+- ACI color picker for layer colors
+- `layer` command opens the layer manager panel
+
+## Install
+
+```bash
+pnpm add @mlightcad/cad-simple-ui-plugin @mlightcad/cad-simple-viewer @mlightcad/data-model
+```
+
+## Quick start
+
+Load the plugin after creating the document manager. Apply the initial UI theme on `host` first so theme/locale/placement buttons work even before a drawing is opened:
+
+```typescript
+import { AcApDocManager, applyUiTheme } from '@mlightcad/cad-simple-viewer'
+import { createSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
+
+const host = document.getElementById('viewer-host')!
+
+applyUiTheme('dark', host)
+
+AcApDocManager.createInstance({ container: host })
+
+await AcApDocManager.instance.pluginManager.loadPlugin(
+  createSimpleUiPlugin({
+    host,
+    toolbar: {
+      placement: 'right',
+      items: 'default'
+    },
+    layerManager: { enabled: true }
+  })
+)
+```
+
+### Lazy registration (smaller initial bundle)
+
+Import from `@mlightcad/cad-simple-ui-plugin/register` so the main plugin bundle is loaded only when you register it:
+
+```typescript
+import { registerSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin/register'
+
+await registerSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
+  host,
+  toolbar: { placement: 'right', items: 'default' },
+  layerManager: { enabled: true }
+})
+```
+
+### Example app pattern (`cad-simple-viewer-example`)
+
+The [vanilla example](../cad-simple-viewer-example) **defers viewer and plugin initialization until the user opens a file** (local upload or predefined sample). That keeps the first paint lightweight:
+
+1. Page load — only file picker UI; no `AcApDocManager` yet.
+2. First open — `applyUiTheme`, `AcApDocManager.createInstance`, lazy export plugins, then `registerSimpleUiPlugin`.
+3. Subsequent opens — reuse the same viewer instance.
+
+You can adopt the same pattern or load the plugin at startup (see Quick start above). Both are supported.
+
+The default toolbar does not include every command the old inline demo had (for example pickbox and line-weight toggles). Add them with `appendItems` when needed:
+
+```typescript
+toolbar: {
+  items: 'default',
+  appendItems: [
+    {
+      id: 'pickbox',
+      label: 'Set Pickbox',
+      requiresDocument: true,
+      action: () => {
+        const valueText = window.prompt('Set pick box size (integer):', '10')
+        if (valueText == null) return
+        const pickboxValue = Number.parseInt(valueText, 10)
+        if (!Number.isFinite(pickboxValue) || pickboxValue <= 0) return
+        AcApDocManager.instance.sendStringToExecute(`PICKBOX\n${pickboxValue}`)
+      }
+    }
+  ]
+}
+```
+
+The built-in theme toggle button updates `COLORTHEME` when a document is open, or applies `applyUiTheme` on `host` when no document is loaded.
+
+### Layer manager bounds
+
+By default the layer manager stays inside `host` and cannot be dragged outside the canvas:
+
+```typescript
+layerManager: {
+  enabled: true,
+  allowMoveOutsideCanvas: false // default
+}
+```
+
+The panel height can be adjusted by dragging the handle at the bottom edge.
+
+Default placement:
+
+- Vertically centered in the canvas, with 150px margin from the top and bottom edges
+- Horizontally on the side opposite the toolbar (`right` toolbar → panel on the left; `left`/`top`/`bottom` toolbar → panel on the right)
+
+## Custom toolbar
+
+Toolbar buttons are configured through `toolbar.items`. You can start from the built-in set, extend it, or replace it entirely.
+
+### `AcExToolbarItem` fields
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique button id |
+| `label` | Tooltip / aria-label (i18n key or plain text if using custom items only) |
+| `icon` | Inline SVG string, DOM element, or factory `() => HTMLElement` |
+| `command` | Passed to `AcApDocManager.sendStringToExecute` (supports `\n`, e.g. `'zoom\nall'`) |
+| `action` | Custom click handler (e.g. open a dialog). Used when no `command` is set |
+| `requiresDocument` | When `false`, button stays enabled before a drawing is opened |
+| `minOpenMode` | Hide below Review/Write (`AcEdOpenMode.Review`) |
+| `children` | Submenu items (parent shows a flyout arrow) |
+| `childIcon` | `'fixed'` (default): parent keeps its own icon; `'selected'`: parent icon follows the active submenu item |
+| `selectedChildId` | Initial submenu selection when `childIcon` is `'selected'` |
+| `toggle` | Two-state button with `getValue`, `on`, and `off` branches |
+| `type` | `'separator'` renders a divider; omit for buttons |
+| `preset` | Reference a built-in button by id (custom layouts only; use `{ preset: 'pan' }`) |
+| `disabled` | `boolean` or `() => boolean` |
+
+Built-in preset ids include: `select`, `pan`, `zoom-extent`, `layer`, `measure`, `export`, `toolbar-placement`, `switch-bg`, `theme`, `locale`, and nested ids such as `placement-top`, `measure-distance`, `export-html`, etc.
+
+### 1. Default toolbar + extra buttons
+
+Keep all predefined buttons and append your own at the end:
+
+```typescript
+import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
+import { createSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
+
+createSimpleUiPlugin({
+  toolbar: {
+    placement: 'right',
+    items: 'default',
+    appendItems: [
+      {
+        id: 'my-redline',
+        label: 'Redline',
+        command: 'sketch',
+        minOpenMode: AcEdOpenMode.Review
+      }
+    ]
+  }
+})
+```
+
+### 2. Custom layout with built-in presets and separators
+
+Pick built-in buttons by id and group them with separators — no need to duplicate icons, labels, or submenu definitions:
+
+```typescript
+import {
+  createSimpleUiPlugin,
+  createToolbarSeparator,
+  toolbarPreset
+} from '@mlightcad/cad-simple-ui-plugin'
+
+createSimpleUiPlugin({
+  toolbar: {
+    placement: 'right',
+    items: [
+      toolbarPreset('select'),
+      toolbarPreset('pan'),
+      toolbarPreset('zoom-extent'),
+      createToolbarSeparator('sep-tools'),
+      toolbarPreset('layer'),
+      toolbarPreset('measure'),
+      createToolbarSeparator('sep-settings'),
+      toolbarPreset('switch-bg'),
+      toolbarPreset('theme'),
+      toolbarPreset('locale')
+    ]
+  }
+})
+```
+
+Equivalent object form:
+
+```typescript
+items: [
+  { preset: 'select' },
+  { preset: 'pan' },
+  { type: 'separator', id: 'sep-tools' },
+  { preset: 'measure' }
+]
+```
+
+### 3. Fully custom toolbar
+
+Replace the default set with your own list:
+
+```typescript
+createSimpleUiPlugin({
+  toolbar: {
+    placement: 'top',
+    items: [
+      {
+        id: 'select',
+        label: 'Select',
+        icon: '<svg ...>...</svg>',
+        command: 'select'
+      },
+      {
+        id: 'pan',
+        label: 'Pan',
+        command: 'pan'
+      },
+      {
+        id: 'zoom',
+        label: 'Zoom',
+        children: [
+          { id: 'zoom-all', label: 'Zoom Extents', command: 'zoom\nall' },
+          { id: 'zoom-window', label: 'Zoom Window', command: 'zoom\nwindow' }
+        ]
+      }
+    ]
+  }
+})
+```
+
+### 4. Button with icon and command
+
+```typescript
+{
+  id: 'line',
+  label: 'Draw Line',
+  icon: '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M4 16 L16 4"/></svg>',
+  command: 'line'
+}
+```
+
+`currentColor` in SVG inherits the toolbar text color and follows light/dark theme.
+
+### 5. Text-only button (no icon)
+
+```typescript
+{
+  id: 'save',
+  label: 'Save',
+  command: 'qsave'
+}
+```
+
+### 6. Submenu (nested commands)
+
+```typescript
+{
+  id: 'draw',
+  label: 'Draw',
+  icon: drawIconSvg,
+  childIcon: 'fixed', // default — parent icon stays the same
+  children: [
+    { id: 'line', label: 'Line', command: 'line' },
+    { id: 'circle', label: 'Circle', command: 'circle' }
+  ]
+}
+```
+
+When the parent icon should reflect the active submenu item:
+
+```typescript
+{
+  id: 'my-export',
+  label: 'Export',
+  icon: exportIconSvg,
+  childIcon: 'selected',
+  selectedChildId: 'export-pdf',
+  children: [
+    { id: 'export-html', label: 'HTML', icon: htmlIcon, command: 'chtml' },
+    { id: 'export-pdf', label: 'PDF', icon: pdfIcon, command: 'cpdf' }
+  ]
+}
+```
+
+Built-in buttons using `childIcon: 'selected'`: `toolbar-placement` only. `export`, `annotation`, and `measure` use fixed parent icons.
+
+Submenu flyout direction follows toolbar placement (e.g. arrow points left when the toolbar is on the right).
+
+### 7. Custom action (no CAD command)
+
+```typescript
+{
+  id: 'help',
+  label: 'Help',
+  requiresDocument: false,
+  action: () => window.open('/help', '_blank')
+}
+```
+
+### 8. Toggle button
+
+```typescript
+{
+  id: 'grid',
+  toggle: {
+    getValue: () => gridVisible,
+    on: { label: 'Hide Grid', icon: gridOnIcon, action: () => setGridVisible(false) },
+    off: { label: 'Show Grid', icon: gridOffIcon, action: () => setGridVisible(true) }
+  }
+}
+```
+
+### 9. Disable toolbar
+
+```typescript
+createSimpleUiPlugin({
+  toolbar: { enabled: false },
+  layerManager: { enabled: true }
+})
+```
+
+### Complete example
+
+```typescript
+import { AcApDocManager, AcEdOpenMode, applyUiTheme } from '@mlightcad/cad-simple-viewer'
+import { createSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
+
+const viewerPane = document.getElementById('viewerPane')!
+
+applyUiTheme('dark', viewerPane)
+
+AcApDocManager.createInstance({ container: document.getElementById('cad-container')! })
+
+await AcApDocManager.instance.pluginManager.loadPlugin(
+  createSimpleUiPlugin({
+    host: viewerPane,
+    toolbar: {
+      placement: 'right',
+      items: 'default',
+      appendItems: [
+        {
+          id: 'open-url',
+          label: 'Open URL',
+          requiresDocument: false,
+          action: () => {
+            const url = window.prompt('Drawing URL:')
+            if (url) void AcApDocManager.instance.openUrl(url)
+          }
+        },
+        {
+          id: 'draw-tools',
+          label: 'Draw',
+          children: [
+            { id: 'line', label: 'Line', command: 'line' },
+            { id: 'circle', label: 'Circle', command: 'circle' }
+          ]
+        }
+      ]
+    },
+    layerManager: {
+      enabled: true,
+      allowMoveOutsideCanvas: false
+    }
+  })
+)
+```
+
+## Layer manager
+
+When enabled, the plugin registers a `layer` command that opens the layer manager palette. The built-in `layerclose` command emits `close-layer-manager`, which the plugin listens for.
+
+Supported columns in v1:
+
+- Name (current layer marked with `*`)
+- On (visibility checkbox)
+- Color (ACI picker)
+
+Double-click a layer row to zoom to that layer.
+
+## API
+
+| Export | Description |
+|--------|-------------|
+| `createSimpleUiPlugin(options)` | Returns an `AcApPlugin` instance |
+| `registerSimpleUiPlugin(pluginManager, options)` | Eager-load helper |
+| `AcExLayerService` | Headless layer operations |
+| `AcExSimpleUiPluginOptions` | Plugin configuration type |
+| `AcExToolbarItem` | Single toolbar button definition |
+| `AcExToolbarItemConfig` | Button, separator, or preset reference in toolbar config |
+| `createToolbarSeparator(id?)` | Helper that creates a separator entry |
+| `toolbarPreset(id)` | Helper that references a built-in button |
+| `createDefaultToolbarPresetMap()` | Built-in items keyed by id (advanced use) |
+| `AcExToolbarPlacement` | `'top' \| 'bottom' \| 'left' \| 'right'` |
+
+## See also
+
+- [cad-simple-viewer-example](../cad-simple-viewer-example) — vanilla TypeScript demo (lazy init on first file open; uses `registerSimpleUiPlugin`)
+- [cad-viewer](../cad-viewer) — full Vue + Element Plus application shell

--- a/packages/cad-simple-ui-plugin/__tests__/AcExLayerService.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcExLayerService.spec.ts
@@ -1,0 +1,224 @@
+const acapRunDatabaseEdit = jest.fn(
+  (_db: unknown, _label: string, fn: () => boolean) => {
+    fn()
+  }
+)
+
+const documentActivatedListeners = new Set<(...args: unknown[]) => void>()
+const sysVarChangedListeners = new Set<(...args: unknown[]) => void>()
+
+jest.mock('@mlightcad/cad-simple-viewer', () => ({
+  acapRunDatabaseEdit,
+  AcApDocManager: {
+    instance: {
+      curDocument: undefined,
+      events: {
+        documentActivated: {
+          addEventListener: (fn: (...args: unknown[]) => void) =>
+            documentActivatedListeners.add(fn),
+          removeEventListener: (fn: (...args: unknown[]) => void) =>
+            documentActivatedListeners.delete(fn)
+        }
+      }
+    }
+  }
+}))
+
+jest.mock('@mlightcad/data-model', () => ({
+  AcDbSysVarManager: {
+    instance: () => ({
+      events: {
+        sysVarChanged: {
+          addEventListener: (fn: (...args: unknown[]) => void) =>
+            sysVarChangedListeners.add(fn),
+          removeEventListener: (fn: (...args: unknown[]) => void) =>
+            sysVarChangedListeners.delete(fn)
+        }
+      }
+    })
+  },
+  AcCmColor: {
+    fromString: jest.fn()
+  }
+}))
+
+import { AcExLayerService } from '../src/service/AcExLayerService'
+
+interface TestLayer {
+  name: string
+  objectId: string
+  isOff: boolean
+  standardFlags?: number
+  isFrozen: boolean
+  color: {
+    toString: () => string
+    cssColor: string
+    clone: () => TestLayer['color']
+  }
+}
+
+const frozenFlag = 0x01
+
+const createColor = (value = '7') => {
+  const color = {
+    toString: () => value,
+    cssColor: '#FFFFFF',
+    clone: () => color
+  }
+  return color
+}
+
+const createLayer = (
+  name: string,
+  isOff = false,
+  standardFlags = 0
+): TestLayer => ({
+  name,
+  objectId: `layer:${name}`,
+  isOff,
+  standardFlags,
+  get isFrozen() {
+    return !!((this.standardFlags ?? 0) & frozenFlag)
+  },
+  color: createColor()
+})
+
+const createDatabase = (layers: TestLayer[], currentLayer = layers[0]?.name) => {
+  const layersByName = new Map(layers.map(layer => [layer.name, layer]))
+  const layersById = new Map(layers.map(layer => [layer.objectId, layer]))
+  const db = {
+    clayer: currentLayer,
+    openObjectForWrite: jest.fn((objectId: string) => layersById.get(objectId)),
+    tables: {
+      layerTable: {
+        getAt: jest.fn((name: string) => layersByName.get(name)),
+        newIterator: () => layers
+      }
+    },
+    events: {
+      layerAppended: {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn()
+      },
+      layerErased: {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn()
+      },
+      layerModified: {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn()
+      }
+    }
+  }
+  return { db, layersByName, layersById }
+}
+
+const createEditor = (database?: ReturnType<typeof createDatabase>['db']) => ({
+  curDocument: database ? { database } : undefined,
+  events: {
+    documentActivated: {
+      addEventListener: (fn: (...args: unknown[]) => void) =>
+        documentActivatedListeners.add(fn),
+      removeEventListener: (fn: (...args: unknown[]) => void) =>
+        documentActivatedListeners.delete(fn)
+    }
+  }
+})
+
+describe('AcExLayerService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    documentActivatedListeners.clear()
+    sysVarChangedListeners.clear()
+  })
+
+  it('getLayers returns a shallow copy of cached layers', () => {
+    const layer0 = createLayer('0', false)
+    const layer1 = createLayer('A', true)
+    const { db } = createDatabase([layer0, layer1], '0')
+    const editor = createEditor(db)
+    const service = new AcExLayerService(editor as never)
+
+    const snapshot = service.getLayers()
+    snapshot.push({
+      name: 'mutated',
+      color: '7',
+      cssColor: '#fff',
+      isOn: true
+    })
+
+    expect(service.getLayers().some(layer => layer.name === 'mutated')).toBe(
+      false
+    )
+    expect(service.getLayers()).toHaveLength(2)
+  })
+
+  it('setLayerOn turns a non-current layer off without changing clayer', () => {
+    const layer0 = createLayer('0', false)
+    const layer1 = createLayer('A', false)
+    const { db } = createDatabase([layer0, layer1], '0')
+    const editor = createEditor(db)
+    const service = new AcExLayerService(editor as never)
+
+    expect(service.setLayerOn('A', false)).toBe(true)
+    expect(layer1.isOff).toBe(true)
+    expect(db.clayer).toBe('0')
+    expect(acapRunDatabaseEdit).toHaveBeenCalledTimes(1)
+  })
+
+  it('setLayerOn switches clayer before turning off the current layer', () => {
+    const layer0 = createLayer('0', false)
+    const layer1 = createLayer('A', false)
+    const { db } = createDatabase([layer0, layer1], '0')
+    const editor = createEditor(db)
+    const service = new AcExLayerService(editor as never)
+
+    expect(service.setLayerOn('0', false)).toBe(true)
+    expect(layer0.isOff).toBe(true)
+    expect(db.clayer).toBe('A')
+    expect(layer1.isOff).toBe(false)
+  })
+
+  it('setAllLayersOn turns on every off layer in one edit', () => {
+    const layer0 = createLayer('0', true)
+    const layer1 = createLayer('A', true)
+    const { db } = createDatabase([layer0, layer1], '0')
+    const editor = createEditor(db)
+    const service = new AcExLayerService(editor as never)
+
+    expect(service.setAllLayersOn()).toBe(true)
+    expect(layer0.isOff).toBe(false)
+    expect(layer1.isOff).toBe(false)
+    expect(acapRunDatabaseEdit).toHaveBeenCalledTimes(1)
+  })
+
+  it('setAllLayersOffExceptCurrent leaves only the current layer on', () => {
+    const layer0 = createLayer('0', false)
+    const layer1 = createLayer('A', false)
+    const layer2 = createLayer('B', false)
+    const { db } = createDatabase([layer0, layer1, layer2], '0')
+    const editor = createEditor(db)
+    const service = new AcExLayerService(editor as never)
+
+    expect(service.setAllLayersOffExceptCurrent()).toBe(true)
+    expect(layer0.isOff).toBe(false)
+    expect(layer1.isOff).toBe(true)
+    expect(layer2.isOff).toBe(true)
+    expect(db.clayer).toBe('0')
+    expect(acapRunDatabaseEdit).toHaveBeenCalledTimes(1)
+  })
+
+  it('setAllLayersOffExceptCurrent is a no-op when only current layer is on', () => {
+    const layer0 = createLayer('0', false)
+    const layer1 = createLayer('A', true)
+    const layer2 = createLayer('B', true)
+    const { db } = createDatabase([layer0, layer1, layer2], '0')
+    const editor = createEditor(db)
+    const service = new AcExLayerService(editor as never)
+
+    expect(service.setAllLayersOffExceptCurrent()).toBe(false)
+    expect(layer0.isOff).toBe(false)
+    expect(layer1.isOff).toBe(true)
+    expect(layer2.isOff).toBe(true)
+  })
+})

--- a/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
@@ -1,0 +1,248 @@
+/** Unit tests for toolbar item resolution and open-mode visibility filtering. */
+jest.mock('@mlightcad/cad-simple-viewer', () => ({
+  AcApDocManager: {
+    instance: {
+      curDocument: undefined
+    }
+  },
+  /** Minimal mock used by {@link createDefaultToolbarItems} annotation visibility toggle. */
+  AcApAnnotation: class {
+    /** @returns Fixed annotation layer name for tests. */
+    getAnnotationLayer() {
+      return 'annotation'
+    }
+  },
+  AcEdOpenMode: {
+    Read: 0,
+    Review: 4,
+    Write: 8
+  }
+}))
+
+import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
+
+import { createDefaultToolbarItems } from '../src/config/defaultToolbarItems'
+import {
+  filterVisibleToolbarItems,
+  isToolbarItemVisible,
+  resolveEffectiveToolbarItem,
+  resolveParentToolbarDisplay,
+  resolveSelectedChildItem,
+  resolveToolbarItems
+} from '../src/config/resolveToolbarItems'
+import { createToolbarSeparator } from '../src/config/toolbarItemUtils'
+
+describe('resolveToolbarItems', () => {
+  it('returns default items when items is default', () => {
+    const items = resolveToolbarItems({ items: 'default' })
+    expect(items.length).toBeGreaterThan(0)
+    expect(items[0].id).toBe('select')
+  })
+
+  it('appends custom items after defaults', () => {
+    const items = resolveToolbarItems({
+      items: 'default',
+      appendItems: [{ id: 'custom', command: 'test' }]
+    })
+    expect(items.some(item => item.id === 'custom')).toBe(true)
+    expect(items[items.length - 1].id).toBe('custom')
+  })
+
+  it('uses custom item list when provided', () => {
+    const items = resolveToolbarItems({
+      items: [{ id: 'only', command: 'only' }]
+    })
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe('only')
+  })
+})
+
+describe('toolbar visibility', () => {
+  it('hides review-only items in read mode', () => {
+    const defaults = createDefaultToolbarItems()
+    const visible = filterVisibleToolbarItems(defaults, AcEdOpenMode.Read)
+    expect(visible.some(item => item.id === 'switch-bg')).toBe(false)
+    expect(visible.some(item => item.id === 'select')).toBe(true)
+  })
+
+  it('shows review-only items in review mode', () => {
+    const defaults = createDefaultToolbarItems()
+    const visible = filterVisibleToolbarItems(defaults, AcEdOpenMode.Review)
+    expect(visible.some(item => item.id === 'switch-bg')).toBe(true)
+  })
+
+  it('respects minOpenMode on individual items', () => {
+    expect(
+      isToolbarItemVisible(
+        { id: 'x', minOpenMode: AcEdOpenMode.Review },
+        AcEdOpenMode.Read
+      )
+    ).toBe(false)
+    expect(
+      isToolbarItemVisible(
+        { id: 'x', minOpenMode: AcEdOpenMode.Review },
+        AcEdOpenMode.Write
+      )
+    ).toBe(true)
+  })
+
+  it('filters nested submenu children by open mode', () => {
+    const items = [
+      {
+        id: 'parent',
+        children: [
+          { id: 'read-child', command: 'a' },
+          {
+            id: 'review-child',
+            command: 'b',
+            minOpenMode: AcEdOpenMode.Review
+          }
+        ]
+      }
+    ]
+    const visible = filterVisibleToolbarItems(items, AcEdOpenMode.Read)
+    expect(visible[0].children?.map(child => child.id)).toEqual(['read-child'])
+  })
+})
+
+describe('resolveEffectiveToolbarItem', () => {
+  it('uses off branch when toggle value is false', () => {
+    const item = resolveEffectiveToolbarItem({
+      id: 'toggle',
+      toggle: {
+        getValue: () => false,
+        on: { label: 'on-label', command: 'on-cmd' },
+        off: { label: 'off-label', command: 'off-cmd' }
+      }
+    })
+    expect(item.label).toBe('off-label')
+    expect(item.command).toBe('off-cmd')
+  })
+})
+
+describe('default toolbar items', () => {
+  it('includes export submenu, theme and locale toggles', () => {
+    const items = createDefaultToolbarItems()
+    const exportItem = items.find(item => item.id === 'export')
+    expect(exportItem?.children?.map(child => child.command)).toEqual([
+      'chtml',
+      'cpdf',
+      'csvg'
+    ])
+    expect(items.some(item => item.id === 'theme')).toBe(true)
+    expect(items.some(item => item.id === 'locale')).toBe(true)
+    expect(items.some(item => item.id === 'toolbar-placement')).toBe(true)
+  })
+
+  it('places toolbar placement button before theme', () => {
+    const items = createDefaultToolbarItems()
+    const themeIndex = items.findIndex(item => item.id === 'theme')
+    expect(items[themeIndex - 1]?.id).toBe('toolbar-placement')
+  })
+
+  it('includes a separator before settings buttons', () => {
+    const items = createDefaultToolbarItems()
+    const switchBgIndex = items.findIndex(item => item.id === 'switch-bg')
+    expect(switchBgIndex).toBeGreaterThan(0)
+    expect(items[switchBgIndex - 1]).toEqual({
+      type: 'separator',
+      id: 'sep-settings'
+    })
+  })
+
+  it('uses selected child icon only for toolbar placement', () => {
+    const items = createDefaultToolbarItems()
+    expect(items.find(item => item.id === 'export')?.childIcon).toBeUndefined()
+    expect(items.find(item => item.id === 'annotation')?.childIcon).toBeUndefined()
+    expect(items.find(item => item.id === 'toolbar-placement')?.childIcon).toBe(
+      'selected'
+    )
+    expect(items.find(item => item.id === 'measure')?.childIcon).toBeUndefined()
+  })
+
+  it('uses dedicated parent icons for export and annotation', () => {
+    const items = createDefaultToolbarItems()
+    expect(items.find(item => item.id === 'export')?.icon).toContain('M11 4h5v5')
+    expect(items.find(item => item.id === 'annotation')?.icon).toContain('M7 14.5')
+  })
+})
+
+describe('parent toolbar display', () => {
+  it('keeps parent icon when childIcon is fixed', () => {
+    const parent = resolveParentToolbarDisplay({
+      id: 'measure',
+      icon: 'parent-icon',
+      childIcon: 'fixed',
+      children: [{ id: 'child', icon: 'child-icon', command: 'x' }]
+    })
+    expect(parent.icon).toBe('parent-icon')
+  })
+
+  it('uses selected child icon when childIcon is selected', () => {
+    const parent = resolveParentToolbarDisplay(
+      {
+        id: 'export',
+        label: 'toolbar.export',
+        icon: 'parent-icon',
+        childIcon: 'selected',
+        selectedChildId: 'export-pdf',
+        children: [
+          { id: 'export-html', icon: 'html-icon', command: 'chtml' },
+          { id: 'export-pdf', icon: 'pdf-icon', command: 'cpdf' }
+        ]
+      },
+      'export-pdf'
+    )
+    expect(parent.icon).toBe('pdf-icon')
+    expect(parent.label).toBe('toolbar.export')
+  })
+
+  it('resolves active child by runtime selection first', () => {
+    const child = resolveSelectedChildItem(
+      {
+        id: 'export',
+        selectedChildId: 'export-html',
+        children: [
+          { id: 'export-html', icon: 'html-icon' },
+          { id: 'export-pdf', icon: 'pdf-icon' }
+        ]
+      },
+      'export-pdf'
+    )
+    expect(child?.id).toBe('export-pdf')
+  })
+})
+
+describe('toolbar presets and separators', () => {
+  it('expands preset references in a custom layout', () => {
+    const items = resolveToolbarItems({
+      items: [
+        { preset: 'select' },
+        { preset: 'pan' },
+        createToolbarSeparator('sep-tools'),
+        { preset: 'measure' }
+      ]
+    })
+    expect(items.map(item => ('preset' in item ? item.preset : item.id))).toEqual([
+      'select',
+      'pan',
+      'sep-tools',
+      'measure'
+    ])
+    expect(items[3].children?.length).toBeGreaterThan(0)
+  })
+
+  it('keeps separators when filtering by open mode', () => {
+    const items = resolveToolbarItems({
+      items: [
+        { preset: 'select' },
+        createToolbarSeparator(),
+        { preset: 'switch-bg' }
+      ]
+    })
+    const visible = filterVisibleToolbarItems(items, AcEdOpenMode.Read)
+    expect(visible.some(item => item.type === 'separator')).toBe(true)
+    expect(visible.some(item => item.id === 'select')).toBe(true)
+    expect(visible.some(item => item.id === 'switch-bg')).toBe(false)
+  })
+})

--- a/packages/cad-simple-ui-plugin/package.json
+++ b/packages/cad-simple-ui-plugin/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@mlightcad/cad-simple-ui-plugin",
+  "version": "1.5.6",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mlightcad/cad-viewer.git"
+  },
+  "files": [
+    "dist",
+    "lib",
+    "README.md",
+    "package.json"
+  ],
+  "main": "./dist/cad-simple-ui-plugin.umd.cjs",
+  "module": "./dist/cad-simple-ui-plugin.js",
+  "types": "./lib/index.d.ts",
+  "sideEffects": [
+    "**/ui/styles.ts"
+  ],
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/cad-simple-ui-plugin.js",
+      "require": "./dist/cad-simple-ui-plugin.umd.cjs"
+    },
+    "./register": {
+      "types": "./lib/register.d.ts",
+      "import": "./dist/cad-simple-ui-plugin-register.js",
+      "require": "./dist/cad-simple-ui-plugin-register.umd.cjs"
+    }
+  },
+  "scripts": {
+    "clean": "rimraf dist lib tsconfig.tsbuildinfo",
+    "build": "tsc && vite build",
+    "lint": "eslint src/",
+    "lint:fix": "eslint --fix --quiet src/"
+  },
+  "devDependencies": {
+    "@mlightcad/cad-simple-viewer": "workspace:*",
+    "@mlightcad/data-model": "^1.9.14"
+  },
+  "peerDependencies": {
+    "@mlightcad/cad-simple-viewer": "workspace:*",
+    "@mlightcad/data-model": "^1.9.14"
+  }
+}

--- a/packages/cad-simple-ui-plugin/project.json
+++ b/packages/cad-simple-ui-plugin/project.json
@@ -1,0 +1,46 @@
+{
+  "name": "@mlightcad/cad-simple-ui-plugin",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/cad-simple-ui-plugin/src",
+  "projectType": "library",
+  "tags": ["npm:private"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc && vite build",
+        "cwd": "packages/cad-simple-ui-plugin"
+      },
+      "dependsOn": ["^build"],
+      "cache": true
+    },
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "rimraf dist lib tsconfig.tsbuildinfo",
+        "cwd": "packages/cad-simple-ui-plugin"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint src/",
+        "cwd": "packages/cad-simple-ui-plugin"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint --fix --quiet src/",
+        "cwd": "packages/cad-simple-ui-plugin"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "jest packages/cad-simple-ui-plugin/__tests__",
+        "cwd": "."
+      }
+    }
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/assets/icons.ts
+++ b/packages/cad-simple-ui-plugin/src/assets/icons.ts
@@ -1,0 +1,117 @@
+/**
+ * Inline SVG icon strings and helpers for toolbar and menu buttons.
+ *
+ * Each `ICON_*` constant is an SVG snippet using `currentColor` for theming.
+ */
+
+/** Select tool icon. */
+export const ICON_SELECT = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M10.4379 15.2979h.002l4.86-4.86-9.722-4.86 4.86 9.72Zm7.562-5.298-3.434 3.434 3.2 3.2-1.132 1.132-3.2-3.2-3.434 3.434-7.6-15.6 15.6 7.6Z"/></svg>'
+
+/** Pan tool icon. */
+export const ICON_PAN = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M15.08 12.8537l.002-.002V5.5897c0-.422-.652-.414-.652 0v3.466c0 .938-1.482.95-1.482 0v-4.83c0-.414-.6381-.414-.6381 0h-.014v4.83c.014.95-1.482.95-1.482 0V3.4437c0-.42-.638-.414-.638 0v5.612c0 .95-1.494.95-1.494 0V4.2317c0-.408-.64-.42-.64 0v6.756c0 .802-1.094 1.088-1.494.388-.26-.446-.518-.892-.776-1.338-.338-.482-1.1-.15-.794.38.326.566.652 1.132.978 1.698.006.012.014.026.02.04.552.946 1.106 1.89 1.658 2.834.19.3.422.578.666.802h-.006c.672.61 1.528.964 2.418 1.052.888.06 1.7921-.124 2.5601-.612.3-.19.572-.416.816-.68.326-.368.57-.776.734-1.204.176-.482.258-.97.258-1.494Zm-.91-8.608-.004-.002c.958-.38 2.058.244 2.058 1.346v7.266c0 .652-.108 1.29-.332 1.894-.216.564-.53 1.114-.964 1.576-.318.34-.666.632-1.046.884-.978.612-2.1461.862-3.2601.774-1.128-.102-2.228-.564-3.098-1.352-.326-.292-.612-.646-.87-1.034-.558-.96-1.114-1.92-1.672-2.88l-.012-.028c-.326-.568-.652-1.138-.978-1.706-.59-1.018.068-2.186 1.156-2.336.536-.074 1.126.116 1.562.72.026.028.04.062.054.096.04.074.082.146.122.218V4.2337c0-1.176 1.244-1.788 2.202-1.278.42-1.278 2.378-1.264 2.792-.014.9721-.51 2.2221.102 2.2221 1.284v.06c.022-.014.046-.026.068-.04Z"/></svg>'
+
+/** Zoom extents icon. */
+export const ICON_ZOOM_EXTENT = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M9.3333 14.125 5.875 10.6667V14.125H9.3333Zm4.7917-3.4583-3.4583 3.4583H14.125V10.6667ZM10.6667 5.875 14.125 9.3333V5.875H10.6667ZM5.875 9.3333 9.3333 5.875H5.875V9.3333Zm9.2083 5.475c1.2333-1.3 1.9083-3.0333 1.9083-4.825-.0083-3.325-2.35-6.1833-5.6083-6.8417C8.125 2.4833 4.85 4.2 3.55 7.2583c-1.3 3.0583-.275 6.6083 2.4583 8.5 2.725 1.8917 6.4167 1.6 8.8167-.6917.0917-.0833.175-.175.2583-.2583Zm1.2583.5917 2.575 2.575c-.3167.3167-.625.625-.9417.9417-.8583-.8583-1.7167-1.7167-2.575-2.575-3.4083 2.9-8.4917 2.5917-11.525-.6917S.9417 7.275 4.1083 4.1083C7.2667.9417 12.3667.8417 15.65 3.875s3.5917 8.1167.6917 11.525Z"/></svg>'
+
+/** Zoom window icon. */
+export const ICON_ZOOM_WINDOW = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M15.0833 14.8083c1.2333-1.3 1.9083-3.0333 1.9083-4.825-.0083-3.325-2.35-6.1833-5.6083-6.8417C8.125 2.4833 4.85 4.2 3.55 7.2583c-1.3 3.0583-.275 6.6083 2.4583 8.5 2.725 1.8917 6.4167 1.6 8.8167-.6917.0917-.0833.175-.175.2583-.2583Zm1.2583.5917 2.575 2.575c-.3167.3167-.625.625-.9417.9417-.8583-.8583-1.7167-1.7167-2.575-2.575-3.4083 2.9-8.4917 2.5917-11.525-.6917C.8417 12.3667.9417 7.275 4.1083 4.1083 7.2667.9417 12.3667.8417 15.65 3.875s3.5917 8.1167.6917 11.525Zm-3.55-2.6083V7.2083H7.2083v5.5833h5.5833ZM5.875 5.875h8.25v8.25H5.875V5.875Z"/></svg>'
+
+/** Layer manager icon. */
+export const ICON_LAYER = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="m434.8 137.65l-149.36-68.1c-16.19-7.4-42.69-7.4-58.88 0L77.3 137.65c-17.6 8-17.6 21.09 0 29.09l148 67.5c16.89 7.7 44.69 7.7 61.58 0l148-67.5c17.52-8 17.52-21.1-.08-29.09M160 308.52l-82.7 37.11c-17.6 8-17.6 21.1 0 29.1l148 67.5c16.89 7.69 44.69 7.69 61.58 0l148-67.5c17.6-8 17.6-21.1 0-29.1l-79.94-38.47"/><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="m160 204.48l-82.8 37.16c-17.6 8-17.6 21.1 0 29.1l148 67.49c16.89 7.7 44.69 7.7 61.58 0l148-67.49c17.7-8 17.7-21.1.1-29.1L352 204.48"/></svg>'
+
+/** Measure tools parent menu icon. */
+export const ICON_MEASURE = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" fill-rule="evenodd" d="M1.5 7h17v6h-17Z M4.25 7h1v2.5h-1Z M7.5 7h.75v1.5H7.5Z M10.25 7h1v2.5h-1Z M13.5 7h.75v1.5H13.5Z M16.25 7h1v2.5h-1Z"/></svg>'
+
+/** Measure distance icon (dimension line between two points). */
+export const ICON_MEASURE_DISTANCE =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><circle cx="4" cy="15" r="1.6" fill="currentColor"/><circle cx="16" cy="5" r="1.6" fill="currentColor"/><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M5.4 13.6 14.6 6.4"/><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M3 15h2.8M16 5h-2.8"/></svg>'
+
+/** Measure angle icon. */
+export const ICON_MEASURE_ANGLE = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="none" stroke="currentColor" stroke-width="1.5" d="M4 16a8 8 0 0 1 12-5"/><path fill="currentColor" d="M16 9h2v2h-2z"/></svg>'
+
+/** Measure area icon. */
+export const ICON_MEASURE_AREA = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="none" stroke="currentColor" stroke-width="1.5" d="M4 6h8v8H4z"/><path fill="currentColor" d="M12 12h4v4h-4z" opacity=".5"/></svg>'
+
+/** Measure arc length icon. */
+export const ICON_MEASURE_ARC = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="none" stroke="currentColor" stroke-width="1.5" d="M4 14a8 8 0 0 1 12-8"/></svg>'
+
+/** Clear measurements icon (ruler with clear mark). */
+export const ICON_CLEAR_MEASUREMENTS =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M3 13h14"/><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M6 11v4M9.5 12v2M13 11v4M16.5 12v2"/><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M6.5 5.5 13.5 12.5M13.5 5.5 6.5 12.5"/></svg>'
+
+/** Switch background icon. */
+export const ICON_SWITCH_BG = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" fill="currentColor"/><rect x="14" y="14" width="7" height="7" fill="none" stroke="currentColor" stroke-width="1"/><path d="M12 4a8 8 0 0 1 7.25 7.25" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round"/><path d="M20.75 10 L17.25 10 L19 12.5 Z" fill="currentColor"/><path d="M12 20a8 8 0 0 1-8-8" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round"/><path d="M6 14 L2.5 14 L4 11 Z" fill="currentColor"/></svg>'
+
+/** Annotation tools parent menu icon. */
+export const ICON_ANNOTATION =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="4" y="6" width="11" height="10" rx="1.2" fill="none" stroke="currentColor" stroke-width="1.5"/><path fill="currentColor" d="M7 14.5 13.5 8l1.5 1.5-6.5 6.5H7v-1.5Z"/><path fill="currentColor" d="M13.2 7.3 15 5.5l1.5 1.5-1.8 1.8-1.5-1.5Z"/></svg>'
+
+/** Freehand review sketch icon. */
+export const ICON_REV_FREEDRAW = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="none" stroke="currentColor" stroke-width="1.5" d="M4 14c2-4 4-6 8-8 2-1 4 0 4 2"/></svg>'
+
+/** Rectangle review icon. */
+export const ICON_REV_RECT = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="4" y="5" width="12" height="10" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>'
+
+/** Revision cloud icon. */
+export const ICON_REV_CLOUD = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="none" stroke="currentColor" stroke-width="1.5" d="M5 12c0-2 1-4 4-4 1-2 4-2 5 0 2 0 3 2 3 4"/></svg>'
+
+/** Circle review icon. */
+export const ICON_REV_CIRCLE = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><circle cx="10" cy="10" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>'
+
+/** Show annotations icon. */
+export const ICON_ANNOTATION_SHOW = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M10 4C5 4 1.73 7.11 1 10c.73 2.89 4 6 9 6s8.27-3.11 9-6c-.73-2.89-4-6-9-6Zm0 10a4 4 0 1 1 0-8 4 4 0 0 1 0 8Z"/></svg>'
+
+/** Hide annotations icon. */
+export const ICON_ANNOTATION_HIDE = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M2 2l16 16M10 6c3.5 0 6.5 2 7.8 4-1 1.6-3 3.4-5.8 4.1M6.2 6.3C3.8 7.4 2.2 9.1 1.2 10c1.3 2.9 5 6 8.8 6 1.2 0 2.3-.3 3.3-.7"/></svg>'
+
+/** Light theme toggle icon (shown when light theme is active). */
+export const ICON_THEME_LIGHT = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><circle cx="10" cy="10" r="4" fill="currentColor"/><path fill="none" stroke="currentColor" stroke-width="1.5" d="M10 2v2M10 16v2M2 10h2M16 10h2M4.2 4.2l1.4 1.4M14.4 14.4l1.4 1.4M4.2 15.8l1.4-1.4M14.4 5.6l1.4-1.4"/></svg>'
+
+/** Dark theme toggle icon (shown when dark theme is active). */
+export const ICON_THEME_DARK = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M10 3a7 7 0 1 0 0 14 9 9 0 0 1 0-14Z"/></svg>'
+
+/** Export submenu parent icon (share from document). */
+export const ICON_EXPORT =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="4" y="7" width="10" height="10" rx="1.2" fill="none" stroke="currentColor" stroke-width="1.5"/><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M11 4h5v5"/><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M10 5 16 11"/></svg>'
+
+/** Export HTML icon. */
+export const ICON_EXPORT_HTML = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M4 3h12v14H4V3Zm2 2v2h8V5H6Zm0 4v6h8V9H6Z"/></svg>'
+
+/** Export PDF icon. */
+export const ICON_EXPORT_PDF = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" d="M5 3h7l3 3v11H5V3Zm6 0v3h3"/><text x="6" y="16" fill="currentColor" font-size="5" font-family="Arial">PDF</text></svg>'
+
+/** Export SVG icon. */
+export const ICON_EXPORT_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="none" stroke="currentColor" stroke-width="1.5" d="M4 4h12v12H4z"/><circle cx="8" cy="10" r="2" fill="currentColor"/></svg>'
+
+/** Toolbar dock / placement parent button. */
+export const ICON_TOOLBAR_PLACEMENT =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="3" y="3" width="14" height="14" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="15" y="5" width="1.5" height="10" rx=".5" fill="currentColor"/></svg>'
+
+export const ICON_PLACEMENT_TOP =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="3" y="3" width="14" height="3" rx=".5" fill="currentColor"/><rect x="5" y="8" width="10" height="9" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>'
+
+export const ICON_PLACEMENT_BOTTOM =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="5" y="3" width="10" height="9" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="3" y="14" width="14" height="3" rx=".5" fill="currentColor"/></svg>'
+
+export const ICON_PLACEMENT_LEFT =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="3" y="3" width="3" height="14" rx=".5" fill="currentColor"/><rect x="8" y="5" width="9" height="10" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>'
+
+export const ICON_PLACEMENT_RIGHT =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="5" y="5" width="9" height="10" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="3" width="3" height="14" rx=".5" fill="currentColor"/></svg>'
+
+/**
+ * Creates a DOM icon element from an SVG string, element, or factory.
+ *
+ * @param icon - Inline SVG markup, existing element, or factory function.
+ * @returns Wrapper span with class `ml-ex-ui-icon`, or a cloned/factory element.
+ */
+export function createIconElement(
+  icon: string | HTMLElement | (() => HTMLElement)
+): HTMLElement {
+  if (typeof icon === 'function') return icon()
+  if (icon instanceof HTMLElement) return icon.cloneNode(true) as HTMLElement
+  const wrapper = document.createElement('span')
+  wrapper.className = 'ml-ex-ui-icon'
+  wrapper.innerHTML = icon
+  return wrapper
+}

--- a/packages/cad-simple-ui-plugin/src/command/AcApLayerUiCmd.ts
+++ b/packages/cad-simple-ui-plugin/src/command/AcApLayerUiCmd.ts
@@ -1,0 +1,24 @@
+import { AcApContext, AcEdCommand } from '@mlightcad/cad-simple-viewer'
+
+import type { AcExLayerManager } from '../ui/AcExLayerManager'
+
+/**
+ * Command that opens the floating layer manager panel.
+ */
+export class AcApLayerUiCmd extends AcEdCommand {
+  /**
+   * @param layerManager - Layer manager instance to show when the command runs.
+   */
+  constructor(private layerManager: AcExLayerManager) {
+    super()
+  }
+
+  /**
+   * Shows the layer manager panel.
+   *
+   * @param _context - Application context (unused).
+   */
+  async execute(_context: AcApContext) {
+    this.layerManager.show()
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
@@ -1,0 +1,303 @@
+import {
+  AcApAnnotation,
+  AcApDocManager,
+  AcEdOpenMode,
+  type AcEdUiTheme
+} from '@mlightcad/cad-simple-viewer'
+
+import {
+  ICON_ANNOTATION,
+  ICON_ANNOTATION_HIDE,
+  ICON_ANNOTATION_SHOW,
+  ICON_CLEAR_MEASUREMENTS,
+  ICON_EXPORT,
+  ICON_EXPORT_HTML,
+  ICON_EXPORT_PDF,
+  ICON_EXPORT_SVG,
+  ICON_LAYER,
+  ICON_MEASURE,
+  ICON_MEASURE_ANGLE,
+  ICON_MEASURE_ARC,
+  ICON_MEASURE_AREA,
+  ICON_MEASURE_DISTANCE,
+  ICON_PAN,
+  ICON_PLACEMENT_BOTTOM,
+  ICON_PLACEMENT_LEFT,
+  ICON_PLACEMENT_RIGHT,
+  ICON_PLACEMENT_TOP,
+  ICON_REV_CIRCLE,
+  ICON_REV_CLOUD,
+  ICON_REV_FREEDRAW,
+  ICON_REV_RECT,
+  ICON_SELECT,
+  ICON_SWITCH_BG,
+  ICON_THEME_DARK,
+  ICON_THEME_LIGHT,
+  ICON_TOOLBAR_PLACEMENT,
+  ICON_ZOOM_EXTENT,
+  ICON_ZOOM_WINDOW
+} from '../assets/icons'
+import type { AcExDefaultToolbarContext, AcExToolbarItem, AcExToolbarPlacement } from './types'
+
+const TOOLBAR_PLACEMENTS: AcExToolbarPlacement[] = [
+  'top',
+  'bottom',
+  'left',
+  'right'
+]
+
+const PLACEMENT_ICONS: Record<AcExToolbarPlacement, string> = {
+  top: ICON_PLACEMENT_TOP,
+  bottom: ICON_PLACEMENT_BOTTOM,
+  left: ICON_PLACEMENT_LEFT,
+  right: ICON_PLACEMENT_RIGHT
+}
+
+const PLACEMENT_LABELS: Record<AcExToolbarPlacement, string> = {
+  top: 'toolbar.placementTop',
+  bottom: 'toolbar.placementBottom',
+  left: 'toolbar.placementLeft',
+  right: 'toolbar.placementRight'
+}
+
+function createToolbarPlacementItem(
+  context?: AcExDefaultToolbarContext
+): AcExToolbarItem {
+  return {
+    id: 'toolbar-placement',
+    label: 'toolbar.placement',
+    icon: ICON_TOOLBAR_PLACEMENT,
+    requiresDocument: false,
+    childIcon: 'selected',
+    selectedChildId: `placement-${context?.getPlacement() ?? 'right'}`,
+    children: TOOLBAR_PLACEMENTS.map(placement => ({
+      id: `placement-${placement}`,
+      label: PLACEMENT_LABELS[placement],
+      icon: PLACEMENT_ICONS[placement],
+      requiresDocument: false,
+      action: () => context?.setPlacement(placement)
+    }))
+  }
+}
+
+/**
+ * Returns whether the annotation layer is currently visible in the active document.
+ *
+ * @returns `true` when the annotation layer is on or no document is open.
+ */
+function isAnnotationVisible(): boolean {
+  const db = AcApDocManager.instance.curDocument?.database
+  if (!db) return true
+  const annotation = new AcApAnnotation(db)
+  const layerName = annotation.getAnnotationLayer()
+  const layer = db.tables.layerTable.getAt(layerName)
+  return layer ? !layer.isOff : true
+}
+
+/**
+ * Builds the built-in toolbar item list (view, measure, export, review, theme, locale).
+ *
+ * @param context - Optional callbacks for theme and locale toggle items.
+ * @returns Default {@link AcExToolbarItem} array.
+ */
+export function createDefaultToolbarItems(
+  context?: AcExDefaultToolbarContext
+): AcExToolbarItem[] {
+  const getTheme = (): AcEdUiTheme => context?.getTheme() ?? 'light'
+  const toggleTheme = () => {
+    const next: AcEdUiTheme = getTheme() === 'dark' ? 'light' : 'dark'
+    context?.setTheme(next)
+  }
+
+  const items: AcExToolbarItem[] = [
+    {
+      id: 'select',
+      label: 'toolbar.select',
+      icon: ICON_SELECT,
+      command: 'select'
+    },
+    {
+      id: 'pan',
+      label: 'toolbar.pan',
+      icon: ICON_PAN,
+      command: 'pan'
+    },
+    {
+      id: 'zoom-extent',
+      label: 'toolbar.zoomExtent',
+      icon: ICON_ZOOM_EXTENT,
+      command: 'zoom\nall'
+    },
+    {
+      id: 'zoom-window',
+      label: 'toolbar.zoomWindow',
+      icon: ICON_ZOOM_WINDOW,
+      command: 'zoom\nwindow'
+    },
+    {
+      id: 'layer',
+      label: 'toolbar.layer',
+      icon: ICON_LAYER,
+      command: 'layer'
+    },
+    {
+      id: 'measure',
+      label: 'toolbar.measure',
+      icon: ICON_MEASURE,
+      children: [
+        {
+          id: 'measure-distance',
+          label: 'toolbar.measureDistance',
+          icon: ICON_MEASURE_DISTANCE,
+          command: 'measuredistance'
+        },
+        {
+          id: 'measure-angle',
+          label: 'toolbar.measureAngle',
+          icon: ICON_MEASURE_ANGLE,
+          command: 'measureangle'
+        },
+        {
+          id: 'measure-area',
+          label: 'toolbar.measureArea',
+          icon: ICON_MEASURE_AREA,
+          command: 'measurearea'
+        },
+        {
+          id: 'measure-arc',
+          label: 'toolbar.measureArc',
+          icon: ICON_MEASURE_ARC,
+          command: 'measurearc'
+        },
+        {
+          id: 'clear-measurements',
+          label: 'toolbar.clearMeasurements',
+          icon: ICON_CLEAR_MEASUREMENTS,
+          command: 'clearmeasurements'
+        }
+      ]
+    },
+    {
+      id: 'export',
+      label: 'toolbar.export',
+      icon: ICON_EXPORT,
+      children: [
+        {
+          id: 'export-html',
+          label: 'toolbar.exportHtml',
+          icon: ICON_EXPORT_HTML,
+          command: 'chtml'
+        },
+        {
+          id: 'export-pdf',
+          label: 'toolbar.exportPdf',
+          icon: ICON_EXPORT_PDF,
+          command: 'cpdf'
+        },
+        {
+          id: 'export-svg',
+          label: 'toolbar.exportSvg',
+          icon: ICON_EXPORT_SVG,
+          command: 'csvg'
+        }
+      ]
+    },
+    {
+      id: 'annotation',
+      label: 'toolbar.annotation',
+      icon: ICON_ANNOTATION,
+      minOpenMode: AcEdOpenMode.Review,
+      children: [
+        {
+          id: 'rev-freedraw',
+          label: 'toolbar.revFreehand',
+          icon: ICON_REV_FREEDRAW,
+          command: 'sketch'
+        },
+        {
+          id: 'rev-rect',
+          label: 'toolbar.revRect',
+          icon: ICON_REV_RECT,
+          command: 'revrect'
+        },
+        {
+          id: 'rev-cloud',
+          label: 'toolbar.revCloud',
+          icon: ICON_REV_CLOUD,
+          command: 'revcloud'
+        },
+        {
+          id: 'rev-circle',
+          label: 'toolbar.revCircle',
+          icon: ICON_REV_CIRCLE,
+          command: 'revcircle'
+        }
+      ]
+    },
+    {
+      id: 'rev-vis',
+      minOpenMode: AcEdOpenMode.Review,
+      toggle: {
+        getValue: isAnnotationVisible,
+        on: {
+          label: 'toolbar.showAnnotation',
+          icon: ICON_ANNOTATION_SHOW,
+          command: 'revvis'
+        },
+        off: {
+          label: 'toolbar.hideAnnotation',
+          icon: ICON_ANNOTATION_HIDE,
+          command: 'revvis'
+        }
+      }
+    },
+    {
+      type: 'separator',
+      id: 'sep-settings'
+    },
+    {
+      id: 'switch-bg',
+      label: 'toolbar.switchBg',
+      icon: ICON_SWITCH_BG,
+      command: 'switchbg',
+      minOpenMode: AcEdOpenMode.Review
+    },
+    createToolbarPlacementItem(context),
+    {
+      id: 'theme',
+      requiresDocument: false,
+      toggle: {
+        getValue: () => getTheme() === 'light',
+        on: {
+          label: 'toolbar.themeLight',
+          icon: ICON_THEME_LIGHT,
+          action: toggleTheme
+        },
+        off: {
+          label: 'toolbar.themeDark',
+          icon: ICON_THEME_DARK,
+          action: toggleTheme
+        }
+      }
+    },
+    {
+      id: 'locale',
+      requiresDocument: false,
+      toggle: {
+        getValue: () => (context?.getLocale() ?? 'en') === 'en',
+        on: {
+          label: 'toolbar.localeEn',
+          icon: '<span style="font-size:10px;font-weight:700;line-height:1">EN</span>',
+          action: () => context?.toggleLocale()
+        },
+        off: {
+          label: 'toolbar.localeZh',
+          icon: '<span style="font-size:10px;font-weight:700;line-height:1">中</span>',
+          action: () => context?.toggleLocale()
+        }
+      }
+    }
+  ]
+
+  return items
+}

--- a/packages/cad-simple-ui-plugin/src/config/resolveToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/resolveToolbarItems.ts
@@ -1,0 +1,204 @@
+import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
+
+import { createDefaultToolbarItems } from './defaultToolbarItems'
+import {
+  expandToolbarItemConfigs,
+  indexToolbarItems,
+  isToolbarSeparatorItem
+} from './toolbarItemUtils'
+import type {
+  AcExDefaultToolbarContext,
+  AcExSimpleUiPluginOptions,
+  AcExToolbarItem
+} from './types'
+
+/**
+ * Builds a lookup map of built-in toolbar items keyed by id (includes nested submenu entries).
+ *
+ * @param context - Context for theme/locale toggle presets.
+ */
+export function createDefaultToolbarPresetMap(
+  context?: AcExDefaultToolbarContext
+): Map<string, AcExToolbarItem> {
+  const map = new Map<string, AcExToolbarItem>()
+  indexToolbarItems(createDefaultToolbarItems(context), map)
+  return map
+}
+
+/**
+ * Resolves the final toolbar item list from plugin options.
+ *
+ * Uses the default set when `items` is `'default'` or omitted, then appends
+ * `appendItems` when present. Preset references in custom lists are expanded
+ * from the built-in item map.
+ *
+ * @param options - Toolbar subsection of plugin options.
+ * @param context - Context for default theme/locale toggle items.
+ * @returns Resolved toolbar items ready for {@link AcExToolbar}.
+ */
+export function resolveToolbarItems(
+  options: AcExSimpleUiPluginOptions['toolbar'],
+  context?: AcExDefaultToolbarContext
+): AcExToolbarItem[] {
+  const toolbar = options ?? {}
+  const presets = createDefaultToolbarPresetMap(context)
+  let items: AcExToolbarItem[]
+
+  if (toolbar.items === 'default' || toolbar.items == null) {
+    items = createDefaultToolbarItems(context)
+  } else {
+    items = expandToolbarItemConfigs(toolbar.items, presets)
+  }
+
+  if (toolbar.appendItems?.length) {
+    items = [
+      ...items,
+      ...expandToolbarItemConfigs(toolbar.appendItems, presets)
+    ]
+  }
+
+  return items
+}
+
+/**
+ * Returns whether a toolbar item should be shown for the given document open mode.
+ *
+ * @param item - Toolbar item to test.
+ * @param openMode - Current document open mode.
+ */
+export function isToolbarItemVisible(
+  item: AcExToolbarItem,
+  openMode: AcEdOpenMode
+): boolean {
+  if (item.minOpenMode == null) return true
+  return openMode >= item.minOpenMode
+}
+
+/**
+ * Merges toggle branch fields into a toolbar item for rendering.
+ *
+ * @param item - Item that may define a `toggle` configuration.
+ * @returns Item with effective label, icon, command, and action from the active branch.
+ */
+export function resolveEffectiveToolbarItem(
+  item: AcExToolbarItem
+): AcExToolbarItem {
+  if (isToolbarSeparatorItem(item)) return item
+  if (!item.toggle) return item
+  const active = item.toggle.getValue()
+  const branch = active ? item.toggle.on : item.toggle.off
+  return {
+    ...item,
+    ...branch,
+    id: item.id,
+    toggle: item.toggle
+  }
+}
+
+/**
+ * Resolves the active submenu child for a parent toolbar item.
+ *
+ * @param item - Parent item with `children`.
+ * @param activeChildId - Runtime-selected child id, if any.
+ */
+export function resolveSelectedChildItem(
+  item: AcExToolbarItem,
+  activeChildId?: string
+): AcExToolbarItem | undefined {
+  if (!item.children?.length) return undefined
+
+  const candidates = [activeChildId, item.selectedChildId].filter(
+    (id): id is string => Boolean(id)
+  )
+  for (const id of candidates) {
+    const match = item.children.find(child => child.id === id)
+    if (match) return match
+  }
+
+  return item.children[0]
+}
+
+/**
+ * Applies parent-button display fields for submenu parents.
+ *
+ * When {@link AcExToolbarItem.childIcon} is `'selected'`, the parent icon is
+ * taken from the active submenu child while the parent label is unchanged.
+ *
+ * @param item - Parent toolbar item (may include `children`).
+ * @param activeChildId - Runtime-selected child id, if any.
+ */
+export function resolveParentToolbarDisplay(
+  item: AcExToolbarItem,
+  activeChildId?: string
+): AcExToolbarItem {
+  const effective = resolveEffectiveToolbarItem(item)
+  if (effective.childIcon !== 'selected' || !effective.children?.length) {
+    return effective
+  }
+
+  const child = resolveSelectedChildItem(effective, activeChildId)
+  if (!child) return effective
+
+  const resolvedChild = resolveEffectiveToolbarItem(child)
+  return {
+    ...effective,
+    icon: resolvedChild.icon ?? effective.icon
+  }
+}
+
+/**
+ * Determines whether a toolbar item needs an open document to be enabled.
+ *
+ * @param item - Toolbar item to inspect.
+ * @returns `requiresDocument` when set, otherwise `true` when `command` is set.
+ */
+export function itemRequiresDocument(item: AcExToolbarItem): boolean {
+  if (isToolbarSeparatorItem(item)) return false
+  if (item.requiresDocument != null) return item.requiresDocument
+  return Boolean(item.command)
+}
+
+/**
+ * Evaluates the disabled state of a toolbar item.
+ *
+ * @param item - Toolbar item with optional static or dynamic `disabled`.
+ */
+export function isToolbarItemDisabled(item: AcExToolbarItem): boolean {
+  if (item.disabled == null) return false
+  return typeof item.disabled === 'function' ? item.disabled() : item.disabled
+}
+
+/**
+ * Filters toolbar items (and nested children) by open mode visibility.
+ *
+ * Parent items with only hidden children are removed unless they have their
+ * own command, action, or toggle.
+ *
+ * @param items - Root toolbar items.
+ * @param openMode - Current document open mode.
+ */
+export function filterVisibleToolbarItems(
+  items: AcExToolbarItem[],
+  openMode: AcEdOpenMode
+): AcExToolbarItem[] {
+  return items
+    .filter(
+      item =>
+        isToolbarSeparatorItem(item) || isToolbarItemVisible(item, openMode)
+    )
+    .map(item => {
+      if (isToolbarSeparatorItem(item) || !item.children?.length) return item
+      const children = filterVisibleToolbarItems(item.children, openMode)
+      return { ...item, children }
+    })
+    .filter(item => {
+      if (isToolbarSeparatorItem(item)) return true
+      return (
+        !item.children ||
+        item.children.length > 0 ||
+        item.command ||
+        item.action ||
+        item.toggle
+      )
+    })
+}

--- a/packages/cad-simple-ui-plugin/src/config/toolbarItemUtils.ts
+++ b/packages/cad-simple-ui-plugin/src/config/toolbarItemUtils.ts
@@ -1,0 +1,114 @@
+import type {
+  AcExToolbarItem,
+  AcExToolbarItemConfig,
+  AcExToolbarPresetRef,
+  AcExToolbarSeparator
+} from './types'
+
+/** Returns whether a toolbar config entry is a visual separator. */
+export function isToolbarSeparatorItem(
+  item: AcExToolbarItemConfig
+): item is AcExToolbarSeparator {
+  return 'type' in item && item.type === 'separator'
+}
+
+/** Returns whether a toolbar config entry references a built-in preset button. */
+export function isToolbarPresetRef(
+  item: AcExToolbarItemConfig
+): item is AcExToolbarPresetRef {
+  return 'preset' in item && typeof item.preset === 'string'
+}
+
+/**
+ * Creates a toolbar separator entry.
+ *
+ * @param id - Optional stable id for debugging.
+ */
+export function createToolbarSeparator(id?: string): AcExToolbarSeparator {
+  return { type: 'separator', id }
+}
+
+/**
+ * References a built-in toolbar button by id when composing a custom layout.
+ *
+ * @param preset - Preset id such as `'pan'` or `'measure'`.
+ */
+export function toolbarPreset(preset: string): AcExToolbarPresetRef {
+  return { preset }
+}
+
+/** Registers button items (and nested children) in a preset lookup map. */
+export function indexToolbarItems(
+  items: AcExToolbarItem[],
+  map: Map<string, AcExToolbarItem>
+): void {
+  for (const item of items) {
+    if (isToolbarSeparatorItem(item)) continue
+    map.set(item.id, item)
+    if (item.children?.length) {
+      indexToolbarItems(item.children, map)
+    }
+  }
+}
+
+/**
+ * Resolves preset references and nested children in a toolbar config list.
+ *
+ * @param items - Raw toolbar configuration entries.
+ * @param presets - Built-in items keyed by id.
+ */
+export function expandToolbarItemConfigs(
+  items: AcExToolbarItemConfig[],
+  presets: Map<string, AcExToolbarItem>
+): AcExToolbarItem[] {
+  return items.flatMap(item => {
+    const expanded = expandToolbarItemConfig(item, presets)
+    return expanded ? [expanded] : []
+  })
+}
+
+function expandToolbarItemConfig(
+  item: AcExToolbarItemConfig,
+  presets: Map<string, AcExToolbarItem>
+): AcExToolbarItem | null {
+  if (isToolbarSeparatorItem(item)) {
+    return {
+      type: 'separator',
+      id: item.id ?? `separator-${Math.random().toString(36).slice(2, 9)}`
+    }
+  }
+
+  if (isToolbarPresetRef(item)) {
+    const preset = presets.get(item.preset)
+    if (!preset) {
+      console.warn(
+        `[cad-simple-ui-plugin] Unknown toolbar preset "${item.preset}".`
+      )
+      return null
+    }
+    return cloneToolbarItem(preset)
+  }
+
+  const buttonItem = item as AcExToolbarItem
+  if (buttonItem.children?.length) {
+    return {
+      ...buttonItem,
+      children: expandToolbarItemConfigs(
+        buttonItem.children as AcExToolbarItemConfig[],
+        presets
+      )
+    }
+  }
+
+  return buttonItem
+}
+
+function cloneToolbarItem(item: AcExToolbarItem): AcExToolbarItem {
+  if (!item.children?.length) {
+    return { ...item }
+  }
+  return {
+    ...item,
+    children: item.children.map(child => cloneToolbarItem(child))
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/config/types.ts
+++ b/packages/cad-simple-ui-plugin/src/config/types.ts
@@ -1,0 +1,141 @@
+import type { AcEdOpenMode, AcEdUiTheme } from '@mlightcad/cad-simple-viewer'
+
+/** Toolbar edge placement relative to the viewer host element. */
+export type AcExToolbarPlacement = 'top' | 'bottom' | 'left' | 'right'
+
+/** Supported UI locale codes for plugin strings. */
+export type AcExLocale = 'en' | 'zh'
+
+/**
+ * Controls how a parent button icon relates to its submenu selection.
+ *
+ * - `'fixed'`: parent keeps its own `icon` (default).
+ * - `'selected'`: parent shows the selected child's `icon`.
+ */
+export type AcExToolbarChildIconMode = 'fixed' | 'selected'
+
+/** Visual separator between toolbar button groups. */
+export interface AcExToolbarSeparator {
+  type: 'separator'
+  /** Optional stable id for debugging. */
+  id?: string
+}
+
+/** Reference to a built-in toolbar button when composing a custom layout. */
+export interface AcExToolbarPresetRef {
+  preset: string
+}
+
+/**
+ * Configuration for a single toolbar button or submenu entry.
+ */
+export interface AcExToolbarItem {
+  /** Stable identifier used for DOM attributes and debugging. */
+  id: string
+  /** When `'separator'`, renders a divider instead of a button. */
+  type?: 'button' | 'separator'
+  /** i18n key under the `simpleUi` namespace (for example `toolbar.select`). */
+  label?: string
+  /** Inline SVG string, DOM element, or factory that produces an icon element. */
+  icon?: string | HTMLElement | (() => HTMLElement)
+  /** CAD command string sent to {@link AcApDocManager.sendStringToExecute}. */
+  command?: string
+  /** Custom click handler. Used when no command is set (e.g. theme toggle). */
+  action?: () => void
+  /**
+   * When false, the button stays enabled without an open document.
+   * Defaults to true when `command` is set, otherwise false.
+   */
+  requiresDocument?: boolean
+  /** Minimum open mode required to show this item (Review shows in Review+Write). */
+  minOpenMode?: AcEdOpenMode
+  /** Static or dynamic disabled state evaluated at render time. */
+  disabled?: boolean | (() => boolean)
+  /** Nested submenu items shown in a dropdown when the button is clicked. */
+  children?: AcExToolbarItem[]
+  /**
+   * When the button has `children`, controls whether the parent icon follows the
+   * selected submenu item. Defaults to `'fixed'`.
+   */
+  childIcon?: AcExToolbarChildIconMode
+  /** Initial submenu selection when {@link childIcon} is `'selected'`. */
+  selectedChildId?: string
+  /** Two-state button that merges `on` or `off` branch fields based on `getValue`. */
+  toggle?: {
+    /** Returns whether the toggle is in the "on" branch. */
+    getValue: () => boolean
+    /** Fields applied when `getValue` returns true. */
+    on: Partial<AcExToolbarItem>
+    /** Fields applied when `getValue` returns false. */
+    off: Partial<AcExToolbarItem>
+  }
+}
+
+/** Resolved toolbar entry: button, separator, or preset reference in config. */
+export type AcExToolbarItemConfig =
+  | AcExToolbarItem
+  | AcExToolbarSeparator
+  | AcExToolbarPresetRef
+
+/**
+ * Callbacks supplied when building the default toolbar (theme and locale toggles).
+ */
+export interface AcExDefaultToolbarContext {
+  /** Returns the current UI theme. */
+  getTheme: () => AcEdUiTheme
+  /** Applies a UI theme change. */
+  setTheme: (theme: AcEdUiTheme) => void
+  /** Returns the active application locale. */
+  getLocale: () => 'en' | 'zh'
+  /** Switches between English and Chinese. */
+  toggleLocale: () => void
+  /** Returns the current toolbar edge placement. */
+  getPlacement: () => AcExToolbarPlacement
+  /** Moves the toolbar to the given host edge. */
+  setPlacement: (placement: AcExToolbarPlacement) => void
+}
+
+/**
+ * Options passed to {@link createSimpleUiPlugin} and {@link registerSimpleUiPlugin}.
+ */
+export interface AcExSimpleUiPluginOptions {
+  /** Viewer host element; defaults to the active view container or `document.body`. */
+  host?: HTMLElement
+  /** @deprecated Locale follows {@link AcApI18n.currentLocale} automatically. */
+  locale?: AcExLocale
+  /** Toolbar configuration. Enabled by default. */
+  toolbar?: {
+    /** When false, the toolbar is not created. */
+    enabled?: boolean
+    /** Edge placement relative to `host`. */
+    placement?: AcExToolbarPlacement
+    /** Toolbar items, `'default'`, or a custom list (may include presets and separators). */
+    items?: AcExToolbarItemConfig[] | 'default'
+    /** Extra items appended after `items`. */
+    appendItems?: AcExToolbarItemConfig[]
+  }
+  /** Layer manager panel configuration. Enabled by default. */
+  layerManager?: {
+    /** When false, the layer manager and `layer` command are not registered. */
+    enabled?: boolean
+    /** When false (default), the panel is clamped inside `host`. */
+    allowMoveOutsideCanvas?: boolean
+  }
+}
+
+/**
+ * Snapshot of a layer row shown in the layer manager UI.
+ */
+export interface AcExLayerInfo {
+  /** Layer table record name. */
+  name: string
+  /** Serialized {@link AcCmColor} string. */
+  color: string
+  /** CSS color derived from the layer color for swatch display. */
+  cssColor: string
+  /** Whether the layer is on (not off). */
+  isOn: boolean
+}
+
+/** Plugin identifier registered with {@link AcApPluginManager}. */
+export const SIMPLE_UI_PLUGIN_NAME = 'SimpleUiPlugin'

--- a/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
+++ b/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
@@ -1,0 +1,213 @@
+import {
+  AcApContext,
+  AcApDocManager,
+  AcApI18n,
+  type AcApLocale,
+  AcApPlugin,
+  AcEdCommandStack,
+  type AcEdUiTheme
+} from '@mlightcad/cad-simple-viewer'
+
+import packageJson from '../package.json'
+import { AcApLayerUiCmd } from './command/AcApLayerUiCmd'
+import { resolveToolbarItems } from './config/resolveToolbarItems'
+import {
+  AcExSimpleUiPluginOptions,
+  AcExToolbarPlacement,
+  SIMPLE_UI_PLUGIN_NAME
+} from './config/types'
+import { AcExI18n, registerSimpleUiI18n } from './i18n'
+import { AcExLayerService } from './service/AcExLayerService'
+import { AcExUiThemeSync } from './theme/AcExUiThemeSync'
+import { AcExLayerManager } from './ui/AcExLayerManager'
+import { AcExToolbar } from './ui/AcExToolbar'
+import { removeUiStylesIfUnused } from './ui/styles'
+
+/**
+ * CAD viewer plugin that adds a framework-agnostic toolbar and layer manager.
+ *
+ * Registers the `layer` command, injects shared UI styles, and keeps theme and
+ * locale in sync with {@link AcApI18n} and the `COLORTHEME` system variable.
+ */
+export class AcApSimpleUiPlugin implements AcApPlugin {
+  /** {@link SIMPLE_UI_PLUGIN_NAME} */
+  name = SIMPLE_UI_PLUGIN_NAME
+  /** Plugin semver string. */
+  version = packageJson.version
+  /** Human-readable plugin summary. */
+  description = 'Framework-agnostic toolbar and layer manager UI'
+
+  /** Layer table observer backing the layer manager panel. */
+  private layerService?: AcExLayerService
+  /** Floating layer manager DOM panel. */
+  private layerManager?: AcExLayerManager
+  /** Configurable toolbar instance. */
+  private toolbar?: AcExToolbar
+  /** Scoped i18n helper for plugin strings. */
+  private i18n?: AcExI18n
+  /** Syncs UI theme with host attribute and database sysvar. */
+  private themeSync?: AcExUiThemeSync
+  /** Current toolbar edge placement (mutable via toolbar settings button). */
+  private toolbarPlacement: AcExToolbarPlacement = 'right'
+  /** Commands registered during {@link onLoad} for cleanup on unload. */
+  private registeredCommands: Array<{ group: string; name: string }> = []
+  /** Refreshes toolbar and layer manager when the app locale changes. */
+  private handleLocaleChanged = () => {
+    this.layerManager?.refreshLocale()
+    this.toolbar?.refresh()
+  }
+
+  /**
+   * @param options - Toolbar, layer manager, and host configuration.
+   */
+  constructor(private readonly options: AcExSimpleUiPluginOptions = {}) {}
+
+  /**
+   * Creates UI components, registers commands, and starts theme sync.
+   *
+   * @param _context - Application context (unused).
+   * @param commandManager - Command stack used to register `layer`.
+   */
+  onLoad(_context: AcApContext, commandManager: AcEdCommandStack): void {
+    registerSimpleUiI18n()
+
+    const resolvedOptions = this.normalizeOptions()
+    const host =
+      resolvedOptions.host ??
+      AcApDocManager.instance.curView?.container ??
+      document.body
+
+    this.toolbarPlacement = resolvedOptions.toolbar?.placement ?? 'right'
+
+    this.themeSync = new AcExUiThemeSync(host, () => this.toolbar?.refresh())
+    this.themeSync.start()
+
+    this.i18n = new AcExI18n()
+    AcApI18n.events.localeChanged.addEventListener(this.handleLocaleChanged)
+
+    const layerEnabled = resolvedOptions.layerManager?.enabled !== false
+    if (layerEnabled) {
+      this.layerService = new AcExLayerService()
+      this.layerManager = new AcExLayerManager({
+        layerService: this.layerService,
+        i18n: this.i18n,
+        host,
+        toolbarPlacement: this.toolbarPlacement,
+        allowMoveOutsideCanvas:
+          resolvedOptions.layerManager?.allowMoveOutsideCanvas ?? false
+      })
+
+      const group = AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME
+      commandManager.addCommand(
+        group,
+        'layer',
+        'layer',
+        new AcApLayerUiCmd(this.layerManager)
+      )
+      this.registeredCommands.push({ group, name: 'layer' })
+    }
+
+    const toolbarEnabled = resolvedOptions.toolbar?.enabled !== false
+    if (toolbarEnabled) {
+      const toolbarContext = {
+        getTheme: () => this.themeSync?.getTheme() ?? 'dark',
+        setTheme: (theme: AcEdUiTheme) => this.themeSync?.setTheme(theme),
+        getLocale: () => AcApI18n.currentLocale,
+        toggleLocale: () => this.toggleLocale(),
+        getPlacement: () => this.toolbarPlacement,
+        setPlacement: (placement: AcExToolbarPlacement) =>
+          this.setToolbarPlacement(placement)
+      }
+      const items = resolveToolbarItems(resolvedOptions.toolbar, toolbarContext)
+      this.toolbar = new AcExToolbar({
+        host,
+        placement: this.toolbarPlacement,
+        items,
+        i18n: this.i18n,
+        onCommand: command => {
+          AcApDocManager.instance.sendStringToExecute(command)
+        }
+      })
+    }
+  }
+
+  /** Updates toolbar placement and repositions the layer manager when applicable. */
+  private setToolbarPlacement(placement: AcExToolbarPlacement) {
+    this.toolbarPlacement = placement
+    this.toolbar?.setPlacement(placement)
+    this.layerManager?.setToolbarPlacement(placement)
+  }
+
+  /**
+   * Tears down UI, unregisters commands, and removes injected styles if unused.
+   *
+   * @param _context - Application context (unused).
+   * @param commandManager - Command stack used to remove registered commands.
+   */
+  onUnload(_context: AcApContext, commandManager: AcEdCommandStack): void {
+    AcApI18n.events.localeChanged.removeEventListener(this.handleLocaleChanged)
+
+    for (const cmd of this.registeredCommands) {
+      commandManager.removeCmd(cmd.group, cmd.name)
+    }
+    this.registeredCommands = []
+
+    this.toolbar?.destroy()
+    this.layerManager?.destroy()
+    this.layerService?.destroy()
+
+    this.toolbar = undefined
+    this.layerManager = undefined
+    this.layerService = undefined
+    this.i18n = undefined
+    this.themeSync?.stop()
+    this.themeSync = undefined
+
+    removeUiStylesIfUnused()
+  }
+
+  /** Toggles {@link AcApI18n.currentLocale} between English and Chinese. */
+  private toggleLocale() {
+    const next: AcApLocale =
+      AcApI18n.currentLocale === 'en' ? 'zh' : 'en'
+    AcApI18n.setCurrentLocale(next)
+  }
+
+  /**
+   * Fills in default option values for toolbar and layer manager sections.
+   *
+   * @returns Resolved options with explicit boolean defaults.
+   */
+  private normalizeOptions(): Required<
+    Omit<AcExSimpleUiPluginOptions, 'host' | 'locale'>
+  > & {
+    host?: HTMLElement
+  } {
+    return {
+      host: this.options.host,
+      toolbar: {
+        enabled: this.options.toolbar?.enabled ?? true,
+        placement: this.options.toolbar?.placement ?? 'right',
+        items: this.options.toolbar?.items ?? 'default',
+        appendItems: this.options.toolbar?.appendItems
+      },
+      layerManager: {
+        enabled: this.options.layerManager?.enabled ?? true,
+        allowMoveOutsideCanvas:
+          this.options.layerManager?.allowMoveOutsideCanvas ?? false
+      }
+    }
+  }
+}
+
+/**
+ * Factory for {@link AcApSimpleUiPlugin}.
+ *
+ * @param options - Plugin configuration.
+ * @returns A new plugin instance ready for {@link AcApPluginManager.loadPlugin}.
+ */
+export function createSimpleUiPlugin(
+  options: AcExSimpleUiPluginOptions = {}
+): AcApSimpleUiPlugin {
+  return new AcApSimpleUiPlugin(options)
+}

--- a/packages/cad-simple-ui-plugin/src/i18n/en.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/en.ts
@@ -1,0 +1,52 @@
+/**
+ * English UI strings for {@link registerSimpleUiI18n}.
+ *
+ * Keys use dot notation (for example `toolbar.select`) and are nested under
+ * the `simpleUi` namespace when registered.
+ */
+export const en: Record<string, string> = {
+  'toolbar.select': 'Select',
+  'toolbar.pan': 'Pan',
+  'toolbar.zoomExtent': 'Zoom Extents',
+  'toolbar.zoomWindow': 'Zoom Window',
+  'toolbar.layer': 'Layer Manager',
+  'toolbar.measure': 'Measure',
+  'toolbar.measureDistance': 'Measure Distance',
+  'toolbar.measureAngle': 'Measure Angle',
+  'toolbar.measureArea': 'Measure Area',
+  'toolbar.measureArc': 'Measure Arc Length',
+  'toolbar.clearMeasurements': 'Clear Measurements',
+  'toolbar.switchBg': 'Switch Background',
+  'toolbar.annotation': 'Annotation',
+  'toolbar.revFreehand': 'Freehand Sketch',
+  'toolbar.revRect': 'Rectangle Review',
+  'toolbar.revCloud': 'Revision Cloud',
+  'toolbar.revCircle': 'Circle Review',
+  'toolbar.showAnnotation': 'Show Annotations',
+  'toolbar.hideAnnotation': 'Hide Annotations',
+  'toolbar.export': 'Export',
+  'toolbar.exportHtml': 'Export HTML',
+  'toolbar.exportPdf': 'Export PDF',
+  'toolbar.exportSvg': 'Export SVG',
+  'toolbar.placement': 'Toolbar Position',
+  'toolbar.placementTop': 'Top',
+  'toolbar.placementBottom': 'Bottom',
+  'toolbar.placementLeft': 'Left',
+  'toolbar.placementRight': 'Right',
+  'toolbar.themeLight': 'Switch to Dark Theme',
+  'toolbar.themeDark': 'Switch to Light Theme',
+  'toolbar.localeEn': 'English (switch to Chinese)',
+  'toolbar.localeZh': '中文 (switch to English)',
+  'layerManager.title': 'Layer Manager',
+  'layerManager.name': 'Name',
+  'layerManager.on': 'On',
+  'layerManager.color': 'Color',
+  'layerManager.zoomToLayer': 'Zoomed to layer: {layer}',
+  'colorPicker.title': 'Select Color',
+  'colorPicker.index': 'Color Index: ',
+  'colorPicker.rgb': 'RGB: ',
+  'colorPicker.input': 'Color',
+  'colorPicker.inputPlaceholder': '1-255 or #RRGGBB',
+  'colorPicker.ok': 'OK',
+  'colorPicker.cancel': 'Cancel'
+}

--- a/packages/cad-simple-ui-plugin/src/i18n/index.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/index.ts
@@ -1,0 +1,76 @@
+import { AcApI18n } from '@mlightcad/cad-simple-viewer'
+
+import { en } from './en'
+import { zh } from './zh'
+
+/** Message namespace prefix merged into {@link AcApI18n}. */
+const MESSAGE_PREFIX = 'simpleUi'
+
+/** Nested locale message tree built from dot-separated keys. */
+interface LocaleMessageTree {
+  [key: string]: string | LocaleMessageTree
+}
+
+/** Whether {@link registerSimpleUiI18n} has already run. */
+let isRegistered = false
+
+/**
+ * Converts flat dot-key messages into a nested object for {@link AcApI18n.mergeLocaleMessage}.
+ *
+ * @param flat - Map of keys like `toolbar.select` to translated strings.
+ */
+function flatToNested(flat: Record<string, string>): LocaleMessageTree {
+  const result: LocaleMessageTree = {}
+  for (const [key, value] of Object.entries(flat)) {
+    const parts = key.split('.')
+    let current = result
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i]
+      const existing = current[part]
+      if (!existing || typeof existing === 'string') {
+        current[part] = {}
+      }
+      current = current[part] as LocaleMessageTree
+    }
+    current[parts[parts.length - 1]] = value
+  }
+  return result
+}
+
+/**
+ * Registers plugin UI strings into {@link AcApI18n}.
+ *
+ * Safe to call multiple times; subsequent calls are no-ops.
+ */
+export function registerSimpleUiI18n(): void {
+  if (isRegistered) return
+  AcApI18n.mergeLocaleMessage('en', {
+    [MESSAGE_PREFIX]: flatToNested(en)
+  })
+  AcApI18n.mergeLocaleMessage('zh', {
+    [MESSAGE_PREFIX]: flatToNested(zh)
+  })
+  isRegistered = true
+}
+
+/**
+ * Scoped translation helper for plugin UI strings under the `simpleUi` namespace.
+ */
+export class AcExI18n {
+  /**
+   * Translates a key relative to the `simpleUi` namespace.
+   *
+   * @param key - Message key without the `simpleUi.` prefix (for example `toolbar.select`).
+   * @param params - Optional `{name}` placeholder replacements.
+   * @returns Translated string, or the key when no translation exists.
+   */
+  t(key: string, params?: Record<string, string>): string {
+    const fullKey = `${MESSAGE_PREFIX}.${key}`
+    const template = AcApI18n.t(fullKey, { fallback: key })
+    if (!params) return template
+    return Object.keys(params).reduce(
+      (result, name) => result.replace(`{${name}}`, params[name]),
+      template
+    )
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/i18n/zh.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/zh.ts
@@ -1,0 +1,52 @@
+/**
+ * Chinese UI strings for {@link registerSimpleUiI18n}.
+ *
+ * Keys use dot notation (for example `toolbar.select`) and are nested under
+ * the `simpleUi` namespace when registered.
+ */
+export const zh: Record<string, string> = {
+  'toolbar.select': '选择',
+  'toolbar.pan': '平移',
+  'toolbar.zoomExtent': '缩放至范围',
+  'toolbar.zoomWindow': '窗口缩放',
+  'toolbar.layer': '图层管理器',
+  'toolbar.measure': '测量',
+  'toolbar.measureDistance': '测量距离',
+  'toolbar.measureAngle': '测量角度',
+  'toolbar.measureArea': '测量面积',
+  'toolbar.measureArc': '测量弧长',
+  'toolbar.clearMeasurements': '清除测量',
+  'toolbar.switchBg': '切换背景',
+  'toolbar.annotation': '审阅标注',
+  'toolbar.revFreehand': '自由手绘',
+  'toolbar.revRect': '矩形标注',
+  'toolbar.revCloud': '修订云线',
+  'toolbar.revCircle': '圆形标注',
+  'toolbar.showAnnotation': '显示标注',
+  'toolbar.hideAnnotation': '隐藏标注',
+  'toolbar.export': '导出',
+  'toolbar.exportHtml': '导出 HTML',
+  'toolbar.exportPdf': '导出 PDF',
+  'toolbar.exportSvg': '导出 SVG',
+  'toolbar.placement': '工具栏位置',
+  'toolbar.placementTop': '上方',
+  'toolbar.placementBottom': '下方',
+  'toolbar.placementLeft': '左侧',
+  'toolbar.placementRight': '右侧',
+  'toolbar.themeLight': '切换为深色主题',
+  'toolbar.themeDark': '切换为浅色主题',
+  'toolbar.localeEn': 'English（切换为中文）',
+  'toolbar.localeZh': '中文（切换为 English）',
+  'layerManager.title': '图层管理器',
+  'layerManager.name': '名称',
+  'layerManager.on': '开',
+  'layerManager.color': '颜色',
+  'layerManager.zoomToLayer': '已缩放至图层：{layer}',
+  'colorPicker.title': '选择颜色',
+  'colorPicker.index': '颜色索引：',
+  'colorPicker.rgb': 'RGB：',
+  'colorPicker.input': '颜色',
+  'colorPicker.inputPlaceholder': '1-255 或 #RRGGBB',
+  'colorPicker.ok': '确定',
+  'colorPicker.cancel': '取消'
+}

--- a/packages/cad-simple-ui-plugin/src/index.ts
+++ b/packages/cad-simple-ui-plugin/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Public entry point for {@link SIMPLE_UI_PLUGIN_NAME}.
+ *
+ * Re-exports the plugin factory, registration helper, configuration types,
+ * i18n utilities, and layer service.
+ */
+export { AcApSimpleUiPlugin, createSimpleUiPlugin } from './createSimpleUiPlugin'
+export { registerSimpleUiPlugin } from './register'
+export type {
+  AcExDefaultToolbarContext,
+  AcExLayerInfo,
+  AcExLocale,
+  AcExSimpleUiPluginOptions,
+  AcExToolbarItem,
+  AcExToolbarItemConfig,
+  AcExToolbarChildIconMode,
+  AcExToolbarPresetRef,
+  AcExToolbarSeparator,
+  AcExToolbarPlacement
+} from './config/types'
+export { SIMPLE_UI_PLUGIN_NAME } from './config/types'
+export { createDefaultToolbarPresetMap } from './config/resolveToolbarItems'
+export {
+  createToolbarSeparator,
+  toolbarPreset
+} from './config/toolbarItemUtils'
+export { AcExI18n, registerSimpleUiI18n } from './i18n'
+export { AcExLayerService } from './service/AcExLayerService'

--- a/packages/cad-simple-ui-plugin/src/register.ts
+++ b/packages/cad-simple-ui-plugin/src/register.ts
@@ -1,0 +1,20 @@
+import type { AcApPluginManager } from '@mlightcad/cad-simple-viewer'
+
+import type { AcExSimpleUiPluginOptions } from './config/types'
+
+/**
+ * Loads the simple UI plugin on the given plugin manager.
+ *
+ * Import from `@mlightcad/cad-simple-ui-plugin/register` so the main plugin
+ * bundle is not pulled into the application entry chunk.
+ *
+ * @param pluginManager - Target plugin manager instance.
+ * @param options - Passed through to {@link createSimpleUiPlugin}.
+ */
+export async function registerSimpleUiPlugin(
+  pluginManager: AcApPluginManager,
+  options: AcExSimpleUiPluginOptions = {}
+): Promise<void> {
+  const { createSimpleUiPlugin } = await import('@mlightcad/cad-simple-ui-plugin')
+  await pluginManager.loadPlugin(createSimpleUiPlugin(options))
+}

--- a/packages/cad-simple-ui-plugin/src/service/AcExLayerService.ts
+++ b/packages/cad-simple-ui-plugin/src/service/AcExLayerService.ts
@@ -1,0 +1,396 @@
+import {
+  AcApDocManager,
+  acapRunDatabaseEdit,
+  AcDbDocumentEventArgs
+} from '@mlightcad/cad-simple-viewer'
+import {
+  AcCmColor,
+  AcDbDatabase,
+  AcDbLayerEventArgs,
+  AcDbLayerModifiedEventArgs,
+  AcDbLayerTableRecord,
+  AcDbSysVarEventArgs,
+  AcDbSysVarManager
+} from '@mlightcad/data-model'
+
+import type { AcExLayerInfo } from '../config/types'
+import { openLayerForWrite, setLayerFrozenState } from './layerEdit'
+
+/** Undo label passed to {@link acapRunDatabaseEdit} for layer mutations. */
+const LAYER_EDIT_LABEL = 'Layer'
+
+/**
+ * Observes the active document's layer table and exposes UI-friendly layer snapshots.
+ *
+ * Subscribers receive notifications when layers are added, modified, or when
+ * `CLAYER` changes. Layer on/off and color edits run inside database transactions.
+ */
+export class AcExLayerService {
+  /** Cached layer rows for the layer manager table. */
+  private layers: AcExLayerInfo[] = []
+  /** Name of the current drawing layer (`CLAYER`). */
+  private currentLayerName = ''
+  /** Database currently bound to layer table events. */
+  private observedDatabase: AcDbDatabase | undefined
+  /** UI refresh callbacks registered via {@link subscribe}. */
+  private listeners = new Set<() => void>()
+  /** Document manager used to resolve the active database. */
+  private readonly editor: AcApDocManager
+
+  /**
+   * @param editor - Document manager instance; defaults to {@link AcApDocManager.instance}.
+   */
+  constructor(editor: AcApDocManager = AcApDocManager.instance) {
+    this.editor = editor
+    this.editor.events.documentActivated.addEventListener(
+      this.handleDocumentActivated
+    )
+    AcDbSysVarManager.instance().events.sysVarChanged.addEventListener(
+      this.handleSysVarChanged
+    )
+    this.bindDatabase(this.getCurrentDatabase())
+  }
+
+  /** Removes event listeners and clears subscribers. */
+  destroy() {
+    this.editor.events.documentActivated.removeEventListener(
+      this.handleDocumentActivated
+    )
+    AcDbSysVarManager.instance().events.sysVarChanged.removeEventListener(
+      this.handleSysVarChanged
+    )
+    this.bindDatabase(undefined)
+    this.listeners.clear()
+  }
+
+  /**
+   * Registers a listener invoked whenever layer data changes.
+   *
+   * @param listener - Callback to invoke on layer or current-layer updates.
+   * @returns Unsubscribe function.
+   */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  /**
+   * Returns a shallow copy of the cached layer list.
+   */
+  getLayers(): AcExLayerInfo[] {
+    return [...this.layers]
+  }
+
+  /**
+   * Returns the name of the current layer (`CLAYER`).
+   */
+  getCurrentLayerName(): string {
+    return this.currentLayerName
+  }
+
+  /**
+   * Turns a layer on or off.
+   *
+   * When turning off the current layer, switches `CLAYER` to another layer first.
+   *
+   * @param layerName - Target layer name.
+   * @param isOn - Desired on state.
+   * @returns `true` when the edit succeeded.
+   */
+  setLayerOn(layerName: string, isOn: boolean): boolean {
+    const db = this.getCurrentDatabase()
+    if (!db || !layerName) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
+
+    return this.runLayerEdit(db, () => {
+      if (!isOn && !this.switchCurrentLayerIfNeeded(db, layerName)) {
+        return false
+      }
+
+      const layer = openLayerForWrite(db, layerName)
+      if (!layer) return false
+
+      layer.isOff = !isOn
+      return true
+    })
+  }
+
+  /**
+   * Turns on every layer in the active database.
+   *
+   * @returns `true` when at least one layer was changed.
+   */
+  setAllLayersOn(): boolean {
+    const db = this.getCurrentDatabase()
+    if (!db) return false
+
+    return this.runLayerEdit(db, () => {
+      let changed = false
+      for (const layer of db.tables.layerTable.newIterator()) {
+        if (!layer.isOff) continue
+        const opened = openLayerForWrite(db, layer.name)
+        if (!opened) continue
+        opened.isOff = false
+        changed = true
+      }
+      return changed
+    })
+  }
+
+  /**
+   * Turns off every layer except the current layer (`CLAYER`).
+   *
+   * CAD requires at least one layer to remain on; this is the maximal "all off"
+   * state the layer manager master checkbox can apply.
+   *
+   * @returns `true` when at least one layer was changed.
+   */
+  setAllLayersOffExceptCurrent(): boolean {
+    const db = this.getCurrentDatabase()
+    if (!db) return false
+
+    return this.runLayerEdit(db, () => {
+      const currentLayer = db.clayer
+      let changed = false
+      for (const layer of db.tables.layerTable.newIterator()) {
+        if (layer.name === currentLayer || layer.isOff) continue
+        const opened = openLayerForWrite(db, layer.name)
+        if (!opened) continue
+        opened.isOff = true
+        changed = true
+      }
+      return changed
+    })
+  }
+
+  /**
+   * Assigns a new color to a layer.
+   *
+   * @param layerName - Target layer name.
+   * @param color - New layer color (cloned before assignment).
+   * @returns `true` when the edit succeeded.
+   */
+  setLayerColor(layerName: string, color: AcCmColor): boolean {
+    const db = this.getCurrentDatabase()
+    if (!db) return false
+    if (!db.tables.layerTable.getAt(layerName)) return false
+
+    return this.runLayerEdit(db, () => {
+      const layer = openLayerForWrite(db, layerName)
+      if (!layer) return false
+      layer.color = color.clone()
+      return true
+    })
+  }
+
+  /** Returns the database of the currently active document, if any. */
+  private getCurrentDatabase(): AcDbDatabase | undefined {
+    return this.editor.curDocument?.database
+  }
+
+  /**
+   * Runs a layer mutation inside an undoable database edit.
+   *
+   * @param db - Database to edit.
+   * @param fn - Mutation callback returning whether a change occurred.
+   */
+  private runLayerEdit(
+    db: AcDbDatabase | undefined,
+    fn: () => boolean
+  ): boolean {
+    if (!db) return false
+    let result = false
+    acapRunDatabaseEdit(db, LAYER_EDIT_LABEL, () => {
+      result = fn()
+    })
+    return result
+  }
+
+  /**
+   * Moves `CLAYER` away from `targetLayerName` before that layer can be turned off.
+   *
+   * @param db - Active database.
+   * @param targetLayerName - Layer about to be turned off.
+   * @returns `false` when no alternate current layer is available.
+   */
+  private switchCurrentLayerIfNeeded(
+    db: AcDbDatabase,
+    targetLayerName: string
+  ): boolean {
+    if (db.clayer !== targetLayerName) return true
+
+    let fallbackLayerName: string | undefined
+    let preferredLayerName: string | undefined
+
+    for (const layer of db.tables.layerTable.newIterator()) {
+      if (layer.name === targetLayerName) continue
+      fallbackLayerName ??= layer.name
+      if (!layer.isOff && !layer.isFrozen) {
+        preferredLayerName = layer.name
+        break
+      }
+    }
+
+    const nextLayerName = preferredLayerName ?? fallbackLayerName
+    if (!nextLayerName) return false
+
+    const nextCurrentLayer = openLayerForWrite(db, nextLayerName)
+    if (!nextCurrentLayer) return false
+
+    nextCurrentLayer.isOff = false
+    setLayerFrozenState(nextCurrentLayer, false)
+    db.clayer = nextCurrentLayer.name
+    this.syncCurrentLayerName(db)
+    return true
+  }
+
+  /**
+   * Converts a layer table record to a UI layer info snapshot.
+   *
+   * @param layer - Source layer record.
+   */
+  private toLayerInfo(layer: AcDbLayerTableRecord): AcExLayerInfo {
+    return {
+      name: layer.name,
+      color: layer.color.toString(),
+      cssColor: layer.color.cssColor || '#FFFFFF',
+      isOn: !layer.isOff
+    }
+  }
+
+  /**
+   * Rebuilds the cached layer list from a database.
+   *
+   * @param db - Database to read, or omit to clear the cache.
+   */
+  private reset(db?: AcDbDatabase) {
+    this.layers = []
+    if (!db) return
+
+    for (const layer of db.tables.layerTable.newIterator()) {
+      this.layers.push(this.toLayerInfo(layer))
+    }
+    this.notify()
+  }
+
+  /**
+   * Finds a cached layer row by name.
+   *
+   * @param name - Layer name.
+   */
+  private findLayerInfo(name: string) {
+    return this.layers.find(layer => layer.name === name)
+  }
+
+  /**
+   * Removes a layer row from the cache by name.
+   *
+   * @param name - Layer name to remove.
+   */
+  private removeLayerInfo(name: string) {
+    const index = this.layers.findIndex(layer => layer.name === name)
+    if (index === -1) return
+    this.layers.splice(index, 1)
+    this.notify()
+  }
+
+  /**
+   * Inserts or updates a layer row in the cache from a table record.
+   *
+   * @param layer - Layer record to reflect in the cache.
+   */
+  private upsertLayerInfo(layer: AcDbLayerTableRecord) {
+    const info = this.findLayerInfo(layer.name)
+    const nextInfo = this.toLayerInfo(layer)
+    if (!info) {
+      this.layers.push(nextInfo)
+    } else {
+      Object.assign(info, nextInfo)
+    }
+    this.notify()
+  }
+
+  /**
+   * Updates {@link currentLayerName} from `db.clayer` and notifies subscribers.
+   *
+   * @param db - Database to read; defaults to the current database.
+   */
+  private syncCurrentLayerName(db = this.getCurrentDatabase()) {
+    this.currentLayerName = db?.clayer || ''
+    this.notify()
+  }
+
+  /** Invokes all registered subscribers. */
+  private notify() {
+    this.listeners.forEach(listener => listener())
+  }
+
+  /** Handles `layerAppended` on the observed database. */
+  private handleLayerAppended = (args: AcDbLayerEventArgs) => {
+    this.upsertLayerInfo(args.layer)
+  }
+
+  /** Handles `layerErased` on the observed database. */
+  private handleLayerErased = (args: AcDbLayerEventArgs) => {
+    this.removeLayerInfo(args.layer.name)
+  }
+
+  /** Handles `layerModified` on the observed database. */
+  private handleLayerModified = (args: AcDbLayerModifiedEventArgs) => {
+    const info = this.findLayerInfo(args.layer.name)
+    if (!info) {
+      this.upsertLayerInfo(args.layer)
+      return
+    }
+    Object.assign(info, this.toLayerInfo(args.layer))
+    this.notify()
+  }
+
+  /**
+   * Switches layer table event bindings to a new database.
+   *
+   * @param db - Database to observe, or `undefined` to detach.
+   */
+  private bindDatabase(db?: AcDbDatabase) {
+    if (this.observedDatabase === db) return
+
+    if (this.observedDatabase) {
+      this.observedDatabase.events.layerAppended.removeEventListener(
+        this.handleLayerAppended
+      )
+      this.observedDatabase.events.layerErased.removeEventListener(
+        this.handleLayerErased
+      )
+      this.observedDatabase.events.layerModified.removeEventListener(
+        this.handleLayerModified
+      )
+    }
+
+    this.observedDatabase = db
+    this.reset(this.observedDatabase)
+    this.syncCurrentLayerName(this.observedDatabase)
+
+    if (!this.observedDatabase) return
+    this.observedDatabase.events.layerAppended.addEventListener(
+      this.handleLayerAppended
+    )
+    this.observedDatabase.events.layerErased.addEventListener(
+      this.handleLayerErased
+    )
+    this.observedDatabase.events.layerModified.addEventListener(
+      this.handleLayerModified
+    )
+  }
+
+  /** Rebinds to the database of a newly activated document. */
+  private handleDocumentActivated = (args: AcDbDocumentEventArgs) => {
+    this.bindDatabase(args.doc.database)
+  }
+
+  /** Syncs current layer name when `CLAYER` changes on the observed database. */
+  private handleSysVarChanged = (args: AcDbSysVarEventArgs) => {
+    if (args.database !== this.observedDatabase) return
+    if (args.name.toUpperCase() !== 'CLAYER') return
+    this.syncCurrentLayerName(args.database)
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/service/layerEdit.ts
+++ b/packages/cad-simple-ui-plugin/src/service/layerEdit.ts
@@ -1,0 +1,42 @@
+import {
+  AcDbDatabase,
+  AcDbLayerTableRecord
+} from '@mlightcad/data-model'
+
+/** Bit mask for the global frozen flag in layer `standardFlags`. */
+export const LAYER_FROZEN_FLAG = 0x01
+
+/**
+ * Opens a layer table record for write access through the database.
+ *
+ * @param db - Active drawing database.
+ * @param layerOrName - Layer record or layer name to open.
+ * @returns Writable layer record, or `undefined` if the layer does not exist.
+ */
+export function openLayerForWrite(
+  db: AcDbDatabase,
+  layerOrName: AcDbLayerTableRecord | string
+): AcDbLayerTableRecord | undefined {
+  const layer =
+    typeof layerOrName === 'string'
+      ? db.tables.layerTable.getAt(layerOrName)
+      : layerOrName
+  if (!layer) return undefined
+  return db.openObjectForWrite<AcDbLayerTableRecord>(layer.objectId)
+}
+
+/**
+ * Sets or clears the frozen bit on a layer's `standardFlags`.
+ *
+ * @param layer - Layer record to update.
+ * @param frozen - Desired frozen state.
+ */
+export function setLayerFrozenState(
+  layer: AcDbLayerTableRecord,
+  frozen: boolean
+) {
+  const flags = layer.standardFlags ?? 0
+  layer.standardFlags = frozen
+    ? flags | LAYER_FROZEN_FLAG
+    : flags & ~LAYER_FROZEN_FLAG
+}

--- a/packages/cad-simple-ui-plugin/src/theme/AcExUiThemeSync.ts
+++ b/packages/cad-simple-ui-plugin/src/theme/AcExUiThemeSync.ts
@@ -1,0 +1,144 @@
+import {
+  AcApDocManager,
+  type AcEdUiTheme,
+  applyUiTheme,
+  isLightColorTheme
+} from '@mlightcad/cad-simple-viewer'
+import {
+  AcDbDatabase,
+  AcDbSystemVariables,
+  type AcDbSysVarEventArgs,
+  AcDbSysVarManager
+} from '@mlightcad/data-model'
+
+/**
+ * Reads the UI theme from a host element's `data-ml-ui-theme` attribute.
+ *
+ * @param host - Viewer host element.
+ * @returns `'light'`, `'dark'`, or `undefined` when unset or invalid.
+ */
+export function readUiThemeFromHost(host: HTMLElement): AcEdUiTheme | undefined {
+  const attr = host.getAttribute('data-ml-ui-theme')
+  if (attr === 'light' || attr === 'dark') return attr
+  return undefined
+}
+
+/**
+ * Reads the UI theme from the drawing `COLORTHEME` system variable.
+ *
+ * @param database - Drawing database.
+ */
+export function readUiThemeFromDatabase(database: AcDbDatabase): AcEdUiTheme {
+  const value = AcDbSysVarManager.instance().getVar(
+    AcDbSystemVariables.COLORTHEME,
+    database
+  )
+  return isLightColorTheme(value) ? 'light' : 'dark'
+}
+
+/**
+ * Keeps `data-ml-ui-theme` on the host in sync with `COLORTHEME` and document activation.
+ */
+export class AcExUiThemeSync {
+  /** Applies theme when `COLORTHEME` changes on the active database. */
+  private handleSysVarChanged = (args: AcDbSysVarEventArgs) => {
+    const database = AcApDocManager.instance.curDocument?.database
+    if (!database || args.database !== database) return
+    if (
+      args.name.toLowerCase() !==
+      AcDbSystemVariables.COLORTHEME.toLowerCase()
+    ) {
+      return
+    }
+    this.applyTheme(isLightColorTheme(args.newVal) ? 'light' : 'dark')
+  }
+
+  /** Applies theme from a newly activated document's database. */
+  private handleDocumentActivated = (args: {
+    doc: { database: AcDbDatabase }
+  }) => {
+    this.applyTheme(readUiThemeFromDatabase(args.doc.database))
+  }
+
+  /**
+   * @param host - Element receiving `applyUiTheme` and `data-ml-ui-theme`.
+   * @param onThemeChanged - Optional callback after each theme application (e.g. toolbar refresh).
+   */
+  constructor(
+    private readonly host: HTMLElement,
+    private readonly onThemeChanged?: () => void
+  ) {}
+
+  /** Subscribes to sysvar and document events and performs an initial sync. */
+  start() {
+    this.syncFromCurrentSource()
+
+    AcDbSysVarManager.instance().events.sysVarChanged.addEventListener(
+      this.handleSysVarChanged
+    )
+    AcApDocManager.instance.events.documentActivated.addEventListener(
+      this.handleDocumentActivated
+    )
+  }
+
+  /** Unsubscribes from sysvar and document events. */
+  stop() {
+    AcDbSysVarManager.instance().events.sysVarChanged.removeEventListener(
+      this.handleSysVarChanged
+    )
+    AcApDocManager.instance.events.documentActivated.removeEventListener(
+      this.handleDocumentActivated
+    )
+  }
+
+  /**
+   * Returns the theme currently applied on the host.
+   *
+   * Defaults to `'dark'` when the attribute is missing.
+   */
+  getTheme(): AcEdUiTheme {
+    return readUiThemeFromHost(this.host) ?? 'dark'
+  }
+
+  /**
+   * Sets the UI theme via `COLORTHEME` when a document is open, otherwise on the host.
+   *
+   * @param theme - Target light or dark theme.
+   */
+  setTheme(theme: AcEdUiTheme) {
+    const database = AcApDocManager.instance.curDocument?.database
+    if (database) {
+      AcDbSysVarManager.instance().setVar(
+        AcDbSystemVariables.COLORTHEME,
+        theme === 'light' ? 1 : 0,
+        database
+      )
+      return
+    }
+    this.applyTheme(theme)
+  }
+
+  /**
+   * Applies theme from the active document or existing host attribute on startup.
+   */
+  private syncFromCurrentSource() {
+    const database = AcApDocManager.instance.curDocument?.database
+    if (database) {
+      this.applyTheme(readUiThemeFromDatabase(database))
+      return
+    }
+
+    const fromHost = readUiThemeFromHost(this.host)
+    if (fromHost) return
+  }
+
+  /**
+   * Calls {@link applyUiTheme} and notifies {@link onThemeChanged}.
+   *
+   * @param theme - Theme to apply.
+   */
+  private applyTheme(theme: AcEdUiTheme) {
+    applyUiTheme(theme, this.host)
+    this.onThemeChanged?.()
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/ui/AcExColorPicker.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExColorPicker.ts
@@ -1,0 +1,239 @@
+import {
+  AcCmColor,
+  AcCmColorMethod
+} from '@mlightcad/data-model'
+
+import type { AcExI18n } from '../i18n'
+import { ensureUiStyles } from './styles'
+
+/**
+ * Modal ACI color picker dialog for layer color selection.
+ *
+ * Presents standard AutoCAD Color Index palettes plus numeric or hex input.
+ */
+export class AcExColorPicker {
+  /** Full-screen backdrop containing the dialog. */
+  private backdrop: HTMLDivElement
+  /** Currently selected ACI index, if any. */
+  private selectedIndex: number | null = null
+  /** Promise resolver set by {@link open}. */
+  private resolve?: (color: AcCmColor | null) => void
+
+  /**
+   * Builds the dialog DOM and appends it to `document.body`.
+   *
+   * @param i18n - i18n helper for dialog labels.
+   * @param initialColor - Optional initial selection.
+   */
+  constructor(
+    private i18n: AcExI18n,
+    initialColor?: AcCmColor
+  ) {
+    ensureUiStyles()
+    this.selectedIndex = this.toColorIndex(initialColor)
+
+    this.backdrop = document.createElement('div')
+    this.backdrop.className = 'ml-ex-ui-color-dialog-backdrop'
+    this.backdrop.addEventListener('mousedown', event => {
+      if (event.target === this.backdrop) this.finish(null)
+    })
+
+    const dialog = document.createElement('div')
+    dialog.className = 'ml-ex-ui-color-dialog'
+    dialog.addEventListener('mousedown', event => event.stopPropagation())
+
+    const title = document.createElement('div')
+    title.className = 'ml-ex-ui-color-dialog-title'
+    title.textContent = this.i18n.t('colorPicker.title')
+    dialog.appendChild(title)
+
+    const largePalette = this.createPalette(
+      Array.from({ length: 240 }, (_, i) => i + 10),
+      'ml-ex-ui-aci-palette-large'
+    )
+    dialog.appendChild(largePalette)
+
+    const smallPalette = this.createPalette(
+      Array.from({ length: 9 }, (_, i) => i + 1),
+      'ml-ex-ui-aci-palette-small'
+    )
+    dialog.appendChild(smallPalette)
+
+    const grayPalette = this.createPalette(
+      Array.from({ length: 6 }, (_, i) => i + 250),
+      'ml-ex-ui-aci-palette-gray'
+    )
+    dialog.appendChild(grayPalette)
+
+    const info = document.createElement('div')
+    info.className = 'ml-ex-ui-aci-info'
+    const indexLabel = document.createElement('span')
+    const rgbLabel = document.createElement('span')
+    info.appendChild(indexLabel)
+    info.appendChild(rgbLabel)
+    dialog.appendChild(info)
+
+    const inputRow = document.createElement('div')
+    inputRow.className = 'ml-ex-ui-aci-input-row'
+    const inputLabel = document.createElement('span')
+    inputLabel.textContent = this.i18n.t('colorPicker.input')
+    const input = document.createElement('input')
+    input.placeholder = this.i18n.t('colorPicker.inputPlaceholder')
+    if (this.selectedIndex != null) {
+      input.value = String(this.selectedIndex)
+    }
+    inputRow.appendChild(inputLabel)
+    inputRow.appendChild(input)
+    dialog.appendChild(inputRow)
+
+    const actions = document.createElement('div')
+    actions.className = 'ml-ex-ui-dialog-actions'
+    const cancelBtn = document.createElement('button')
+    cancelBtn.type = 'button'
+    cancelBtn.className = 'ml-ex-ui-btn'
+    cancelBtn.textContent = this.i18n.t('colorPicker.cancel')
+    cancelBtn.addEventListener('click', () => this.finish(null))
+    const okBtn = document.createElement('button')
+    okBtn.type = 'button'
+    okBtn.className = 'ml-ex-ui-btn ml-ex-ui-btn-primary'
+    okBtn.textContent = this.i18n.t('colorPicker.ok')
+    okBtn.addEventListener('click', () => this.finish(this.toSelectedColor()))
+    actions.appendChild(cancelBtn)
+    actions.appendChild(okBtn)
+    dialog.appendChild(actions)
+
+    const updateInfo = () => {
+      if (this.selectedIndex == null) {
+        indexLabel.textContent = this.i18n.t('colorPicker.index')
+        rgbLabel.textContent = this.i18n.t('colorPicker.rgb')
+        return
+      }
+      const color = new AcCmColor()
+      color.colorIndex = this.selectedIndex
+      indexLabel.textContent = `${this.i18n.t('colorPicker.index')}${this.selectedIndex}`
+      rgbLabel.textContent = `${this.i18n.t('colorPicker.rgb')}${color.red}, ${color.green}, ${color.blue}`
+    }
+
+    const selectIndex = (index: number) => {
+      this.selectedIndex = index
+      input.value = String(index)
+      dialog.querySelectorAll('.ml-ex-ui-aci-cell').forEach(cell => {
+        cell.classList.toggle(
+          'selected',
+          Number((cell as HTMLElement).dataset.index) === index
+        )
+      })
+      updateInfo()
+    }
+
+    dialog.querySelectorAll('.ml-ex-ui-aci-cell').forEach(cell => {
+      cell.addEventListener('click', () => {
+        selectIndex(Number((cell as HTMLElement).dataset.index))
+      })
+    })
+
+    input.addEventListener('keydown', event => {
+      if (event.key !== 'Enter') return
+      const parsed = this.parseInput(input.value)
+      if (parsed == null) return
+      selectIndex(parsed)
+    })
+
+    updateInfo()
+    this.backdrop.appendChild(dialog)
+    document.body.appendChild(this.backdrop)
+  }
+
+  /**
+   * Returns a promise resolved when the user confirms or cancels the dialog.
+   *
+   * @returns Selected color, or `null` on cancel or backdrop click.
+   */
+  open(): Promise<AcCmColor | null> {
+    return new Promise(resolve => {
+      this.resolve = resolve
+    })
+  }
+
+  /**
+   * Removes the dialog and resolves the {@link open} promise.
+   *
+   * @param color - Selected color, or `null` when dismissed.
+   */
+  private finish(color: AcCmColor | null) {
+    this.backdrop.remove()
+    this.resolve?.(color)
+    this.resolve = undefined
+  }
+
+  /**
+   * Builds a grid of clickable ACI swatches.
+   *
+   * @param indices - ACI color indices to include.
+   * @param className - CSS class for the palette container.
+   */
+  private createPalette(indices: number[], className: string) {
+    const palette = document.createElement('div')
+    palette.className = className
+    indices.forEach(index => {
+      const cell = document.createElement('button')
+      cell.type = 'button'
+      cell.className = 'ml-ex-ui-aci-cell'
+      cell.dataset.index = String(index)
+      cell.style.background = this.rgb(index)
+      if (this.selectedIndex === index) {
+        cell.classList.add('selected')
+      }
+      palette.appendChild(cell)
+    })
+    return palette
+  }
+
+  /**
+   * Returns the CSS color for an ACI index.
+   *
+   * @param index - ACI color index (1–255).
+   */
+  private rgb(index: number): string {
+    const color = new AcCmColor()
+    color.colorIndex = index
+    return color.cssColor || '#FFFFFF'
+  }
+
+  /**
+   * Extracts an ACI index from an initial color, when applicable.
+   *
+   * @param color - Optional initial color.
+   */
+  private toColorIndex(color?: AcCmColor): number | null {
+    if (!color) return null
+    if (color.isByACI && color.colorIndex != null) return color.colorIndex
+    return null
+  }
+
+  /**
+   * Parses manual color input as an ACI index or convertible color string.
+   *
+   * @param value - User input (1–255, or a color string).
+   */
+  private parseInput(value: string): number | null {
+    const trimmed = value.trim()
+    if (/^\d+$/.test(trimmed)) {
+      const index = Number(trimmed)
+      if (index >= 1 && index <= 255) return index
+      return null
+    }
+    const color = AcCmColor.fromString(trimmed)
+    if (!color || color.isByLayer || color.isByBlock) return null
+    if (color.isByACI && color.colorIndex != null) return color.colorIndex
+    return null
+  }
+
+  /**
+   * Builds the confirmed {@link AcCmColor} from the current selection.
+   */
+  private toSelectedColor(): AcCmColor | null {
+    if (this.selectedIndex == null) return null
+    return new AcCmColor(AcCmColorMethod.ByACI, this.selectedIndex)
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/ui/AcExDropdownMenu.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExDropdownMenu.ts
@@ -1,0 +1,110 @@
+import { createIconElement } from '../assets/icons'
+import type { AcExToolbarItem } from '../config/types'
+import type { AcExI18n } from '../i18n'
+
+/**
+ * Fixed-position dropdown menu for toolbar submenu items.
+ *
+ * Closes on outside click and positions itself near the anchor button.
+ */
+export class AcExDropdownMenu {
+  /** Menu root element appended to the theme host. */
+  private root: HTMLDivElement
+  /** Handler invoked when a menu item is chosen. */
+  private onSelect?: (item: AcExToolbarItem) => void
+  /** Handler invoked when the menu is closed. */
+  private onClose?: () => void
+  /** Closes the menu when the user clicks outside. */
+  private handleDocumentClick = (event: MouseEvent) => {
+    if (!(event.target instanceof Node)) return
+    if (this.root.contains(event.target)) return
+    this.close()
+  }
+
+  /**
+   * @param i18n - i18n helper for item labels.
+   * @param items - Submenu items to render.
+   * @param anchor - Toolbar button used for positioning.
+   * @param themeHost - Theme host so `--ml-ui-*` CSS variables are inherited.
+   */
+  constructor(
+    private i18n: AcExI18n,
+    items: AcExToolbarItem[],
+    anchor: HTMLElement,
+    private themeHost: HTMLElement
+  ) {
+    this.root = document.createElement('div')
+    this.root.className = 'ml-ex-ui-dropdown'
+    this.root.setAttribute('role', 'menu')
+
+    items.forEach(item => {
+      const button = document.createElement('button')
+      button.type = 'button'
+      button.className = 'ml-ex-ui-dropdown-item'
+      button.setAttribute('role', 'menuitem')
+      if (item.icon) {
+        button.appendChild(createIconElement(item.icon))
+      }
+      const label = document.createElement('span')
+      label.textContent = item.label ? this.i18n.t(item.label) : item.id
+      button.appendChild(label)
+      button.addEventListener('click', event => {
+        event.stopPropagation()
+        this.onSelect?.(item)
+        this.close()
+      })
+      this.root.appendChild(button)
+    })
+
+    this.themeHost.appendChild(this.root)
+    this.positionNear(anchor)
+    document.addEventListener('mousedown', this.handleDocumentClick, true)
+  }
+
+  /**
+   * Sets the callback invoked when a menu item is selected.
+   *
+   * @param handler - Selection handler.
+   */
+  setOnSelect(handler: (item: AcExToolbarItem) => void) {
+    this.onSelect = handler
+  }
+
+  /**
+   * Sets the callback invoked when the menu closes.
+   *
+   * @param handler - Close handler.
+   */
+  setOnClose(handler: () => void) {
+    this.onClose = handler
+  }
+
+  /** Detaches the menu and removes the document click listener. */
+  close() {
+    document.removeEventListener('mousedown', this.handleDocumentClick, true)
+    this.root.remove()
+    this.onClose?.()
+  }
+
+  /**
+   * Positions the menu below the anchor, flipping above when near the viewport edge.
+   *
+   * @param anchor - Reference button bounding box.
+   */
+  private positionNear(anchor: HTMLElement) {
+    const rect = anchor.getBoundingClientRect()
+    const menuRect = this.root.getBoundingClientRect()
+    let top = rect.bottom + 4
+    let left = rect.left
+
+    if (top + menuRect.height > window.innerHeight - 8) {
+      top = rect.top - menuRect.height - 4
+    }
+    if (left + menuRect.width > window.innerWidth - 8) {
+      left = window.innerWidth - menuRect.width - 8
+    }
+
+    this.root.style.top = `${Math.max(8, top)}px`
+    this.root.style.left = `${Math.max(8, left)}px`
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/ui/AcExLayerManager.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExLayerManager.ts
@@ -1,0 +1,496 @@
+import { AcApDocManager, eventBus } from '@mlightcad/cad-simple-viewer'
+import { AcCmColor } from '@mlightcad/data-model'
+
+import type { AcExLayerInfo, AcExToolbarPlacement } from '../config/types'
+import type { AcExI18n } from '../i18n'
+import type { AcExLayerService } from '../service/AcExLayerService'
+import { AcExColorPicker } from './AcExColorPicker'
+import { ensureUiStyles } from './styles'
+
+/** Minimum top/bottom margin for default panel placement and height. */
+const LAYER_MANAGER_VERTICAL_MARGIN = 150
+/** Horizontal inset from the host edge for default placement. */
+const LAYER_MANAGER_HORIZONTAL_MARGIN = 8
+/** Minimum panel height (px). */
+const LAYER_MANAGER_MIN_HEIGHT = 120
+
+/** Constructor options for {@link AcExLayerManager}. */
+export interface AcExLayerManagerOptions {
+  /** Layer data service backing the table rows. */
+  layerService: AcExLayerService
+  /** i18n helper for panel labels. */
+  i18n: AcExI18n
+  /** Viewer host used for containment and default positioning. */
+  host: HTMLElement
+  /** Toolbar placement used to pick the opposite side for the panel. */
+  toolbarPlacement?: AcExToolbarPlacement
+  /** When false, the panel is clamped inside `host`. */
+  allowMoveOutsideCanvas?: boolean
+}
+
+/**
+ * Draggable, resizable floating panel for layer visibility and color editing.
+ */
+export class AcExLayerManager {
+  /** Root panel element. */
+  private root: HTMLDivElement
+  /** Layer table body receiving row nodes. */
+  private tbody!: HTMLTableSectionElement
+  /** Header checkbox toggling all layers on/off. */
+  private masterCheckbox!: HTMLInputElement
+  /** Panel title label element. */
+  private titleEl!: HTMLSpanElement
+  /** Name column header cell. */
+  private nameHeaderEl!: HTMLTableCellElement
+  /** On column header label. */
+  private onLabelEl!: HTMLSpanElement
+  /** Color column header cell. */
+  private colorHeaderEl!: HTMLTableCellElement
+  /** Unsubscribe function from {@link AcExLayerService.subscribe}. */
+  private unsubscribe?: () => void
+  /** Active pointer drag state for header dragging. */
+  private dragState?: {
+    pointerId: number
+    offsetX: number
+    offsetY: number
+  }
+  /** Active pointer resize state for the bottom handle. */
+  private resizeState?: {
+    pointerId: number
+    startY: number
+    startHeight: number
+  }
+  /** Whether the panel may be positioned outside the host bounds. */
+  private readonly allowMoveOutsideCanvas: boolean
+  /** Viewer host reference. */
+  private readonly host: HTMLElement
+  /** Layer service providing row data and mutations. */
+  private readonly layerService: AcExLayerService
+  /** i18n helper for labels and toasts. */
+  private readonly i18n: AcExI18n
+  /** Toolbar placement for default horizontal positioning. */
+  private toolbarPlacement: AcExToolbarPlacement
+  /** Whether the user has manually dragged the panel. */
+  private hasUserPosition = false
+  /** Whether the user has manually resized the panel height. */
+  private hasUserResize = false
+
+  /** Hides the panel when the global `close-layer-manager` event fires. */
+  private handleCloseLayerManager = () => {
+    this.hide()
+  }
+
+  /**
+   * @param options - Layer service, i18n, host, and placement options.
+   */
+  constructor(options: AcExLayerManagerOptions) {
+    this.layerService = options.layerService
+    this.i18n = options.i18n
+    this.host = options.host
+    this.toolbarPlacement = options.toolbarPlacement ?? 'right'
+    this.allowMoveOutsideCanvas = options.allowMoveOutsideCanvas ?? false
+    ensureUiStyles()
+
+    this.root = document.createElement('div')
+    this.root.className = 'ml-ex-ui-layer-manager is-hidden'
+    if (!this.allowMoveOutsideCanvas) {
+      this.root.classList.add('is-contained')
+    }
+
+    const header = document.createElement('div')
+    header.className = 'ml-ex-ui-layer-manager-header'
+
+    const title = document.createElement('span')
+    this.titleEl = title
+    title.textContent = options.i18n.t('layerManager.title')
+
+    const closeBtn = document.createElement('button')
+    closeBtn.type = 'button'
+    closeBtn.className = 'ml-ex-ui-layer-manager-close'
+    closeBtn.setAttribute('aria-label', 'Close')
+    closeBtn.textContent = '×'
+    closeBtn.addEventListener('click', () => this.hide())
+
+    header.appendChild(title)
+    header.appendChild(closeBtn)
+    this.bindDrag(header)
+
+    const tableWrap = document.createElement('div')
+    tableWrap.className = 'ml-ex-ui-layer-table-wrap'
+
+    const table = document.createElement('table')
+    table.className = 'ml-ex-ui-layer-table'
+
+    const thead = document.createElement('thead')
+    const headRow = document.createElement('tr')
+
+    const nameTh = document.createElement('th')
+    this.nameHeaderEl = nameTh
+    nameTh.textContent = options.i18n.t('layerManager.name')
+
+    const onTh = document.createElement('th')
+    onTh.className = 'center'
+    const onHeader = document.createElement('div')
+    onHeader.className = 'ml-ex-ui-layer-header-on'
+    const onLabel = document.createElement('span')
+    this.onLabelEl = onLabel
+    onLabel.textContent = options.i18n.t('layerManager.on')
+    this.masterCheckbox = document.createElement('input')
+    this.masterCheckbox.type = 'checkbox'
+    this.masterCheckbox.addEventListener('change', () => {
+      if (this.masterCheckbox.checked) {
+        this.layerService.setAllLayersOn()
+      } else {
+        this.layerService.setAllLayersOffExceptCurrent()
+      }
+    })
+    onHeader.appendChild(onLabel)
+    onHeader.appendChild(this.masterCheckbox)
+    onTh.appendChild(onHeader)
+
+    const colorTh = document.createElement('th')
+    colorTh.className = 'center'
+    this.colorHeaderEl = colorTh
+    colorTh.textContent = options.i18n.t('layerManager.color')
+
+    headRow.appendChild(nameTh)
+    headRow.appendChild(onTh)
+    headRow.appendChild(colorTh)
+    thead.appendChild(headRow)
+
+    this.tbody = document.createElement('tbody')
+
+    table.appendChild(thead)
+    table.appendChild(this.tbody)
+    tableWrap.appendChild(table)
+
+    this.root.appendChild(header)
+    this.root.appendChild(tableWrap)
+
+    const resizeHandle = document.createElement('div')
+    resizeHandle.className = 'ml-ex-ui-layer-manager-resize'
+    resizeHandle.setAttribute('aria-label', 'Resize')
+    this.bindResize(resizeHandle)
+    this.root.appendChild(resizeHandle)
+
+    if (this.allowMoveOutsideCanvas) {
+      document.body.appendChild(this.root)
+    } else {
+      if (getComputedStyle(this.host).position === 'static') {
+        this.host.style.position = 'relative'
+      }
+      this.host.appendChild(this.root)
+    }
+
+    this.unsubscribe = this.layerService.subscribe(() => this.renderRows())
+    eventBus.on('close-layer-manager', this.handleCloseLayerManager)
+    this.renderRows()
+  }
+
+  /** Shows the panel and applies default position when not yet user-placed. */
+  show() {
+    this.root.classList.remove('is-hidden')
+    if (!this.hasUserPosition) {
+      this.applyDefaultPosition()
+    }
+    this.renderRows()
+  }
+
+  /** Hides the panel without destroying it. */
+  hide() {
+    this.root.classList.add('is-hidden')
+  }
+
+  /** Shows the panel if hidden, otherwise hides it. */
+  toggle() {
+    if (this.root.classList.contains('is-hidden')) {
+      this.show()
+    } else {
+      this.hide()
+    }
+  }
+
+  /** Whether the panel is currently visible. */
+  get visible() {
+    return !this.root.classList.contains('is-hidden')
+  }
+
+  /**
+   * Updates toolbar placement used for default horizontal positioning.
+   *
+   * @param placement - Current toolbar edge placement.
+   */
+  setToolbarPlacement(placement: AcExToolbarPlacement) {
+    this.toolbarPlacement = placement
+    if (!this.hasUserPosition && this.visible) {
+      this.applyDefaultPosition()
+    }
+  }
+
+  /** Updates header labels after a locale change. */
+  refreshLocale() {
+    this.titleEl.textContent = this.i18n.t('layerManager.title')
+    this.nameHeaderEl.textContent = this.i18n.t('layerManager.name')
+    this.onLabelEl.textContent = this.i18n.t('layerManager.on')
+    this.colorHeaderEl.textContent = this.i18n.t('layerManager.color')
+  }
+
+  /** Unsubscribes from events and removes the panel from the DOM. */
+  destroy() {
+    eventBus.off('close-layer-manager', this.handleCloseLayerManager)
+    this.unsubscribe?.()
+    this.root.remove()
+  }
+
+  /** Rebuilds table body rows from {@link AcExLayerService} data. */
+  private renderRows() {
+    const layers = this.layerService.getLayers()
+    const currentLayer = this.layerService.getCurrentLayerName()
+    this.tbody.replaceChildren()
+
+    layers.forEach(layer => {
+      this.tbody.appendChild(this.createRow(layer, currentLayer))
+    })
+
+    const allOn = layers.length > 0 && layers.every(layer => layer.isOn)
+    const someOn = layers.some(layer => layer.isOn)
+    this.masterCheckbox.checked = allOn
+    this.masterCheckbox.indeterminate = someOn && !allOn
+  }
+
+  /**
+   * Creates a table row for one layer.
+   *
+   * @param layer - Layer snapshot to display.
+   * @param currentLayer - Name of the current drawing layer (`CLAYER`).
+   */
+  private createRow(layer: AcExLayerInfo, currentLayer: string) {
+    const row = document.createElement('tr')
+    row.addEventListener('dblclick', () => {
+      const success = AcApDocManager.instance.curView?.zoomToFitLayer(layer.name)
+      if (success) {
+        this.showToast(
+          this.i18n.t('layerManager.zoomToLayer', { layer: layer.name })
+        )
+      }
+    })
+
+    const nameCell = document.createElement('td')
+    nameCell.textContent =
+      layer.name === currentLayer ? `${layer.name} *` : layer.name
+
+    const onCell = document.createElement('td')
+    onCell.className = 'center'
+    const checkbox = document.createElement('input')
+    checkbox.type = 'checkbox'
+    checkbox.checked = layer.isOn
+    checkbox.addEventListener('change', () => {
+      this.layerService.setLayerOn(layer.name, checkbox.checked)
+    })
+    onCell.appendChild(checkbox)
+
+    const colorCell = document.createElement('td')
+    colorCell.className = 'center'
+    const swatch = document.createElement('span')
+    swatch.className = 'ml-ex-ui-layer-color'
+    swatch.style.background = layer.cssColor
+    swatch.addEventListener('click', async () => {
+      const initial = AcCmColor.fromString(layer.color)
+      const picker = new AcExColorPicker(this.i18n, initial ?? undefined)
+      const selected = await picker.open()
+      if (selected) {
+        this.layerService.setLayerColor(layer.name, selected)
+      }
+    })
+    colorCell.appendChild(swatch)
+
+    row.appendChild(nameCell)
+    row.appendChild(onCell)
+    row.appendChild(colorCell)
+    return row
+  }
+
+  /**
+   * Enables drag-to-move on the panel header.
+   *
+   * @param header - Header element receiving pointer events.
+   */
+  private bindDrag(header: HTMLElement) {
+    header.addEventListener('pointerdown', event => {
+      if (!(event.target instanceof HTMLElement)) return
+      if (event.target.closest('.ml-ex-ui-layer-manager-close')) return
+
+      const rect = this.root.getBoundingClientRect()
+      this.dragState = {
+        pointerId: event.pointerId,
+        offsetX: event.clientX - rect.left,
+        offsetY: event.clientY - rect.top
+      }
+      header.setPointerCapture(event.pointerId)
+    })
+
+    header.addEventListener('pointermove', event => {
+      if (!this.dragState || event.pointerId !== this.dragState.pointerId) return
+      this.hasUserPosition = true
+      this.setPosition(
+        event.clientX - this.dragState.offsetX,
+        event.clientY - this.dragState.offsetY
+      )
+    })
+
+    const endDrag = (event: PointerEvent) => {
+      if (!this.dragState || event.pointerId !== this.dragState.pointerId) return
+      this.dragState = undefined
+      header.releasePointerCapture(event.pointerId)
+    }
+
+    header.addEventListener('pointerup', endDrag)
+    header.addEventListener('pointercancel', endDrag)
+  }
+
+  /**
+   * Enables vertical resize via the bottom handle.
+   *
+   * @param handle - Resize handle element.
+   */
+  private bindResize(handle: HTMLElement) {
+    handle.addEventListener('pointerdown', event => {
+      event.preventDefault()
+      this.resizeState = {
+        pointerId: event.pointerId,
+        startY: event.clientY,
+        startHeight: this.root.offsetHeight
+      }
+      handle.setPointerCapture(event.pointerId)
+    })
+
+    handle.addEventListener('pointermove', event => {
+      if (!this.resizeState || event.pointerId !== this.resizeState.pointerId) {
+        return
+      }
+      const delta = event.clientY - this.resizeState.startY
+      const maxHeight = this.getResizeMaxPanelHeight()
+      const nextHeight = Math.max(
+        LAYER_MANAGER_MIN_HEIGHT,
+        Math.min(maxHeight, this.resizeState.startHeight + delta)
+      )
+      this.hasUserResize = true
+      this.root.style.height = `${nextHeight}px`
+      this.root.style.maxHeight = `${nextHeight}px`
+    })
+
+    const endResize = (event: PointerEvent) => {
+      if (!this.resizeState || event.pointerId !== this.resizeState.pointerId) {
+        return
+      }
+      this.resizeState = undefined
+      handle.releasePointerCapture(event.pointerId)
+    }
+
+    handle.addEventListener('pointerup', endResize)
+    handle.addEventListener('pointercancel', endResize)
+  }
+
+  /**
+   * Default panel height: canvas height minus 150px top and bottom margins.
+   */
+  private getDefaultPanelHeight(): number {
+    if (this.allowMoveOutsideCanvas) {
+      return Math.max(
+        LAYER_MANAGER_MIN_HEIGHT,
+        window.innerHeight - LAYER_MANAGER_VERTICAL_MARGIN * 2
+      )
+    }
+    return Math.max(
+      LAYER_MANAGER_MIN_HEIGHT,
+      this.host.clientHeight - LAYER_MANAGER_VERTICAL_MARGIN * 2
+    )
+  }
+
+  /**
+   * Maximum height while the user is resizing (full canvas; no 150px margin).
+   */
+  private getResizeMaxPanelHeight(): number {
+    if (this.allowMoveOutsideCanvas) {
+      return Math.max(LAYER_MANAGER_MIN_HEIGHT, window.innerHeight)
+    }
+    return Math.max(LAYER_MANAGER_MIN_HEIGHT, this.host.clientHeight)
+  }
+
+  /**
+   * Centers the panel vertically and places it on the side opposite the toolbar.
+   */
+  private applyDefaultPosition() {
+    if (!this.hasUserResize) {
+      const defaultHeight = this.getDefaultPanelHeight()
+      this.root.style.height = `${defaultHeight}px`
+      this.root.style.maxHeight = `${defaultHeight}px`
+    }
+
+    const hostWidth = this.host.clientWidth
+    const hostHeight = this.host.clientHeight
+    const panelWidth = this.root.offsetWidth
+    const panelHeight = this.root.offsetHeight
+    const availableHeight = hostHeight - LAYER_MANAGER_VERTICAL_MARGIN * 2
+    const top =
+      LAYER_MANAGER_VERTICAL_MARGIN +
+      Math.max(0, (availableHeight - panelHeight) / 2)
+
+    let left: number
+    if (this.toolbarPlacement === 'right') {
+      left = LAYER_MANAGER_HORIZONTAL_MARGIN
+    } else {
+      left = Math.max(
+        LAYER_MANAGER_HORIZONTAL_MARGIN,
+        hostWidth - panelWidth - LAYER_MANAGER_HORIZONTAL_MARGIN
+      )
+    }
+
+    if (this.allowMoveOutsideCanvas) {
+      const hostRect = this.host.getBoundingClientRect()
+      this.root.style.left = `${hostRect.left + left}px`
+      this.root.style.top = `${hostRect.top + top}px`
+      return
+    }
+
+    this.root.style.left = `${left}px`
+    this.root.style.top = `${top}px`
+  }
+
+  /**
+   * Sets panel position in viewport or host-local coordinates.
+   *
+   * @param clientLeft - Desired left edge in viewport coordinates.
+   * @param clientTop - Desired top edge in viewport coordinates.
+   */
+  private setPosition(clientLeft: number, clientTop: number) {
+    if (this.allowMoveOutsideCanvas) {
+      this.root.style.left = `${clientLeft}px`
+      this.root.style.top = `${clientTop}px`
+      return
+    }
+
+    const hostRect = this.host.getBoundingClientRect()
+    let left = clientLeft - hostRect.left
+    let top = clientTop - hostRect.top
+    const maxLeft = Math.max(0, this.host.clientWidth - this.root.offsetWidth)
+    const maxTop = Math.max(0, this.host.clientHeight - this.root.offsetHeight)
+    left = Math.max(0, Math.min(left, maxLeft))
+    top = Math.max(0, Math.min(top, maxTop))
+    this.root.style.left = `${left}px`
+    this.root.style.top = `${top}px`
+  }
+
+  /**
+   * Shows a short-lived toast message at the top of the viewport.
+   *
+   * @param message - Text to display.
+   */
+  private showToast(message: string) {
+    const toast = document.createElement('div')
+    toast.className = 'ml-ex-ui-toast'
+    toast.textContent = message
+    document.body.appendChild(toast)
+    window.setTimeout(() => toast.remove(), 1500)
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/ui/AcExToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExToolbar.ts
@@ -1,0 +1,275 @@
+import { AcApDocManager, AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
+
+import { createIconElement } from '../assets/icons'
+import {
+  filterVisibleToolbarItems,
+  isToolbarItemDisabled,
+  itemRequiresDocument,
+  resolveParentToolbarDisplay
+} from '../config/resolveToolbarItems'
+import { isToolbarSeparatorItem } from '../config/toolbarItemUtils'
+import type { AcExToolbarItem, AcExToolbarPlacement } from '../config/types'
+import type { AcExI18n } from '../i18n'
+import { AcExDropdownMenu } from './AcExDropdownMenu'
+import { ensureUiStyles } from './styles'
+
+/** Constructor options for {@link AcExToolbar}. */
+export interface AcExToolbarOptions {
+  /** Viewer host element that receives the toolbar root node. */
+  host: HTMLElement
+  /** Edge placement of the toolbar. */
+  placement: AcExToolbarPlacement
+  /** Toolbar item definitions to render. */
+  items: AcExToolbarItem[]
+  /** i18n helper for button labels and tooltips. */
+  i18n: AcExI18n
+  /** Invoked when a leaf item with a `command` is activated. */
+  onCommand: (command: string) => void
+}
+
+/**
+ * Plain-DOM floating toolbar with dropdown submenus and toggle buttons.
+ *
+ * Disables command buttons while a document is loading and filters items by
+ * document open mode.
+ */
+export class AcExToolbar {
+  /** Root toolbar container appended to the host. */
+  private root: HTMLDivElement
+  /** Currently open submenu, if any. */
+  private openDropdown?: AcExDropdownMenu
+  /** Whether the toolbar is globally disabled during document open. */
+  private isDisabled = false
+  /** Current document open mode used for item visibility. */
+  private openMode = AcEdOpenMode.Read
+  /** Whether an active document is loaded. */
+  private hasDocument = false
+  /** Item list last passed to {@link updateItems} or the constructor. */
+  private items: AcExToolbarItem[]
+  /** Runtime submenu selection for parents with {@link AcExToolbarItem.childIcon} `'selected'`. */
+  private selectedChildByParent = new Map<string, string>()
+
+  /** Re-renders buttons when a document becomes active. */
+  private handleDocumentActivated = () => {
+    this.hasDocument = Boolean(AcApDocManager.instance.curDocument)
+    this.isDisabled = false
+    this.root.classList.remove('is-disabled')
+    this.openMode =
+      AcApDocManager.instance.curDocument?.openMode ?? AcEdOpenMode.Read
+    this.renderButtons()
+  }
+
+  /** Disables the toolbar while a document is opening. */
+  private handleDocumentToBeOpened = () => {
+    this.isDisabled = true
+    this.root.classList.add('is-disabled')
+  }
+
+  /**
+   * @param options - Host, placement, items, i18n, and command callback.
+   */
+  constructor(private options: AcExToolbarOptions) {
+    ensureUiStyles()
+    this.items = options.items
+    this.seedSelectedChildren(options.items)
+
+    this.root = document.createElement('div')
+    this.root.className = `ml-ex-ui-toolbar is-${this.getOrientationClass()} is-${options.placement}`
+    this.root.setAttribute('role', 'toolbar')
+    options.host.appendChild(this.root)
+
+    AcApDocManager.instance.events.documentActivated.addEventListener(
+      this.handleDocumentActivated
+    )
+    AcApDocManager.instance.events.documentToBeOpened.addEventListener(
+      this.handleDocumentToBeOpened
+    )
+
+    this.handleDocumentActivated()
+  }
+
+  /**
+   * Replaces the toolbar item list and re-renders buttons.
+   *
+   * @param items - New toolbar items.
+   */
+  updateItems(items: AcExToolbarItem[]) {
+    this.items = items
+    this.seedSelectedChildren(items)
+    this.renderButtons()
+  }
+
+  /** Refreshes open mode and re-renders (e.g. after locale or theme change). */
+  refresh() {
+    this.openMode =
+      AcApDocManager.instance.curDocument?.openMode ?? AcEdOpenMode.Read
+    this.renderButtons()
+  }
+
+  /**
+   * Moves the toolbar to another host edge and updates orientation classes.
+   *
+   * @param placement - Target edge placement.
+   */
+  setPlacement(placement: AcExToolbarPlacement) {
+    if (this.options.placement === placement) return
+    this.options.placement = placement
+    this.selectedChildByParent.set('toolbar-placement', `placement-${placement}`)
+    this.root.className = `ml-ex-ui-toolbar is-${this.getOrientationClass()} is-${placement}`
+    this.renderButtons()
+  }
+
+  /**
+   * Sets the active submenu child for a parent button.
+   *
+   * @param parentId - Parent toolbar item id.
+   * @param childId - Selected child item id.
+   */
+  setSelectedChild(parentId: string, childId: string) {
+    this.selectedChildByParent.set(parentId, childId)
+  }
+
+  /** Current toolbar edge placement. */
+  get placement() {
+    return this.options.placement
+  }
+
+  /** Removes listeners, closes dropdowns, and detaches the toolbar DOM. */
+  destroy() {
+    this.openDropdown?.close()
+    AcApDocManager.instance.events.documentActivated.removeEventListener(
+      this.handleDocumentActivated
+    )
+    AcApDocManager.instance.events.documentToBeOpened.removeEventListener(
+      this.handleDocumentToBeOpened
+    )
+    this.root.remove()
+  }
+
+  /**
+   * Returns the CSS orientation class suffix for the current placement.
+   *
+   * @returns `'vertical'` for left/right, `'horizontal'` for top/bottom.
+   */
+  private getOrientationClass() {
+    return this.options.placement === 'left' ||
+      this.options.placement === 'right'
+      ? 'vertical'
+      : 'horizontal'
+  }
+
+  /** Rebuilds all toolbar buttons from {@link items}. */
+  private renderButtons() {
+    this.openDropdown?.close()
+    this.openDropdown = undefined
+    this.root.replaceChildren()
+
+    const visibleItems = filterVisibleToolbarItems(this.items, this.openMode)
+    visibleItems.forEach(item => {
+      if (isToolbarSeparatorItem(item)) {
+        const separator = document.createElement('div')
+        separator.className = 'ml-ex-ui-toolbar-separator'
+        separator.setAttribute('role', 'separator')
+        if (item.id) {
+          separator.dataset.toolbarItemId = item.id
+        }
+        this.root.appendChild(separator)
+        return
+      }
+
+      const effective = resolveParentToolbarDisplay(
+        item,
+        this.selectedChildByParent.get(item.id)
+      )
+      const button = document.createElement('button')
+      button.type = 'button'
+      button.className = 'ml-ex-ui-toolbar-btn'
+      button.title = effective.label
+        ? this.options.i18n.t(effective.label)
+        : effective.id
+      button.setAttribute('aria-label', button.title)
+
+      if (effective.children?.length) {
+        button.classList.add('has-children')
+      }
+
+      if (effective.icon) {
+        button.appendChild(createIconElement(effective.icon))
+      } else if (effective.label) {
+        const text = document.createElement('span')
+        text.textContent = this.options.i18n.t(effective.label)
+        text.style.fontSize = '11px'
+        text.style.padding = '0 4px'
+        button.appendChild(text)
+      }
+
+      const disabled =
+        (itemRequiresDocument(effective) &&
+          (this.isDisabled || !this.hasDocument)) ||
+        isToolbarItemDisabled(effective)
+      button.disabled = disabled
+
+      button.addEventListener('click', event => {
+        event.stopPropagation()
+        if (button.disabled) return
+
+        if (effective.children?.length) {
+          const visibleChildren = filterVisibleToolbarItems(
+            effective.children,
+            this.openMode
+          )
+          if (visibleChildren.length === 0) return
+
+          this.openDropdown?.close()
+          const dropdown = new AcExDropdownMenu(
+            this.options.i18n,
+            visibleChildren,
+            button,
+            this.options.host
+          )
+          dropdown.setOnSelect(child => {
+            if (item.childIcon === 'selected') {
+              this.selectedChildByParent.set(item.id, child.id)
+            }
+            if (child.action) {
+              child.action()
+            } else if (child.command) {
+              this.options.onCommand(child.command)
+            }
+            if (item.childIcon === 'selected' || item.toggle) {
+              this.renderButtons()
+            }
+          })
+          dropdown.setOnClose(() => {
+            if (this.openDropdown === dropdown) {
+              this.openDropdown = undefined
+            }
+          })
+          this.openDropdown = dropdown
+          return
+        }
+
+        if (effective.action) {
+          effective.action()
+        } else if (effective.command) {
+          this.options.onCommand(effective.command)
+        }
+        if (item.toggle) {
+          window.setTimeout(() => this.renderButtons(), 0)
+        }
+      })
+
+      this.root.appendChild(button)
+    })
+  }
+
+  /** Seeds submenu selection from {@link AcExToolbarItem.selectedChildId}. */
+  private seedSelectedChildren(items: AcExToolbarItem[]) {
+    for (const item of items) {
+      if (isToolbarSeparatorItem(item)) continue
+      if (item.childIcon === 'selected' && item.selectedChildId) {
+        this.selectedChildByParent.set(item.id, item.selectedChildId)
+      }
+    }
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -1,0 +1,414 @@
+const STYLE_ID = 'ml-ex-ui-styles'
+
+/**
+ * Injects shared plugin UI styles into `document.head` once.
+ *
+ * Safe to call from multiple components; subsequent calls are no-ops.
+ */
+export function ensureUiStyles() {
+  if (document.getElementById(STYLE_ID)) return
+
+  const style = document.createElement('style')
+  style.id = STYLE_ID
+  style.textContent = `
+    .ml-ex-ui-toolbar {
+      position: absolute;
+      z-index: 30;
+      display: flex;
+      gap: 4px;
+      padding: 6px;
+      background: var(--ml-ui-bg, #ffffff);
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      box-shadow: var(--ml-ui-shadow, 0 2px 6px rgba(0, 0, 0, 0.12));
+      border-radius: 6px;
+      box-sizing: border-box;
+    }
+
+    .ml-ex-ui-toolbar.is-horizontal {
+      flex-direction: row;
+      align-items: center;
+    }
+
+    .ml-ex-ui-toolbar.is-vertical {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .ml-ex-ui-toolbar.is-top { top: 8px; left: 50%; transform: translateX(-50%); }
+    .ml-ex-ui-toolbar.is-bottom { bottom: 8px; left: 50%; transform: translateX(-50%); }
+    .ml-ex-ui-toolbar.is-left { left: 8px; top: 50%; transform: translateY(-50%); }
+    .ml-ex-ui-toolbar.is-right { right: 8px; top: 50%; transform: translateY(-50%); }
+
+    .ml-ex-ui-toolbar.is-disabled {
+      opacity: 0.55;
+      pointer-events: none;
+    }
+
+    .ml-ex-ui-toolbar-separator {
+      flex: 0 0 auto;
+      background: var(--ml-ui-border, #dcdfe6);
+    }
+
+    .ml-ex-ui-toolbar.is-horizontal .ml-ex-ui-toolbar-separator {
+      width: 1px;
+      align-self: stretch;
+      margin: 2px 4px;
+      min-height: 24px;
+    }
+
+    .ml-ex-ui-toolbar.is-vertical .ml-ex-ui-toolbar-separator {
+      height: 1px;
+      width: auto;
+      margin: 4px 2px;
+      min-width: 24px;
+    }
+
+    .ml-ex-ui-toolbar-btn {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 32px;
+      min-height: 32px;
+      padding: 4px;
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      border-radius: 4px;
+      background: var(--ml-ui-bg, #ffffff);
+      color: var(--ml-ui-text, #303133);
+      cursor: pointer;
+      font-size: 12px;
+    }
+
+    .ml-ex-ui-toolbar-btn:hover:not(:disabled) {
+      border-color: var(--ml-ui-accent, #409eff);
+      color: var(--ml-ui-accent, #409eff);
+    }
+
+    .ml-ex-ui-toolbar-btn:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .ml-ex-ui-toolbar-btn.has-children::after {
+      content: '';
+      position: absolute;
+      width: 0;
+      height: 0;
+      border-style: solid;
+    }
+
+    .ml-ex-ui-toolbar.is-right .ml-ex-ui-toolbar-btn.has-children::after {
+      left: 2px;
+      top: 50%;
+      margin-top: -4px;
+      border-width: 4px 5px 4px 0;
+      border-color: transparent var(--ml-ui-text-muted, #606266) transparent transparent;
+    }
+
+    .ml-ex-ui-toolbar.is-left .ml-ex-ui-toolbar-btn.has-children::after {
+      right: 2px;
+      top: 50%;
+      margin-top: -4px;
+      border-width: 4px 0 4px 5px;
+      border-color: transparent transparent transparent var(--ml-ui-text-muted, #606266);
+    }
+
+    .ml-ex-ui-toolbar.is-top .ml-ex-ui-toolbar-btn.has-children::after {
+      bottom: 2px;
+      left: 50%;
+      margin-left: -4px;
+      border-width: 5px 4px 0 4px;
+      border-color: var(--ml-ui-text-muted, #606266) transparent transparent transparent;
+    }
+
+    .ml-ex-ui-toolbar.is-bottom .ml-ex-ui-toolbar-btn.has-children::after {
+      top: 2px;
+      left: 50%;
+      margin-left: -4px;
+      border-width: 0 4px 5px 4px;
+      border-color: transparent transparent var(--ml-ui-text-muted, #606266) transparent;
+    }
+
+    .ml-ex-ui-icon {
+      display: inline-flex;
+      width: 18px;
+      height: 18px;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .ml-ex-ui-icon svg {
+      width: 18px;
+      height: 18px;
+    }
+
+    .ml-ex-ui-dropdown {
+      position: fixed;
+      z-index: 100;
+      min-width: 160px;
+      padding: 4px;
+      background: var(--ml-ui-bg, #ffffff);
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      box-shadow: var(--ml-ui-shadow, 0 6px 18px rgba(0, 0, 0, 0.35));
+      border-radius: 6px;
+    }
+
+    .ml-ex-ui-dropdown-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      padding: 6px 8px;
+      border: none;
+      border-radius: 4px;
+      background: transparent;
+      color: var(--ml-ui-text, #303133);
+      cursor: pointer;
+      font-size: 12px;
+      text-align: left;
+    }
+
+    .ml-ex-ui-dropdown-item:hover {
+      background: var(--ml-ui-border, rgba(0, 0, 0, 0.06));
+    }
+
+    .ml-ex-ui-layer-manager {
+      position: fixed;
+      z-index: 90;
+      width: min(280px, calc(100vw - 24px));
+      min-height: 120px;
+      display: flex;
+      flex-direction: column;
+      background: var(--ml-ui-bg, #ffffff);
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      box-shadow: var(--ml-ui-shadow, 0 6px 18px rgba(0, 0, 0, 0.35));
+      border-radius: 8px;
+      overflow: hidden;
+      color: var(--ml-ui-text, #303133);
+      font-size: 12px;
+    }
+
+    .ml-ex-ui-layer-manager.is-contained {
+      position: absolute;
+      width: min(280px, calc(100% - 16px));
+      max-height: 100%;
+    }
+
+    .ml-ex-ui-layer-manager.is-hidden {
+      display: none;
+    }
+
+    .ml-ex-ui-layer-manager-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 10px;
+      border-bottom: 1px solid var(--ml-ui-border, #dcdfe6);
+      cursor: move;
+      user-select: none;
+      font-weight: 600;
+    }
+
+    .ml-ex-ui-layer-manager-close {
+      border: none;
+      background: transparent;
+      color: var(--ml-ui-text-muted, #606266);
+      cursor: pointer;
+      font-size: 16px;
+      line-height: 1;
+      padding: 2px 6px;
+    }
+
+    .ml-ex-ui-layer-table-wrap {
+      overflow: auto;
+      flex: 1;
+    }
+
+    .ml-ex-ui-layer-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .ml-ex-ui-layer-table th,
+    .ml-ex-ui-layer-table td {
+      padding: 4px 8px;
+      border-bottom: 1px solid var(--ml-ui-border, #dcdfe6);
+      text-align: left;
+    }
+
+    .ml-ex-ui-layer-table th {
+      position: sticky;
+      top: 0;
+      background: var(--ml-ui-bg, #ffffff);
+      z-index: 1;
+    }
+
+    .ml-ex-ui-layer-table td.center,
+    .ml-ex-ui-layer-table th.center {
+      text-align: center;
+      vertical-align: middle;
+    }
+
+    .ml-ex-ui-layer-header-on {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+    }
+
+    .ml-ex-ui-layer-header-on span {
+      line-height: 1;
+    }
+
+    .ml-ex-ui-layer-header-on input[type='checkbox'] {
+      margin: 0;
+    }
+
+    .ml-ex-ui-layer-manager-resize {
+      flex: 0 0 auto;
+      height: 6px;
+      cursor: ns-resize;
+      background: transparent;
+    }
+
+    .ml-ex-ui-layer-manager-resize:hover {
+      background: var(--ml-ui-border, rgba(0, 0, 0, 0.06));
+    }
+
+    .ml-ex-ui-layer-color {
+      display: inline-block;
+      width: 20px;
+      height: 20px;
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      border-radius: 3px;
+      cursor: pointer;
+    }
+
+    .ml-ex-ui-color-dialog-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 120;
+      background: var(--ml-ui-overlay, rgba(0, 0, 0, 0.18));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .ml-ex-ui-color-dialog {
+      width: min(520px, calc(100vw - 24px));
+      background: var(--ml-ui-bg, #ffffff);
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      border-radius: 8px;
+      box-shadow: var(--ml-ui-shadow, 0 6px 18px rgba(0, 0, 0, 0.35));
+      padding: 12px;
+      color: var(--ml-ui-text, #303133);
+    }
+
+    .ml-ex-ui-color-dialog-title {
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+
+    .ml-ex-ui-aci-palette-large {
+      display: grid;
+      grid-template-columns: repeat(24, 1fr);
+      gap: 1px;
+      margin-bottom: 6px;
+    }
+
+    .ml-ex-ui-aci-palette-small,
+    .ml-ex-ui-aci-palette-gray {
+      display: grid;
+      gap: 1px;
+      margin-bottom: 6px;
+    }
+
+    .ml-ex-ui-aci-palette-small {
+      grid-template-columns: repeat(9, 1fr);
+    }
+
+    .ml-ex-ui-aci-palette-gray {
+      grid-template-columns: repeat(6, 1fr);
+    }
+
+    .ml-ex-ui-aci-cell {
+      width: 100%;
+      aspect-ratio: 1;
+      border: 1px solid rgba(0, 0, 0, 0.15);
+      cursor: pointer;
+    }
+
+    .ml-ex-ui-aci-cell.selected {
+      outline: 2px solid var(--ml-ui-accent, #409eff);
+      outline-offset: -1px;
+    }
+
+    .ml-ex-ui-aci-info {
+      display: flex;
+      justify-content: space-between;
+      margin: 8px 0;
+      color: var(--ml-ui-text-muted, #606266);
+    }
+
+    .ml-ex-ui-aci-input-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+
+    .ml-ex-ui-aci-input-row input {
+      flex: 1;
+      padding: 4px 6px;
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      border-radius: 4px;
+      background: var(--ml-ui-bg, #ffffff);
+      color: var(--ml-ui-text, #303133);
+    }
+
+    .ml-ex-ui-dialog-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+
+    .ml-ex-ui-btn {
+      padding: 4px 12px;
+      border-radius: 4px;
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      background: var(--ml-ui-bg, #ffffff);
+      color: var(--ml-ui-text, #303133);
+      cursor: pointer;
+      font-size: 12px;
+    }
+
+    .ml-ex-ui-btn-primary {
+      border-color: var(--ml-ui-accent, #409eff);
+      background: var(--ml-ui-accent, #409eff);
+      color: #fff;
+    }
+
+    .ml-ex-ui-toast {
+      position: fixed;
+      top: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 200;
+      padding: 8px 14px;
+      border-radius: 6px;
+      background: var(--ml-ui-bg, #ffffff);
+      color: var(--ml-ui-text, #303133);
+      border: 1px solid var(--ml-ui-border, #dcdfe6);
+      box-shadow: var(--ml-ui-shadow, 0 2px 6px rgba(0, 0, 0, 0.12));
+    }
+  `
+  document.head.appendChild(style)
+}
+
+/**
+ * Removes injected UI styles when no toolbar or layer manager remains in the DOM.
+ */
+export function removeUiStylesIfUnused() {
+  if (document.querySelector('.ml-ex-ui-toolbar, .ml-ex-ui-layer-manager')) return
+  document.getElementById(STYLE_ID)?.remove()
+}

--- a/packages/cad-simple-ui-plugin/tsconfig.json
+++ b/packages/cad-simple-ui-plugin/tsconfig.json
@@ -4,14 +4,9 @@
     "resolveJsonModule": true,
     "rootDir": "./src",
     "outDir": "./lib",
-    "baseUrl": "./src",
     "paths": {
-      "@mlightcad/cad-svg-plugin": [
-        "./index.ts"
-      ]
+      "@mlightcad/cad-simple-ui-plugin": ["./src/index.ts"]
     }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/cad-simple-ui-plugin/vite.config.ts
+++ b/packages/cad-simple-ui-plugin/vite.config.ts
@@ -1,3 +1,4 @@
+/** Vite library build configuration for {@link packageName} dual entry bundles (`index`, `register`). */
 import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
@@ -6,8 +7,8 @@ import {
   createLibRollupOutput
 } from '../vite-config/pluginRollupOutput'
 
-const packageName = '@mlightcad/cad-pdf-plugin'
-const pluginId = 'cad-pdf-plugin'
+const packageName = '@mlightcad/cad-simple-ui-plugin'
+const pluginId = 'cad-simple-ui-plugin'
 
 export default defineConfig({
   build: {
@@ -24,7 +25,7 @@ export default defineConfig({
     },
     minify: true,
     rollupOptions: {
-      external: [packageName],
+      external: [packageName, '@mlightcad/cad-simple-viewer', '@mlightcad/data-model'],
       output: createLibRollupOutput(pluginId)
     }
   },

--- a/packages/cad-simple-viewer-example/index.html
+++ b/packages/cad-simple-viewer-example/index.html
@@ -92,36 +92,6 @@
         background: #111827;
       }
 
-      .viewer-toolbar {
-        height: 48px;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0 0.75rem;
-        border-bottom: 1px solid #1f2937;
-        background: #0b1220;
-      }
-
-      .toolbar-button {
-        border: 1px solid #374151;
-        border-radius: 6px;
-        background: #1f2937;
-        color: #e5e7eb;
-        padding: 0.35rem 0.7rem;
-        font-size: 0.82rem;
-        cursor: pointer;
-      }
-
-      .toolbar-button:hover {
-        background: #273447;
-      }
-
-      .toolbar-button:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        background: #111827;
-      }
-
       .viewer-canvas-area {
         position: relative;
         flex: 1;
@@ -249,13 +219,6 @@
           flex: 1;
           min-height: 0;
         }
-
-        .viewer-toolbar {
-          flex-wrap: wrap;
-          height: auto;
-          min-height: 48px;
-          padding: 0.45rem 0.75rem;
-        }
       }
     </style>
   </head>
@@ -335,61 +298,6 @@
       </aside>
 
       <main class="viewer-pane" id="viewerPane">
-        <header class="viewer-toolbar">
-          <button type="button" class="toolbar-button" id="toolbarOpenButton">Open</button>
-          <button
-            type="button"
-            class="toolbar-button"
-            id="toolbarZoomButton"
-            disabled
-          >
-            Zoom Fit
-          </button>
-          <button
-            type="button"
-            class="toolbar-button"
-            id="toolbarZoomWindowButton"
-            disabled
-          >
-            Zoom to Window
-          </button>
-          <button type="button" class="toolbar-button" id="toolbarBgButton" disabled>
-            Switch BG
-          </button>
-          <button
-            type="button"
-            class="toolbar-button"
-            id="toolbarPickboxButton"
-            disabled
-          >
-            Set Pickbox
-          </button>
-          <button
-            type="button"
-            class="toolbar-button"
-            id="toolbarLineWeightButton"
-            disabled
-          >
-            LineWeight: On
-          </button>
-          <button
-            type="button"
-            class="toolbar-button"
-            id="toolbarExportHtmlButton"
-            disabled
-          >
-            Export HTML
-          </button>
-          <button
-            type="button"
-            class="toolbar-button"
-            id="toolbarExportPdfButton"
-            disabled
-          >
-            Export PDF
-          </button>
-        </header>
-
         <section class="viewer-canvas-area">
           <div class="empty-state" id="emptyState">
             <button type="button" class="open-main-button" id="centerOpenButton">Open File</button>

--- a/packages/cad-simple-viewer-example/package.json
+++ b/packages/cad-simple-viewer-example/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@mlightcad/cad-html-plugin": "workspace:*",
     "@mlightcad/cad-pdf-plugin": "workspace:*",
+    "@mlightcad/cad-simple-ui-plugin": "workspace:*",
     "@mlightcad/cad-svg-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.9.14",

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -1,28 +1,14 @@
+import { registerSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin/register'
 import {
   AcApDocManager,
   AcApOpenDatabaseOptions,
-  AcEdOpenMode
+  AcEdOpenMode,
+  applyUiTheme
 } from '@mlightcad/cad-simple-viewer'
-import {
-  AcDbSystemVariables,
-  AcDbSysVarManager,
-  log
-} from '@mlightcad/data-model'
+import { log } from '@mlightcad/data-model'
 
 import { registerLazyPlugins } from './register'
 
-/**
- * Demo-only command alias overrides used by the example app.
- *
- * Purpose:
- * - Provide visible alias differences from built-in defaults so the alias
- *   feature can be validated quickly in command line UI and execution flow.
- *
- * Behavior:
- * - This object is passed to `AcApDocManager.createInstance({ commandAliases })`.
- * - For commands listed here, these aliases replace the built-in defaults.
- * - Commands not listed keep their built-in alias set.
- */
 const EXAMPLE_COMMAND_ALIASES = {
   LINE: ['LX'],
   CIRCLE: ['CI'],
@@ -33,23 +19,14 @@ class CadViewerApp {
   private container: HTMLDivElement
   private fileInput: HTMLInputElement
   private centerOpenButton: HTMLButtonElement
-  private toolbarOpenButton: HTMLButtonElement
-  private toolbarZoomButton: HTMLButtonElement
-  private toolbarZoomWindowButton: HTMLButtonElement
-  private toolbarBgButton: HTMLButtonElement
-  private toolbarPickboxButton: HTMLButtonElement
-  private toolbarLineWeightButton: HTMLButtonElement
-  private toolbarExportHtmlButton: HTMLButtonElement
-  private toolbarExportPdfButton: HTMLButtonElement
   private viewerPane: HTMLElement
   private emptyState: HTMLDivElement
   private predefinedButtons: NodeListOf<HTMLButtonElement>
   private fileSidebar: HTMLElement
   private fileSidebarToggle: HTMLButtonElement
   private fileSidebarSubtitle: HTMLSpanElement
-  private isInitialized: boolean = false
-  private hasOpenedFile: boolean = false
-  private hasLoadedDocument: boolean = false
+  private isInitialized = false
+  private hasOpenedFile = false
 
   constructor() {
     this.container = document.getElementById('cad-container') as HTMLDivElement
@@ -58,30 +35,6 @@ class CadViewerApp {
     ) as HTMLInputElement
     this.centerOpenButton = document.getElementById(
       'centerOpenButton'
-    ) as HTMLButtonElement
-    this.toolbarOpenButton = document.getElementById(
-      'toolbarOpenButton'
-    ) as HTMLButtonElement
-    this.toolbarZoomButton = document.getElementById(
-      'toolbarZoomButton'
-    ) as HTMLButtonElement
-    this.toolbarZoomWindowButton = document.getElementById(
-      'toolbarZoomWindowButton'
-    ) as HTMLButtonElement
-    this.toolbarBgButton = document.getElementById(
-      'toolbarBgButton'
-    ) as HTMLButtonElement
-    this.toolbarPickboxButton = document.getElementById(
-      'toolbarPickboxButton'
-    ) as HTMLButtonElement
-    this.toolbarLineWeightButton = document.getElementById(
-      'toolbarLineWeightButton'
-    ) as HTMLButtonElement
-    this.toolbarExportHtmlButton = document.getElementById(
-      'toolbarExportHtmlButton'
-    ) as HTMLButtonElement
-    this.toolbarExportPdfButton = document.getElementById(
-      'toolbarExportPdfButton'
     ) as HTMLButtonElement
     this.viewerPane = document.getElementById('viewerPane') as HTMLElement
     this.emptyState = document.getElementById('emptyState') as HTMLDivElement
@@ -97,43 +50,52 @@ class CadViewerApp {
     ) as HTMLSpanElement
 
     this.setupFileHandling()
-    this.setupToolbarActions()
     this.setupPredefinedFileActions()
     this.setupMobileSidebar()
     this.updateEmptyStateVisibility()
-    this.updateToolbarButtonsState()
   }
 
-  private initialize() {
-    if (!this.isInitialized) {
-      try {
-        AcApDocManager.createInstance({
-          container: this.container,
-          busyIndicatorHost: this.viewerPane,
-          autoResize: true,
-          baseUrl: 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/',
-          commandAliases: EXAMPLE_COMMAND_ALIASES,
-          webworkerFileUrls: {
-            mtextRender: './workers/mtext-renderer-worker.js',
-            dxfParser: './workers/dxf-parser-worker.js',
-            dwgParser: './workers/libredwg-parser-worker.js'
-          },
-          htmlViewerRuntimeUrl: './viewer-runtime.iife.js'
-        })
+  private async initialize() {
+    if (this.isInitialized) return
 
-        registerLazyPlugins()
+    try {
+      applyUiTheme('dark', this.viewerPane)
 
-        AcApDocManager.instance.events.documentActivated.addEventListener(
-          args => {
-            document.title = args.doc.docTitle
-          }
-        )
+      AcApDocManager.createInstance({
+        container: this.container,
+        busyIndicatorHost: this.viewerPane,
+        autoResize: true,
+        baseUrl: 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/',
+        commandAliases: EXAMPLE_COMMAND_ALIASES,
+        webworkerFileUrls: {
+          mtextRender: './workers/mtext-renderer-worker.js',
+          dxfParser: './workers/dxf-parser-worker.js',
+          dwgParser: './workers/libredwg-parser-worker.js'
+        },
+        htmlViewerRuntimeUrl: './viewer-runtime.iife.js'
+      })
 
-        this.isInitialized = true
-      } catch (error) {
-        log.error('Failed to initialize CAD viewer:', error)
-        this.showMessage('Failed to initialize CAD viewer', 'error')
-      }
+      registerLazyPlugins()
+
+      await registerSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
+        host: this.viewerPane,
+        toolbar: {
+          placement: 'right',
+          items: 'default'
+        },
+        layerManager: { enabled: true }
+      })
+
+      AcApDocManager.instance.events.documentActivated.addEventListener(
+        args => {
+          document.title = args.doc.docTitle
+        }
+      )
+
+      this.isInitialized = true
+    } catch (error) {
+      log.error('Failed to initialize CAD viewer:', error)
+      this.showMessage('Failed to initialize CAD viewer', 'error')
     }
   }
 
@@ -149,97 +111,13 @@ class CadViewerApp {
     this.centerOpenButton.addEventListener('click', () => {
       this.fileInput.click()
     })
-
-    this.toolbarOpenButton.addEventListener('click', () => {
-      this.fileInput.click()
-    })
-  }
-
-  private setupToolbarActions() {
-    this.toolbarZoomButton.addEventListener('click', () => {
-      if (!this.hasLoadedDocument || !this.isInitialized) {
-        return
-      }
-      AcApDocManager.instance.sendStringToExecute('zoom\\nall')
-    })
-
-    this.toolbarZoomWindowButton.addEventListener('click', () => {
-      if (!this.hasLoadedDocument || !this.isInitialized) {
-        return
-      }
-      AcApDocManager.instance.sendStringToExecute('zoom\\nwindow')
-    })
-
-    this.toolbarBgButton.addEventListener('click', () => {
-      if (!this.hasLoadedDocument || !this.isInitialized) {
-        return
-      }
-      AcApDocManager.instance.sendStringToExecute('switchbg')
-    })
-
-    this.toolbarPickboxButton.addEventListener('click', () => {
-      if (!this.hasLoadedDocument || !this.isInitialized) {
-        return
-      }
-
-      const currentPickbox = AcDbSysVarManager.instance().getVar(
-        AcDbSystemVariables.PICKBOX,
-        AcApDocManager.instance.curDocument.database
-      )
-      const initialPickbox =
-        currentPickbox == null ? '10' : String(currentPickbox)
-      const valueText = window.prompt(
-        'Set pick box size (integer):',
-        initialPickbox
-      )
-      if (valueText == null) {
-        return
-      }
-
-      const pickboxValue = Number.parseInt(valueText, 10)
-      if (!Number.isFinite(pickboxValue) || pickboxValue <= 0) {
-        this.showMessage('Pickbox size must be a positive integer', 'error')
-        return
-      }
-
-      AcApDocManager.instance.sendStringToExecute(
-        `${AcDbSystemVariables.PICKBOX}\n${pickboxValue}`
-      )
-      this.showMessage(`Pickbox set to: ${pickboxValue}`, 'success')
-    })
-
-    this.toolbarLineWeightButton.addEventListener('click', () => {
-      if (!this.hasLoadedDocument || !this.isInitialized) {
-        return
-      }
-      const db = AcApDocManager.instance.curDocument.database
-      db.lwdisplay = !db.lwdisplay
-      this.updateLineWeightButtonLabel()
-    })
-
-    this.toolbarExportHtmlButton.addEventListener('click', () => {
-      if (!this.hasLoadedDocument || !this.isInitialized) {
-        return
-      }
-      AcApDocManager.instance.sendStringToExecute('chtml')
-    })
-
-    this.toolbarExportPdfButton.addEventListener('click', () => {
-      if (!this.hasLoadedDocument || !this.isInitialized) {
-        return
-      }
-      AcApDocManager.instance.sendStringToExecute('cpdf')
-    })
   }
 
   private setupPredefinedFileActions() {
     this.predefinedButtons.forEach(button => {
       button.addEventListener('click', () => {
         const url = button.dataset.fileUrl
-        if (!url) {
-          return
-        }
-        // Hide empty-state open button as soon as a predefined file is selected.
+        if (!url) return
         this.hasOpenedFile = true
         this.updateEmptyStateVisibility()
         this.predefinedButtons.forEach(item => item.classList.remove('active'))
@@ -267,10 +145,7 @@ class CadViewerApp {
       }
 
       const target = event.target
-      if (!(target instanceof Node)) {
-        return
-      }
-
+      if (!(target instanceof Node)) return
       if (!this.fileSidebar.contains(target)) {
         this.setFileSidebarExpanded(false)
       }
@@ -297,7 +172,7 @@ class CadViewerApp {
   }
 
   private async loadLocalFile(file: File) {
-    this.initialize()
+    await this.initialize()
 
     const fileName = file.name.toLowerCase()
     if (!fileName.endsWith('.dxf') && !fileName.endsWith('.dwg')) {
@@ -312,7 +187,6 @@ class CadViewerApp {
       const options: AcApOpenDatabaseOptions = {
         minimumChunkSize: 1000,
         mode: AcEdOpenMode.Write,
-        // Override line weight display setting to false so that line weights are not displayed by default
         sysVars: {
           lwdisplay: false
         }
@@ -339,7 +213,7 @@ class CadViewerApp {
   }
 
   private async loadPredefinedFile(url: string) {
-    this.initialize()
+    await this.initialize()
     this.clearMessages()
 
     try {
@@ -368,35 +242,11 @@ class CadViewerApp {
 
   private onFileOpened() {
     this.hasOpenedFile = true
-    this.hasLoadedDocument = true
     this.updateEmptyStateVisibility()
-    this.updateToolbarButtonsState()
   }
 
   private updateEmptyStateVisibility() {
     this.emptyState.classList.toggle('hidden', this.hasOpenedFile)
-  }
-
-  private updateToolbarButtonsState() {
-    this.toolbarZoomButton.disabled = !this.hasLoadedDocument
-    this.toolbarZoomWindowButton.disabled = !this.hasLoadedDocument
-    this.toolbarBgButton.disabled = !this.hasLoadedDocument
-    this.toolbarPickboxButton.disabled = !this.hasLoadedDocument
-    this.toolbarLineWeightButton.disabled = !this.hasLoadedDocument
-    this.toolbarExportHtmlButton.disabled = !this.hasLoadedDocument
-    this.toolbarExportPdfButton.disabled = !this.hasLoadedDocument
-    this.updateLineWeightButtonLabel()
-  }
-
-  private updateLineWeightButtonLabel() {
-    const showLineWeight =
-      this.hasLoadedDocument && this.isInitialized
-        ? AcApDocManager.instance.curDocument.database.lwdisplay
-        : false
-
-    this.toolbarLineWeightButton.textContent = showLineWeight
-      ? 'LineWeight: On'
-      : 'LineWeight: Off'
   }
 
   private getFileNameFromUrl(url: string) {
@@ -453,9 +303,7 @@ class CadViewerApp {
     setTimeout(() => {
       popup.style.opacity = '0'
       setTimeout(() => {
-        if (popup.parentNode) {
-          popup.parentNode.removeChild(popup)
-        }
+        popup.remove()
       }, 200)
     }, 1200)
   }

--- a/packages/cad-svg-plugin/src/AcApSvgPlugin.ts
+++ b/packages/cad-svg-plugin/src/AcApSvgPlugin.ts
@@ -4,6 +4,7 @@ import {
   AcEdCommandStack
 } from '@mlightcad/cad-simple-viewer'
 
+import packageJson from '../package.json'
 import { AcApConvertToSvgCmd } from './AcApConvertToSvgCmd'
 
 /**
@@ -16,7 +17,7 @@ export class AcApSvgPlugin implements AcApPlugin {
   /** @inheritdoc */
   name = 'SvgPlugin'
   /** @inheritdoc */
-  version = '1.0.0'
+  version = packageJson.version
   /** @inheritdoc */
   description = 'SVG export (csvg) command'
 

--- a/packages/cad-svg-plugin/vite.config.ts
+++ b/packages/cad-svg-plugin/vite.config.ts
@@ -2,8 +2,8 @@ import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
 import {
-  createPluginEntryFileName,
-  createPluginLibRollupOutput
+  createLibEntryFileName,
+  createLibRollupOutput
 } from '../vite-config/pluginRollupOutput'
 
 const packageName = '@mlightcad/cad-svg-plugin'
@@ -20,12 +20,12 @@ export default defineConfig({
       },
       name: pluginId,
       fileName: (format, entryName) =>
-        createPluginEntryFileName(pluginId, format, entryName)
+        createLibEntryFileName(pluginId, format, entryName)
     },
     minify: true,
     rollupOptions: {
       external: [packageName],
-      output: createPluginLibRollupOutput(pluginId)
+      output: createLibRollupOutput(pluginId)
     }
   },
   plugins: [peerDepsExternal() as PluginOption]

--- a/packages/vite-config/pluginRollupOutput.ts
+++ b/packages/vite-config/pluginRollupOutput.ts
@@ -4,7 +4,8 @@ import type { ManualChunksOption, OutputOptions } from 'rollup'
 export const PLUGIN_PACKAGE_IDS = [
   'cad-pdf-plugin',
   'cad-html-plugin',
-  'cad-svg-plugin'
+  'cad-svg-plugin',
+  'cad-simple-ui-plugin'
 ] as const
 
 /** Core viewer libraries shipped from this monorepo. */
@@ -74,15 +75,9 @@ export function createLibEntryFileName(
   return format === 'es' ? `${base}.js` : `${base}.umd.cjs`
 }
 
-/** @deprecated Use {@link createLibEntryFileName}. */
-export const createPluginEntryFileName = createLibEntryFileName
-
 export function createLibChunkFileName(packageId: string): string {
   return `${packageId}-[name]-[hash].js`
 }
-
-/** @deprecated Use {@link createLibChunkFileName}. */
-export const createPluginChunkFileName = createLibChunkFileName
 
 /**
  * Merges all code for a library entry into a single `{packageId}` chunk
@@ -97,15 +92,9 @@ export function createLibManualChunks(packageId: string): ManualChunksOption {
   }
 }
 
-/** @deprecated Use {@link createLibManualChunks}. */
-export const createPluginLibManualChunks = createLibManualChunks
-
 export function createLibRollupOutput(packageId: string): OutputOptions {
   return {
     manualChunks: createLibManualChunks(packageId),
     chunkFileNames: createLibChunkFileName(packageId)
   }
 }
-
-/** @deprecated Use {@link createLibRollupOutput}. */
-export const createPluginLibRollupOutput = createLibRollupOutput

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,15 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0(jspdf@4.2.1)
 
+  packages/cad-simple-ui-plugin:
+    devDependencies:
+      '@mlightcad/cad-simple-viewer':
+        specifier: workspace:*
+        version: link:../cad-simple-viewer
+      '@mlightcad/data-model':
+        specifier: ^1.10.0
+        version: 1.10.0
+
   packages/cad-simple-viewer:
     devDependencies:
       '@mlightcad/data-model':
@@ -251,6 +260,9 @@ importers:
       '@mlightcad/cad-pdf-plugin':
         specifier: workspace:*
         version: link:../cad-pdf-plugin
+      '@mlightcad/cad-simple-ui-plugin':
+        specifier: workspace:*
+        version: link:../cad-simple-ui-plugin
       '@mlightcad/cad-simple-viewer':
         specifier: workspace:*
         version: link:../cad-simple-viewer


### PR DESCRIPTION
## Summary

- Add **`@mlightcad/cad-simple-ui-plugin`**: framework-agnostic toolbar and layer manager UI for `cad-simple-viewer` (plain DOM, no Vue/React), with configurable toolbar items, theme/locale sync, and lazy registration entry point.
- Refactor **`cad-simple-viewer-example`** to remove inline toolbar HTML/handlers and load the new plugin via `registerSimpleUiPlugin`.
- Document the **plugin system** and official plugins in root README (EN/ZH); align export plugin vite configs with shared rollup helpers and remove deprecated aliases from `pluginRollupOutput`.

## Test plan

- [ ] `pnpm build` succeeds for `cad-simple-ui-plugin` and dependent packages
- [ ] `pnpm test` passes for `cad-simple-ui-plugin` unit tests (`AcExLayerService`, `resolveToolbarItems`)
- [ ] Run `cad-simple-viewer-example` locally: open a DXF/DWG, verify toolbar (view, measure, export, theme, locale) and layer manager work
- [ ] Confirm lazy export plugins (`chtml`, `cpdf`, `csvg`) still load on demand from the toolbar export menu
- [ ] Verify theme toggle syncs with `COLORTHEME` sysvar and `--ml-ui-*` CSS tokens on the viewer host
