### PR TITLE
refactor(three-renderer): extract shared glyph entity base for MTEXT and SHAPE

### DIFF
--- a/packages/three-renderer/__tests__/AcTrMText.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMText.spec.ts
@@ -9,6 +9,7 @@ jest.mock('../src/renderer', () => ({
 
 import type { AcTrBatchDrawPolicy } from '../src/draw/AcTrBatchDrawPolicy'
 import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
+import { AcTrGlyphEntity } from '../src/object/AcTrGlyphEntity'
 import { AcTrMText } from '../src/object/AcTrMText'
 import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
 import { AcTrStyleManager } from '../src/style/AcTrStyleManager'
@@ -24,14 +25,14 @@ type GeometryHost = THREE.Object3D & {
 }
 
 type RaycastHost = THREE.Object3D & {
-  _mtext?: Pick<MTextObject, 'raycast'>
+  _rendered?: Pick<MTextObject, 'raycast'>
   wcsBbox: THREE.Box3
 }
 
-const privateMethods = AcTrMText.prototype as unknown as {
-  attachMText(this: AcTrMText, mtext: MTextObject): void
+const privateMethods = AcTrGlyphEntity.prototype as unknown as {
+  attachRendered(this: AcTrMText, rendered: MTextObject): void
   computeGeometryBox(this: GeometryHost): THREE.Box3
-  updateSelectionBox(this: GeometryHost, mtext: MTextObject): void
+  updateSelectionBox(this: GeometryHost, rendered: MTextObject): void
   hasGeometry(object: THREE.Object3D): boolean
   raycast(
     this: RaycastHost,
@@ -188,7 +189,7 @@ describe('AcTrMText', () => {
     )
     const mtext = createSyncMTextObject(placementRoot)
 
-    privateMethods.attachMText.call(entity, mtext)
+    privateMethods.attachRendered.call(entity, mtext)
 
     expect(getSceneDrawableUserData(placementRoot).noBatch).toBe(true)
     expect(entity.children).toHaveLength(1)
@@ -207,7 +208,7 @@ describe('AcTrMText', () => {
     const placementRoot = createPlacementRoot({ x: 10, y: 20, z: 0 }, [0, 8])
     const mtext = createSyncMTextObject(placementRoot)
 
-    privateMethods.attachMText.call(entity, mtext)
+    privateMethods.attachRendered.call(entity, mtext)
 
     expect(getSceneDrawableUserData(placementRoot).noBatch).toBeUndefined()
     expect(entity.children).toHaveLength(2)
@@ -231,7 +232,7 @@ function createRaycastHost(options: {
 }): RaycastHost {
   const host = new THREE.Object3D() as RaycastHost
   host.wcsBbox = options.wcsBbox
-  host._mtext = {
+  host._rendered = {
     raycast: options.mtextRaycast
   }
   host.updateMatrixWorld(true)

--- a/packages/three-renderer/src/object/AcTrGlyphEntity.ts
+++ b/packages/three-renderer/src/object/AcTrGlyphEntity.ts
@@ -1,0 +1,349 @@
+import {
+  AcGePoint3dLike,
+  AcGiSubEntityTraits,
+  AcGiTextStyle,
+  log
+} from '@mlightcad/data-model'
+import { ColorSettings, MTextObject } from '@mlightcad/mtext-renderer'
+import * as THREE from 'three'
+
+import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
+import { AcTrMTextRenderer } from '../renderer'
+import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
+import {
+  AcTrMTextColorUtil,
+  type AcTrMTextEntityTraits,
+  AcTrSubEntityTraitsUtil
+} from '../util'
+import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
+import {
+  getSceneDrawableUserData,
+  resolveMTextRenderRoot
+} from '../util/AcTrObjectUserData'
+import { AcTrEntity } from './AcTrEntity'
+
+/** Scratch box reused by {@link AcTrGlyphEntity.raycast} during bbox fallback. */
+const _raycastBox = /*@__PURE__*/ new THREE.Box3()
+/** Scratch point reused by {@link AcTrGlyphEntity.raycast} during bbox fallback. */
+const _raycastPoint = /*@__PURE__*/ new THREE.Vector3()
+
+/**
+ * Base display object for CAD entities rendered through the shared mtext-renderer
+ * pipeline, including MTEXT and SHAPE.
+ *
+ * Subclasses supply glyph-specific renderer input and API calls. This class owns
+ * the shared integration concerns: trait/color snapshots, batch/unbatch placement,
+ * selection-box construction, raycast fallback, and invalid-geometry cleanup.
+ */
+export abstract class AcTrGlyphEntity extends AcTrEntity {
+  /** Latest rendered output returned by the mtext-renderer, when available. */
+  protected _rendered?: MTextObject
+  /** Resolved CAD text style passed to the mtext-renderer. */
+  protected _style: AcGiTextStyle
+  /** Color resolution settings derived from entity traits and background color. */
+  protected _colorSettings: ColorSettings
+  /** Snapshot of color/layer traits used for rematerialization and unbatched drawables. */
+  protected _entityTraits: AcTrMTextEntityTraits
+
+  /**
+   * Creates a glyph entity and optionally draws it immediately.
+   *
+   * @param context Active renderer context that owns style and batching policy.
+   * @param traits CAD sub-entity traits used to resolve color and layer behavior.
+   * @param style Resolved text style for the mtext-renderer.
+   * @param delay When `true`, skips the initial {@link syncDraw} call so callers can
+   *   finish setup before geometry is built.
+   */
+  protected constructor(
+    context: AcTrRenderContext,
+    traits: AcGiSubEntityTraits,
+    style: AcGiTextStyle,
+    delay: boolean = false
+  ) {
+    super(context)
+    this._style = style
+    this._entityTraits = AcTrMTextColorUtil.snapshotEntityTraits(traits)
+    this._colorSettings = AcTrMTextColorUtil.buildColorSettingsFromTraits(
+      traits,
+      context.styleManager.currentBackgroundColor
+    )
+    if (!delay) {
+      this.syncDraw()
+    }
+  }
+
+  /**
+   * Reapplies CAD text materials from the stored entity traits snapshot.
+   *
+   * Called when layer color or background changes so glyph drawables pick up the
+   * latest resolved display color without rebuilding geometry.
+   *
+   * @param layerTraits Optional layer-level trait overrides, typically the owning
+   *   layer color when the entity color is BYLAYER.
+   */
+  refreshTextMaterials(layerTraits?: Partial<AcGiSubEntityTraits>): void {
+    this._colorSettings = AcTrMTextColorUtil.buildColorSettingsFromTraits(
+      {
+        ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
+        color: this._entityTraits.color,
+        layer: this._entityTraits.layer
+      },
+      this.renderContext.styleManager.currentBackgroundColor
+    )
+    if (layerTraits?.color && this._entityTraits.color.isByLayer) {
+      const rgb = layerTraits.color.RGB
+      if (typeof rgb === 'number') {
+        this._colorSettings.byLayerColor = rgb
+      }
+    }
+    AcTrMTextColorUtil.rematerializeTextHierarchy(
+      this,
+      this._entityTraits,
+      this.renderContext.styleManager
+    )
+  }
+
+  /**
+   * Returns the insertion point used to resolve batch versus unbatch placement.
+   *
+   * @returns World-space insertion point for this glyph entity.
+   */
+  protected abstract getDrawPosition(): AcGePoint3dLike
+
+  /**
+   * Renders this entity synchronously through the shared mtext-renderer.
+   *
+   * @param renderer Initialized mtext-renderer facade.
+   * @returns Rendered glyph object tree from the mtext-renderer.
+   */
+  protected abstract renderSync(renderer: AcTrMTextRenderer): MTextObject
+
+  /**
+   * Renders this entity asynchronously through the shared mtext-renderer.
+   *
+   * @param renderer Initialized mtext-renderer facade.
+   * @returns Promise that resolves to the rendered glyph object tree.
+   */
+  protected abstract renderAsync(
+    renderer: AcTrMTextRenderer
+  ): Promise<MTextObject>
+
+  /**
+   * Builds a short human-readable label for render-failure logging.
+   *
+   * @returns Description fragment appended to the shared failure log message.
+   */
+  protected abstract describeRenderFailure(): string
+
+  /**
+   * Builds glyph geometry synchronously and attaches it to this entity.
+   *
+   * No-op when the mtext-renderer has not been initialized yet.
+   */
+  override syncDraw(): void {
+    const mtextRenderer = AcTrMTextRenderer.getInstance()
+    if (!mtextRenderer) return
+
+    try {
+      this._rendered = this.renderSync(mtextRenderer)
+      this.attachRendered(this._rendered)
+    } catch (error) {
+      log.info(
+        `Failed to render ${this.describeRenderFailure()} with the following error:\n`,
+        error
+      )
+    }
+  }
+
+  /**
+   * Builds glyph geometry asynchronously and attaches it to this entity.
+   *
+   * No-op when the mtext-renderer has not been initialized yet.
+   */
+  override async asyncDraw() {
+    const mtextRenderer = AcTrMTextRenderer.getInstance()
+    if (!mtextRenderer) return
+
+    try {
+      this._rendered = await this.renderAsync(mtextRenderer)
+      this.attachRendered(this._rendered)
+    } catch (error) {
+      log.info(
+        `Failed to render ${this.describeRenderFailure()} with the following error:\n`,
+        error
+      )
+    }
+  }
+
+  /**
+   * Gets intersections between a casted ray and this glyph entity.
+   *
+   * The mtext renderer provides a logical hit-test when its cached layout is
+   * still available. After this entity is flattened for batching, that logical
+   * hierarchy may no longer report a hit. In that case we fall back to the
+   * entity selection box, which is rebuilt from rendered child geometry in
+   * {@link updateSelectionBox}.
+   *
+   * @param raycaster Raycaster configured by the active view.
+   * @param intersects Output array populated with any detected intersections.
+   */
+  raycast(raycaster: THREE.Raycaster, intersects: THREE.Intersection[]) {
+    const previousLength = intersects.length
+
+    this._rendered?.raycast(raycaster, intersects)
+    if (intersects.length > previousLength || this.wcsBbox.isEmpty()) return
+
+    _raycastBox.copy(this.wcsBbox)
+    if (raycaster.ray.intersectBox(_raycastBox, _raycastPoint)) {
+      intersects.push({
+        distance: raycaster.ray.origin.distanceTo(_raycastPoint),
+        point: _raycastPoint.clone(),
+        object: this,
+        face: null,
+        faceIndex: undefined,
+        uv: undefined
+      })
+    }
+  }
+
+  /**
+   * Resolves whether this glyph entity should batch with other drawables.
+   *
+   * Delegates to {@link AcTrBatchDrawPolicy} using the subclass insertion point.
+   *
+   * @returns `'batch'` when the entity can share batched geometry, otherwise
+   *   `'unbatch'`.
+   */
+  override resolveDrawMode(): AcTrDrawMode {
+    return this.batchDrawPolicy.resolveDrawMode({
+      position: this.getDrawPosition()
+    })
+  }
+
+  /**
+   * Attaches rendered glyph output and prepares it for batching and selection.
+   *
+   * The mtext renderer can return a nested hierarchy of meshes and line objects.
+   * Batched entities flatten that hierarchy so each renderable leaf becomes a
+   * direct child of this entity. Unbatched entities keep the renderer root intact
+   * and store trait metadata on the drawable for per-object material updates.
+   * Every leaf is marked for bounding-box-based intersection because glyph
+   * outlines are often too thin for pleasant CAD-style point selection.
+   *
+   * @param rendered Rendered glyph object returned by the shared mtext-renderer.
+   */
+  protected attachRendered(rendered: MTextObject) {
+    this.add(rendered)
+    const renderRoot = resolveMTextRenderRoot(rendered)
+    if (this.resolveDrawMode() === 'unbatch') {
+      this.markDrawableUnbatched(renderRoot)
+      AcTrMTextColorUtil.storeTextEntityTraitsOnDrawable(
+        renderRoot,
+        this._entityTraits
+      )
+    } else {
+      this.flatten()
+    }
+    this.removeInvalidGeometryLeaves()
+    this.traverse(object => {
+      getSceneDrawableUserData(object).bboxIntersectionCheck = true
+    })
+    this.updateSelectionBox(rendered)
+  }
+
+  /**
+   * Rebuilds the entity selection box used by the scene spatial index.
+   *
+   * The box exposed by the mtext renderer describes its logical layout, including
+   * vertical space above baseline-drawn glyphs. The box computed from rendered
+   * children tracks visible geometry more closely. Use child geometry as the
+   * anchor for selection, then merge the renderer box only when it overlaps the
+   * geometry so legitimate spacing is preserved while displaced renderer boxes
+   * are ignored.
+   *
+   * @param rendered Rendered glyph object whose logical box is used as fallback.
+   */
+  protected updateSelectionBox(rendered: MTextObject) {
+    const geometryBox = this.computeGeometryBox()
+    if (geometryBox.isEmpty()) {
+      this.wcsBbox = rendered.box
+      return
+    }
+    if (!rendered.box.isEmpty() && rendered.box.intersectsBox(geometryBox)) {
+      this.wcsBbox = geometryBox.clone().union(rendered.box)
+      return
+    }
+    this.wcsBbox = geometryBox
+  }
+
+  /**
+   * Computes a bounding box from all renderable child geometry.
+   *
+   * Each child geometry owns a local bounding box. After flattening, child
+   * transforms carry placement that used to live in intermediate groups, so
+   * each child box is transformed by the child's matrix before being unioned
+   * into the result.
+   *
+   * @returns Bounding box containing all child meshes, lines, and points.
+   */
+  protected computeGeometryBox() {
+    const box = new THREE.Box3()
+    const childBox = new THREE.Box3()
+
+    this.updateMatrixWorld(true)
+    this.traverse(object => {
+      if (!this.hasGeometry(object)) return
+
+      const geometry = object.geometry
+      const boundingBox =
+        AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
+      if (boundingBox == null) return
+
+      object.updateMatrixWorld(true)
+      childBox.copy(boundingBox).applyMatrix4(object.matrixWorld)
+      box.union(childBox)
+    })
+
+    return box
+  }
+
+  /**
+   * Drops render leaves whose buffer positions contain NaN or Infinity.
+   *
+   * Degenerate glyph meshes would poison bounding-box aggregation and flood the
+   * console with THREE.js warnings during batching.
+   */
+  protected removeInvalidGeometryLeaves() {
+    const invalidObjects: THREE.Object3D[] = []
+    this.traverse(object => {
+      if (!this.hasGeometry(object)) return
+      if (AcTrBufferGeometryUtil.hasFinitePositions(object.geometry)) return
+      invalidObjects.push(object)
+    })
+
+    for (const object of invalidObjects) {
+      object.parent?.remove(object)
+      if (this.hasGeometry(object)) {
+        object.geometry.dispose()
+      }
+    }
+  }
+
+  /**
+   * Type guard for Three.js objects that expose buffer geometry.
+   *
+   * Glyph render trees may contain plain grouping nodes as well as renderable
+   * leaves. This guard keeps bounding-box collection focused on leaves that can
+   * contribute visible geometry.
+   *
+   * @param object Object in the glyph render subtree.
+   * @returns `true` when the object is a mesh, line, or point-like render leaf.
+   */
+  protected hasGeometry(
+    object: THREE.Object3D
+  ): object is THREE.Mesh | THREE.Line | THREE.Points {
+    return (
+      'geometry' in object && object.geometry instanceof THREE.BufferGeometry
+    )
+  }
+}

--- a/packages/three-renderer/src/object/AcTrGlyphEntity.ts
+++ b/packages/three-renderer/src/object/AcTrGlyphEntity.ts
@@ -46,19 +46,20 @@ export abstract class AcTrGlyphEntity extends AcTrEntity {
   protected _entityTraits: AcTrMTextEntityTraits
 
   /**
-   * Creates a glyph entity and optionally draws it immediately.
+   * Creates a glyph entity with shared trait and color state.
+   *
+   * Subclasses must assign entity-specific fields before calling {@link syncDraw}.
+   * The base constructor intentionally does not draw so subclass fields are
+   * available to {@link renderSync} and {@link describeRenderFailure}.
    *
    * @param context Active renderer context that owns style and batching policy.
    * @param traits CAD sub-entity traits used to resolve color and layer behavior.
    * @param style Resolved text style for the mtext-renderer.
-   * @param delay When `true`, skips the initial {@link syncDraw} call so callers can
-   *   finish setup before geometry is built.
    */
   protected constructor(
     context: AcTrRenderContext,
     traits: AcGiSubEntityTraits,
-    style: AcGiTextStyle,
-    delay: boolean = false
+    style: AcGiTextStyle
   ) {
     super(context)
     this._style = style
@@ -67,9 +68,6 @@ export abstract class AcTrGlyphEntity extends AcTrEntity {
       traits,
       context.styleManager.currentBackgroundColor
     )
-    if (!delay) {
-      this.syncDraw()
-    }
   }
 
   /**

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -1,44 +1,30 @@
 import {
   AcGiMTextData,
   AcGiSubEntityTraits,
-  AcGiTextStyle,
-  log
+  AcGiTextStyle
 } from '@mlightcad/data-model'
-import {
-  ColorSettings,
-  MTextData,
-  MTextObject
-} from '@mlightcad/mtext-renderer'
-import * as THREE from 'three'
+import { MTextData } from '@mlightcad/mtext-renderer'
 
-import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
 import { AcTrMTextRenderer } from '../renderer'
 import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
-import {
-  AcTrMTextColorUtil,
-  type AcTrMTextEntityTraits,
-  AcTrSubEntityTraitsUtil
-} from '../util'
-import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
-import {
-  getSceneDrawableUserData,
-  resolveMTextRenderRoot
-} from '../util/AcTrObjectUserData'
-import { AcTrEntity } from './AcTrEntity'
+import { AcTrGlyphEntity } from './AcTrGlyphEntity'
 
-// Reuse scratch objects during hover/pick hit-testing; raycast can run very
-// often while the pointer moves, so keeping these allocations out of the hot
-// path avoids needless garbage collection pressure.
-const _raycastBox = /*@__PURE__*/ new THREE.Box3()
-const _raycastPoint = /*@__PURE__*/ new THREE.Vector3()
-
-export class AcTrMText extends AcTrEntity {
-  private _mtext?: MTextObject
+/**
+ * Display object for a CAD MTEXT entity rendered through the mtext-renderer.
+ */
+export class AcTrMText extends AcTrGlyphEntity {
+  /** Source MTEXT data from the CAD database. */
   private _text: AcGiMTextData
-  private _style: AcGiTextStyle
-  private _colorSettings: ColorSettings
-  private _entityTraits: AcTrMTextEntityTraits
 
+  /**
+   * Creates an MTEXT display object.
+   *
+   * @param text MTEXT content and placement from the CAD database.
+   * @param traits CAD sub-entity traits used to resolve color and layer behavior.
+   * @param style Text style applied by the mtext-renderer.
+   * @param context Active renderer context that owns style and batching policy.
+   * @param delay When `true`, skips the initial draw so callers can finish setup first.
+   */
   constructor(
     text: AcGiMTextData,
     traits: AcGiSubEntityTraits,
@@ -46,40 +32,8 @@ export class AcTrMText extends AcTrEntity {
     context: AcTrRenderContext,
     delay: boolean = false
   ) {
-    super(context)
+    super(context, traits, { ...style }, delay)
     this._text = text
-    this._style = { ...style }
-    this._entityTraits = AcTrMTextColorUtil.snapshotEntityTraits(traits)
-    this._colorSettings = AcTrMTextColorUtil.buildColorSettingsFromTraits(
-      traits,
-      context.styleManager.currentBackgroundColor
-    )
-    if (!delay) {
-      this.syncDraw()
-    }
-  }
-
-  /** Reapplies CAD text materials from the entity traits snapshot. */
-  refreshTextMaterials(layerTraits?: Partial<AcGiSubEntityTraits>): void {
-    this._colorSettings = AcTrMTextColorUtil.buildColorSettingsFromTraits(
-      {
-        ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
-        color: this._entityTraits.color,
-        layer: this._entityTraits.layer
-      },
-      this.renderContext.styleManager.currentBackgroundColor
-    )
-    if (layerTraits?.color && this._entityTraits.color.isByLayer) {
-      const rgb = layerTraits.color.RGB
-      if (typeof rgb === 'number') {
-        this._colorSettings.byLayerColor = rgb
-      }
-    }
-    AcTrMTextColorUtil.rematerializeTextHierarchy(
-      this,
-      this._entityTraits,
-      this.renderContext.styleManager
-    )
   }
 
   /**
@@ -89,6 +43,8 @@ export class AcTrMText extends AcTrEntity {
    * often carries large DWG elevations while linework/symbols on the same
    * layer may sit at Z=0, so preserving insertion Z would depth-clip glyphs
    * even though the label's XY is inside the viewport.
+   *
+   * @returns MTEXT payload suitable for the mtext-renderer.
    */
   private toPlanViewMTextData(): MTextData {
     const source = this._text as MTextData
@@ -103,238 +59,39 @@ export class AcTrMText extends AcTrEntity {
     }
   }
 
-  override syncDraw(): void {
-    const mtextRenderer = AcTrMTextRenderer.getInstance()
-    if (!mtextRenderer) return
-
-    try {
-      const style = this._style
-      const mtextData = this.toPlanViewMTextData()
-
-      this._mtext = mtextRenderer.syncRenderMText(
-        mtextData,
-        style,
-        this._colorSettings
-      )
-      this.attachMText(this._mtext)
-    } catch (error) {
-      log.info(
-        `Failed to render mtext '${this._text.text}' with the following error:\n`,
-        error
-      )
-    }
-  }
-
-  override async asyncDraw() {
-    const mtextRenderer = AcTrMTextRenderer.getInstance()
-    if (!mtextRenderer) return
-
-    try {
-      const style = this._style
-      const mtextData = this.toPlanViewMTextData()
-
-      const mtext = await mtextRenderer.asyncRenderMText(
-        mtextData,
-        style,
-        this._colorSettings
-      )
-      this._mtext = mtext
-      this.attachMText(this._mtext)
-    } catch (error) {
-      log.info(
-        `Failed to render mtext '${this._text.text}' with the following error:\n`,
-        error
-      )
-    }
+  /**
+   * @inheritdoc
+   */
+  protected override getDrawPosition() {
+    return this._text.position
   }
 
   /**
-   * Gets intersections between a casted ray and this MTEXT entity.
-   *
-   * The mtext renderer provides a logical, per-character raycast that is useful
-   * when its cached layout is still available.  After this entity is flattened
-   * for batching, however, that logical hierarchy may no longer be able to
-   * report a hit.  In that case we fall back to the entity selection box, which
-   * is rebuilt from the actual rendered child geometry in
-   * {@link updateSelectionBox}.
-   *
-   * This two-step approach keeps precise text picking when possible while still
-   * making point selection robust for MTEXT whose renderer-provided logical box
-   * is offset from the visible glyph geometry.
-   *
-   * @param raycaster Raycaster configured by the active view.
-   * @param intersects Output array populated with any detected intersections.
+   * @inheritdoc
    */
-  raycast(raycaster: THREE.Raycaster, intersects: THREE.Intersection[]) {
-    const previousLength = intersects.length
-
-    // Prefer the mtext renderer's own character/layout hit-test.  If it reports
-    // a hit, keep that result because it is usually more precise than the
-    // entity-level fallback below.
-    this._mtext?.raycast(raycaster, intersects)
-    if (intersects.length > previousLength || this.wcsBbox.isEmpty()) return
-
-    // Fallback path: use the selection box derived from rendered geometry.  This
-    // is what protects point selection when the renderer's logical MTEXT box is
-    // shifted by attachment/alignment handling.
-    _raycastBox.copy(this.wcsBbox)
-    if (raycaster.ray.intersectBox(_raycastBox, _raycastPoint)) {
-      intersects.push({
-        distance: raycaster.ray.origin.distanceTo(_raycastPoint),
-        point: _raycastPoint.clone(),
-        object: this,
-        face: null,
-        faceIndex: undefined,
-        uv: undefined
-      })
-    }
-  }
-
-  /**
-   * Attaches a rendered MTEXT object to this entity and prepares it for viewer
-   * batching and selection.
-   *
-   * The mtext renderer can return a nested hierarchy of meshes and line objects.
-   * The CAD renderer flattens that hierarchy so each renderable leaf becomes a
-   * direct child of the entity, which keeps batching simple and preserves the
-   * visual transforms.  After flattening, every leaf is marked for
-   * bounding-box-based intersection because text glyph outlines are often too
-   * thin or fragmented for pleasant CAD-style point selection.
-   *
-   * @param mtext Rendered MTEXT object returned by the shared MTEXT renderer.
-   */
-  override resolveDrawMode(): AcTrDrawMode {
-    return this.batchDrawPolicy.resolveDrawMode({
-      position: this._text.position
-    })
-  }
-
-  private attachMText(mtext: MTextObject) {
-    this.add(mtext)
-    const renderRoot = resolveMTextRenderRoot(mtext)
-    if (this.resolveDrawMode() === 'unbatch') {
-      this.markDrawableUnbatched(renderRoot)
-      AcTrMTextColorUtil.storeTextEntityTraitsOnDrawable(
-        renderRoot,
-        this._entityTraits
-      )
-    } else {
-      this.flatten()
-    }
-    this.removeInvalidGeometryLeaves()
-    this.traverse(object => {
-      // Text picking should behave like CAD object picking: the visible glyph
-      // area should be selectable even when the pointer lands inside a hollow
-      // glyph or between tiny outline segments.
-      getSceneDrawableUserData(object).bboxIntersectionCheck = true
-    })
-    this.updateSelectionBox(mtext)
-  }
-
-  /**
-   * Rebuilds the entity selection box used by the scene spatial index.
-   *
-   * The box exposed by the mtext renderer describes its logical MTEXT layout,
-   * including per-line vertical space above baseline-drawn glyphs.  The box
-   * computed from rendered children tracks visible geometry more closely, but
-   * by itself it can trim off that leading space and make edit overlays drift
-   * when they round-trip through the MTEXT input box.
-   *
-   * Use child geometry as the anchor for selection, then merge the renderer box
-   * only when it overlaps the geometry.  This keeps legitimate line spacing while
-   * still ignoring the known bad case where an aligned renderer box is displaced
-   * away from the glyphs.
-   *
-   * @param mtext Rendered MTEXT object whose logical box is used as fallback.
-   */
-  private updateSelectionBox(mtext: MTextObject) {
-    const geometryBox = this.computeGeometryBox()
-    if (geometryBox.isEmpty()) {
-      this.wcsBbox = mtext.box
-      return
-    }
-    if (!mtext.box.isEmpty() && mtext.box.intersectsBox(geometryBox)) {
-      this.wcsBbox = geometryBox.clone().union(mtext.box)
-      return
-    }
-    this.wcsBbox = geometryBox
-  }
-
-  /**
-   * Computes a bounding box from all renderable child geometry.
-   *
-   * Each child geometry owns a local bounding box.  After MTEXT flattening,
-   * child transforms carry the placement that used to live in intermediate
-   * groups, so each child box is transformed by the child's matrix before being
-   * unioned into the result.  The returned box is the selection extent that best
-   * matches the visible MTEXT glyph/decoration geometry at attachment time.
-   *
-   * @returns Bounding box containing all child meshes, lines, and points.
-   */
-  private computeGeometryBox() {
-    const box = new THREE.Box3()
-    const childBox = new THREE.Box3()
-
-    this.updateMatrixWorld(true)
-    this.traverse(object => {
-      if (!this.hasGeometry(object)) return
-
-      const geometry = object.geometry
-      // Some renderer outputs already have bounds; compute lazily for those
-      // that do not so custom/generated geometries still contribute.
-      const boundingBox =
-        AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
-      if (boundingBox == null) return
-
-      object.updateMatrixWorld(true)
-      // Move the child's local geometry box into the entity's current coordinate
-      // frame before unioning.  This preserves translation/rotation/scale left on
-      // the child by flattening.
-      childBox.copy(boundingBox).applyMatrix4(object.matrixWorld)
-      box.union(childBox)
-    })
-
-    return box
-  }
-
-  /**
-   * Drops render leaves whose buffer positions contain NaN/Infinity.
-   *
-   * PCCAD tolerance MTEXT can occasionally emit degenerate glyph meshes; keeping
-   * them would poison bounding-box aggregation and flood the console with THREE.js
-   * warnings during batching.
-   */
-  private removeInvalidGeometryLeaves() {
-    const invalidObjects: THREE.Object3D[] = []
-    this.traverse(object => {
-      if (!this.hasGeometry(object)) return
-      if (AcTrBufferGeometryUtil.hasFinitePositions(object.geometry)) return
-      invalidObjects.push(object)
-    })
-
-    for (const object of invalidObjects) {
-      object.parent?.remove(object)
-      if (this.hasGeometry(object)) {
-        object.geometry.dispose()
-      }
-    }
-  }
-
-  /**
-   * Type guard for Three.js objects that expose buffer geometry.
-   *
-   * MTEXT render trees may contain plain grouping nodes as well as renderable
-   * leaves.  This guard keeps bounding-box collection focused on the leaves that
-   * can actually contribute visible geometry.
-   *
-   * @param object Object in the MTEXT render subtree.
-   * @returns True when the object is a mesh, line, or point-like render leaf.
-   */
-  private hasGeometry(
-    object: THREE.Object3D
-  ): object is THREE.Mesh | THREE.Line | THREE.Points {
-    return (
-      'geometry' in object && object.geometry instanceof THREE.BufferGeometry
+  protected override renderSync(renderer: AcTrMTextRenderer) {
+    return renderer.syncRenderMText(
+      this.toPlanViewMTextData(),
+      this._style,
+      this._colorSettings
     )
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override async renderAsync(renderer: AcTrMTextRenderer) {
+    return renderer.asyncRenderMText(
+      this.toPlanViewMTextData(),
+      this._style,
+      this._colorSettings
+    )
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override describeRenderFailure() {
+    return `mtext '${this._text.text}'`
   }
 }

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -32,8 +32,11 @@ export class AcTrMText extends AcTrGlyphEntity {
     context: AcTrRenderContext,
     delay: boolean = false
   ) {
-    super(context, traits, { ...style }, delay)
+    super(context, traits, { ...style })
     this._text = text
+    if (!delay) {
+      this.syncDraw()
+    }
   }
 
   /**

--- a/packages/three-renderer/src/object/AcTrShape.ts
+++ b/packages/three-renderer/src/object/AcTrShape.ts
@@ -1,43 +1,31 @@
 import {
   AcGiShapeData,
   AcGiSubEntityTraits,
-  AcGiTextStyle,
-  log
+  AcGiTextStyle
 } from '@mlightcad/data-model'
-import {
-  ColorSettings,
-  MTextObject,
-  ShapeData
-} from '@mlightcad/mtext-renderer'
-import * as THREE from 'three'
+import { ShapeData } from '@mlightcad/mtext-renderer'
 
-import type { AcTrDrawMode } from '../draw/AcTrDrawMode'
 import { AcTrMTextRenderer } from '../renderer'
 import { AcTrRenderContext } from '../renderer/AcTrRenderContext'
-import {
-  AcTrMTextColorUtil,
-  type AcTrMTextEntityTraits,
-  AcTrSubEntityTraitsUtil,
-  resolveShapeGlyphKey,
-  resolveShapeTextStyle
-} from '../util'
-import { AcTrBufferGeometryUtil } from '../util/AcTrBufferGeometryUtil'
-import {
-  getSceneDrawableUserData,
-  resolveMTextRenderRoot
-} from '../util/AcTrObjectUserData'
-import { AcTrEntity } from './AcTrEntity'
+import { resolveShapeGlyphKey, resolveShapeTextStyle } from '../util'
+import { AcTrGlyphEntity } from './AcTrGlyphEntity'
 
-const _raycastBox = /*@__PURE__*/ new THREE.Box3()
-const _raycastPoint = /*@__PURE__*/ new THREE.Vector3()
-
-export class AcTrShape extends AcTrEntity {
-  private _rendered?: MTextObject
+/**
+ * Display object for a CAD SHAPE entity rendered through the mtext-renderer.
+ */
+export class AcTrShape extends AcTrGlyphEntity {
+  /** Source SHAPE data from the CAD database. */
   private _shape: AcGiShapeData
-  private _style: AcGiTextStyle
-  private _colorSettings: ColorSettings
-  private _entityTraits: AcTrMTextEntityTraits
 
+  /**
+   * Creates a SHAPE display object.
+   *
+   * @param shape SHAPE definition and placement from the CAD database.
+   * @param traits CAD sub-entity traits used to resolve color and layer behavior.
+   * @param style Optional text style override; resolved against shape and context when omitted.
+   * @param context Active renderer context that owns style and batching policy.
+   * @param delay When `true`, skips the initial draw so callers can finish setup first.
+   */
   constructor(
     shape: AcGiShapeData,
     traits: AcGiSubEntityTraits,
@@ -45,40 +33,13 @@ export class AcTrShape extends AcTrEntity {
     context: AcTrRenderContext,
     delay: boolean = false
   ) {
-    super(context)
-    this._shape = shape
-    this._style = resolveShapeTextStyle(shape, style, context)
-    this._entityTraits = AcTrMTextColorUtil.snapshotEntityTraits(traits)
-    this._colorSettings = AcTrMTextColorUtil.buildColorSettingsFromTraits(
+    super(
+      context,
       traits,
-      context.styleManager.currentBackgroundColor
+      resolveShapeTextStyle(shape, style, context),
+      delay
     )
-    if (!delay) {
-      this.syncDraw()
-    }
-  }
-
-  /** Reapplies CAD text materials from the entity traits snapshot. */
-  refreshTextMaterials(layerTraits?: Partial<AcGiSubEntityTraits>): void {
-    this._colorSettings = AcTrMTextColorUtil.buildColorSettingsFromTraits(
-      {
-        ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
-        color: this._entityTraits.color,
-        layer: this._entityTraits.layer
-      },
-      this.renderContext.styleManager.currentBackgroundColor
-    )
-    if (layerTraits?.color && this._entityTraits.color.isByLayer) {
-      const rgb = layerTraits.color.RGB
-      if (typeof rgb === 'number') {
-        this._colorSettings.byLayerColor = rgb
-      }
-    }
-    AcTrMTextColorUtil.rematerializeTextHierarchy(
-      this,
-      this._entityTraits,
-      this.renderContext.styleManager
-    )
+    this._shape = shape
   }
 
   /**
@@ -86,6 +47,8 @@ export class AcTrShape extends AcTrEntity {
    *
    * mtext-renderer falls back from shape name to shape number when both are
    * present; SHAPE entities should use the name exclusively when it is set.
+   *
+   * @returns SHAPE payload suitable for the mtext-renderer.
    */
   private toRenderableShapeData(): ShapeData {
     const source = this._shape as ShapeData
@@ -97,147 +60,41 @@ export class AcTrShape extends AcTrEntity {
     }
   }
 
-  override syncDraw() {
-    const mtextRenderer = AcTrMTextRenderer.getInstance()
-    if (!mtextRenderer) return
-
-    try {
-      this._rendered = mtextRenderer.syncRenderShape(
-        this.toRenderableShapeData(),
-        this._style,
-        this._colorSettings
-      )
-      this.attachRendered(this._rendered)
-    } catch (error) {
-      log.info(
-        `Failed to render shape '${this.describeShape()}' with the following error:\n`,
-        error
-      )
-    }
+  /**
+   * @inheritdoc
+   */
+  protected override getDrawPosition() {
+    return this._shape.position
   }
 
-  override async asyncDraw() {
-    const mtextRenderer = AcTrMTextRenderer.getInstance()
-    if (!mtextRenderer) return
-
-    try {
-      this._rendered = await mtextRenderer.asyncRenderShape(
-        this.toRenderableShapeData(),
-        this._style,
-        this._colorSettings
-      )
-      this.attachRendered(this._rendered)
-    } catch (error) {
-      log.info(
-        `Failed to render shape '${this.describeShape()}' with the following error:\n`,
-        error
-      )
-    }
-  }
-
-  raycast(raycaster: THREE.Raycaster, intersects: THREE.Intersection[]) {
-    const previousLength = intersects.length
-
-    this._rendered?.raycast(raycaster, intersects)
-    if (intersects.length > previousLength || this.wcsBbox.isEmpty()) return
-
-    _raycastBox.copy(this.wcsBbox)
-    if (raycaster.ray.intersectBox(_raycastBox, _raycastPoint)) {
-      intersects.push({
-        distance: raycaster.ray.origin.distanceTo(_raycastPoint),
-        point: _raycastPoint.clone(),
-        object: this,
-        face: null,
-        faceIndex: undefined,
-        uv: undefined
-      })
-    }
-  }
-
-  private describeShape() {
-    return this._shape.name?.trim() || String(this._shape.shapeNumber ?? '')
-  }
-
-  override resolveDrawMode(): AcTrDrawMode {
-    return this.batchDrawPolicy.resolveDrawMode({
-      position: this._shape.position
-    })
-  }
-
-  private attachRendered(rendered: MTextObject) {
-    this.add(rendered)
-    const renderRoot = resolveMTextRenderRoot(rendered)
-    if (this.resolveDrawMode() === 'unbatch') {
-      this.markDrawableUnbatched(renderRoot)
-      AcTrMTextColorUtil.storeTextEntityTraitsOnDrawable(
-        renderRoot,
-        this._entityTraits
-      )
-    } else {
-      this.flatten()
-    }
-    this.removeInvalidGeometryLeaves()
-    this.traverse(object => {
-      getSceneDrawableUserData(object).bboxIntersectionCheck = true
-    })
-    this.updateSelectionBox(rendered)
-  }
-
-  private updateSelectionBox(rendered: MTextObject) {
-    const geometryBox = this.computeGeometryBox()
-    if (geometryBox.isEmpty()) {
-      this.wcsBbox = rendered.box
-      return
-    }
-    if (!rendered.box.isEmpty() && rendered.box.intersectsBox(geometryBox)) {
-      this.wcsBbox = geometryBox.clone().union(rendered.box)
-      return
-    }
-    this.wcsBbox = geometryBox
-  }
-
-  private computeGeometryBox() {
-    const box = new THREE.Box3()
-    const childBox = new THREE.Box3()
-
-    this.updateMatrixWorld(true)
-    this.traverse(object => {
-      if (!this.hasGeometry(object)) return
-
-      const geometry = object.geometry
-      const boundingBox =
-        AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
-      if (boundingBox == null) return
-
-      object.updateMatrixWorld(true)
-      childBox.copy(boundingBox).applyMatrix4(object.matrixWorld)
-      box.union(childBox)
-    })
-
-    return box
-  }
-
-  private removeInvalidGeometryLeaves() {
-    const invalidObjects: THREE.Object3D[] = []
-    this.traverse(object => {
-      if (!this.hasGeometry(object)) return
-      if (AcTrBufferGeometryUtil.hasFinitePositions(object.geometry)) return
-      invalidObjects.push(object)
-    })
-
-    for (const object of invalidObjects) {
-      object.parent?.remove(object)
-      if (this.hasGeometry(object)) {
-        object.geometry.dispose()
-      }
-    }
-  }
-
-  private hasGeometry(
-    object: THREE.Object3D
-  ): object is THREE.Mesh | THREE.Line | THREE.Points {
-    return (
-      'geometry' in object && object.geometry instanceof THREE.BufferGeometry
+  /**
+   * @inheritdoc
+   */
+  protected override renderSync(renderer: AcTrMTextRenderer) {
+    return renderer.syncRenderShape(
+      this.toRenderableShapeData(),
+      this._style,
+      this._colorSettings
     )
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override async renderAsync(renderer: AcTrMTextRenderer) {
+    return renderer.asyncRenderShape(
+      this.toRenderableShapeData(),
+      this._style,
+      this._colorSettings
+    )
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override describeRenderFailure() {
+    const label =
+      this._shape.name?.trim() || String(this._shape.shapeNumber ?? '')
+    return `shape '${label}'`
   }
 }

--- a/packages/three-renderer/src/object/AcTrShape.ts
+++ b/packages/three-renderer/src/object/AcTrShape.ts
@@ -33,13 +33,11 @@ export class AcTrShape extends AcTrGlyphEntity {
     context: AcTrRenderContext,
     delay: boolean = false
   ) {
-    super(
-      context,
-      traits,
-      resolveShapeTextStyle(shape, style, context),
-      delay
-    )
+    super(context, traits, resolveShapeTextStyle(shape, style, context))
     this._shape = shape
+    if (!delay) {
+      this.syncDraw()
+    }
   }
 
   /**

--- a/packages/three-renderer/src/object/index.ts
+++ b/packages/three-renderer/src/object/index.ts
@@ -1,4 +1,5 @@
 export * from './AcTrEntity'
+export * from './AcTrGlyphEntity'
 export * from './AcTrGroup'
 export * from './AcTrImage'
 export * from './AcTrLine'


### PR DESCRIPTION
## Summary
- Introduce `AcTrGlyphEntity` as an abstract base class for CAD entities rendered through the mtext-renderer pipeline (MTEXT and SHAPE).
- Move duplicated integration logic into the base: trait/color snapshots, sync/async draw, raycast fallback, batch/unbatch placement, selection box construction, and invalid-geometry cleanup.
- Slim down `AcTrMText` and `AcTrShape` to only supply entity-specific render input and renderer API calls.

## Test plan
- [ ] Open a drawing with MTEXT labels and verify rendering, selection, and layer color updates
- [ ] Open a drawing with SHAPE entities and verify rendering and picking
- [ ] Confirm batched vs unbatched glyph entities still behave correctly at large coordinates