### PR TITLE
feat: improve current layer indicator in layer manager UI

### DIFF
--- a/packages/cad-simple-ui-plugin/src/i18n/en.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/en.ts
@@ -41,6 +41,7 @@ export const en: Record<string, string> = {
   'layerManager.name': 'Name',
   'layerManager.on': 'On',
   'layerManager.color': 'Color',
+  'layerManager.currentLayer': 'Current layer',
   'layerManager.zoomToLayer': 'Zoomed to layer: {layer}',
   'colorPicker.title': 'Select Color',
   'colorPicker.index': 'Color Index: ',

--- a/packages/cad-simple-ui-plugin/src/i18n/zh.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/zh.ts
@@ -41,6 +41,7 @@ export const zh: Record<string, string> = {
   'layerManager.name': '名称',
   'layerManager.on': '开',
   'layerManager.color': '颜色',
+  'layerManager.currentLayer': '当前图层',
   'layerManager.zoomToLayer': '已缩放至图层：{layer}',
   'colorPicker.title': '选择颜色',
   'colorPicker.index': '颜色索引：',

--- a/packages/cad-simple-ui-plugin/src/ui/AcExLayerManager.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExLayerManager.ts
@@ -329,8 +329,18 @@ export class AcExLayerManager {
     })
 
     const nameCell = document.createElement('td')
-    nameCell.textContent =
-      layer.name === currentLayer ? `${layer.name} *` : layer.name
+    const nameEl = document.createElement('span')
+    nameEl.className = 'ml-ex-ui-layer-name'
+    nameEl.textContent = layer.name
+    if (layer.name === currentLayer) {
+      const marker = document.createElement('span')
+      marker.className = 'ml-ex-ui-layer-current-marker'
+      marker.textContent = '*'
+      marker.title = this.i18n.t('layerManager.currentLayer')
+      marker.setAttribute('aria-hidden', 'true')
+      nameEl.appendChild(marker)
+    }
+    nameCell.appendChild(nameEl)
 
     const onCell = document.createElement('td')
     onCell.className = 'center'

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -275,6 +275,17 @@ export function ensureUiStyles() {
       background: var(--ml-ui-border, rgba(0, 0, 0, 0.06));
     }
 
+    .ml-ex-ui-layer-name {
+      display: inline-flex;
+      align-items: center;
+      gap: 2px;
+    }
+
+    .ml-ex-ui-layer-current-marker {
+      color: var(--ml-ui-accent, #409eff);
+      font-weight: 600;
+    }
+
     .ml-ex-ui-layer-color {
       display: inline-block;
       width: 20px;

--- a/packages/cad-viewer/src/component/palette/MlLayerList.vue
+++ b/packages/cad-viewer/src/component/palette/MlLayerList.vue
@@ -2,6 +2,7 @@
   <el-table
     :data="layers"
     class="ml-layer-list"
+    :row-class-name="getRowClassName"
     @row-dblclick="handleRowDbClick"
   >
     <el-table-column
@@ -10,7 +11,21 @@
       min-width="120"
       sortable
       show-overflow-tooltip
-    />
+    >
+      <template #default="scope">
+        <span class="ml-layer-list-name">
+          {{ scope.row.name }}
+          <span
+            v-if="scope.row.name === currentLayerName"
+            class="ml-layer-list-current-marker"
+            :title="t('main.toolPalette.layerManager.layerList.currentLayer')"
+            aria-hidden="true"
+          >
+            *
+          </span>
+        </span>
+      </template>
+    </el-table-column>
     <el-table-column
       property="isOn"
       :label="t('main.toolPalette.layerManager.layerList.on')"
@@ -97,7 +112,10 @@ const props = defineProps<Props>()
  * layers: reactive array of LayerInfo retrieved from editor.
  * This composable also updates automatically when CAD document changes.
  */
-const { layers, setLayerOn, setLayerColor } = useLayers(props.editor)
+const { layers, currentLayerName, setLayerOn, setLayerColor } = useLayers(props.editor)
+
+const getRowClassName = ({ row }: { row: LayerInfo }) =>
+  row.name === currentLayerName.value ? 'ml-layer-list-row--current' : ''
 
 /**
  * ===== Master Layer Visibility Toggle =====
@@ -242,5 +260,20 @@ const handleColorDialogCancel = () => {
 .ml-layer-list-color {
   width: 20px;
   height: 20px;
+}
+
+.ml-layer-list-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.ml-layer-list-current-marker {
+  color: var(--el-color-primary);
+  font-weight: 600;
+}
+
+.ml-layer-list .ml-layer-list-row--current > td.el-table__cell {
+  font-weight: 600;
 }
 </style>

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -547,6 +547,7 @@ export default {
         name: 'Name',
         on: 'On',
         color: 'Color',
+        currentLayer: 'Current layer',
         zoomToLayer: 'Zoomed to the clicked layer "{layer}"'
       }
     }

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -511,6 +511,7 @@ export default {
         name: '名称',
         on: '可见',
         color: '颜色',
+        currentLayer: '当前图层',
         zoomToLayer: '已缩放到所点击的图层"{layer}"'
       }
     }


### PR DESCRIPTION
## Summary
- Replace inline `layerName *` suffix with a styled asterisk marker and tooltip in both cad-viewer and cad-simple-ui-plugin layer managers
- Highlight the current layer row with bold text in MlLayerList
- Add i18n strings for the current-layer tooltip (en/zh)

## Test plan
- [ ] Open layer manager in cad-viewer example and verify current layer shows blue asterisk with tooltip
- [ ] Verify current layer row is bold in the layer list
- [ ] Switch current layer and confirm marker updates
- [ ] Open layer manager in cad-simple-viewer example and verify consistent marker styling