### PR TITLE
refactor: extract layer appearance controller and fix INSERT layer-0 inheritance

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApLayerService.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApLayerService.spec.ts
@@ -221,4 +221,32 @@ describe('AcApLayerService', () => {
     expect(docB.restoreLayerPreviousState()).toBe(true)
     expect(dbB.layers.get('0')?.isOff).toBe(false)
   })
+
+  test('resolveLayerTraits returns sub-entity traits from the layer table', () => {
+    const db = createMockDatabase()
+    db.layers.set('WALL', {
+      name: 'WALL',
+      isOff: false,
+      isFrozen: false,
+      standardFlags: 0,
+      color: { clone: () => new AcCmColor(AcCmColorMethod.ByACI, 3) },
+      lineStyle: 'DASHED',
+      lineWeight: 50,
+      transparency: 0.5
+    } as never)
+
+    const service = new AcApLayerService(db as never)
+    const traits = service.getEffectiveLayerTraits('WALL')
+
+    expect(traits).toEqual({
+      layer: 'WALL',
+      color: expect.any(AcCmColor),
+      lineType: 'DASHED',
+      lineWeight: 50,
+      transparency: 0.5
+    })
+    expect(AcApLayerService.resolveLayerTraits(db as never, 'MISSING')).toBe(
+      undefined
+    )
+  })
 })

