### PR TITLE
fix: sync layer appearance to batched drawables and text on style changes

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcTrView2dLayerSync.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrView2dLayerSync.spec.ts
@@ -1,0 +1,60 @@
+import * as THREE from 'three'
+
+/**
+ * Regression guard for {@link AcTrView2d.applyLayerMaterialUpdates}: remaps must
+ * fan out to each layout once, not once per layout per layout.
+ */
+describe('layer material remap fan-out', () => {
+  it('updates each layout scene layer once when materials are remapped', () => {
+    const oldMaterial = new THREE.LineBasicMaterial({ color: 0xffffff })
+    const newMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
+
+    const materials: Record<number, THREE.Material> = {
+      [oldMaterial.id]: newMaterial
+    }
+
+    const wallLayerA = { updateMaterial: jest.fn() }
+    const wallLayerB = { updateMaterial: jest.fn() }
+    const layouts = [
+      {
+        getLayer: (name: string) => (name === 'WALL' ? wallLayerA : undefined)
+      },
+      {
+        getLayer: (name: string) => (name === 'WALL' ? wallLayerB : undefined)
+      }
+    ]
+
+    const layerName = 'WALL'
+    const hasRemappedLayerMaterials = Object.entries(materials).some(
+      ([oldId, material]) => material.id !== Number(oldId)
+    )
+    expect(hasRemappedLayerMaterials).toBe(true)
+
+    layouts.forEach(layout => {
+      const sceneLayer = layout.getLayer(layerName)
+      if (!sceneLayer) {
+        return
+      }
+
+      for (const id in materials) {
+        const oldId = Number(id)
+        const material = materials[id]
+        if (material.id === oldId) {
+          continue
+        }
+        sceneLayer.updateMaterial(oldId, material)
+      }
+    })
+
+    expect(wallLayerA.updateMaterial).toHaveBeenCalledTimes(1)
+    expect(wallLayerA.updateMaterial).toHaveBeenCalledWith(
+      oldMaterial.id,
+      newMaterial
+    )
+    expect(wallLayerB.updateMaterial).toHaveBeenCalledTimes(1)
+    expect(wallLayerB.updateMaterial).toHaveBeenCalledWith(
+      oldMaterial.id,
+      newMaterial
+    )
+  })
+})

--- a/packages/cad-simple-viewer/src/view/AcTrLayer.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayer.ts
@@ -1,9 +1,10 @@
-import { AcDbObjectId } from '@mlightcad/data-model'
+import { AcDbObjectId, AcGiSubEntityTraits } from '@mlightcad/data-model'
 import {
   AcTrBatchedGroup,
   AcTrBatchedGroupStats,
   AcTrEntity,
-  AcTrPreviewSubsetOptions
+  AcTrPreviewSubsetOptions,
+  AcTrStyleManager
 } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 