--- a/packages/cad-simple-viewer/__tests__/AcTrInheritedLayerMaterialMapper.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrInheritedLayerMaterialMapper.spec.ts
@@ -1,0 +1,198 @@
+import { AcGiSubEntityTraits } from '@mlightcad/data-model'
+import {
+  AcTrRenderer,
+  getMaterialMetadata,
+  setMaterialMetadata
+} from '@mlightcad/three-renderer'
+import * as THREE from 'three'
+
+import { AcTrInheritedLayerMaterialMapper } from '../src/view/AcTrInheritedLayerMaterialMapper'
+
+describe('AcTrInheritedLayerMaterialMapper', () => {
+  it('remaps layer-0 ByLayer materials to the INSERT layer', () => {
+    const sourceMaterial = new THREE.LineBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(sourceMaterial, {
+      layer: '0',
+      materialKey: 'layer0',
+      isByLayerColor: true,
+      isByLayerLineType: false,
+      isByLayerLineWeight: false,
+      isByLayerTransparency: false,
+      isForeground: false
+    })
+
+    const reboundMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    setMaterialMetadata(reboundMaterial, {
+      layer: 'INSERT',
+      materialKey: 'insert',
+      isByLayerColor: true,
+      isByLayerLineType: false,
+      isByLayerLineWeight: false,
+      isByLayerTransparency: false,
+      isForeground: false
+    })
+
+    const getLayerBoundMaterial = jest.fn(() => reboundMaterial)
+    const renderer = {
+      getLayerBoundMaterial
+    } as unknown as AcTrRenderer
+
+    const mapper = new AcTrInheritedLayerMaterialMapper(
+      () =>
+        ({
+          layer: 'INSERT'
+        }) as Partial<AcGiSubEntityTraits>,
+      renderer
+    )
+
+    const mesh = new THREE.Line(new THREE.BufferGeometry(), sourceMaterial)
+    mesh.userData.layerName = '0'
+
+    mapper.remap([mesh], '0', 'INSERT')
+
+    expect(mesh.userData.layerName).toBe('INSERT')
+    expect(mesh.material).toBe(reboundMaterial)
+    expect(mesh.userData.styleMaterialId).toBe(reboundMaterial.id)
+    expect(getLayerBoundMaterial).toHaveBeenCalled()
+  })
+
+  it('skips explicit foreground materials on layer 0', () => {
+    const sourceMaterial = new THREE.LineBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(sourceMaterial, {
+      layer: '0',
+      materialKey: 'fg',
+      isByLayerColor: false,
+      isByLayerLineType: false,
+      isByLayerLineWeight: false,
+      isByLayerTransparency: false,
+      isForeground: true
+    })
+
+    const getLayerBoundMaterial = jest.fn()
+    const renderer = {
+      getLayerBoundMaterial
+    } as unknown as AcTrRenderer
+
+    const mapper = new AcTrInheritedLayerMaterialMapper(
+      () => ({ layer: 'INSERT' }),
+      renderer
+    )
+
+    const mesh = new THREE.Line(new THREE.BufferGeometry(), sourceMaterial)
+    mesh.userData.layerName = '0'
+
+    mapper.remap([mesh], '0', 'INSERT')
+
+    expect(mesh.userData.layerName).toBe('INSERT')
+    expect(mesh.material).toBe(sourceMaterial)
+    expect(getLayerBoundMaterial).not.toHaveBeenCalled()
+  })
+
+  it('remaps layer-0 foreground materials with other ByLayer bindings', () => {
+    const sourceMaterial = new THREE.LineBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(sourceMaterial, {
+      layer: '0',
+      materialKey: 'layer0-lw',
+      isByLayerColor: false,
+      isByLayerLineType: false,
+      isByLayerLineWeight: true,
+      isByLayerTransparency: false,
+      isForeground: true
+    })
+
+    const reboundMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const getLayerBoundMaterial = jest.fn(() => reboundMaterial)
+    const renderer = {
+      getLayerBoundMaterial
+    } as unknown as AcTrRenderer
+
+    const mapper = new AcTrInheritedLayerMaterialMapper(
+      () => ({ layer: 'INSERT' }),
+      renderer
+    )
+
+    const mesh = new THREE.Line(new THREE.BufferGeometry(), sourceMaterial)
+    mesh.userData.layerName = '0'
+
+    mapper.remap([mesh], '0', 'INSERT')
+
+    expect(mesh.material).toBe(reboundMaterial)
+    expect(getMaterialMetadata(sourceMaterial).isByLayerColor).toBe(true)
+    expect(getLayerBoundMaterial).toHaveBeenCalled()
+  })
+
+  it('sets styleMaterialId when remapping array materials', () => {
+    const sourceMaterial = new THREE.LineBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(sourceMaterial, {
+      layer: '0',
+      materialKey: 'layer0',
+      isByLayerColor: true,
+      isByLayerLineType: false,
+      isByLayerLineWeight: false,
+      isByLayerTransparency: false,
+      isForeground: false
+    })
+
+    const reboundMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const renderer = {
+      getLayerBoundMaterial: jest.fn(() => reboundMaterial)
+    } as unknown as AcTrRenderer
+
+    const mapper = new AcTrInheritedLayerMaterialMapper(
+      () => ({ layer: 'INSERT' }),
+      renderer
+    )
+
+    const mesh = new THREE.Line(new THREE.BufferGeometry(), [
+      sourceMaterial,
+      sourceMaterial
+    ])
+    mesh.userData.layerName = '0'
+
+    mapper.remap([mesh], '0', 'INSERT')
+
+    expect(mesh.userData.styleMaterialId).toBe(reboundMaterial.id)
+  })
+
+  it('clears styleMaterialId when array materials remap to different ids', () => {
+    const sourceMaterialA = new THREE.LineBasicMaterial({ color: 0xffffff })
+    const sourceMaterialB = new THREE.LineBasicMaterial({ color: 0x00ff00 })
+    setMaterialMetadata(sourceMaterialA, {
+      layer: '0',
+      materialKey: 'layer0-a',
+      isByLayerColor: true,
+      isForeground: false
+    })
+    setMaterialMetadata(sourceMaterialB, {
+      layer: '0',
+      materialKey: 'layer0-b',
+      isByLayerColor: true,
+      isForeground: false
+    })
+
+    const reboundMaterialA = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const reboundMaterialB = new THREE.LineBasicMaterial({ color: 0x0000ff })
+    const renderer = {
+      getLayerBoundMaterial: jest.fn((material: THREE.Material) =>
+        material === sourceMaterialA ? reboundMaterialA : reboundMaterialB
+      )
+    } as unknown as AcTrRenderer
+
+    const mapper = new AcTrInheritedLayerMaterialMapper(
+      () => ({ layer: 'INSERT' }),
+      renderer
+    )
+
+    const mesh = new THREE.Line(new THREE.BufferGeometry(), [
+      sourceMaterialA,
+      sourceMaterialB
+    ])
+    mesh.userData.layerName = '0'
+    mesh.userData.styleMaterialId = sourceMaterialA.id
+
+    mapper.remap([mesh], '0', 'INSERT')
+
+    expect(mesh.userData.styleMaterialId).toBeUndefined()
+    expect(mesh.material).toEqual([reboundMaterialA, reboundMaterialB])
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcTrView2dLayerSync.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrView2dLayerSync.spec.ts
@@ -1,60 +1,228 @@
+import { AcCmColor } from '@mlightcad/data-model'
+import {
+  AcTrEntity,
+  AcTrRenderContext,
+  AcTrRenderer,
+  getSceneDrawableUserData,
+  setMaterialMetadata
+} from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 
+import { AcTrLayerAppearanceController } from '../src/view/AcTrLayerAppearanceController'
+import { AcTrLayer } from '../src/view/AcTrLayer'
+import { AcTrScene } from '../src/view/AcTrScene'
+
 /**
- * Regression guard for {@link AcTrView2d.applyLayerMaterialUpdates}: remaps must
- * fan out to each layout once, not once per layout per layout.
+ * Regression guard for remapped material ids: each layout scene layer must be
+ * updated once when {@link AcTrLayer.syncAppearanceFromRecord} runs.
  */
 describe('layer material remap fan-out', () => {
-  it('updates each layout scene layer once when materials are remapped', () => {
+  it('updates batched materials once per remapped id', () => {
     const oldMaterial = new THREE.LineBasicMaterial({ color: 0xffffff })
     const newMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
-
     const materials: Record<number, THREE.Material> = {
       [oldMaterial.id]: newMaterial
     }
 
-    const wallLayerA = { updateMaterial: jest.fn() }
-    const wallLayerB = { updateMaterial: jest.fn() }
-    const layouts = [
-      {
-        getLayer: (name: string) => (name === 'WALL' ? wallLayerA : undefined)
-      },
-      {
-        getLayer: (name: string) => (name === 'WALL' ? wallLayerB : undefined)
-      }
-    ]
+    const wallLayer = new AcTrLayer({
+      name: 'WALL',
+      isFrozen: false,
+      isOff: false,
+      color: new AcCmColor()
+    })
+    const updateMaterial = jest.spyOn(wallLayer, 'updateMaterial')
 
-    const layerName = 'WALL'
-    const hasRemappedLayerMaterials = Object.entries(materials).some(
-      ([oldId, material]) => material.id !== Number(oldId)
+    const renderer = {
+      getLayerBoundMaterial: jest.fn(
+        (material: THREE.Material) => material
+      ),
+      styleManager: {
+        getLineMaterial: jest.fn(),
+        getMTextFillMaterial: jest.fn()
+      }
+    } as unknown as AcTrRenderer
+
+    wallLayer.syncAppearanceFromRecord(
+      'WALL',
+      { layer: 'WALL' },
+      materials,
+      renderer
     )
-    expect(hasRemappedLayerMaterials).toBe(true)
 
-    layouts.forEach(layout => {
-      const sceneLayer = layout.getLayer(layerName)
-      if (!sceneLayer) {
-        return
-      }
+    expect(updateMaterial).toHaveBeenCalledTimes(1)
+    expect(updateMaterial).toHaveBeenCalledWith(oldMaterial.id, newMaterial)
+  })
 
-      for (const id in materials) {
-        const oldId = Number(id)
-        const material = materials[id]
-        if (material.id === oldId) {
-          continue
-        }
-        sceneLayer.updateMaterial(oldId, material)
-      }
+  it('rebinds unbatched drawables via objectLayerName after INSERT inheritance', () => {
+    const oldMaterial = new THREE.LineBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(oldMaterial, {
+      layer: '0',
+      isByLayerColor: true
     })
 
-    expect(wallLayerA.updateMaterial).toHaveBeenCalledTimes(1)
-    expect(wallLayerA.updateMaterial).toHaveBeenCalledWith(
-      oldMaterial.id,
-      newMaterial
+    const reboundMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const materials: Record<number, THREE.Material> = {}
+
+    const wallLayer = new AcTrLayer({
+      name: 'INSERT',
+      isFrozen: false,
+      isOff: false,
+      color: new AcCmColor()
+    })
+
+    const line = new THREE.Line(new THREE.BufferGeometry(), oldMaterial)
+    line.userData.layerName = 'INSERT'
+    getSceneDrawableUserData(line).noBatch = true
+
+    const entity = new AcTrEntity(new AcTrRenderContext())
+    entity.objectId = 'insert-line'
+    entity.add(line)
+    wallLayer.addEntity(entity)
+
+    let drawable: THREE.Line | undefined
+    const unbatchedObjects = (
+      wallLayer.internalObject as unknown as { _unbatchedObjects: THREE.Group }
+    )._unbatchedObjects
+    unbatchedObjects.traverse(child => {
+      if (drawable || !(child instanceof THREE.Line)) {
+        return
+      }
+      drawable = child
+    })
+    expect(drawable).toBeDefined()
+    expect(drawable!.material).toBe(oldMaterial)
+
+    const getLayerBoundMaterial = jest.fn(() => reboundMaterial)
+    const renderer = {
+      getLayerBoundMaterial,
+      styleManager: {
+        getLineMaterial: jest.fn(),
+        getMTextFillMaterial: jest.fn()
+      }
+    } as unknown as AcTrRenderer
+
+    wallLayer.syncAppearanceFromRecord(
+      'INSERT',
+      { layer: 'INSERT' },
+      materials,
+      renderer
     )
-    expect(wallLayerB.updateMaterial).toHaveBeenCalledTimes(1)
-    expect(wallLayerB.updateMaterial).toHaveBeenCalledWith(
-      oldMaterial.id,
-      newMaterial
+
+    expect(drawable!.material).toBe(reboundMaterial)
+    expect(getSceneDrawableUserData(drawable!).styleMaterialId).toBe(
+      reboundMaterial.id
     )
+    expect(getLayerBoundMaterial).toHaveBeenCalled()
+  })
+
+  it('syncs each layout scene layer once via the appearance controller', () => {
+    const oldMaterial = new THREE.LineBasicMaterial({ color: 0xffffff })
+    const newMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const materials: Record<number, THREE.Material> = {
+      [oldMaterial.id]: newMaterial
+    }
+
+    const sceneLayerA = {
+      syncAppearanceFromRecord: jest.fn()
+    } as unknown as AcTrLayer
+    const sceneLayerB = {
+      syncAppearanceFromRecord: jest.fn()
+    } as unknown as AcTrLayer
+
+    const scene = {
+      forEachSceneLayer: jest.fn(
+        (
+          layerName: string,
+          fn: (sceneLayer: AcTrLayer) => void
+        ) => {
+          expect(layerName).toBe('WALL')
+          fn(sceneLayerA)
+          fn(sceneLayerB)
+        }
+      )
+    } as unknown as AcTrScene
+
+    const renderer = {
+      updateLayerMaterial: jest.fn(() => materials)
+    } as unknown as AcTrRenderer
+
+    const controller = new AcTrLayerAppearanceController(
+      scene,
+      renderer,
+      () => ({ layer: 'WALL' })
+    )
+
+    controller.syncFromLiveRecord({
+      name: 'WALL'
+    } as Parameters<AcTrLayerAppearanceController['syncFromLiveRecord']>[0])
+
+    expect(scene.forEachSceneLayer).toHaveBeenCalledTimes(1)
+    expect(sceneLayerA.syncAppearanceFromRecord).toHaveBeenCalledTimes(1)
+    expect(sceneLayerB.syncAppearanceFromRecord).toHaveBeenCalledTimes(1)
+    expect(renderer.updateLayerMaterial).toHaveBeenCalledWith('WALL', {
+      layer: 'WALL'
+    })
+  })
+
+  it('resolves layer traits from renderer draw context by default', () => {
+    const layer = {
+      name: 'WALL',
+      color: new AcCmColor(),
+      lineStyle: 'Continuous',
+      lineWeight: 25,
+      transparency: 0
+    }
+    const database = {
+      tables: {
+        layerTable: {
+          getAt: jest.fn(() => layer)
+        }
+      }
+    }
+
+    const renderer = {
+      context: { database },
+      updateLayerMaterial: jest.fn(() => ({}))
+    } as unknown as AcTrRenderer
+
+    const controller = new AcTrLayerAppearanceController(
+      {
+        forEachSceneLayer: jest.fn()
+      } as unknown as AcTrScene,
+      renderer
+    )
+
+    controller.syncFromLiveRecord({
+      name: 'WALL'
+    } as Parameters<AcTrLayerAppearanceController['syncFromLiveRecord']>[0])
+
+    expect(database.tables.layerTable.getAt).toHaveBeenCalledWith('WALL')
+    expect(renderer.updateLayerMaterial).toHaveBeenCalledWith('WALL', {
+      layer: 'WALL',
+      color: layer.color,
+      lineType: layer.lineStyle,
+      lineWeight: layer.lineWeight,
+      transparency: layer.transparency
+    })
+  })
+
+  it('skips layer sync when draw database is not yet bound', () => {
+    const renderer = {
+      context: { database: undefined },
+      updateLayerMaterial: jest.fn(() => ({}))
+    } as unknown as AcTrRenderer
+
+    const controller = new AcTrLayerAppearanceController(
+      {
+        forEachSceneLayer: jest.fn()
+      } as unknown as AcTrScene,
+      renderer
+    )
+
+    controller.syncFromLiveRecord({
+      name: 'WALL'
+    } as Parameters<AcTrLayerAppearanceController['syncFromLiveRecord']>[0])
+
+    expect(renderer.updateLayerMaterial).not.toHaveBeenCalled()
   })
 })

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1158,6 +1158,7 @@ export class AcApDocManager {
       doc: this.context.doc,
       mode: this.getDocumentEventMode(options)
     })
+    ;(this.curView as AcTrView2d).bindDrawDatabase(this.context.doc.database)
     ;(this.curView as AcTrView2d).progressiveRendering =
       options?.progressiveRendering ?? false
     this.curView.clear()

--- a/packages/cad-simple-viewer/src/service/AcApLayerService.ts
+++ b/packages/cad-simple-viewer/src/service/AcApLayerService.ts
@@ -4,7 +4,8 @@ import {
   AcDbDatabase,
   AcDbEntity,
   AcDbLayerTableRecord,
-  AcDbObjectId
+  AcDbObjectId,
+  AcGiSubEntityTraits
 } from '@mlightcad/data-model'
 
 import type { AcApLayerPreviousSnapshot } from '../app/AcApLayerSessionState'
@@ -1210,5 +1211,42 @@ export class AcApLayerService {
     }
 
     return restored
+  }
+
+  /**
+   * Resolves live layer-table traits for rendering and style synchronization.
+   *
+   * @param layerName - Name of the layer to resolve from the layer table.
+   * @returns Resolved sub-entity traits, or undefined when the layer is missing.
+   */
+  getEffectiveLayerTraits(
+    layerName: string
+  ): Partial<AcGiSubEntityTraits> | undefined {
+    return AcApLayerService.resolveLayerTraits(this.db, layerName)
+  }
+
+  /**
+   * Resolves live layer-table traits from the given database.
+   *
+   * @param db - Database whose layer table supplies the record.
+   * @param layerName - Name of the layer to resolve.
+   * @returns Resolved sub-entity traits, or undefined when the layer is missing.
+   */
+  static resolveLayerTraits(
+    db: AcDbDatabase,
+    layerName: string
+  ): Partial<AcGiSubEntityTraits> | undefined {
+    const layer = db.tables.layerTable.getAt(layerName)
+    if (!layer) {
+      return undefined
+    }
+
+    return {
+      layer: layer.name,
+      color: layer.color.clone(),
+      lineType: layer.lineStyle,
+      lineWeight: layer.lineWeight,
+      transparency: layer.transparency
+    }
   }
 }

--- a/packages/cad-simple-viewer/src/view/AcTrInheritedLayerMaterialMapper.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrInheritedLayerMaterialMapper.ts
@@ -1,0 +1,164 @@
+import { AcGiSubEntityTraits } from '@mlightcad/data-model'
+import {
+  AcTrRenderer,
+  getMaterialMetadata,
+  getSceneDrawableUserData,
+  hasByLayerBinding,
+  setMaterialMetadata,
+  syncStyleMaterialIdFromMaterials
+} from '@mlightcad/three-renderer'
+import * as THREE from 'three'
+
+/**
+ * Remaps layer metadata and material bindings when block contents inherit an INSERT layer.
+ *
+ * AutoCAD requires entities authored on layer "0" inside a block to inherit the INSERT's
+ * layer for ByLayer traits. This mapper mutates drawable `userData.layerName` and rebinds
+ * materials via the renderer style cache so subsequent layer-level style edits target the
+ * correct material instances.
+ */
+export class AcTrInheritedLayerMaterialMapper {
+  /**
+   * @param getLayerTraits - Resolves live layer-table traits for an effective layer name.
+   * @param renderer - Renderer used to rebind materials through the style cache.
+   */
+  constructor(
+    private readonly getLayerTraits: (
+      layerName: string
+    ) => Partial<AcGiSubEntityTraits> | undefined,
+    private readonly renderer: AcTrRenderer
+  ) {}
+
+  /**
+   * Remaps materials for objects in a layer bucket after INSERT decomposition.
+   *
+   * @param objects - Root objects in the current layer bucket to traverse and remap.
+   * @param sourceLayerName - Layer name found in the block definition before inheritance.
+   * @param effectiveLayerName - Final layer name used by rendering and style updates.
+   */
+  remap(
+    objects: THREE.Object3D[],
+    sourceLayerName: string,
+    effectiveLayerName: string
+  ): void {
+    if (sourceLayerName === effectiveLayerName) {
+      return
+    }
+
+    const layerTraits = this.getLayerTraits(effectiveLayerName)
+    for (const object of objects) {
+      object.traverse(child => {
+        const inheritsInsertLayer = child.userData.layerName === sourceLayerName
+        if (inheritsInsertLayer) {
+          child.userData.layerName = effectiveLayerName
+        }
+
+        if (!('material' in child)) {
+          return
+        }
+        // Only layer-"0" (or the current source bucket) inherits INSERT traits.
+        // Attributes/text on other layers must keep their own layer materials.
+        if (!inheritsInsertLayer) {
+          return
+        }
+
+        const material = child.material
+        if (Array.isArray(material)) {
+          const materials = material as THREE.Material[]
+          child.material = materials.map(entry => {
+            if (!this.shouldRemap(entry, sourceLayerName)) {
+              return entry
+            }
+            return (
+              this.renderer.getLayerBoundMaterial(
+                this.promoteLayerZeroByLayerColor(entry, sourceLayerName),
+                effectiveLayerName,
+                layerTraits
+              ) ?? entry
+            )
+          })
+          syncStyleMaterialIdFromMaterials(
+            getSceneDrawableUserData(child),
+            child.material as THREE.Material[]
+          )
+          return
+        }
+
+        if (!this.shouldRemap(material as THREE.Material, sourceLayerName)) {
+          return
+        }
+
+        const remappedMaterial = this.renderer.getLayerBoundMaterial(
+          this.promoteLayerZeroByLayerColor(
+            material as THREE.Material,
+            sourceLayerName
+          ),
+          effectiveLayerName,
+          layerTraits
+        )
+        if (!remappedMaterial) {
+          return
+        }
+        child.material = remappedMaterial
+        syncStyleMaterialIdFromMaterials(
+          getSceneDrawableUserData(child),
+          remappedMaterial
+        )
+      })
+    }
+  }
+
+  /**
+   * Layer-0 block contents with ByLayer color resolve to ACI-7 foreground materials before
+   * INSERT remapping. Those materials must still inherit the INSERT layer when their colour
+   * is layer-bound, while explicit ACI-7 entities on layer 0 stay untouched.
+   *
+   * @param material - Candidate material to evaluate for INSERT-layer rebinding.
+   * @param sourceLayerName - Layer name from the block definition before inheritance.
+   * @returns True when the material should be rebound to the INSERT layer.
+   */
+  private shouldRemap(
+    material: THREE.Material,
+    sourceLayerName: string
+  ): boolean {
+    const metadata = getMaterialMetadata(material)
+    if (metadata.isForeground !== true) {
+      return true
+    }
+    if (sourceLayerName !== '0') {
+      return false
+    }
+    if (metadata.isByLayerColor === true) {
+      return true
+    }
+    return (
+      sourceLayerName === '0' &&
+      (metadata.isByLayerLineType === true ||
+        metadata.isByLayerLineWeight === true ||
+        metadata.isByLayerTransparency === true)
+    )
+  }
+
+  /**
+   * Some DXF conversion paths lose `isByLayerColor` on layer-0 block contents while still
+   * retaining other ByLayer markers (lineType/lineWeight/transparency). For AutoCAD-compatible
+   * INSERT inheritance, treat such colors as inheritable when remapping from layer "0".
+   *
+   * @param material - Material whose ByLayer metadata may need normalization.
+   * @param sourceLayerName - Source bucket layer name (typically `"0"`).
+   * @returns The same material instance, possibly with patched metadata.
+   */
+  private promoteLayerZeroByLayerColor(
+    material: THREE.Material,
+    sourceLayerName: string
+  ): THREE.Material {
+    const metadata = getMaterialMetadata(material)
+    const hasAnyOtherByLayerBinding =
+      hasByLayerBinding(metadata) && metadata.isByLayerColor !== true
+
+    if (sourceLayerName === '0' && hasAnyOtherByLayerBinding) {
+      setMaterialMetadata(material, { isByLayerColor: true })
+    }
+    return material
+  }
+}

--- a/packages/cad-simple-viewer/src/view/AcTrLayer.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayer.ts
@@ -4,6 +4,7 @@ import {
   AcTrBatchedGroupStats,
   AcTrEntity,
   AcTrPreviewSubsetOptions,
+  AcTrRenderer,
   AcTrStyleManager
 } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
@@ -194,6 +195,53 @@ export class AcTrLayer {
    */
   updateMaterial(oldId: number, material: THREE.Material) {
     this._group.updateMaterial(oldId, material)
+  }
+
+  /**
+   * Refreshes drawable materials after a layer-table style change.
+   *
+   * Updates batched material ids when the style cache remaps instances, patches
+   * unbatched drawables, and rematerializes text glyph hierarchies.
+   *
+   * @param layerName - Target layer whose drawables should be refreshed.
+   * @param layerTraits - Resolved layer traits from the live layer-table record.
+   * @param materials - Style-cache material map, keyed by previous material id.
+   * @param renderer - Renderer used to rebind layer-bound materials.
+   */
+  syncAppearanceFromRecord(
+    layerName: string,
+    layerTraits: Partial<AcGiSubEntityTraits>,
+    materials: Record<number, THREE.Material>,
+    renderer: AcTrRenderer
+  ): void {
+    const needsIdPatch = Object.entries(materials).some(
+      ([oldId, material]) => material.id !== Number(oldId)
+    )
+
+    if (needsIdPatch) {
+      for (const id in materials) {
+        const oldId = Number(id)
+        const material = materials[id]
+        if (material.id === oldId) {
+          continue
+        }
+        this.updateMaterial(oldId, material)
+      }
+    }
+
+    this._group.syncAppearanceFromRecord(
+      layerName,
+      layerTraits,
+      materials,
+      needsIdPatch,
+      (material, boundLayerName, boundLayerTraits) =>
+        renderer.getLayerBoundMaterial(
+          material,
+          boundLayerName,
+          boundLayerTraits
+        ),
+      renderer.styleManager
+    )
   }
 
   /** Rebinds batched drawables whose materials follow live layer-table style. */

--- a/packages/cad-simple-viewer/src/view/AcTrLayerAppearanceController.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayerAppearanceController.ts
@@ -1,0 +1,121 @@
+import {
+  AcDbLayerTableRecord,
+  AcDbLayerTableRecordAttrs,
+  AcGiSubEntityTraits
+} from '@mlightcad/data-model'
+import { AcTrRenderer } from '@mlightcad/three-renderer'
+import * as THREE from 'three'
+
+import { AcApLayerService } from '../service/AcApLayerService'
+import { AcTrScene } from './AcTrScene'
+
+/**
+ * Synchronizes scene drawable materials with live layer-table style changes.
+ *
+ * The host view ({@link AcTrView2d}) delegates layer add/update and background
+ * refresh entry points here so material cache updates, scene fan-out, and text
+ * rematerialization stay out of the view class.
+ */
+export class AcTrLayerAppearanceController {
+  /**
+   * @param scene - Scene whose layout layer groups receive appearance updates.
+   * @param renderer - Renderer whose draw context supplies the active database.
+   * @param getLayerTraits - Optional override for resolving live layer-table traits.
+   */
+  constructor(
+    private readonly scene: AcTrScene,
+    private readonly renderer: AcTrRenderer,
+    private readonly getLayerTraits?: (
+      layerName: string
+    ) => Partial<AcGiSubEntityTraits> | undefined
+  ) {}
+
+  /**
+   * Returns true when a layer-table edit may require material refresh.
+   *
+   * @param changes - Partial layer record attributes from the edit event.
+   * @returns True when color, linetype, lineweight, or transparency changed.
+   */
+  layerStyleMayHaveChanged(
+    changes: Partial<AcDbLayerTableRecordAttrs>
+  ): boolean {
+    return (
+      changes.color != null ||
+      changes.linetype != null ||
+      changes.lineWeight !== undefined ||
+      changes.transparency != null
+    )
+  }
+
+  /**
+   * Refreshes cached layer materials from the live layer-table record and
+   * propagates the result to batched drawables and text hierarchies.
+   *
+   * @param layer - Live layer-table record whose traits should drive the refresh.
+   */
+  syncFromLiveRecord(layer: AcDbLayerTableRecord): void {
+    const layerTraits = this.getEffectiveLayerTraits(layer.name)
+    if (!layerTraits) {
+      return
+    }
+
+    const materials = this.renderer.updateLayerMaterial(layer.name, layerTraits)
+    this.scene.forEachSceneLayer(layer.name, sceneLayer =>
+      sceneLayer.syncAppearanceFromRecord(
+        layer.name,
+        layerTraits,
+        materials,
+        this.renderer
+      )
+    )
+  }
+
+  /**
+   * Rebinds text materials after INSERT groups are split/reparented or when the
+   * canvas background changes (ACI-7 foreground inversion).
+   *
+   * @param root - Object subtree to traverse for text refresh hooks.
+   * @param layerTraits - Optional resolved traits passed through to text wrappers.
+   */
+  refreshTextMaterialsInObjectTree(
+    root: THREE.Object3D,
+    layerTraits?: Partial<AcGiSubEntityTraits>
+  ): void {
+    root.traverse(child => {
+      const refresh = (
+        child as {
+          refreshTextMaterials?: (
+            layerTraits?: Partial<AcGiSubEntityTraits>
+          ) => void
+        }
+      ).refreshTextMaterials
+      if (typeof refresh === 'function') {
+        refresh.call(child, layerTraits)
+      }
+    })
+  }
+
+  /**
+   * Builds resolved layer traits used when syncing appearance or remapping INSERT layers.
+   *
+   * Reads the active draw database from {@link AcTrRenderer.context} unless a custom
+   * resolver was supplied to the constructor.
+   *
+   * @param layerName - Name of the layer to resolve from the active database.
+   * @returns Resolved sub-entity traits, or undefined when the layer is missing.
+   */
+  getEffectiveLayerTraits(
+    layerName: string
+  ): Partial<AcGiSubEntityTraits> | undefined {
+    if (this.getLayerTraits) {
+      return this.getLayerTraits(layerName)
+    }
+
+    const database = this.renderer.context.database
+    if (!database) {
+      return undefined
+    }
+
+    return AcApLayerService.resolveLayerTraits(database, layerName)
+  }
+}

--- a/packages/cad-simple-viewer/src/view/AcTrScene.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrScene.ts
@@ -389,6 +389,24 @@ export class AcTrScene {
   }
 
   /**
+   * Invokes a callback for every scene layer group with the given name across layouts.
+   *
+   * @param layerName - Layer name shared by each layout's {@link AcTrLayer} bucket.
+   * @param fn - Callback invoked with the scene layer and owning layout.
+   */
+  forEachSceneLayer(
+    layerName: string,
+    fn: (sceneLayer: AcTrLayer, layout: AcTrLayout) => void
+  ): void {
+    this._layouts.forEach(layout => {
+      const sceneLayer = layout.getLayer(layerName)
+      if (sceneLayer) {
+        fn(sceneLayer, layout)
+      }
+    })
+  }
+
+  /**
    * Add the specified transient entity into this scene
    * @param entity Input one transient entity
    */

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -18,7 +18,6 @@ import {
   AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint2dLike,
-  AcGiSubEntityTraits,
   log
 } from '@mlightcad/data-model'
 import { AcDbSystemVariables } from '@mlightcad/data-model'
@@ -27,11 +26,7 @@ import {
   AcTrGroup,
   AcTrHtmlTransientManager,
   AcTrRenderer,
-  AcTrViewportView,
-  getMaterialMetadata,
-  getSceneDrawableUserData,
-  hasByLayerBinding,
-  setMaterialMetadata
+  AcTrViewportView
 } from '@mlightcad/three-renderer'
 import { AcTrMatrixUtil } from '@mlightcad/three-renderer'
 import * as THREE from 'three'
@@ -68,7 +63,9 @@ import {
   assertAcTrGroupWcsBboxesConsistent,
   unionGroupWcsChildBoxes
 } from './AcTrGroupWcsBboxAssert'
+import { AcTrInheritedLayerMaterialMapper } from './AcTrInheritedLayerMaterialMapper'
 import { AcTrLayer } from './AcTrLayer'
+import { AcTrLayerAppearanceController } from './AcTrLayerAppearanceController'
 import { AcTrLayoutView } from './AcTrLayoutView'
 import { AcTrLayoutViewManager } from './AcTrLayoutViewManager'
 import { sortPickResults } from './AcTrPickResultUtil'
@@ -192,6 +189,10 @@ export class AcTrView2d extends AcEdBaseView {
   private readonly _progressiveOpenFit: AcTrProgressiveOpenFitController
   /** Entity display policy for layer-aware conversion skipping. */
   private readonly _entityDisplay: AcTrEntityDisplayController
+  /** Layer appearance sync for style-table changes and text refresh. */
+  private readonly _layerAppearance: AcTrLayerAppearanceController
+  /** INSERT layer-0 inheritance material remapping. */
+  private readonly _inheritedLayerMaterialMapper: AcTrInheritedLayerMaterialMapper
   /**
    * Layer names with an in-flight {@link convertMissingEntitiesOnLayer} pass.
    *
@@ -256,6 +257,14 @@ export class AcTrView2d extends AcEdBaseView {
     })
 
     this._scene = this.createScene()
+    this._layerAppearance = new AcTrLayerAppearanceController(
+      this._scene,
+      this._renderer
+    )
+    this._inheritedLayerMaterialMapper = new AcTrInheritedLayerMaterialMapper(
+      layerName => this._layerAppearance.getEffectiveLayerTraits(layerName),
+      this._renderer
+    )
     // Initialize background color through setter to keep renderer/cursor in sync.
     this.backgroundColor =
       mergedOptions.background ?? ACGI_MODEL_SPACE_BACKGROUND
@@ -637,7 +646,9 @@ export class AcTrView2d extends AcEdBaseView {
     this._renderer.setClearColor(value)
     // Updates style-manager background, repaints ACI-7 / bg-follow materials.
     this._renderer.currentBackgroundColor = value
-    this.refreshTextMaterialsInObjectTree(this._scene.internalScene)
+    this._layerAppearance.refreshTextMaterialsInObjectTree(
+      this._scene.internalScene
+    )
     this.editor.syncCursorBackground(value)
     this._isDirty = true
   }
@@ -650,10 +661,21 @@ export class AcTrView2d extends AcEdBaseView {
   }
 
   /**
+   * Binds the active drawing database on the renderer draw context.
+   *
+   * Called before document read so layer-table traits are available while layers
+   * are appended during open, and again after open to refresh display sysvars.
+   */
+  bindDrawDatabase(database: AcDbDatabase | undefined): void {
+    this._renderer.context.database = database
+  }
+
+  /**
    * Re-reads layout background sysvars from the active database. Called after
    * a document is opened so DWG-stored values take effect.
    */
   syncDisplaySysVars(database: AcDbDatabase) {
+    this.bindDrawDatabase(database)
     this.applyCanvasBackground(
       readLayoutBackgroundColor(database, this.isModelSpaceLayout(database))
     )
@@ -1135,180 +1157,11 @@ export class AcTrView2d extends AcEdBaseView {
   }
 
   /**
-   * Applies renderer material remaps to every scene layer group with `layerName`.
-   */
-  private applyLayerMaterialUpdates(
-    layerName: string,
-    materials: Record<number, THREE.Material>
-  ) {
-    if (!this.hasRemappedLayerMaterials(materials)) {
-      return
-    }
-
-    this._scene.layouts.forEach(layout => {
-      const sceneLayer = layout.getLayer(layerName)
-      if (!sceneLayer) return
-
-      for (const id in materials) {
-        const oldId = Number(id)
-        const material = materials[id]
-        if (material.id === oldId) {
-          continue
-        }
-        sceneLayer.updateMaterial(oldId, material)
-      }
-    })
-  }
-
-  /** True when at least one cached material was replaced with a new instance. */
-  private hasRemappedLayerMaterials(
-    materials: Record<number, THREE.Material>
-  ): boolean {
-    return Object.entries(materials).some(
-      ([oldId, material]) => material.id !== Number(oldId)
-    )
-  }
-
-  /**
-   * Refreshes cached layer materials from the live layer-table record and
-   * propagates the result to batched drawables and text hierarchies.
-   *
-   * ByLayer colour keys stay symbolic, so a colour-only layer edit usually
-   * repaints cache entries in place. Remap/patch paths run only when a material
-   * id actually changes; clone/unbatched text paths still rebind afterward.
-   */
-  private syncLayerAppearanceFromLiveRecord(layer: AcDbLayerTableRecord) {
-    const layerTraits = this.getEffectiveLayerTraits(layer.name)
-    if (!layerTraits) {
-      return
-    }
-
-    const materials = this._renderer.updateLayerMaterial(layer.name, layerTraits)
-    const needsIdPatch = this.hasRemappedLayerMaterials(materials)
-
-    this.applyLayerMaterialUpdates(layer.name, materials)
-
-    this._scene.layouts.forEach(layout => {
-      const sceneLayer = layout.getLayer(layer.name)
-      if (!sceneLayer) {
-        return
-      }
-
-      this.syncLayerSceneDrawables(
-        sceneLayer,
-        layer.name,
-        layerTraits,
-        materials,
-        needsIdPatch
-      )
-      sceneLayer.rebindMaterialsForLayer(
-        layer.name,
-        layerTraits,
-        (material, boundLayerName, boundLayerTraits) =>
-          this._renderer.getLayerBoundMaterial(
-            material,
-            boundLayerName,
-            boundLayerTraits
-          ),
-        this._renderer.styleManager
-      )
-      sceneLayer.rematerializeLayerTextDrawables(
-        layer.name,
-        this._renderer.styleManager,
-        layerTraits
-      )
-    })
-  }
-
-  /**
-   * Patches remapped materials, rebinds layer-bound drawables, and refreshes
-   * text entity wrappers in one scene traversal per layout.
-   */
-  private syncLayerSceneDrawables(
-    sceneLayer: AcTrLayer,
-    layerName: string,
-    layerTraits: Partial<AcGiSubEntityTraits>,
-    materials: Record<number, THREE.Material>,
-    needsIdPatch: boolean
-  ) {
-    sceneLayer.internalObject.traverse(object => {
-      const refresh = (
-        object as {
-          refreshTextMaterials?: (
-            layerTraits?: Partial<AcGiSubEntityTraits>
-          ) => void
-        }
-      ).refreshTextMaterials
-      if (typeof refresh === 'function') {
-        refresh.call(object, layerTraits)
-      }
-
-      if (!('material' in object)) {
-        return
-      }
-
-      const drawable = object as THREE.Mesh | THREE.Line | THREE.LineSegments
-      let material = drawable.material as THREE.Material
-
-      if (needsIdPatch) {
-        const remapped =
-          materials[material.id] ??
-          (getSceneDrawableUserData(object).styleMaterialId != null
-            ? materials[getSceneDrawableUserData(object).styleMaterialId!]
-            : undefined)
-        if (remapped && remapped !== material) {
-          drawable.material = remapped
-          getSceneDrawableUserData(object).styleMaterialId = remapped.id
-          material = remapped
-        }
-      }
-
-      if (
-        !this.shouldRebindLayerDrawableMaterial(material, layerName, object)
-      ) {
-        return
-      }
-
-      const rebound = this._renderer.getLayerBoundMaterial(
-        material,
-        layerName,
-        layerTraits
-      )
-      if (!rebound || rebound === material) {
-        return
-      }
-
-      drawable.material = rebound
-      getSceneDrawableUserData(object).styleMaterialId = rebound.id
-    })
-  }
-
-  private shouldRebindLayerDrawableMaterial(
-    material: THREE.Material,
-    layerName: string,
-    object: THREE.Object3D
-  ): boolean {
-    const metadata = getMaterialMetadata(material)
-    const objectLayerName = object.userData.layerName as string | undefined
-
-    if (metadata.layer !== layerName && objectLayerName !== layerName) {
-      return false
-    }
-    if (metadata.isByLayerColor === true) {
-      return true
-    }
-    if (metadata.isForeground === true) {
-      return false
-    }
-    return hasByLayerBinding(metadata)
-  }
-
-  /**
    * @inheritdoc
    */
   addLayer(layer: AcDbLayerTableRecord) {
     this._scene.addLayer(this.toLayerInfo(layer))
-    this.syncLayerAppearanceFromLiveRecord(layer)
+    this._layerAppearance.syncFromLiveRecord(layer)
     this._isDirty = true
   }
 
@@ -1321,8 +1174,8 @@ export class AcTrView2d extends AcEdBaseView {
   ) {
     this._scene.updateLayer(this.toLayerInfo(layer))
 
-    if (this.layerStyleMayHaveChanged(changes)) {
-      this.syncLayerAppearanceFromLiveRecord(layer)
+    if (this._layerAppearance.layerStyleMayHaveChanged(changes)) {
+      this._layerAppearance.syncFromLiveRecord(layer)
     }
 
     if (
@@ -1919,17 +1772,6 @@ export class AcTrView2d extends AcEdBaseView {
     }
   }
 
-  private layerStyleMayHaveChanged(
-    changes: Partial<AcDbLayerTableRecordAttrs>
-  ): boolean {
-    return (
-      changes.color != null ||
-      changes.linetype != null ||
-      changes.lineWeight !== undefined ||
-      changes.transparency != null
-    )
-  }
-
   private toLayerInfo(layer: AcDbLayerTableRecord) {
     return {
       name: layer.name,
@@ -2101,7 +1943,7 @@ export class AcTrView2d extends AcEdBaseView {
           ) {
             // Even when a block expands to a single layer bucket, children authored on
             // layer "0" still inherit the INSERT layer for ByLayer traits (color, etc.).
-            this.remapInheritedLayerObjects(
+            this._inheritedLayerMaterialMapper.remap(
               (threeEntity as AcTrGroup).children,
               '0',
               threeEntity.layerName
@@ -2258,7 +2100,11 @@ export class AcTrView2d extends AcEdBaseView {
       // Keep runtime layer metadata/material cache aligned with the inherited layer so
       // later layer style edits (color, linetype, lineweight, transparency) target this
       // object set correctly.
-      this.remapInheritedLayerObjects(objects, layerName, effectiveLayerName)
+      this._inheritedLayerMaterialMapper.remap(
+        objects,
+        layerName,
+        effectiveLayerName
+      )
 
       // One INSERT can expand to children from multiple layers. Here we create one
       // render entity per layer bucket but preserve the INSERT object id for all
@@ -2283,7 +2129,7 @@ export class AcTrView2d extends AcEdBaseView {
       for (let i = 0; i < objects.length; i++) {
         entity.add(objects[i])
       }
-      this.refreshTextMaterialsInObjectTree(entity)
+      this._layerAppearance.refreshTextMaterialsInObjectTree(entity)
       this._scene.addEntity(entity, true)
       this.applySessionHiddenObjectState(groupObjectId)
       entity.dispose()
@@ -2295,176 +2141,6 @@ export class AcTrView2d extends AcEdBaseView {
       void this._progressiveOpenFit.afterGeometryBatch(() =>
         this.resolveLayoutFitBox()
       )
-    }
-  }
-
-  /**
-   * Rebinds text materials after INSERT groups are split/reparented by layer.
-   *
-   * Layer remapping can replace mesh materials; text must keep entity-trait
-   * colours (especially ACI-7 foreground on paper layouts).
-   */
-  private refreshTextMaterialsInObjectTree(
-    root: THREE.Object3D,
-    layerTraits?: Partial<AcGiSubEntityTraits>
-  ) {
-    root.traverse(child => {
-      const refresh = (
-        child as {
-          refreshTextMaterials?: (
-            layerTraits?: Partial<AcGiSubEntityTraits>
-          ) => void
-        }
-      ).refreshTextMaterials
-      if (typeof refresh === 'function') {
-        refresh.call(child, layerTraits)
-      }
-    })
-  }
-
-  /**
-   * Remaps layer metadata/material bindings from a source layer to the effective render layer.
-   *
-   * During block decomposition, one INSERT may be split into multiple layer buckets. For
-   * children authored on layer "0", AutoCAD requires inheriting the INSERT's own layer.
-   * This method applies that inheritance by mutating each child's `userData.layerName` and
-   * re-binding materials via renderer cache, so subsequent layer-level style changes still
-   * hit the correct material instances.
-   *
-   * @param objects - Root objects in the current layer bucket to traverse and remap.
-   * @param sourceLayerName - Layer name found in block definition before inheritance.
-   * @param effectiveLayerName - Final layer name used by rendering and style updates.
-   */
-  private remapInheritedLayerObjects(
-    objects: THREE.Object3D[],
-    sourceLayerName: string,
-    effectiveLayerName: string
-  ) {
-    if (sourceLayerName === effectiveLayerName) return
-
-    const renderer = this._renderer
-    const layerTraits = this.getEffectiveLayerTraits(effectiveLayerName)
-    for (const object of objects) {
-      object.traverse(child => {
-        const inheritsInsertLayer = child.userData.layerName === sourceLayerName
-        if (inheritsInsertLayer) {
-          child.userData.layerName = effectiveLayerName
-        }
-
-        if (!('material' in child)) return
-        // Only layer-"0" (or the current source bucket) inherits INSERT traits.
-        // Attributes/text on other layers must keep their own layer materials.
-        if (!inheritsInsertLayer) return
-
-        const material = child.material
-        if (Array.isArray(material)) {
-          const materials = material as THREE.Material[]
-          child.material = materials.map(entry => {
-            if (
-              !this.shouldRemapInheritedLayerMaterial(entry, sourceLayerName)
-            ) {
-              return entry
-            }
-            return (
-              renderer.getLayerBoundMaterial(
-                this.promoteLayerZeroByLayerColor(entry, sourceLayerName),
-                effectiveLayerName,
-                layerTraits
-              ) ?? entry
-            )
-          })
-          return
-        }
-
-        if (
-          !this.shouldRemapInheritedLayerMaterial(
-            material as THREE.Material,
-            sourceLayerName
-          )
-        ) {
-          return
-        }
-
-        const remappedMaterial = renderer.getLayerBoundMaterial(
-          this.promoteLayerZeroByLayerColor(
-            material as THREE.Material,
-            sourceLayerName
-          ),
-          effectiveLayerName,
-          layerTraits
-        )
-        if (!remappedMaterial) {
-          return
-        }
-        child.material = remappedMaterial
-        child.userData.styleMaterialId = remappedMaterial.id
-      })
-    }
-  }
-
-  /**
-   * Layer-0 block contents with ByLayer color resolve to ACI-7 foreground materials before
-   * INSERT remapping. Those materials must still inherit the INSERT layer when their colour
-   * is layer-bound, while explicit ACI-7 entities on layer 0 stay untouched.
-   */
-  private shouldRemapInheritedLayerMaterial(
-    material: THREE.Material,
-    sourceLayerName: string
-  ): boolean {
-    const metadata = getMaterialMetadata(material)
-    if (metadata.isForeground !== true) {
-      return true
-    }
-    if (sourceLayerName !== '0') {
-      return false
-    }
-    if (metadata.isByLayerColor === true) {
-      return true
-    }
-    const promoted = this.promoteLayerZeroByLayerColor(
-      material,
-      sourceLayerName
-    )
-    return getMaterialMetadata(promoted).isByLayerColor === true
-  }
-
-  /**
-   * Some DXF conversion paths lose `isByLayerColor` on layer-0 block contents while still
-   * retaining other ByLayer markers (lineType/lineWeight/transparency). For AutoCAD-compatible
-   * INSERT inheritance, treat such colors as inheritable when remapping from layer "0".
-   */
-  private promoteLayerZeroByLayerColor(
-    material: THREE.Material,
-    sourceLayerName: string
-  ): THREE.Material {
-    const metadata = getMaterialMetadata(material)
-    const hasAnyOtherByLayerBinding =
-      hasByLayerBinding(metadata) && metadata.isByLayerColor !== true
-
-    if (sourceLayerName === '0' && hasAnyOtherByLayerBinding) {
-      setMaterialMetadata(material, { isByLayerColor: true })
-    }
-    return material
-  }
-
-  /**
-   * Builds the resolved layer traits used when layer-0 block content inherits an INSERT layer.
-   */
-  private getEffectiveLayerTraits(
-    layerName: string
-  ): Partial<AcGiSubEntityTraits> | undefined {
-    const layer =
-      AcApDocManager.instance.curDocument.database.tables.layerTable.getAt(
-        layerName
-      )
-    if (!layer) return undefined
-
-    return {
-      layer: layer.name,
-      color: layer.color.clone(),
-      lineType: layer.lineStyle,
-      lineWeight: layer.lineWeight,
-      transparency: layer.transparency
     }
   }
 

--- a/packages/cad-simple-viewer/src/view/index.ts
+++ b/packages/cad-simple-viewer/src/view/index.ts
@@ -1,3 +1,5 @@
 export * from './AcEdViewKeyHandler'
+export * from './AcTrInheritedLayerMaterialMapper'
+export * from './AcTrLayerAppearanceController'
 export * from './AcTrScene'
 export * from './AcTrView2d'

--- a/packages/three-renderer/__tests__/AcTrBatchedGroupLayerStyle.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupLayerStyle.spec.ts
@@ -1,0 +1,120 @@
+import * as THREE from 'three'
+
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import { AcTrEntity } from '../src/object/AcTrEntity'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { setMaterialMetadata } from '../src/style/AcTrMaterialMetadata'
+import { getSceneDrawableUserData } from '../src/util/AcTrObjectUserData'
+
+function createEntity(
+  objectId: string,
+  ...drawables: THREE.Object3D[]
+): AcTrEntity {
+  const entity = new AcTrEntity(new AcTrRenderContext())
+  entity.objectId = objectId
+  entity.visible = true
+  for (const drawable of drawables) {
+    entity.add(drawable)
+  }
+  return entity
+}
+
+describe('AcTrBatchedGroup layer style rebind', () => {
+  it('rebindMaterialsForLayer respects runtime objectLayerName for INSERT inheritance', () => {
+    const group = new AcTrBatchedGroup()
+    const sourceMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(sourceMaterial, {
+      layer: '0',
+      materialKey: 'layer0',
+      isByLayerColor: true
+    })
+
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(1, 1),
+      sourceMaterial
+    )
+    mesh.userData.layerName = 'INSERT'
+    getSceneDrawableUserData(mesh).noBatch = true
+
+    group.addEntity(createEntity('insert-mesh', mesh))
+
+    let targetMesh: THREE.Mesh | undefined
+    group.traverse(child => {
+      if (
+        targetMesh ||
+        !(child instanceof THREE.Mesh) ||
+        child === mesh
+      ) {
+        return
+      }
+      if (child.geometry instanceof THREE.PlaneGeometry) {
+        targetMesh = child
+      }
+    })
+    expect(targetMesh).toBeDefined()
+
+    const reboundMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 })
+    setMaterialMetadata(reboundMaterial, {
+      layer: 'INSERT',
+      materialKey: 'insert',
+      isByLayerColor: true
+    })
+
+    const getLayerBoundMaterial = jest.fn(() => reboundMaterial)
+
+    group.rebindMaterialsForLayer(
+      'INSERT',
+      { layer: 'INSERT' },
+      getLayerBoundMaterial
+    )
+
+    expect(targetMesh!.material).toBe(reboundMaterial)
+    expect(getSceneDrawableUserData(targetMesh!).styleMaterialId).toBe(
+      reboundMaterial.id
+    )
+    expect(getLayerBoundMaterial).toHaveBeenCalled()
+  })
+
+  it('syncAppearanceFromRecord refreshes unbatched drawables in one traversal', () => {
+    const group = new AcTrBatchedGroup()
+    const sourceMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff })
+    setMaterialMetadata(sourceMaterial, {
+      layer: '0',
+      materialKey: 'layer0',
+      isByLayerColor: true
+    })
+
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(1, 1),
+      sourceMaterial
+    )
+    mesh.userData.layerName = 'INSERT'
+    getSceneDrawableUserData(mesh).noBatch = true
+
+    group.addEntity(createEntity('insert-mesh', mesh))
+
+    const reboundMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 })
+    const getLayerBoundMaterial = jest.fn(() => reboundMaterial)
+    const unbatchedObjects = (
+      group as unknown as { _unbatchedObjects: THREE.Group }
+    )._unbatchedObjects
+    const unbatchedTraverse = jest.spyOn(unbatchedObjects, 'traverse')
+    const fullTraverse = jest.spyOn(group, 'traverse')
+
+    group.syncAppearanceFromRecord(
+      'INSERT',
+      { layer: 'INSERT' },
+      {},
+      false,
+      getLayerBoundMaterial,
+      {
+        getLineMaterial: jest.fn(),
+        getMTextFillMaterial: jest.fn()
+      } as never
+    )
+
+    expect(unbatchedTraverse).toHaveBeenCalledTimes(1)
+    expect(fullTraverse).not.toHaveBeenCalled()
+    expect(getLayerBoundMaterial).toHaveBeenCalled()
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrMaterialMetadata.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMaterialMetadata.spec.ts
@@ -1,0 +1,49 @@
+import * as THREE from 'three'
+
+import {
+  followsLayerStyle,
+  setMaterialMetadata
+} from '../src/style/AcTrMaterialMetadata'
+
+describe('followsLayerStyle', () => {
+  it('returns true when material is ByLayer color on the target layer', () => {
+    const material = new THREE.LineBasicMaterial()
+    setMaterialMetadata(material, {
+      layer: 'WALL',
+      isByLayerColor: true
+    })
+
+    expect(followsLayerStyle(material, 'WALL')).toBe(true)
+  })
+
+  it('returns true when objectLayerName matches after INSERT inheritance', () => {
+    const material = new THREE.LineBasicMaterial()
+    setMaterialMetadata(material, {
+      layer: '0',
+      isByLayerColor: true
+    })
+
+    expect(followsLayerStyle(material, 'INSERT', 'INSERT')).toBe(true)
+    expect(followsLayerStyle(material, 'INSERT')).toBe(false)
+  })
+
+  it('returns false for explicit foreground materials', () => {
+    const material = new THREE.LineBasicMaterial()
+    setMaterialMetadata(material, {
+      layer: 'WALL',
+      isForeground: true
+    })
+
+    expect(followsLayerStyle(material, 'WALL')).toBe(false)
+  })
+
+  it('returns true for other ByLayer bindings without explicit color flag', () => {
+    const material = new THREE.LineBasicMaterial()
+    setMaterialMetadata(material, {
+      layer: 'WALL',
+      isByLayerLineWeight: true
+    })
+
+    expect(followsLayerStyle(material, 'WALL')).toBe(true)
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrObjectUserData.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrObjectUserData.spec.ts
@@ -1,0 +1,50 @@
+import * as THREE from 'three'
+
+import {
+  getSceneDrawableUserData,
+  patchDrawableMaterialFromCache,
+  syncStyleMaterialIdFromMaterials
+} from '../src/util/AcTrObjectUserData'
+
+describe('drawable style material helpers', () => {
+  it('syncStyleMaterialIdFromMaterials stores one id for uniform array materials', () => {
+    const material = new THREE.LineBasicMaterial()
+    const userData = getSceneDrawableUserData(new THREE.Line())
+
+    syncStyleMaterialIdFromMaterials(userData, [material, material])
+
+    expect(userData.styleMaterialId).toBe(material.id)
+  })
+
+  it('syncStyleMaterialIdFromMaterials clears styleMaterialId for mixed array materials', () => {
+    const materialA = new THREE.LineBasicMaterial()
+    const materialB = new THREE.LineBasicMaterial()
+    const userData = getSceneDrawableUserData(new THREE.Line())
+    userData.styleMaterialId = materialA.id
+
+    syncStyleMaterialIdFromMaterials(userData, [materialA, materialB])
+
+    expect(userData.styleMaterialId).toBeUndefined()
+  })
+
+  it('patchDrawableMaterialFromCache remaps every array material slot', () => {
+    const oldMaterialA = new THREE.LineBasicMaterial({ color: 0xffffff })
+    const oldMaterialB = new THREE.LineBasicMaterial({ color: 0x00ff00 })
+    const newMaterialA = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const newMaterialB = new THREE.LineBasicMaterial({ color: 0x0000ff })
+    const materials: Record<number, THREE.Material> = {
+      [oldMaterialA.id]: newMaterialA,
+      [oldMaterialB.id]: newMaterialB
+    }
+
+    const line = new THREE.Line(new THREE.BufferGeometry(), [
+      oldMaterialA,
+      oldMaterialB
+    ])
+
+    patchDrawableMaterialFromCache(line, materials)
+
+    expect(line.material).toEqual([newMaterialA, newMaterialB])
+    expect(getSceneDrawableUserData(line).styleMaterialId).toBeUndefined()
+  })
+})

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -1,4 +1,4 @@
-import { AcCmColor, AcGiSubEntityTraits } from '@mlightcad/data-model'
+import { AcGiSubEntityTraits } from '@mlightcad/data-model'
 import * as THREE from 'three'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
@@ -10,8 +10,8 @@ import {
 import { AcTrPointSymbolCreator } from '../geometry/AcTrPointSymbolCreator'
 import { AcTrEntity } from '../object'
 import {
-  getMaterialMetadata,
-  hasByLayerBinding
+  followsLayerStyle,
+  getMaterialMetadata
 } from '../style/AcTrMaterialMetadata'
 import { AcTrStyleManager } from '../style/AcTrStyleManager'
 import {
@@ -25,7 +25,9 @@ import {
   copyHighlightObjectFlags,
   getHighlightUserData,
   getSceneDrawableUserData,
-  markHighlightOverlayGroup
+  markHighlightOverlayGroup,
+  patchDrawableMaterialFromCache,
+  syncStyleMaterialIdFromMaterials
 } from '../util/AcTrObjectUserData'
 import { isObjectHierarchyVisible } from '../util/AcTrVisibility'
 import { AcTrBatchGeometryUserData } from './AcTrBatchedGeometryInfo'
@@ -479,6 +481,66 @@ export class AcTrBatchedGroup extends THREE.Group {
   }
 
   /**
+   * Refreshes batched and unbatched drawables after a layer-table style change.
+   *
+   * Runs one unbatched-object traversal for text refresh, cache id patching, and
+   * layer-bound remapping instead of scanning the full batched geometry tree.
+   */
+  syncAppearanceFromRecord(
+    layerName: string,
+    layerTraits: Partial<AcGiSubEntityTraits>,
+    materials: Record<number, THREE.Material>,
+    needsIdPatch: boolean,
+    getLayerBoundMaterial: (
+      material: THREE.Material,
+      layerName: string,
+      layerTraits?: Partial<AcGiSubEntityTraits>
+    ) => THREE.Material | undefined,
+    styleManager?: AcTrStyleManager
+  ) {
+    this.rebindBatchedMaterialsForLayer(
+      layerName,
+      layerTraits,
+      getLayerBoundMaterial,
+      styleManager
+    )
+
+    this._unbatchedObjects.traverse(object => {
+      const refresh = (
+        object as {
+          refreshTextMaterials?: (
+            layerTraits?: Partial<AcGiSubEntityTraits>
+          ) => void
+        }
+      ).refreshTextMaterials
+      if (typeof refresh === 'function') {
+        refresh.call(object, layerTraits)
+      }
+
+      if (!('material' in object)) {
+        return
+      }
+
+      const drawable = object as THREE.Mesh | THREE.Line | THREE.LineSegments
+      if (needsIdPatch) {
+        patchDrawableMaterialFromCache(drawable, materials)
+      }
+
+      this.rebindUnbatchedDrawableMaterial(
+        drawable,
+        layerName,
+        layerTraits,
+        getLayerBoundMaterial,
+        styleManager
+      )
+    })
+
+    if (styleManager) {
+      this.rematerializeLayerTextDrawables(layerName, styleManager, layerTraits)
+    }
+  }
+
+  /**
    * Rebinds layer-bound batch materials after a layer-table style change.
    *
    * Batched MTEXT/TEXT glyphs and cloned unbatched drawables may not share the
@@ -486,6 +548,38 @@ export class AcTrBatchedGroup extends THREE.Group {
    * {@link AcTrStyleManager.updateLayerMaterial}.
    */
   rebindMaterialsForLayer(
+    layerName: string,
+    layerTraits: Partial<AcGiSubEntityTraits>,
+    getLayerBoundMaterial: (
+      material: THREE.Material,
+      layerName: string,
+      layerTraits?: Partial<AcGiSubEntityTraits>
+    ) => THREE.Material | undefined,
+    styleManager?: AcTrStyleManager
+  ) {
+    this.rebindBatchedMaterialsForLayer(
+      layerName,
+      layerTraits,
+      getLayerBoundMaterial,
+      styleManager
+    )
+
+    this._unbatchedObjects.traverse(object => {
+      if (!('material' in object)) {
+        return
+      }
+
+      this.rebindUnbatchedDrawableMaterial(
+        object as THREE.Mesh | THREE.Line | THREE.LineSegments,
+        layerName,
+        layerTraits,
+        getLayerBoundMaterial,
+        styleManager
+      )
+    })
+  }
+
+  private rebindBatchedMaterialsForLayer(
     layerName: string,
     layerTraits: Partial<AcGiSubEntityTraits>,
     getLayerBoundMaterial: (
@@ -504,7 +598,7 @@ export class AcTrBatchedGroup extends THREE.Group {
         if (!material || reboundByOldId.has(materialId)) {
           continue
         }
-        if (!this.shouldFollowLayerStyle(material, layerName)) {
+        if (!followsLayerStyle(material, layerName, layerName)) {
           continue
         }
 
@@ -513,7 +607,8 @@ export class AcTrBatchedGroup extends THREE.Group {
           layerName,
           layerTraits,
           getLayerBoundMaterial,
-          styleManager
+          styleManager,
+          layerName
         )
         if (!rebound) {
           continue
@@ -528,15 +623,26 @@ export class AcTrBatchedGroup extends THREE.Group {
         this.updateMaterial(materialId, rebound)
       }
     }
+  }
 
-    this._unbatchedObjects.traverse(object => {
-      if (!('material' in object)) {
-        return
-      }
+  private rebindUnbatchedDrawableMaterial(
+    drawable: THREE.Mesh | THREE.Line | THREE.LineSegments,
+    layerName: string,
+    layerTraits: Partial<AcGiSubEntityTraits>,
+    getLayerBoundMaterial: (
+      material: THREE.Material,
+      layerName: string,
+      layerTraits?: Partial<AcGiSubEntityTraits>
+    ) => THREE.Material | undefined,
+    styleManager?: AcTrStyleManager
+  ) {
+    const objectLayerName = drawable.userData.layerName as string | undefined
+    const effectiveObjectLayerName = objectLayerName ?? layerName
+    const drawableUserData = getSceneDrawableUserData(drawable)
 
-      const material = object.material as THREE.Material
-      if (!this.shouldFollowLayerStyle(material, layerName)) {
-        return
+    const rebindSingle = (material: THREE.Material): THREE.Material => {
+      if (!followsLayerStyle(material, layerName, effectiveObjectLayerName)) {
+        return material
       }
 
       const rebound = this.resolveLayerBoundMaterial(
@@ -544,20 +650,35 @@ export class AcTrBatchedGroup extends THREE.Group {
         layerName,
         layerTraits,
         getLayerBoundMaterial,
-        styleManager
+        styleManager,
+        effectiveObjectLayerName
       )
       if (!rebound) {
-        return
+        return material
       }
 
       if (rebound === material) {
         this.refreshLayerBoundMaterialColor(material, layerTraits)
-        return
+        return material
       }
 
-      object.material = rebound
-      getSceneDrawableUserData(object).styleMaterialId = rebound.id
-    })
+      return rebound
+    }
+
+    const currentMaterial = drawable.material
+    if (Array.isArray(currentMaterial)) {
+      drawable.material = currentMaterial.map(rebindSingle)
+      syncStyleMaterialIdFromMaterials(drawableUserData, drawable.material)
+      return
+    }
+
+    const rebound = rebindSingle(currentMaterial)
+    if (rebound === currentMaterial) {
+      return
+    }
+
+    drawable.material = rebound
+    syncStyleMaterialIdFromMaterials(drawableUserData, rebound)
   }
 
   /**
@@ -571,23 +692,17 @@ export class AcTrBatchedGroup extends THREE.Group {
     styleManager: AcTrStyleManager,
     layerTraits?: Partial<AcGiSubEntityTraits>
   ) {
-    const fallbackTraits = AcTrMTextColorUtil.snapshotEntityTraits({
-      ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
-      color: (() => {
-        const color = new AcCmColor()
-        color.setByLayer()
-        return color
-      })(),
-      layer: layerName
-    })
-
     for (const root of this._unbatchedObjects.children) {
       const storedTraits = getSceneDrawableUserData(root).textEntityTraits
-      const traits =
-        storedTraits != null
-          ? AcTrMTextColorUtil.cloneEntityTraits(storedTraits)
-          : fallbackTraits
-      AcTrMTextColorUtil.rematerializeTextHierarchy(root, traits, styleManager)
+      if (storedTraits == null) {
+        continue
+      }
+
+      AcTrMTextColorUtil.rematerializeTextHierarchy(
+        root,
+        AcTrMTextColorUtil.cloneEntityTraits(storedTraits),
+        styleManager
+      )
     }
 
     if (!layerTraits?.color) {
@@ -598,7 +713,7 @@ export class AcTrBatchedGroup extends THREE.Group {
       for (const materialId of [...group.keys()]) {
         const batches = group.get(materialId)
         const material = batches?.[0]?.material as THREE.Material | undefined
-        if (!material || !this.shouldFollowLayerStyle(material, layerName)) {
+        if (!material || !followsLayerStyle(material, layerName, layerName)) {
           continue
         }
         this.refreshLayerBoundMaterialColor(material, layerTraits)
@@ -615,7 +730,8 @@ export class AcTrBatchedGroup extends THREE.Group {
       layerName: string,
       layerTraits?: Partial<AcGiSubEntityTraits>
     ) => THREE.Material | undefined,
-    styleManager?: AcTrStyleManager
+    styleManager?: AcTrStyleManager,
+    objectLayerName?: string
   ): THREE.Material | undefined {
     const rebound = getLayerBoundMaterial(material, layerName, layerTraits)
     if (rebound) {
@@ -624,15 +740,21 @@ export class AcTrBatchedGroup extends THREE.Group {
     if (!styleManager) {
       return undefined
     }
-    return this.resolveLayerBoundReplacement(material, layerName, styleManager)
+    return this.resolveLayerBoundReplacement(
+      material,
+      layerName,
+      styleManager,
+      objectLayerName ?? layerName
+    )
   }
 
   private resolveLayerBoundReplacement(
     material: THREE.Material,
     layerName: string,
-    styleManager: AcTrStyleManager
+    styleManager: AcTrStyleManager,
+    objectLayerName: string
   ): THREE.Material | undefined {
-    if (!this.shouldFollowLayerStyle(material, layerName)) {
+    if (!followsLayerStyle(material, layerName, objectLayerName)) {
       return undefined
     }
 
@@ -679,23 +801,6 @@ export class AcTrBatchedGroup extends THREE.Group {
     }
 
     return undefined
-  }
-
-  private shouldFollowLayerStyle(
-    material: THREE.Material,
-    layerName: string
-  ): boolean {
-    const metadata = getMaterialMetadata(material)
-    if (metadata.layer !== layerName) {
-      return false
-    }
-    if (metadata.isByLayerColor === true) {
-      return true
-    }
-    if (metadata.isForeground === true) {
-      return false
-    }
-    return hasByLayerBinding(metadata)
   }
 
   /**

--- a/packages/three-renderer/src/index.ts
+++ b/packages/three-renderer/src/index.ts
@@ -35,6 +35,9 @@ export {
   isHighlightCloneDrawable,
   isHighlightOverlayDescendant,
   markHighlightOverlayGroup,
+  patchDrawableMaterialFromCache,
+  resolveCachedMaterialRemap,
+  syncStyleMaterialIdFromMaterials,
   type AcTrHighlightOverlayGroup,
   type AcTrHighlightOverlayGroupUserData
 } from './util/AcTrObjectUserData'

--- a/packages/three-renderer/src/renderer/AcTrRenderContext.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderContext.ts
@@ -1,4 +1,5 @@
 import {
+  AcDbDatabase,
   ACGI_DARK_THEME_FOREGROUND,
   ACGI_LIGHT_THEME_FOREGROUND,
   AcGiContext,
@@ -28,6 +29,12 @@ import { AcTrStyleManager } from '../style/AcTrStyleManager'
 export class AcTrRenderContext extends AcGiContext {
   readonly styleManager: AcTrStyleManager
   batchDrawPolicy: AcTrBatchDrawPolicy
+
+  /**
+   * Database being drawn. Narrows {@link AcGiContext.database} from `unknown`
+   * to {@link AcDbDatabase} for three-renderer consumers.
+   */
+  database: AcDbDatabase | undefined = undefined
 
   constructor(
     styleManager: AcTrStyleManager = new AcTrStyleManager(),

--- a/packages/three-renderer/src/style/AcTrMaterialMetadata.ts
+++ b/packages/three-renderer/src/style/AcTrMaterialMetadata.ts
@@ -93,3 +93,34 @@ export function hasByLayerBinding(
     metadata.isByLayerTransparency === true
   )
 }
+
+/**
+ * Returns whether a drawable material should follow live layer-table style updates.
+ *
+ * When {@link objectLayerName} is supplied, drawables remapped to another layer
+ * (for example layer-0 INSERT inheritance) still participate in layer sync even
+ * if cached metadata still references the source layer name.
+ *
+ * @param material - Drawable material whose metadata drives the decision.
+ * @param layerName - Layer name targeted by the current sync pass.
+ * @param objectLayerName - Optional runtime layer name on the drawable after INSERT remapping.
+ * @returns True when the material should receive live layer-table style updates.
+ */
+export function followsLayerStyle(
+  material: THREE.Material,
+  layerName: string,
+  objectLayerName?: string
+): boolean {
+  const metadata = getMaterialMetadata(material)
+
+  if (metadata.layer !== layerName && objectLayerName !== layerName) {
+    return false
+  }
+  if (metadata.isByLayerColor === true) {
+    return true
+  }
+  if (metadata.isForeground === true) {
+    return false
+  }
+  return hasByLayerBinding(metadata)
+}

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -193,6 +193,78 @@ export function getSceneDrawableUserData(
   return getObjectUserData(object) as AcTrSceneDrawableUserData
 }
 
+/**
+ * Resolves a style-cache material remap for one drawable material instance.
+ */
+export function resolveCachedMaterialRemap(
+  material: THREE.Material,
+  materials: Record<number, THREE.Material>,
+  styleMaterialId?: number
+): THREE.Material | undefined {
+  return (
+    materials[material.id] ??
+    (styleMaterialId != null ? materials[styleMaterialId] : undefined)
+  )
+}
+
+/**
+ * Keeps {@link AcTrStyledDrawableUserData.styleMaterialId} aligned with drawable materials.
+ *
+ * Array materials only store a style id when every slot shares the same material id.
+ */
+export function syncStyleMaterialIdFromMaterials(
+  userData: AcTrStyledDrawableUserData,
+  material: THREE.Material | THREE.Material[]
+): void {
+  if (Array.isArray(material)) {
+    const ids = new Set(material.map(entry => entry.id))
+    if (ids.size === 1) {
+      userData.styleMaterialId = material[0].id
+      return
+    }
+    delete userData.styleMaterialId
+    return
+  }
+
+  userData.styleMaterialId = material.id
+}
+
+type AcTrMaterialDrawable = THREE.Mesh | THREE.Line | THREE.LineSegments
+
+/**
+ * Patches drawable material slots after the style cache replaces material instances.
+ */
+export function patchDrawableMaterialFromCache(
+  drawable: AcTrMaterialDrawable,
+  materials: Record<number, THREE.Material>
+): void {
+  const userData = getSceneDrawableUserData(drawable)
+  const current = drawable.material
+
+  if (Array.isArray(current)) {
+    drawable.material = current.map(entry => {
+      const remapped = resolveCachedMaterialRemap(
+        entry,
+        materials,
+        userData.styleMaterialId
+      )
+      return remapped && remapped !== entry ? remapped : entry
+    })
+    syncStyleMaterialIdFromMaterials(userData, drawable.material)
+    return
+  }
+
+  const remapped = resolveCachedMaterialRemap(
+    current,
+    materials,
+    userData.styleMaterialId
+  )
+  if (remapped && remapped !== current) {
+    drawable.material = remapped
+    syncStyleMaterialIdFromMaterials(userData, remapped)
+  }
+}
+
 export function getHighlightUserData(
   object: THREE.Object3D
 ): AcTrHighlightObjectUserData {

--- a/packages/three-renderer/src/util/AcTrShapeStyleUtil.ts
+++ b/packages/three-renderer/src/util/AcTrShapeStyleUtil.ts
@@ -1,5 +1,4 @@
 import {
-  AcDbDatabase,
   AcGiShapeData,
   AcGiTextStyle
 } from '@mlightcad/data-model'
@@ -108,7 +107,7 @@ export function resolveShapeTextStyle(
     }
   }
 
-  const database = context.database as AcDbDatabase | undefined
+  const database = context.database
   if (!database) {
     return { ...EMPTY_TEXT_STYLE }
   }


### PR DESCRIPTION
## Summary

- Extract layer appearance synchronization from `AcTrView2d` into `AcTrLayerAppearanceController`, keeping material cache updates, scene fan-out, and text rematerialization out of the view class.
- Add `AcTrInheritedLayerMaterialMapper` so block entities on layer "0" inherit the INSERT layer for ByLayer color, linetype, lineweight, and transparency (AutoCAD semantics).
- Extend `three-renderer` with material metadata helpers, batched-group layer style sync, and `AcApLayerService.resolveLayerTraits` for resolving live layer-table traits.
- Add unit tests covering layer trait resolution, inherited layer remapping, batched group styling, and material metadata utilities.

## Test plan

- [ ] Open a drawing with blocks whose contents are on layer "0"; verify ByLayer color/linetype/lineweight follow the INSERT layer
- [ ] Change layer color, linetype, lineweight, or transparency in the layer manager; confirm batched geometry and text update immediately
- [ ] Toggle layer on/off and freeze/unfreeze; confirm visibility still works as before
- [ ] Change canvas background (ACI-7 foreground inversion); confirm text materials refresh correctly inside INSERT groups
- [ ] Run `pnpm nx test cad-simple-viewer` and `pnpm nx test three-renderer`