@@ -193,6 +194,38 @@ export class AcTrLayer {
    */
   updateMaterial(oldId: number, material: THREE.Material) {
     this._group.updateMaterial(oldId, material)
+  }
+
+  /** Rebinds batched drawables whose materials follow live layer-table style. */
+  rebindMaterialsForLayer(
+    layerName: string,
+    layerTraits: Partial<AcGiSubEntityTraits>,
+    getLayerBoundMaterial: (
+      material: THREE.Material,
+      layerName: string,
+      layerTraits?: Partial<AcGiSubEntityTraits>
+    ) => THREE.Material | undefined,
+    styleManager?: AcTrStyleManager
+  ) {
+    this._group.rebindMaterialsForLayer(
+      layerName,
+      layerTraits,
+      getLayerBoundMaterial,
+      styleManager
+    )
+  }
+
+  /** Rematerializes MTEXT/TEXT drawables stored as unbatched glyph subtrees. */
+  rematerializeLayerTextDrawables(
+    layerName: string,
+    styleManager: AcTrStyleManager,
+    layerTraits?: Partial<AcGiSubEntityTraits>
+  ) {
+    this._group.rematerializeLayerTextDrawables(
+      layerName,
+      styleManager,
+      layerTraits
+    )
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -29,6 +29,7 @@ import {
   AcTrRenderer,
   AcTrViewportView,
   getMaterialMetadata,
+  getSceneDrawableUserData,
   hasByLayerBinding,
   setMaterialMetadata
 } from '@mlightcad/three-renderer'
@@ -1140,7 +1141,7 @@ export class AcTrView2d extends AcEdBaseView {
     layerName: string,
     materials: Record<number, THREE.Material>
   ) {
-    if (Object.keys(materials).length === 0) {
+    if (!this.hasRemappedLayerMaterials(materials)) {
       return
     }
 
@@ -1149,40 +1150,157 @@ export class AcTrView2d extends AcEdBaseView {
       if (!sceneLayer) return
 
       for (const id in materials) {
-        sceneLayer.updateMaterial(Number(id), materials[id])
+        const oldId = Number(id)
+        const material = materials[id]
+        if (material.id === oldId) {
+          continue
+        }
+        sceneLayer.updateMaterial(oldId, material)
       }
     })
   }
 
+  /** True when at least one cached material was replaced with a new instance. */
+  private hasRemappedLayerMaterials(
+    materials: Record<number, THREE.Material>
+  ): boolean {
+    return Object.entries(materials).some(
+      ([oldId, material]) => material.id !== Number(oldId)
+    )
+  }
+
   /**
-   * Builds layer-style traits from the live layer record for material refresh.
+   * Refreshes cached layer materials from the live layer-table record and
+   * propagates the result to batched drawables and text hierarchies.
+   *
+   * ByLayer colour keys stay symbolic, so a colour-only layer edit usually
+   * repaints cache entries in place. Remap/patch paths run only when a material
+   * id actually changes; clone/unbatched text paths still rebind afterward.
    */
-  private buildLayerStyleTraits(
-    layer: AcDbLayerTableRecord,
-    changes: Partial<AcDbLayerTableRecordAttrs>
-  ): Partial<AcGiSubEntityTraits> | undefined {
-    if (!this.layerStyleMayHaveChanged(changes)) {
-      return undefined
+  private syncLayerAppearanceFromLiveRecord(layer: AcDbLayerTableRecord) {
+    const layerTraits = this.getEffectiveLayerTraits(layer.name)
+    if (!layerTraits) {
+      return
     }
 
-    const traits: Partial<AcGiSubEntityTraits> = {
-      layer: layer.name
-    }
+    const materials = this._renderer.updateLayerMaterial(layer.name, layerTraits)
+    const needsIdPatch = this.hasRemappedLayerMaterials(materials)
 
-    if (changes.color != null) {
-      traits.color = layer.color.clone()
-    }
-    if (changes.linetype != null) {
-      traits.lineType = layer.lineStyle
-    }
-    if (changes.lineWeight !== undefined) {
-      traits.lineWeight = layer.lineWeight
-    }
-    if (changes.transparency != null) {
-      traits.transparency = layer.transparency
-    }
+    this.applyLayerMaterialUpdates(layer.name, materials)
 
-    return traits
+    this._scene.layouts.forEach(layout => {
+      const sceneLayer = layout.getLayer(layer.name)
+      if (!sceneLayer) {
+        return
+      }
+
+      this.syncLayerSceneDrawables(
+        sceneLayer,
+        layer.name,
+        layerTraits,
+        materials,
+        needsIdPatch
+      )
+      sceneLayer.rebindMaterialsForLayer(
+        layer.name,
+        layerTraits,
+        (material, boundLayerName, boundLayerTraits) =>
+          this._renderer.getLayerBoundMaterial(
+            material,
+            boundLayerName,
+            boundLayerTraits
+          ),
+        this._renderer.styleManager
+      )
+      sceneLayer.rematerializeLayerTextDrawables(
+        layer.name,
+        this._renderer.styleManager,
+        layerTraits
+      )
+    })
+  }
+
+  /**
+   * Patches remapped materials, rebinds layer-bound drawables, and refreshes
+   * text entity wrappers in one scene traversal per layout.
+   */
+  private syncLayerSceneDrawables(
+    sceneLayer: AcTrLayer,
+    layerName: string,
+    layerTraits: Partial<AcGiSubEntityTraits>,
+    materials: Record<number, THREE.Material>,
+    needsIdPatch: boolean
+  ) {
+    sceneLayer.internalObject.traverse(object => {
+      const refresh = (
+        object as {
+          refreshTextMaterials?: (
+            layerTraits?: Partial<AcGiSubEntityTraits>
+          ) => void
+        }
+      ).refreshTextMaterials
+      if (typeof refresh === 'function') {
+        refresh.call(object, layerTraits)
+      }
+
+      if (!('material' in object)) {
+        return
+      }
+
+      const drawable = object as THREE.Mesh | THREE.Line | THREE.LineSegments
+      let material = drawable.material as THREE.Material
+
+      if (needsIdPatch) {
+        const remapped =
+          materials[material.id] ??
+          (getSceneDrawableUserData(object).styleMaterialId != null
+            ? materials[getSceneDrawableUserData(object).styleMaterialId!]
+            : undefined)
+        if (remapped && remapped !== material) {
+          drawable.material = remapped
+          getSceneDrawableUserData(object).styleMaterialId = remapped.id
+          material = remapped
+        }
+      }
+
+      if (
+        !this.shouldRebindLayerDrawableMaterial(material, layerName, object)
+      ) {
+        return
+      }
+
+      const rebound = this._renderer.getLayerBoundMaterial(
+        material,
+        layerName,
+        layerTraits
+      )
+      if (!rebound || rebound === material) {
+        return
+      }
+
+      drawable.material = rebound
+      getSceneDrawableUserData(object).styleMaterialId = rebound.id
+    })
+  }
+
+  private shouldRebindLayerDrawableMaterial(
+    material: THREE.Material,
+    layerName: string,
+    object: THREE.Object3D
+  ): boolean {
+    const metadata = getMaterialMetadata(material)
+    const objectLayerName = object.userData.layerName as string | undefined
+
+    if (metadata.layer !== layerName && objectLayerName !== layerName) {
+      return false
+    }
+    if (metadata.isByLayerColor === true) {
+      return true
+    }
+    if (metadata.isForeground === true) {
+      return false
+    }
+    return hasByLayerBinding(metadata)
   }
 
   /**
@@ -1190,16 +1308,7 @@ export class AcTrView2d extends AcEdBaseView {
    */
   addLayer(layer: AcDbLayerTableRecord) {
     this._scene.addLayer(this.toLayerInfo(layer))
-
-    const traits: Partial<AcGiSubEntityTraits> = {
-      layer: layer.name,
-      color: layer.color.clone(),
-      lineType: layer.lineStyle,
-      lineWeight: layer.lineWeight,
-      transparency: layer.transparency
-    }
-    const materials = this._renderer.updateLayerMaterial(layer.name, traits)
-    this.applyLayerMaterialUpdates(layer.name, materials)
+    this.syncLayerAppearanceFromLiveRecord(layer)
     this._isDirty = true
   }
 
@@ -1212,10 +1321,8 @@ export class AcTrView2d extends AcEdBaseView {
   ) {
     this._scene.updateLayer(this.toLayerInfo(layer))
 
-    const traits = this.buildLayerStyleTraits(layer, changes)
-    if (traits) {
-      const materials = this._renderer.updateLayerMaterial(layer.name, traits)
-      this.applyLayerMaterialUpdates(layer.name, materials)
+    if (this.layerStyleMayHaveChanged(changes)) {
+      this.syncLayerAppearanceFromLiveRecord(layer)
     }
 
     if (
@@ -2197,12 +2304,20 @@ export class AcTrView2d extends AcEdBaseView {
    * Layer remapping can replace mesh materials; text must keep entity-trait
    * colours (especially ACI-7 foreground on paper layouts).
    */
-  private refreshTextMaterialsInObjectTree(root: THREE.Object3D) {
+  private refreshTextMaterialsInObjectTree(
+    root: THREE.Object3D,
+    layerTraits?: Partial<AcGiSubEntityTraits>
+  ) {
     root.traverse(child => {
-      const refresh = (child as { refreshTextMaterials?: () => void })
-        .refreshTextMaterials
+      const refresh = (
+        child as {
+          refreshTextMaterials?: (
+            layerTraits?: Partial<AcGiSubEntityTraits>
+          ) => void
+        }
+      ).refreshTextMaterials
       if (typeof refresh === 'function') {
-        refresh.call(child)
+        refresh.call(child, layerTraits)
       }
     })
   }

--- a/packages/three-renderer/__tests__/AcTrBatchedGroupLayerText.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupLayerText.spec.ts
@@ -1,0 +1,135 @@
+import { AcCmColor } from '@mlightcad/data-model'
+import * as THREE from 'three'
+
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import { AcTrEntity } from '../src/object/AcTrEntity'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { AcTrStyleManager } from '../src/style/AcTrStyleManager'
+import {
+  AcTrMTextColorUtil,
+  AcTrSubEntityTraitsUtil
+} from '../src/util'
+import { getSceneDrawableUserData } from '../src/util/AcTrObjectUserData'
+
+function createEntity(
+  objectId: string,
+  ...drawables: THREE.Object3D[]
+): AcTrEntity {
+  const entity = new AcTrEntity(new AcTrRenderContext())
+  entity.objectId = objectId
+  entity.visible = true
+  for (const drawable of drawables) {
+    entity.add(drawable)
+  }
+  return entity
+}
+
+describe('AcTrBatchedGroup layer text rematerialization', () => {
+  it('rematerializeLayerTextDrawables uses stored explicit entity traits', () => {
+    const styleManager = new AcTrStyleManager()
+    const group = new AcTrBatchedGroup()
+
+    const explicitColor = new AcCmColor()
+    explicitColor.setRGB(255, 0, 0)
+    const traits = AcTrMTextColorUtil.snapshotEntityTraits({
+      ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
+      color: explicitColor,
+      layer: 'TXT'
+    })
+
+    const placementRoot = new THREE.Group()
+    AcTrMTextColorUtil.storeTextEntityTraitsOnDrawable(placementRoot, traits)
+    getSceneDrawableUserData(placementRoot).noBatch = true
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(1, 1),
+      new THREE.MeshBasicMaterial({ color: 0xff0000 })
+    )
+    placementRoot.add(mesh)
+
+    group.addEntity(createEntity('text-1', placementRoot))
+
+    let targetMesh: THREE.Mesh | undefined
+    group.traverse(child => {
+      if (targetMesh || !(child instanceof THREE.Mesh)) {
+        return
+      }
+      if (child.geometry instanceof THREE.PlaneGeometry) {
+        targetMesh = child
+      }
+    })
+    expect(targetMesh).toBeDefined()
+
+    const yellow = new AcCmColor()
+    yellow.setRGB(255, 255, 0)
+    styleManager.updateLayerMaterial('TXT', {
+      layer: 'TXT',
+      color: yellow
+    })
+
+    group.rematerializeLayerTextDrawables('TXT', styleManager, {
+      layer: 'TXT',
+      color: yellow
+    })
+
+    const material = targetMesh!.material as THREE.MeshBasicMaterial
+    expect(material.color.getHex()).toBe(0xff0000)
+    expect(material.color.getHex()).not.toBe(0xffff00)
+  })
+
+  it('rematerializeLayerTextDrawables refreshes ByLayer text from stored traits', () => {
+    const styleManager = new AcTrStyleManager()
+    const group = new AcTrBatchedGroup()
+
+    const byLayerColor = new AcCmColor()
+    byLayerColor.setByLayer()
+    const traits = AcTrMTextColorUtil.snapshotEntityTraits({
+      ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
+      color: byLayerColor,
+      layer: 'TXT'
+    })
+
+    const placementRoot = new THREE.Group()
+    AcTrMTextColorUtil.storeTextEntityTraitsOnDrawable(placementRoot, traits)
+    getSceneDrawableUserData(placementRoot).noBatch = true
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(1, 1),
+      new THREE.MeshBasicMaterial({ color: 0xffffff })
+    )
+    placementRoot.add(mesh)
+
+    group.addEntity(createEntity('text-2', placementRoot))
+
+    const byLayerEntityTraits = {
+      ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
+      color: byLayerColor.clone(),
+      layer: 'TXT'
+    }
+    styleManager.getMTextFillMaterial(byLayerEntityTraits)
+
+    let targetMesh: THREE.Mesh | undefined
+    group.traverse(child => {
+      if (targetMesh || !(child instanceof THREE.Mesh)) {
+        return
+      }
+      if (child.geometry instanceof THREE.PlaneGeometry) {
+        targetMesh = child
+      }
+    })
+    expect(targetMesh).toBeDefined()
+
+    const yellow = new AcCmColor()
+    yellow.setRGB(255, 255, 0)
+    styleManager.updateLayerMaterial('TXT', {
+      layer: 'TXT',
+      color: yellow
+    })
+
+    group.rematerializeLayerTextDrawables('TXT', styleManager, {
+      layer: 'TXT',
+      color: yellow
+    })
+
+    const material = targetMesh!.material as THREE.MeshBasicMaterial
+    expect(material.color.getHex()).toBe(0xffff00)
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrMTextColorUtil.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMTextColorUtil.spec.ts
@@ -160,6 +160,92 @@ describe('AcTrMTextColorUtil', () => {
     expect(material.userData.layer).toBe('CARTOUCHE')
   })
 
+  it('rematerializes ByLayer text when layer colour changes and material rgb is stale', () => {
+    const styleManager = new AcTrStyleManager()
+    styleManager.currentBackgroundColor = ACGI_PAPER_SPACE_BACKGROUND
+
+    const color = new AcCmColor()
+    color.setByLayer()
+    const entityTraits = {
+      ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
+      color,
+      layer: 'txt'
+    }
+    const traits = AcTrMTextColorUtil.snapshotEntityTraits(entityTraits)
+
+    styleManager.getMTextFillMaterial(entityTraits)
+    const yellow = new AcCmColor()
+    yellow.setRGB(255, 255, 0)
+    styleManager.updateLayerMaterial('txt', {
+      layer: 'txt',
+      color: yellow
+    })
+
+    const staleMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(staleMaterial, {
+      layer: 'txt',
+      materialKey: 'stale-by-layer',
+      isForeground: false,
+      isByLayerColor: true,
+      isByLayerLineType: false,
+      isByLayerLineWeight: false,
+      isByLayerTransparency: false
+    })
+
+    const root = new THREE.Group()
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), staleMaterial)
+    root.add(mesh)
+
+    AcTrMTextColorUtil.rematerializeTextHierarchy(root, traits, styleManager)
+
+    const material = mesh.material as THREE.MeshBasicMaterial
+    expect(material).not.toBe(staleMaterial)
+    expect(material.color.getHex()).toBe(0xffff00)
+    expect(material.userData.layer).toBe('txt')
+  })
+
+  it('rematerializes ByLayer text when metadata lost the ByLayer flag but traits are ByLayer', () => {
+    const styleManager = new AcTrStyleManager()
+    styleManager.currentBackgroundColor = ACGI_PAPER_SPACE_BACKGROUND
+
+    const color = new AcCmColor()
+    color.setByLayer()
+    const entityTraits = {
+      ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
+      color,
+      layer: 'txt'
+    }
+    const traits = AcTrMTextColorUtil.snapshotEntityTraits(entityTraits)
+
+    styleManager.getMTextFillMaterial(entityTraits)
+    const yellow = new AcCmColor()
+    yellow.setRGB(255, 255, 0)
+    styleManager.updateLayerMaterial('txt', {
+      layer: 'txt',
+      color: yellow
+    })
+
+    const staleMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(staleMaterial, {
+      layer: 'txt',
+      materialKey: 'stale-inferred-by-layer',
+      isForeground: false,
+      isByLayerLineType: false,
+      isByLayerLineWeight: false,
+      isByLayerTransparency: false
+    })
+
+    const root = new THREE.Group()
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), staleMaterial)
+    root.add(mesh)
+
+    AcTrMTextColorUtil.rematerializeTextHierarchy(root, traits, styleManager)
+
+    const material = mesh.material as THREE.MeshBasicMaterial
+    expect(material).not.toBe(staleMaterial)
+    expect(material.color.getHex()).toBe(0xffff00)
+  })
+
   it('normalizes numeric trait colours when snapshotting entity traits', () => {
     const traits = AcTrMTextColorUtil.snapshotEntityTraits({
       ...AcTrSubEntityTraitsUtil.createDefaultTraits(),

--- a/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
@@ -1,4 +1,4 @@
-import { AcCmColor } from '@mlightcad/data-model'
+import { AcCmColor, AcGiLineWeight } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
 import {
@@ -104,6 +104,140 @@ describe('AcTrStyleManager', () => {
     }) as THREE.LineBasicMaterial
 
     expect(refreshed.color.getHex()).toBe(0xffff00)
+  })
+
+  it('does not share materials between ByLayer and explicit colours that resolve to the same rgb', () => {
+    const styleManager = new AcTrStyleManager()
+    const byLayerTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    byLayerTraits.layer = 'ROAD'
+    byLayerTraits.color.setByLayer()
+
+    const explicitTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    explicitTraits.layer = 'ROAD'
+    explicitTraits.color.setRGB(255, 0, 0)
+
+    const byLayerMaterial = styleManager.getLineMaterial(byLayerTraits)
+    const explicitMaterial = styleManager.getLineMaterial(explicitTraits)
+
+    expect(byLayerMaterial).not.toBe(explicitMaterial)
+
+    const layerColor = new AcCmColor()
+    layerColor.setRGB(255, 0, 0)
+    const updates = styleManager.updateLayerMaterial('ROAD', {
+      layer: 'ROAD',
+      color: layerColor
+    })
+
+    expect(updates[byLayerMaterial.id]).toBe(byLayerMaterial)
+    expect(
+      (byLayerMaterial as THREE.LineBasicMaterial).color.getHex()
+    ).toBe(0xff0000)
+    expect(
+      (explicitMaterial as THREE.LineBasicMaterial).color.getHex()
+    ).toBe(0xff0000)
+  })
+
+  it('does not share materials across layers for the same explicit colour', () => {
+    const styleManager = new AcTrStyleManager()
+    const roadTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    roadTraits.layer = 'ROAD'
+    roadTraits.color.setRGB(255, 0, 0)
+
+    const wallTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    wallTraits.layer = 'WALL'
+    wallTraits.color.setRGB(255, 0, 0)
+
+    const roadMaterial = styleManager.getLineMaterial(roadTraits)
+    const wallMaterial = styleManager.getLineMaterial(wallTraits)
+
+    expect(roadMaterial).not.toBe(wallMaterial)
+  })
+
+  it('refreshes ByLayer line materials in place when the layer colour changes', () => {
+    const styleManager = new AcTrStyleManager()
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.layer = 'Wall'
+    traits.color.setByLayer()
+
+    const original = styleManager.getLineMaterial(
+      traits
+    ) as THREE.LineBasicMaterial
+
+    const red = new AcCmColor()
+    red.setRGB(255, 0, 0)
+    const updates = styleManager.updateLayerMaterial('Wall', {
+      layer: 'Wall',
+      color: red
+    })
+    const refreshed = updates[original.id] as THREE.LineBasicMaterial
+
+    expect(refreshed).toBe(original)
+    expect(refreshed.color.getHex()).toBe(0xff0000)
+
+    const green = new AcCmColor()
+    green.setRGB(0, 255, 0)
+    const secondUpdates = styleManager.updateLayerMaterial('Wall', {
+      layer: 'Wall',
+      color: green
+    })
+
+    expect(secondUpdates[original.id]).toBe(original)
+    expect(refreshed.color.getHex()).toBe(0x00ff00)
+  })
+
+  it('updates layer materials when traits still carry ByLayer color but metadata lost the flag', () => {
+    const styleManager = new AcTrStyleManager()
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.layer = 'ROAD'
+    traits.color.setByLayer()
+
+    const original = styleManager.getLineMaterial(
+      traits
+    ) as THREE.LineBasicMaterial
+    setMaterialMetadata(original, { isByLayerColor: false })
+
+    const green = new AcCmColor()
+    green.setRGB(0, 255, 0)
+    const updates = styleManager.updateLayerMaterial('ROAD', {
+      layer: 'ROAD',
+      color: green
+    })
+    const updated = updates[original.id] as THREE.LineBasicMaterial
+
+    expect(updated).toBeDefined()
+    expect(updated.color.getHex()).toBe(0x00ff00)
+  })
+
+  it('preserves ByLayer resolved colour when lineweight change remaps the material key', () => {
+    const styleManager = new AcTrStyleManager()
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.layer = 'Wall'
+    traits.color.setByLayer()
+
+    const original = styleManager.getLineMaterial(
+      traits
+    ) as THREE.LineBasicMaterial
+
+    const red = new AcCmColor()
+    red.setRGB(255, 0, 0)
+    const colorUpdates = styleManager.updateLayerMaterial('Wall', {
+      layer: 'Wall',
+      color: red
+    })
+    expect(
+      (colorUpdates[original.id] as THREE.LineBasicMaterial).color.getHex()
+    ).toBe(0xff0000)
+
+    const weightUpdates = styleManager.updateLayerMaterial('Wall', {
+      layer: 'Wall',
+      color: red.clone(),
+      lineWeight: AcGiLineWeight.LineWeight070
+    })
+    const remapped = weightUpdates[original.id] as THREE.LineBasicMaterial
+
+    expect(remapped).toBeDefined()
+    expect(remapped).not.toBe(original)
+    expect(remapped.color.getHex()).toBe(0xff0000)
   })
 
   it('remaps layer-0 foreground ByLayer materials to inherited INSERT layer color', () => {

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -1,3 +1,4 @@
+import { AcCmColor, AcGiSubEntityTraits } from '@mlightcad/data-model'
 import * as THREE from 'three'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
@@ -8,9 +9,17 @@ import {
 } from '../draw/AcTrBatchDrawPolicy'
 import { AcTrPointSymbolCreator } from '../geometry/AcTrPointSymbolCreator'
 import { AcTrEntity } from '../object'
-import { getMaterialMetadata } from '../style/AcTrMaterialMetadata'
+import {
+  getMaterialMetadata,
+  hasByLayerBinding
+} from '../style/AcTrMaterialMetadata'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
-import { AcTrBufferGeometryUtil, AcTrMaterialUtil } from '../util'
+import {
+  AcTrBufferGeometryUtil,
+  AcTrMaterialUtil,
+  AcTrMTextColorUtil,
+  AcTrSubEntityTraitsUtil
+} from '../util'
 import {
   type AcTrHighlightOverlayGroup,
   copyHighlightObjectFlags,
@@ -467,6 +476,226 @@ export class AcTrBatchedGroup extends THREE.Group {
         drawableUserData.styleMaterialId = material.id
       }
     })
+  }
+
+  /**
+   * Rebinds layer-bound batch materials after a layer-table style change.
+   *
+   * Batched MTEXT/TEXT glyphs and cloned unbatched drawables may not share the
+   * same material instance as the style-manager cache entry updated by
+   * {@link AcTrStyleManager.updateLayerMaterial}.
+   */
+  rebindMaterialsForLayer(
+    layerName: string,
+    layerTraits: Partial<AcGiSubEntityTraits>,
+    getLayerBoundMaterial: (
+      material: THREE.Material,
+      layerName: string,
+      layerTraits?: Partial<AcGiSubEntityTraits>
+    ) => THREE.Material | undefined,
+    styleManager?: AcTrStyleManager
+  ) {
+    const reboundByOldId = new Map<number, THREE.Material>()
+
+    for (const group of this.groups) {
+      for (const materialId of [...group.keys()]) {
+        const batches = group.get(materialId)
+        const material = batches?.[0]?.material as THREE.Material | undefined
+        if (!material || reboundByOldId.has(materialId)) {
+          continue
+        }
+        if (!this.shouldFollowLayerStyle(material, layerName)) {
+          continue
+        }
+
+        const rebound = this.resolveLayerBoundMaterial(
+          material,
+          layerName,
+          layerTraits,
+          getLayerBoundMaterial,
+          styleManager
+        )
+        if (!rebound) {
+          continue
+        }
+
+        if (rebound === material) {
+          this.refreshLayerBoundMaterialColor(material, layerTraits)
+          continue
+        }
+
+        reboundByOldId.set(materialId, rebound)
+        this.updateMaterial(materialId, rebound)
+      }
+    }
+
+    this._unbatchedObjects.traverse(object => {
+      if (!('material' in object)) {
+        return
+      }
+
+      const material = object.material as THREE.Material
+      if (!this.shouldFollowLayerStyle(material, layerName)) {
+        return
+      }
+
+      const rebound = this.resolveLayerBoundMaterial(
+        material,
+        layerName,
+        layerTraits,
+        getLayerBoundMaterial,
+        styleManager
+      )
+      if (!rebound) {
+        return
+      }
+
+      if (rebound === material) {
+        this.refreshLayerBoundMaterialColor(material, layerTraits)
+        return
+      }
+
+      object.material = rebound
+      getSceneDrawableUserData(object).styleMaterialId = rebound.id
+    })
+  }
+
+  /**
+   * Rebinds MTEXT/TEXT glyph materials under unbatched placement roots.
+   *
+   * Entity wrappers are not kept in the scene tree after batching, so layer
+   * colour updates must rematerialize the cloned glyph subtrees directly.
+   */
+  rematerializeLayerTextDrawables(
+    layerName: string,
+    styleManager: AcTrStyleManager,
+    layerTraits?: Partial<AcGiSubEntityTraits>
+  ) {
+    const fallbackTraits = AcTrMTextColorUtil.snapshotEntityTraits({
+      ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
+      color: (() => {
+        const color = new AcCmColor()
+        color.setByLayer()
+        return color
+      })(),
+      layer: layerName
+    })
+
+    for (const root of this._unbatchedObjects.children) {
+      const storedTraits = getSceneDrawableUserData(root).textEntityTraits
+      const traits =
+        storedTraits != null
+          ? AcTrMTextColorUtil.cloneEntityTraits(storedTraits)
+          : fallbackTraits
+      AcTrMTextColorUtil.rematerializeTextHierarchy(root, traits, styleManager)
+    }
+
+    if (!layerTraits?.color) {
+      return
+    }
+
+    for (const group of this.groups) {
+      for (const materialId of [...group.keys()]) {
+        const batches = group.get(materialId)
+        const material = batches?.[0]?.material as THREE.Material | undefined
+        if (!material || !this.shouldFollowLayerStyle(material, layerName)) {
+          continue
+        }
+        this.refreshLayerBoundMaterialColor(material, layerTraits)
+      }
+    }
+  }
+
+  private resolveLayerBoundMaterial(
+    material: THREE.Material,
+    layerName: string,
+    layerTraits: Partial<AcGiSubEntityTraits>,
+    getLayerBoundMaterial: (
+      material: THREE.Material,
+      layerName: string,
+      layerTraits?: Partial<AcGiSubEntityTraits>
+    ) => THREE.Material | undefined,
+    styleManager?: AcTrStyleManager
+  ): THREE.Material | undefined {
+    const rebound = getLayerBoundMaterial(material, layerName, layerTraits)
+    if (rebound) {
+      return rebound
+    }
+    if (!styleManager) {
+      return undefined
+    }
+    return this.resolveLayerBoundReplacement(material, layerName, styleManager)
+  }
+
+  private resolveLayerBoundReplacement(
+    material: THREE.Material,
+    layerName: string,
+    styleManager: AcTrStyleManager
+  ): THREE.Material | undefined {
+    if (!this.shouldFollowLayerStyle(material, layerName)) {
+      return undefined
+    }
+
+    const metadata = getMaterialMetadata(material)
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.layer = layerName
+    traits.color.setByLayer()
+    traits.drawOrder = metadata.drawOrder ?? 0
+
+    if (metadata.drawOrder === 0 && metadata.isForeground !== true) {
+      return styleManager.getMTextFillMaterial(traits)
+    }
+
+    return styleManager.getLineMaterial(traits, true)
+  }
+
+  private refreshLayerBoundMaterialColor(
+    material: THREE.Material,
+    layerTraits: Partial<AcGiSubEntityTraits>
+  ) {
+    const rgb = layerTraits.color?.RGB
+    if (typeof rgb !== 'number') {
+      return
+    }
+    const currentRgb = this.getMaterialDisplayRgb(material)
+    if (currentRgb === rgb) {
+      return
+    }
+    AcTrMaterialUtil.setMaterialColor(material, new THREE.Color(rgb))
+  }
+
+  private getMaterialDisplayRgb(material: THREE.Material): number | undefined {
+    if (
+      material instanceof THREE.MeshBasicMaterial ||
+      material instanceof THREE.LineBasicMaterial
+    ) {
+      return material.color.getHex()
+    }
+
+    const shaderMaterial = material as THREE.ShaderMaterial
+    const uniformColor = shaderMaterial.uniforms?.u_color?.value
+    if (uniformColor instanceof THREE.Color) {
+      return uniformColor.getHex()
+    }
+
+    return undefined
+  }
+
+  private shouldFollowLayerStyle(
+    material: THREE.Material,
+    layerName: string
+  ): boolean {
+    const metadata = getMaterialMetadata(material)
+    if (metadata.layer !== layerName) {
+      return false
+    }
+    if (metadata.isByLayerColor === true) {
+      return true
+    }
+    if (metadata.isForeground === true) {
+      return false
+    }
+    return hasByLayerBinding(metadata)
   }
 
   /**
@@ -1393,6 +1622,11 @@ export class AcTrBatchedGroup extends THREE.Group {
       clonedDrawable.bboxIntersectionCheck =
         sourceDrawable.bboxIntersectionCheck
       clonedDrawable.bakedWorldMatrix = source.matrixWorld.toArray()
+      if (sourceDrawable.textEntityTraits) {
+        clonedDrawable.textEntityTraits = AcTrMTextColorUtil.cloneEntityTraits(
+          sourceDrawable.textEntityTraits
+        )
+      }
     }
     cloned.updateMatrix()
     cloned.updateMatrixWorld(true)
@@ -1463,6 +1697,11 @@ export class AcTrBatchedGroup extends THREE.Group {
     const clonedDrawable = getSceneDrawableUserData(cloned)
     clonedDrawable.bboxIntersectionCheck = sourceDrawable.bboxIntersectionCheck
     clonedDrawable.bakedWorldMatrix = source.matrixWorld.toArray()
+    if (sourceDrawable.textEntityTraits) {
+      clonedDrawable.textEntityTraits = AcTrMTextColorUtil.cloneEntityTraits(
+        sourceDrawable.textEntityTraits
+      )
+    }
 
     cloned.traverse(child => {
       if (!this.hasMaterial(child)) {

--- a/packages/three-renderer/src/index.ts
+++ b/packages/three-renderer/src/index.ts
@@ -18,6 +18,7 @@ export * from './renderer'
 export * from './viewport'
 export * from './style/AcTrMaterialMetadata'
 export { AcTrLinePatternShaders } from './style/AcTrLinePatternShaders'
+export { AcTrStyleManager } from './style/AcTrStyleManager'
 export {
   createGradientHatchShaderMaterial,
   createGradientHatchShaderMaterialFromUniforms,
@@ -30,6 +31,7 @@ export {
 export * from './util/AcTrMTextColorUtil'
 export { AcTrMatrixUtil } from './util/AcTrMatrixUtil'
 export {
+  getSceneDrawableUserData,
   isHighlightCloneDrawable,
   isHighlightOverlayDescendant,
   markHighlightOverlayGroup,

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -60,7 +60,7 @@ export class AcTrMText extends AcTrEntity {
   }
 
   /** Reapplies CAD text materials from the entity traits snapshot. */
-  refreshTextMaterials(): void {
+  refreshTextMaterials(layerTraits?: Partial<AcGiSubEntityTraits>): void {
     this._colorSettings = AcTrMTextColorUtil.buildColorSettingsFromTraits(
       {
         ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
@@ -69,6 +69,12 @@ export class AcTrMText extends AcTrEntity {
       },
       this.renderContext.styleManager.currentBackgroundColor
     )
+    if (layerTraits?.color && this._entityTraits.color.isByLayer) {
+      const rgb = layerTraits.color.RGB
+      if (typeof rgb === 'number') {
+        this._colorSettings.byLayerColor = rgb
+      }
+    }
     AcTrMTextColorUtil.rematerializeTextHierarchy(
       this,
       this._entityTraits,
@@ -208,6 +214,10 @@ export class AcTrMText extends AcTrEntity {
     const renderRoot = resolveMTextRenderRoot(mtext)
     if (this.resolveDrawMode() === 'unbatch') {
       this.markDrawableUnbatched(renderRoot)
+      AcTrMTextColorUtil.storeTextEntityTraitsOnDrawable(
+        renderRoot,
+        this._entityTraits
+      )
     } else {
       this.flatten()
     }

--- a/packages/three-renderer/src/object/AcTrShape.ts
+++ b/packages/three-renderer/src/object/AcTrShape.ts
@@ -59,7 +59,7 @@ export class AcTrShape extends AcTrEntity {
   }
 
   /** Reapplies CAD text materials from the entity traits snapshot. */
-  refreshTextMaterials(): void {
+  refreshTextMaterials(layerTraits?: Partial<AcGiSubEntityTraits>): void {
     this._colorSettings = AcTrMTextColorUtil.buildColorSettingsFromTraits(
       {
         ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
@@ -68,6 +68,12 @@ export class AcTrShape extends AcTrEntity {
       },
       this.renderContext.styleManager.currentBackgroundColor
     )
+    if (layerTraits?.color && this._entityTraits.color.isByLayer) {
+      const rgb = layerTraits.color.RGB
+      if (typeof rgb === 'number') {
+        this._colorSettings.byLayerColor = rgb
+      }
+    }
     AcTrMTextColorUtil.rematerializeTextHierarchy(
       this,
       this._entityTraits,
@@ -163,6 +169,10 @@ export class AcTrShape extends AcTrEntity {
     const renderRoot = resolveMTextRenderRoot(rendered)
     if (this.resolveDrawMode() === 'unbatch') {
       this.markDrawableUnbatched(renderRoot)
+      AcTrMTextColorUtil.storeTextEntityTraitsOnDrawable(
+        renderRoot,
+        this._entityTraits
+      )
     } else {
       this.flatten()
     }

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -179,6 +179,11 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
     this._context.styleManager.currentBackgroundColor = value
   }
 
+  /** Shared style/material cache used by entity conversion and layer updates. */
+  get styleManager() {
+    return this._context.styleManager
+  }
+
   /**
    * Sets the clear color used when clearing the canvas.
    *

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -125,14 +125,15 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
    */
   protected createMaterialImpl(
     traits: AcGiSubEntityTraits,
-    options: AcTrFillMaterialOptions
+    options: AcTrFillMaterialOptions,
+    layerColorRgb?: number
   ): THREE.Material {
     const style = traits.fillType
     const side = options.side ?? 'front'
     const threeSide = side === 'back' ? THREE.BackSide : THREE.FrontSide
     const rgb = this.shouldTrackBackground(traits, options)
       ? this.options.currentBackgroundColor
-      : this.resolveTraitsRgb(traits)
+      : this.resolveMaterialRgb(traits, layerColorRgb)
 
     let material: THREE.Material
     if (style.gradient) {
@@ -328,17 +329,17 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const bgSuffix = this.shouldTrackBackground(traits, options)
       ? '_bgfill'
       : ''
-    const rgb = this.shouldTrackBackground(traits, options)
-      ? this.options.currentBackgroundColor
-      : this.resolveTraitsRgb(traits)
-    // Use color + layer + rebaseOffset + pattern info for key
+    const colorKey = this.shouldTrackBackground(traits, options)
+      ? String(this.options.currentBackgroundColor)
+      : this.buildKeyColorSegment(traits)
+    // Use colour semantics + layer + rebaseOffset + pattern info for key
     if (style.gradient) {
       const gradient = style.gradient
       const bounds = normalizeGradientBounds(options.gradientBounds)
       return [
         'gradient',
         traits.layer,
-        rgb,
+        colorKey,
         gradient.name || 'LINEAR',
         gradient.angle ?? 0,
         gradient.shift ?? 0,
@@ -357,7 +358,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
 
     const isSolid = !style.definitionLines || style.definitionLines.length === 0
     if (isSolid) {
-      return `solid_${traits.layer}_${rgb}${sideSuffix}${drawOrderSuffix}${bgSuffix}`
+      return `solid_${traits.layer}_${colorKey}${sideSuffix}${drawOrderSuffix}${bgSuffix}`
     }
 
     const patternHash = style.definitionLines
@@ -379,7 +380,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     return [
       'hatch',
       traits.layer,
-      rgb,
+      colorKey,
       style.patternAngle,
       options.rebaseOffset.x,
       options.rebaseOffset.y,

--- a/packages/three-renderer/src/style/AcTrLineMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrLineMaterialManager.ts
@@ -26,27 +26,22 @@ export interface AcTrLineMaterialOptions {
 export class AcTrLineMaterialManager extends AcTrMaterialManager<AcTrLineMaterialOptions> {
   /**
    * Builds a stable material key from traits.
-   * Key differs for shader vs basic, ByLayer vs ByEntity.
+   * Every key includes the effective layer so layer-scoped updates stay precise.
    */
   protected buildKey(
     traits: AcGiSubEntityTraits,
     options: AcTrLineMaterialOptions
   ): string {
-    const hasByLayerKeyTraits = this.hasByLayerKeyTraits(traits)
     const lineWidth = this.resolveLineWidth(traits.lineWeight)
     const mode = this.getMaterialMode(traits, options)
     const drawOrderSuffix = this.buildDrawOrderSuffix(traits)
-    const rgb = this.resolveTraitsRgb(traits)
+    const colorKey = this.buildKeyColorSegment(traits)
 
     if (mode === 'shader') {
-      return hasByLayerKeyTraits
-        ? `layer_${mode}_${traits.layer}_${traits.lineType.name}_${rgb}_${traits.lineTypeScale}_${lineWidth}${drawOrderSuffix}`
-        : `entity_${mode}_${traits.lineType.name}_${rgb}_${traits.lineTypeScale}_${lineWidth}${drawOrderSuffix}`
+      return `${traits.layer}_${mode}_${traits.lineType.name}_${colorKey}_${traits.lineTypeScale}_${lineWidth}${drawOrderSuffix}`
     }
 
-    return hasByLayerKeyTraits
-      ? `layer_${mode}_${traits.layer}_${rgb}_${lineWidth}${drawOrderSuffix}`
-      : `entity_${mode}_${rgb}_${lineWidth}${drawOrderSuffix}`
+    return `${traits.layer}_${mode}_${colorKey}_${lineWidth}${drawOrderSuffix}`
   }
 
   /** Returns true if a shader material is required. */
@@ -71,10 +66,11 @@ export class AcTrLineMaterialManager extends AcTrMaterialManager<AcTrLineMateria
 
   protected createMaterialImpl(
     traits: AcGiSubEntityTraits,
-    options: AcTrLineMaterialOptions = {}
+    options: AcTrLineMaterialOptions = {},
+    layerColorRgb?: number
   ): THREE.Material {
     let material: THREE.Material
-    const rgb = this.resolveTraitsRgb(traits)
+    const rgb = this.resolveMaterialRgb(traits, layerColorRgb)
 
     const scales = this.getLineTypeScales()
     const scale = scales.ltscale * scales.celtscale * traits.lineTypeScale

--- a/packages/three-renderer/src/style/AcTrMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrMaterialManager.ts
@@ -95,8 +95,9 @@ export abstract class AcTrMaterialManager<T> {
    * For each qualifying material:
    * 1. Rebuild merged traits (old traits + new layer-level traits)
    * 2. Compute a NEW material key
-   * 3. Dispose old material
-   * 4. Create the new material
+   * 3. When the key is unchanged (typical for ByLayer colour-only updates),
+   *    refresh the cached material colour in place and keep the same id
+   * 4. Otherwise dispose the old material, create a new one, and remap ids
    * 5. Update cache/keyToTraits
    * 6. Return mapping { oldMaterialId → newMaterial }
    */
@@ -110,11 +111,6 @@ export abstract class AcTrMaterialManager<T> {
     for (const oldKey of Object.keys(this.cache)) {
       const oldMaterial = this.cache[oldKey]
       const metadata = getMaterialMetadata(oldMaterial)
-
-      const isTarget =
-        metadata.layer === layerName && hasByLayerBinding(metadata)
-      if (!isTarget) continue
-
       const oldTraits = this.keyToTraits[oldKey]
       if (!oldTraits) continue
 
@@ -123,9 +119,25 @@ export abstract class AcTrMaterialManager<T> {
         oldMaterial
       )
 
+      const isTarget =
+        metadata.layer === layerName &&
+        (hasByLayerBinding(metadata) ||
+          hasByLayerBinding(byLayerBindings) ||
+          this.shouldInheritLayerColor(
+            oldTraits,
+            byLayerBindings,
+            oldMaterial
+          ))
+      if (!isTarget) continue
+
       // Step 1: merged traits (only mutate traits that are actually ByLayer)
       const mergedTraits = this.cloneTraits(oldTraits)
-      this.applyInheritedLayerTraits(mergedTraits, newTraits, byLayerBindings)
+      this.applyInheritedLayerTraits(
+        mergedTraits,
+        newTraits,
+        byLayerBindings,
+        oldMaterial
+      )
       if (newTraits.layer != null) {
         mergedTraits.layer = newTraits.layer
       }
@@ -135,17 +147,28 @@ export abstract class AcTrMaterialManager<T> {
 
       const oldMaterialId = oldMaterial.id
 
+      if (newKey === oldKey) {
+        if (byLayerBindings.isByLayerColor && newTraits.color) {
+          this.refreshMaterialResolvedColor(oldMaterial, newTraits)
+        }
+        this.keyToTraits[oldKey] = mergedTraits
+        idMap[oldMaterialId] = oldMaterial
+        continue
+      }
+
       // Step 3: dispose old
       oldMaterial.dispose()
       delete this.cache[oldKey]
       delete this.keyToTraits[oldKey]
 
       // Step 4: create new material
+      const layerRgb = newTraits.color?.RGB
       const newMaterial = this.createMaterial(
         newKey,
         mergedTraits,
         mergedTraits,
-        byLayerBindings
+        byLayerBindings,
+        typeof layerRgb === 'number' ? layerRgb : undefined
       )
 
       // Step 5: store merged traits
@@ -262,19 +285,34 @@ export abstract class AcTrMaterialManager<T> {
       layer: layerName
     }
     const byLayerBindings = this.resolveByLayerBindings(traits, material)
-    this.applyInheritedLayerTraits(remappedTraits, layerTraits, byLayerBindings)
+    this.applyInheritedLayerTraits(
+      remappedTraits,
+      layerTraits,
+      byLayerBindings,
+      material
+    )
     const remappedKey = this.buildKey(remappedTraits, remappedTraits)
 
     if (this.cache[remappedKey]) {
-      return this.cache[remappedKey]
+      const cached = this.cache[remappedKey]
+      if (
+        remappedTraits.color.isByLayer &&
+        layerTraits?.color &&
+        getMaterialMetadata(cached).isByLayerColor
+      ) {
+        this.refreshMaterialResolvedColor(cached, layerTraits)
+      }
+      return cached
     }
 
     this.keyToTraits[remappedKey] = remappedTraits
+    const layerRgb = layerTraits?.color?.RGB
     return this.createMaterial(
       remappedKey,
       remappedTraits,
       remappedTraits,
-      byLayerBindings
+      byLayerBindings,
+      typeof layerRgb === 'number' ? layerRgb : undefined
     )
   }
 
@@ -307,17 +345,21 @@ export abstract class AcTrMaterialManager<T> {
   private applyInheritedLayerTraits(
     traits: AcGiSubEntityTraits & T,
     layerTraits?: Partial<AcGiSubEntityTraits>,
-    byLayerBindings?: AcTrByLayerBindingFlags
+    byLayerBindings?: AcTrByLayerBindingFlags,
+    material?: THREE.Material
   ) {
     if (!layerTraits) return
 
-    const isByLayerColor = byLayerBindings?.isByLayerColor === true
     const isByLayerLineType = byLayerBindings?.isByLayerLineType === true
     const isByLayerLineWeight = byLayerBindings?.isByLayerLineWeight === true
     const isByLayerTransparency =
       byLayerBindings?.isByLayerTransparency === true
 
-    if (isByLayerColor && layerTraits.color) {
+    if (
+      this.shouldInheritLayerColor(traits, byLayerBindings, material) &&
+      layerTraits.color &&
+      !traits.color.isByLayer
+    ) {
       traits.color = layerTraits.color.clone()
     }
 
@@ -335,6 +377,34 @@ export abstract class AcTrMaterialManager<T> {
   }
 
   /**
+   * Returns whether a cached material should follow live layer colour updates.
+   */
+  protected shouldInheritLayerColor(
+    traits: AcGiSubEntityTraits,
+    byLayerBindings?: AcTrByLayerBindingFlags,
+    material?: THREE.Material
+  ): boolean {
+    const metadata = material ? getMaterialMetadata(material) : undefined
+
+    if (byLayerBindings?.isByLayerColor === true) {
+      return true
+    }
+    if (traits.color?.isByLayer === true) {
+      return true
+    }
+    if (metadata?.isByLayerColor === true) {
+      return true
+    }
+    if (metadata?.isByLayerColor === false) {
+      return !!traits.color?.isByLayer
+    }
+    if (metadata?.isForeground === true) {
+      return false
+    }
+    return this.hasByLayerKeyTraits(traits)
+  }
+
+  /**
    * Resolves ByLayer binding flags from explicit metadata first, then falls back
    * to symbolic traits when metadata is unavailable.
    */
@@ -349,7 +419,8 @@ export abstract class AcTrMaterialManager<T> {
 
     return {
       isByLayerColor:
-        metadata?.isByLayerColor ?? traits.color.isByLayer === true,
+        metadata?.isByLayerColor === true ||
+        (traits.color.isByLayer === true && metadata?.isForeground !== true),
       isByLayerLineType:
         metadata?.isByLayerLineType ?? traits.lineType.type === 'ByLayer',
       isByLayerLineWeight:
@@ -379,9 +450,10 @@ export abstract class AcTrMaterialManager<T> {
     key: string,
     traits: AcGiSubEntityTraits,
     options: T,
-    byLayerBindings?: AcTrByLayerBindingFlags
+    byLayerBindings?: AcTrByLayerBindingFlags,
+    layerColorRgb?: number
   ): THREE.Material {
-    const material = this.createMaterialImpl(traits, options)
+    const material = this.createMaterialImpl(traits, options, layerColorRgb)
     const isForeground = this.shouldTrackForeground(traits, options)
     const isBackgroundFill = this.shouldTrackBackground(traits, options)
 
@@ -487,12 +559,48 @@ export abstract class AcTrMaterialManager<T> {
     )
   }
 
+  /**
+   * Resolves the RGB written into a Three.js material.
+   *
+   * Cache keys stay symbolic (`color.toString()`), but materials still carry
+   * the current layer-table swatch when it is available.
+   */
+  protected resolveMaterialRgb(
+    traits: AcGiSubEntityTraits,
+    layerColorRgb?: number
+  ): number {
+    if (traits.color.isByLayer && typeof layerColorRgb === 'number') {
+      return layerColorRgb
+    }
+    return this.resolveTraitsRgb(traits)
+  }
+
+  /**
+   * Builds the colour portion of a material cache key from symbolic CAD colour.
+   */
+  protected buildKeyColorSegment(traits: AcGiSubEntityTraits): string {
+    return traits.color.toString()
+  }
+
+  /** Repaints one cached material from resolved layer-table colour. */
+  protected refreshMaterialResolvedColor(
+    material: THREE.Material,
+    layerTraits: Partial<AcGiSubEntityTraits>
+  ): void {
+    const rgb = layerTraits.color?.RGB
+    if (typeof rgb !== 'number') {
+      return
+    }
+    AcTrMaterialUtil.setMaterialColor(material, new THREE.Color(rgb))
+  }
+
   /** Subclass must build stable key. */
   protected abstract buildKey(traits: AcGiSubEntityTraits, options: T): string
 
   /** Subclass must create material. */
   protected abstract createMaterialImpl(
     traits: AcGiSubEntityTraits,
-    options: T
+    options: T,
+    layerColorRgb?: number
   ): THREE.Material
 }

--- a/packages/three-renderer/src/style/AcTrPointMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrPointMaterialManager.ts
@@ -23,10 +23,8 @@ export class AcTrPointMaterialManager extends AcTrMaterialManager<AcTrPointMater
   ): string {
     const size = options.size ?? 1
     const drawOrderSuffix = this.buildDrawOrderSuffix(traits)
-    const rgb = this.resolveTraitsRgb(traits)
-    return this.hasByLayerKeyTraits(traits)
-      ? `layer_${traits.layer}_${rgb}_${size}${drawOrderSuffix}`
-      : `entity_${rgb}_${size}${drawOrderSuffix}`
+    const colorKey = this.buildKeyColorSegment(traits)
+    return `${traits.layer}_${colorKey}_${size}${drawOrderSuffix}`
   }
 
   /** Returns true if color is ByLayer. */
@@ -36,10 +34,11 @@ export class AcTrPointMaterialManager extends AcTrMaterialManager<AcTrPointMater
 
   protected createMaterialImpl(
     traits: AcGiSubEntityTraits,
-    options: AcTrPointMaterialOptions = {}
+    options: AcTrPointMaterialOptions = {},
+    layerColorRgb?: number
   ): THREE.Material {
     return new THREE.PointsMaterial({
-      color: this.resolveTraitsRgb(traits),
+      color: this.resolveMaterialRgb(traits, layerColorRgb),
       size: options.size
     })
   }

--- a/packages/three-renderer/src/util/AcTrMTextColorUtil.ts
+++ b/packages/three-renderer/src/util/AcTrMTextColorUtil.ts
@@ -11,6 +11,7 @@ import * as THREE from 'three'
 import { getMaterialMetadata } from '../style/AcTrMaterialMetadata'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
 import { AcTrSubEntityTraitsUtil } from './AcTrEntityTraitsUtil'
+import { getSceneDrawableUserData } from './AcTrObjectUserData'
 
 export type AcTrMTextEntityTraits = Pick<AcGiSubEntityTraits, 'color' | 'layer'>
 
@@ -50,6 +51,25 @@ export class AcTrMTextColorUtil {
       color: this.normalizeEntityColor(traits.color),
       layer: traits.layer
     }
+  }
+
+  /** Clones a text-entity traits snapshot for storage on scene drawables. */
+  static cloneEntityTraits(
+    traits: AcTrMTextEntityTraits
+  ): AcTrMTextEntityTraits {
+    return {
+      color: traits.color.clone(),
+      layer: traits.layer
+    }
+  }
+
+  /** Stores a text traits snapshot on one drawable for later rematerialization. */
+  static storeTextEntityTraitsOnDrawable(
+    object: THREE.Object3D,
+    traits: AcTrMTextEntityTraits
+  ): void {
+    getSceneDrawableUserData(object).textEntityTraits =
+      AcTrMTextColorUtil.cloneEntityTraits(traits)
   }
 
   /**
@@ -193,6 +213,18 @@ export class AcTrMTextColorUtil {
       expectedRgb !== ACGI_PAPER_SPACE_BACKGROUND &&
       metadata.isForeground !== true &&
       (entityTraits.color.isByLayer || entityTraits.color.isByBlock)
+    ) {
+      return true
+    }
+
+    if (entityTraits.color.isByLayer && metadata.isByLayerColor === true) {
+      return true
+    }
+    if (
+      entityTraits.color.isByLayer &&
+      metadata.isByLayerColor !== false &&
+      metadata.isForeground !== true &&
+      (metadata.layer == null || metadata.layer === entityTraits.layer)
     ) {
       return true
     }

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -1,6 +1,8 @@
 import { AcGePoint3dLike } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
+import type { AcTrMTextEntityTraits } from './AcTrMTextColorUtil'
+
 /**
  * Relative-to-eye flags stored on {@link THREE.Object3D.userData}.
  *
@@ -48,6 +50,8 @@ export interface AcTrPickableObjectUserData {
  */
 export interface AcTrStyledDrawableUserData {
   styleMaterialId?: number
+  /** Entity colour/layer snapshot for unbatched MTEXT/TEXT placement roots. */
+  textEntityTraits?: AcTrMTextEntityTraits
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix layer material remapping so each layout scene layer is updated once when cached materials are replaced, avoiding duplicate fan-out.
- Propagate live layer-table style changes through ByLayer material rebind, batched drawable patching, and MTEXT/TEXT rematerialization so colour and lineweight edits repaint correctly.
- Harden material cache keys so ByLayer and explicit colours (and separate layers with the same RGB) no longer share cache entries that block in-place layer updates.

## Test plan
- [ ] Change a layer colour in the layer manager and confirm batched lines/fills/points update immediately across model and paper layouts.
- [ ] Edit a ByLayer MTEXT/TEXT entity layer colour and confirm explicit entity colours are preserved while ByLayer text follows the layer.
