### PR TITLE
feat(ui): replace layer panel with toolbar popover and add collapsible toolbar

### DIFF
--- a/packages/cad-simple-ui-plugin/README.md
+++ b/packages/cad-simple-ui-plugin/README.md
@@ -12,9 +12,10 @@ This plugin provides ready-to-use CAD viewer chrome without Vue, React, or Eleme
 - Default toolbar includes view/review tools, export submenu, toolbar placement, theme and locale toggles
 - UI theme follows `COLORTHEME` sysvar and `--ml-ui-*` tokens on `host` automatically
 - Locale follows `AcApI18n.currentLocale` automatically
-- Floating layer manager (name, visibility, color)
+- Layer list popover anchored to the toolbar layer button (name, visibility, color)
 - ACI color picker for layer colors
-- `layer` command opens the layer manager panel
+- Layer popover opens from the toolbar button or the `layer` command; closes on outside click
+- Optional collapsible toolbar (like HTML export viewer): hide tool buttons and show only a chevron toggle
 
 ## Install
 
@@ -42,8 +43,7 @@ await AcApDocManager.instance.pluginManager.loadPlugin(
     toolbar: {
       placement: 'right',
       items: 'default'
-    },
-    layerManager: { enabled: true }
+    }
   })
 )
 ```
@@ -57,8 +57,7 @@ import { registerSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin/register
 
 await registerSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
   host,
-  toolbar: { placement: 'right', items: 'default' },
-  layerManager: { enabled: true }
+  toolbar: { placement: 'right', items: 'default' }
 })
 ```
 
@@ -96,23 +95,31 @@ toolbar: {
 
 The built-in theme toggle button updates `COLORTHEME` when a document is open, or applies `applyUiTheme` on `host` when no document is loaded.
 
-### Layer manager bounds
+### Layer popover
 
-By default the layer manager stays inside `host` and cannot be dragged outside the canvas:
+The layer list is a **popover** (not a floating panel). It is enabled automatically when the resolved toolbar includes a layer button (`id: 'layer'` or `{ preset: 'layer' }`). No separate `layerManager` option is required.
+
+Behavior:
+
+- Click the layer toolbar button to open or close the popover
+- Click the canvas or other UI outside the popover to dismiss it
+- On vertical toolbars (`left` / `right`), popover height aligns with the toolbar (minimum 320px)
+- On narrow hosts (≤640px width), the popover uses a bottom-sheet layout sized for mobile
+
+The built-in `layerclose` command emits `close-layer-manager`, which the plugin listens for.
+
+### Collapsible toolbar
+
+Set `toolbar.collapsible: true` to append a chevron toggle at the end of the toolbar (same behavior as the HTML export viewer). When collapsed, only the toggle button is shown; anchored popovers such as the layer list are closed automatically.
 
 ```typescript
-layerManager: {
-  enabled: true,
-  allowMoveOutsideCanvas: false // default
+toolbar: {
+  placement: 'right',
+  items: 'default',
+  collapsible: true,
+  defaultCollapsed: false // optional, default false
 }
 ```
-
-The panel height can be adjusted by dragging the handle at the bottom edge.
-
-Default placement:
-
-- Vertically centered in the canvas, with 150px margin from the top and bottom edges
-- Horizontally on the side opposite the toolbar (`right` toolbar → panel on the left; `left`/`top`/`bottom` toolbar → panel on the right)
 
 ## Custom toolbar
 
@@ -127,6 +134,7 @@ Toolbar buttons are configured through `toolbar.items`. You can start from the b
 | `icon` | Inline SVG string, DOM element, or factory `() => HTMLElement` |
 | `command` | Passed to `AcApDocManager.sendStringToExecute` (supports `\n`, e.g. `'zoom\nall'`) |
 | `action` | Custom click handler (e.g. open a dialog). Used when no `command` is set |
+| `anchorAction` | Popover-style handler that receives the anchor button element. Takes precedence over `command` and `action` |
 | `requiresDocument` | When `false`, button stays enabled before a drawing is opened |
 | `minOpenMode` | Hide below Review/Write (`AcEdOpenMode.Review`) |
 | `children` | Submenu items (parent shows a flyout arrow) |
@@ -323,10 +331,11 @@ Submenu flyout direction follows toolbar placement (e.g. arrow points left when 
 
 ```typescript
 createSimpleUiPlugin({
-  toolbar: { enabled: false },
-  layerManager: { enabled: true }
+  toolbar: { enabled: false }
 })
 ```
+
+Disabling the toolbar also disables the layer popover, because the layer UI is tied to the layer toolbar button.
 
 ### Complete example
 
@@ -365,10 +374,6 @@ await AcApDocManager.instance.pluginManager.loadPlugin(
           ]
         }
       ]
-    },
-    layerManager: {
-      enabled: true,
-      allowMoveOutsideCanvas: false
     }
   })
 )
@@ -376,7 +381,7 @@ await AcApDocManager.instance.pluginManager.loadPlugin(
 
 ## Layer manager
 
-When enabled, the plugin registers a `layer` command that opens the layer manager palette. The built-in `layerclose` command emits `close-layer-manager`, which the plugin listens for.
+When the toolbar includes a layer button, the plugin registers a `layer` command and wires the button to the layer popover automatically.
 
 Supported columns in v1:
 
@@ -385,6 +390,17 @@ Supported columns in v1:
 - Color (ACI picker)
 
 Double-click a layer row to zoom to that layer.
+
+To use the layer UI in a custom toolbar, include the built-in preset or a button with `id: 'layer'`:
+
+```typescript
+items: [
+  toolbarPreset('select'),
+  toolbarPreset('layer')
+]
+```
+
+Omit the layer button from `items` if you do not want the layer popover or `layer` command.
 
 ## API
 

--- a/packages/cad-simple-ui-plugin/src/assets/icons.ts
+++ b/packages/cad-simple-ui-plugin/src/assets/icons.ts
@@ -99,6 +99,22 @@ export const ICON_PLACEMENT_LEFT =
 export const ICON_PLACEMENT_RIGHT =
   '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="5" y="5" width="9" height="10" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="3" width="3" height="14" rx=".5" fill="currentColor"/></svg>'
 
+/** Collapse toolbar (chevron toward compact edge). */
+export const ICON_CHEVRON_UP =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M10 6.5 5.5 11h9L10 6.5Z"/></svg>'
+
+/** Expand toolbar (chevron toward expanded edge). */
+export const ICON_CHEVRON_DOWN =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M10 13.5 14.5 9h-9L10 13.5Z"/></svg>'
+
+/** Collapse horizontal toolbar (chevron toward compact edge). */
+export const ICON_CHEVRON_RIGHT =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M13.5 10 9 14.5V5.5L13.5 10Z"/></svg>'
+
+/** Expand horizontal toolbar (chevron toward expanded edge). */
+export const ICON_CHEVRON_LEFT =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M6.5 10 11 14.5V5.5L6.5 10Z"/></svg>'
+
 /**
  * Creates a DOM icon element from an SVG string, element, or factory.
  *

--- a/packages/cad-simple-ui-plugin/src/command/AcApLayerUiCmd.ts
+++ b/packages/cad-simple-ui-plugin/src/command/AcApLayerUiCmd.ts
@@ -3,22 +3,22 @@ import { AcApContext, AcEdCommand } from '@mlightcad/cad-simple-viewer'
 import type { AcExLayerManager } from '../ui/AcExLayerManager'
 
 /**
- * Command that opens the floating layer manager panel.
+ * Command that toggles the layer manager popover.
  */
 export class AcApLayerUiCmd extends AcEdCommand {
   /**
-   * @param layerManager - Layer manager instance to show when the command runs.
+   * @param layerManager - Layer manager instance to toggle when the command runs.
    */
   constructor(private layerManager: AcExLayerManager) {
     super()
   }
 
   /**
-   * Shows the layer manager panel.
+   * Toggles the layer manager popover.
    *
    * @param _context - Application context (unused).
    */
   async execute(_context: AcApContext) {
-    this.layerManager.show()
+    this.layerManager.toggleFromCommand()
   }
 }

--- a/packages/cad-simple-ui-plugin/src/config/resolveToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/resolveToolbarItems.ts
@@ -155,7 +155,7 @@ export function resolveParentToolbarDisplay(
 export function itemRequiresDocument(item: AcExToolbarItem): boolean {
   if (isToolbarSeparatorItem(item)) return false
   if (item.requiresDocument != null) return item.requiresDocument
-  return Boolean(item.command)
+  return Boolean(item.command || item.anchorAction)
 }
 
 /**
@@ -198,6 +198,7 @@ export function filterVisibleToolbarItems(
         item.children.length > 0 ||
         item.command ||
         item.action ||
+        item.anchorAction ||
         item.toggle
       )
     })

--- a/packages/cad-simple-ui-plugin/src/config/toolbarItemUtils.ts
+++ b/packages/cad-simple-ui-plugin/src/config/toolbarItemUtils.ts
@@ -37,6 +37,20 @@ export function toolbarPreset(preset: string): AcExToolbarPresetRef {
   return { preset }
 }
 
+/** Returns whether a resolved toolbar item list includes the given button id. */
+export function toolbarItemsIncludeItem(
+  items: AcExToolbarItem[],
+  itemId: string
+): boolean {
+  return items.some(item => {
+    if (isToolbarSeparatorItem(item)) return false
+    if (item.id === itemId) return true
+    return item.children
+      ? toolbarItemsIncludeItem(item.children, itemId)
+      : false
+  })
+}
+
 /** Registers button items (and nested children) in a preset lookup map. */
 export function indexToolbarItems(
   items: AcExToolbarItem[],

--- a/packages/cad-simple-ui-plugin/src/config/types.ts
+++ b/packages/cad-simple-ui-plugin/src/config/types.ts
@@ -43,6 +43,11 @@ export interface AcExToolbarItem {
   /** Custom click handler. Used when no command is set (e.g. theme toggle). */
   action?: () => void
   /**
+   * Popover-style click handler that receives the anchor button element.
+   * When set, takes precedence over `command` and `action`.
+   */
+  anchorAction?: (anchor: HTMLElement) => void
+  /**
    * When false, the button stays enabled without an open document.
    * Defaults to true when `command` is set, otherwise false.
    */
@@ -113,13 +118,10 @@ export interface AcExSimpleUiPluginOptions {
     items?: AcExToolbarItemConfig[] | 'default'
     /** Extra items appended after `items`. */
     appendItems?: AcExToolbarItemConfig[]
-  }
-  /** Layer manager panel configuration. Enabled by default. */
-  layerManager?: {
-    /** When false, the layer manager and `layer` command are not registered. */
-    enabled?: boolean
-    /** When false (default), the panel is clamped inside `host`. */
-    allowMoveOutsideCanvas?: boolean
+    /** When true, show a collapse/expand toggle at the end of the toolbar. */
+    collapsible?: boolean
+    /** Initial collapsed state when {@link collapsible} is true. */
+    defaultCollapsed?: boolean
   }
 }
 

--- a/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
+++ b/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
@@ -12,7 +12,12 @@ import packageJson from '../package.json'
 import { AcApLayerUiCmd } from './command/AcApLayerUiCmd'
 import { resolveToolbarItems } from './config/resolveToolbarItems'
 import {
+  isToolbarSeparatorItem,
+  toolbarItemsIncludeItem
+} from './config/toolbarItemUtils'
+import {
   AcExSimpleUiPluginOptions,
+  AcExToolbarItem,
   AcExToolbarPlacement,
   SIMPLE_UI_PLUGIN_NAME
 } from './config/types'
@@ -25,8 +30,9 @@ import { removeUiStylesIfUnused } from './ui/styles'
 /**
  * CAD viewer plugin that adds a framework-agnostic toolbar and layer manager.
  *
- * Registers the `layer` command, injects shared UI styles, and keeps theme and
- * locale in sync with {@link AcApI18n} and the `COLORTHEME` system variable.
+ * Registers the `layer` command when the toolbar includes a layer button, injects
+ * shared UI styles, and keeps theme and locale in sync with {@link AcApI18n} and
+ * the `COLORTHEME` system variable.
  */
 export class AcApSimpleUiPlugin implements AcApPlugin {
   /** {@link SIMPLE_UI_PLUGIN_NAME} */
@@ -36,7 +42,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   /** Human-readable plugin summary. */
   description = 'Framework-agnostic toolbar and layer manager UI'
 
-  /** Floating layer manager DOM panel. */
+  /** Layer list popover anchored to the toolbar layer button. */
   private layerManager?: AcExLayerManager
   /** Configurable toolbar instance. */
   private toolbar?: AcExToolbar
@@ -82,15 +88,27 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     this.i18n = new AcExI18n()
     AcApI18n.events.localeChanged.addEventListener(this.handleLocaleChanged)
 
-    const layerEnabled = resolvedOptions.layerManager?.enabled !== false
-    if (layerEnabled) {
+    const toolbarEnabled = resolvedOptions.toolbar?.enabled !== false
+    const toolbarContext = {
+      getTheme: () => this.themeSync?.getTheme() ?? 'dark',
+      setTheme: (theme: AcEdUiTheme) => this.themeSync?.setTheme(theme),
+      getLocale: () => AcApI18n.currentLocale,
+      toggleLocale: () => this.toggleLocale(),
+      getPlacement: () => this.toolbarPlacement,
+      setPlacement: (placement: AcExToolbarPlacement) =>
+        this.setToolbarPlacement(placement)
+    }
+    const toolbarItems = toolbarEnabled
+      ? resolveToolbarItems(resolvedOptions.toolbar, toolbarContext)
+      : []
+
+    if (toolbarItemsIncludeItem(toolbarItems, 'layer')) {
       this.layerManager = new AcExLayerManager({
         editor: AcApDocManager.instance,
         i18n: this.i18n,
         host,
         toolbarPlacement: this.toolbarPlacement,
-        allowMoveOutsideCanvas:
-          resolvedOptions.layerManager?.allowMoveOutsideCanvas ?? false
+        resolveLayerAnchor: () => this.toolbar?.getLayerButtonAnchor()
       })
 
       const group = AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME
@@ -103,28 +121,52 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       this.registeredCommands.push({ group, name: 'layer' })
     }
 
-    const toolbarEnabled = resolvedOptions.toolbar?.enabled !== false
     if (toolbarEnabled) {
-      const toolbarContext = {
-        getTheme: () => this.themeSync?.getTheme() ?? 'dark',
-        setTheme: (theme: AcEdUiTheme) => this.themeSync?.setTheme(theme),
-        getLocale: () => AcApI18n.currentLocale,
-        toggleLocale: () => this.toggleLocale(),
-        getPlacement: () => this.toolbarPlacement,
-        setPlacement: (placement: AcExToolbarPlacement) =>
-          this.setToolbarPlacement(placement)
-      }
-      const items = resolveToolbarItems(resolvedOptions.toolbar, toolbarContext)
+      const items = this.withLayerPopoverAction(toolbarItems)
       this.toolbar = new AcExToolbar({
         host,
         placement: this.toolbarPlacement,
         items,
         i18n: this.i18n,
+        collapsible: resolvedOptions.toolbar?.collapsible ?? false,
+        defaultCollapsed: resolvedOptions.toolbar?.defaultCollapsed ?? false,
+        onCollapse: () => {
+          this.layerManager?.hide()
+        },
         onCommand: command => {
           AcApDocManager.instance.sendStringToExecute(command)
         }
       })
     }
+  }
+
+  /**
+   * Wires the built-in layer toolbar button to the layer manager popover.
+   *
+   * @param items - Resolved toolbar items.
+   */
+  private withLayerPopoverAction(items: AcExToolbarItem[]): AcExToolbarItem[] {
+    if (!this.layerManager) return items
+
+    return items.map(item => {
+      if (isToolbarSeparatorItem(item)) return item
+
+      let next = item
+      if (item.id === 'layer') {
+        next = {
+          ...item,
+          command: undefined,
+          anchorAction: anchor => this.layerManager!.toggle(anchor)
+        }
+      }
+      if (next.children?.length) {
+        next = {
+          ...next,
+          children: this.withLayerPopoverAction(next.children)
+        }
+      }
+      return next
+    })
   }
 
   /** Updates toolbar placement and repositions the layer manager when applicable. */
@@ -168,7 +210,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   }
 
   /**
-   * Fills in default option values for toolbar and layer manager sections.
+   * Fills in default option values for the toolbar section.
    *
    * @returns Resolved options with explicit boolean defaults.
    */
@@ -183,12 +225,9 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
         enabled: this.options.toolbar?.enabled ?? true,
         placement: this.options.toolbar?.placement ?? 'right',
         items: this.options.toolbar?.items ?? 'default',
-        appendItems: this.options.toolbar?.appendItems
-      },
-      layerManager: {
-        enabled: this.options.layerManager?.enabled ?? true,
-        allowMoveOutsideCanvas:
-          this.options.layerManager?.allowMoveOutsideCanvas ?? false
+        appendItems: this.options.toolbar?.appendItems,
+        collapsible: this.options.toolbar?.collapsible ?? false,
+        defaultCollapsed: this.options.toolbar?.defaultCollapsed ?? false
       }
     }
   }

--- a/packages/cad-simple-ui-plugin/src/i18n/command-en.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/command-en.ts
@@ -1,0 +1,10 @@
+/**
+ * English command message entries merged into {@link AcApI18n} under `command`.
+ */
+export const commandEn = {
+  ACAD: {
+    layer: {
+      description: 'Opens or closes the layer manager popover'
+    }
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/i18n/command-zh.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/command-zh.ts
@@ -1,0 +1,10 @@
+/**
+ * Chinese command message entries merged into {@link AcApI18n} under `command`.
+ */
+export const commandZh = {
+  ACAD: {
+    layer: {
+      description: '打开或关闭图层管理器弹出面板'
+    }
+  }
+}

--- a/packages/cad-simple-ui-plugin/src/i18n/en.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/en.ts
@@ -37,6 +37,8 @@ export const en: Record<string, string> = {
   'toolbar.themeDark': 'Switch to Light Theme',
   'toolbar.localeEn': 'English (switch to Chinese)',
   'toolbar.localeZh': '中文 (switch to English)',
+  'toolbar.collapse': 'Collapse toolbar',
+  'toolbar.expand': 'Expand toolbar',
   'layerManager.title': 'Layer Manager',
   'layerManager.name': 'Name',
   'layerManager.on': 'On',

--- a/packages/cad-simple-ui-plugin/src/i18n/index.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/index.ts
@@ -1,5 +1,7 @@
 import { AcApI18n } from '@mlightcad/cad-simple-viewer'
 
+import { commandEn } from './command-en'
+import { commandZh } from './command-zh'
 import { en } from './en'
 import { zh } from './zh'
 
@@ -45,9 +47,11 @@ function flatToNested(flat: Record<string, string>): LocaleMessageTree {
 export function registerSimpleUiI18n(): void {
   if (isRegistered) return
   AcApI18n.mergeLocaleMessage('en', {
+    command: commandEn,
     [MESSAGE_PREFIX]: flatToNested(en)
   })
   AcApI18n.mergeLocaleMessage('zh', {
+    command: commandZh,
     [MESSAGE_PREFIX]: flatToNested(zh)
   })
   isRegistered = true

--- a/packages/cad-simple-ui-plugin/src/i18n/zh.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/zh.ts
@@ -37,6 +37,8 @@ export const zh: Record<string, string> = {
   'toolbar.themeDark': '切换为浅色主题',
   'toolbar.localeEn': 'English（切换为中文）',
   'toolbar.localeZh': '中文（切换为 English）',
+  'toolbar.collapse': '收起工具栏',
+  'toolbar.expand': '展开工具栏',
   'layerManager.title': '图层管理器',
   'layerManager.name': '名称',
   'layerManager.on': '开',

--- a/packages/cad-simple-ui-plugin/src/ui/AcExLayerManager.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExLayerManager.ts
@@ -2,7 +2,8 @@ import {
   AcApDocManager,
   type AcApLayerInfo,
   AcApLayerStore,
-  eventBus} from '@mlightcad/cad-simple-viewer'
+  eventBus
+} from '@mlightcad/cad-simple-viewer'
 import { AcCmColor } from '@mlightcad/data-model'
 
 import type { AcExToolbarPlacement } from '../config/types'
@@ -10,12 +11,23 @@ import type { AcExI18n } from '../i18n'
 import { AcExColorPicker } from './AcExColorPicker'
 import { ensureUiStyles } from './styles'
 
-/** Minimum top/bottom margin for default panel placement and height. */
-const LAYER_MANAGER_VERTICAL_MARGIN = 150
-/** Horizontal inset from the host edge for default placement. */
-const LAYER_MANAGER_HORIZONTAL_MARGIN = 8
-/** Minimum panel height (px). */
-const LAYER_MANAGER_MIN_HEIGHT = 120
+/** Minimum popover height on desktop (px); also used when the toolbar is shorter. */
+const LAYER_POPOVER_MIN_HEIGHT = 320
+/** Absolute minimum popover height (px). */
+const LAYER_POPOVER_ABSOLUTE_MIN_HEIGHT = 120
+/** Gap between anchor button and popover (px). */
+const LAYER_POPOVER_GAP = 4
+/** Viewport edge inset when clamping position (px). */
+const LAYER_POPOVER_VIEWPORT_INSET = 8
+/** Host width at or below which compact (mobile) layout is used (px). */
+const LAYER_POPOVER_COMPACT_BREAKPOINT = 640
+/** Preferred height ratio for compact layout relative to the host height. */
+const LAYER_POPOVER_COMPACT_HEIGHT_RATIO = 0.55
+/** Maximum height for compact layout (px). */
+const LAYER_POPOVER_COMPACT_MAX_HEIGHT = 420
+
+/** Stable id for the popover title element (used by aria-labelledby). */
+const LAYER_MANAGER_TITLE_ID = 'ml-ex-ui-layer-manager-title'
 
 /** Constructor options for {@link AcExLayerManager}. */
 export interface AcExLayerManagerOptions {
@@ -23,19 +35,24 @@ export interface AcExLayerManagerOptions {
   editor: AcApDocManager
   /** i18n helper for panel labels. */
   i18n: AcExI18n
-  /** Viewer host used for containment and default positioning. */
+  /** Viewer host used for containment and theme CSS variables. */
   host: HTMLElement
-  /** Toolbar placement used to pick the opposite side for the panel. */
+  /** Toolbar placement used to position the popover relative to the anchor. */
   toolbarPlacement?: AcExToolbarPlacement
-  /** When false, the panel is clamped inside `host`. */
-  allowMoveOutsideCanvas?: boolean
+  /**
+   * Resolves the layer toolbar button, expanding a collapsed toolbar when needed.
+   * Falls back to querying the host when not provided.
+   */
+  resolveLayerAnchor?: () => HTMLElement | undefined
 }
 
 /**
- * Draggable, resizable floating panel for layer visibility and color editing.
+ * Layer list popover anchored to the toolbar layer button.
+ *
+ * Opens on layer button click and closes on outside interaction (canvas, other UI).
  */
 export class AcExLayerManager {
-  /** Root panel element. */
+  /** Root popover element. */
   private root: HTMLDivElement
   /** Layer table body receiving row nodes. */
   private tbody!: HTMLTableSectionElement
@@ -49,20 +66,6 @@ export class AcExLayerManager {
   private onLabelEl!: HTMLSpanElement
   /** Color column header cell. */
   private colorHeaderEl!: HTMLTableCellElement
-  /** Active pointer drag state for header dragging. */
-  private dragState?: {
-    pointerId: number
-    offsetX: number
-    offsetY: number
-  }
-  /** Active pointer resize state for the bottom handle. */
-  private resizeState?: {
-    pointerId: number
-    startY: number
-    startHeight: number
-  }
-  /** Whether the panel may be positioned outside the host bounds. */
-  private readonly allowMoveOutsideCanvas: boolean
   /** Viewer host reference. */
   private readonly host: HTMLElement
   /** Document manager whose active document supplies layer data. */
@@ -71,15 +74,42 @@ export class AcExLayerManager {
   private subscribedLayerStore?: AcApLayerStore
   /** i18n helper for labels and toasts. */
   private readonly i18n: AcExI18n
-  /** Toolbar placement for default horizontal positioning. */
+  /** Toolbar placement for popover positioning. */
   private toolbarPlacement: AcExToolbarPlacement
-  /** Whether the user has manually dragged the panel. */
-  private hasUserPosition = false
-  /** Whether the user has manually resized the panel height. */
-  private hasUserResize = false
+  /** Button element the popover is anchored to, when visible. */
+  private anchor?: HTMLElement
+  /** Element focused before the popover opened. */
+  private previousFocus?: HTMLElement
+  /** Re-positions the popover when the viewer host is resized. */
+  private readonly resizeObserver: ResizeObserver
+  /** Resolves the layer toolbar button when invoked from the `layer` command. */
+  private readonly resolveLayerAnchor?: () => HTMLElement | undefined
 
-  /** Hides the panel when the global `close-layer-manager` event fires. */
+  /** Hides the popover when the global `close-layer-manager` event fires. */
   private handleCloseLayerManager = () => {
+    this.hide()
+  }
+
+  /** Closes the popover when the user interacts outside it and the anchor. */
+  private handleDocumentPointerDown = (event: PointerEvent) => {
+    if (!this.visible) return
+    if (!(event.target instanceof Node)) return
+    if (this.root.contains(event.target)) return
+    if (this.anchor?.contains(event.target)) return
+    if (
+      event.target instanceof Element &&
+      event.target.closest('.ml-ex-ui-color-dialog-backdrop')
+    ) {
+      return
+    }
+    this.hide()
+  }
+
+  /** Closes the popover when the user presses Escape. */
+  private handleDocumentKeyDown = (event: KeyboardEvent) => {
+    if (!this.visible || event.key !== 'Escape') return
+    event.preventDefault()
+    event.stopPropagation()
     this.hide()
   }
 
@@ -91,32 +121,25 @@ export class AcExLayerManager {
     this.i18n = options.i18n
     this.host = options.host
     this.toolbarPlacement = options.toolbarPlacement ?? 'right'
-    this.allowMoveOutsideCanvas = options.allowMoveOutsideCanvas ?? false
+    this.resolveLayerAnchor = options.resolveLayerAnchor
     ensureUiStyles()
 
     this.root = document.createElement('div')
     this.root.className = 'ml-ex-ui-layer-manager is-hidden'
-    if (!this.allowMoveOutsideCanvas) {
-      this.root.classList.add('is-contained')
-    }
+    this.root.setAttribute('role', 'dialog')
+    this.root.setAttribute('aria-modal', 'false')
+    this.root.setAttribute('aria-labelledby', LAYER_MANAGER_TITLE_ID)
 
     const header = document.createElement('div')
     header.className = 'ml-ex-ui-layer-manager-header'
 
     const title = document.createElement('span')
     this.titleEl = title
+    title.id = LAYER_MANAGER_TITLE_ID
     title.textContent = options.i18n.t('layerManager.title')
 
-    const closeBtn = document.createElement('button')
-    closeBtn.type = 'button'
-    closeBtn.className = 'ml-ex-ui-layer-manager-close'
-    closeBtn.setAttribute('aria-label', 'Close')
-    closeBtn.textContent = '×'
-    closeBtn.addEventListener('click', () => this.hide())
-
     header.appendChild(title)
-    header.appendChild(closeBtn)
-    this.bindDrag(header)
+    this.bindPopoverPointerGuard(header)
 
     const tableWrap = document.createElement('div')
     tableWrap.className = 'ml-ex-ui-layer-table-wrap'
@@ -171,21 +194,13 @@ export class AcExLayerManager {
 
     this.root.appendChild(header)
     this.root.appendChild(tableWrap)
+    this.bindPopoverPointerGuard(tableWrap)
 
-    const resizeHandle = document.createElement('div')
-    resizeHandle.className = 'ml-ex-ui-layer-manager-resize'
-    resizeHandle.setAttribute('aria-label', 'Resize')
-    this.bindResize(resizeHandle)
-    this.root.appendChild(resizeHandle)
-
-    if (this.allowMoveOutsideCanvas) {
-      document.body.appendChild(this.root)
-    } else {
-      if (getComputedStyle(this.host).position === 'static') {
-        this.host.style.position = 'relative'
-      }
-      this.host.appendChild(this.root)
+    if (getComputedStyle(this.host).position === 'static') {
+      this.host.style.position = 'relative'
     }
+
+    this.host.appendChild(this.root)
 
     this.editor.events.documentActivated.addEventListener(
       this.handleDocumentActivated
@@ -193,6 +208,13 @@ export class AcExLayerManager {
     this.bindToActiveDocument()
     eventBus.on('close-layer-manager', this.handleCloseLayerManager)
     this.renderRows()
+
+    this.resizeObserver = new ResizeObserver(() => {
+      if (this.visible && this.anchor) {
+        this.positionNear(this.anchor)
+      }
+    })
+    this.resizeObserver.observe(this.host)
   }
 
   /** Layer store for the active document, when one is open. */
@@ -221,43 +243,85 @@ export class AcExLayerManager {
     this.renderRows()
   }
 
-  /** Shows the panel and applies default position when not yet user-placed. */
-  show() {
+  /**
+   * Shows the popover anchored to the given toolbar button.
+   *
+   * @param anchor - Layer toolbar button used for positioning.
+   */
+  show(anchor: HTMLElement) {
+    this.previousFocus =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : undefined
+    this.anchor = anchor
     this.root.classList.remove('is-hidden')
-    if (!this.hasUserPosition) {
-      this.applyDefaultPosition()
-    }
+    this.positionNear(anchor)
     this.renderRows()
+    document.addEventListener('pointerdown', this.handleDocumentPointerDown, true)
+    document.addEventListener('keydown', this.handleDocumentKeyDown, true)
+    this.focusInitialControl()
   }
 
-  /** Hides the panel without destroying it. */
+  /** Hides the popover without destroying it. */
   hide() {
     this.root.classList.add('is-hidden')
+    document.removeEventListener(
+      'pointerdown',
+      this.handleDocumentPointerDown,
+      true
+    )
+    document.removeEventListener('keydown', this.handleDocumentKeyDown, true)
+    const restoreFocus = this.anchor ?? this.previousFocus
+    this.anchor = undefined
+    this.previousFocus = undefined
+    if (restoreFocus?.isConnected) {
+      restoreFocus.focus()
+    }
   }
 
-  /** Shows the panel if hidden, otherwise hides it. */
-  toggle() {
-    if (this.root.classList.contains('is-hidden')) {
-      this.show()
-    } else {
+  /**
+   * Shows the popover if hidden, otherwise hides it.
+   *
+   * @param anchor - Layer toolbar button used for positioning.
+   */
+  toggle(anchor: HTMLElement) {
+    if (this.visible && this.anchor === anchor) {
+      this.hide()
+      return
+    }
+    this.show(anchor)
+  }
+
+  /**
+   * Toggles the popover using the layer toolbar button when available.
+   *
+   * Used by the `layer` CAD command when invoked without a direct anchor.
+   */
+  toggleFromCommand() {
+    const anchor = this.findLayerButtonAnchor()
+    if (anchor) {
+      this.toggle(anchor)
+      return
+    }
+    if (this.visible) {
       this.hide()
     }
   }
 
-  /** Whether the panel is currently visible. */
+  /** Whether the popover is currently visible. */
   get visible() {
     return !this.root.classList.contains('is-hidden')
   }
 
   /**
-   * Updates toolbar placement used for default horizontal positioning.
+   * Updates toolbar placement used for popover positioning.
    *
    * @param placement - Current toolbar edge placement.
    */
   setToolbarPlacement(placement: AcExToolbarPlacement) {
     this.toolbarPlacement = placement
-    if (!this.hasUserPosition && this.visible) {
-      this.applyDefaultPosition()
+    if (this.visible && this.anchor) {
+      this.positionNear(this.anchor)
     }
   }
 
@@ -269,9 +333,16 @@ export class AcExLayerManager {
     this.colorHeaderEl.textContent = this.i18n.t('layerManager.color')
   }
 
-  /** Removes event listeners and removes the panel from the DOM. */
+  /** Removes event listeners and removes the popover from the DOM. */
   destroy() {
+    this.resizeObserver.disconnect()
     eventBus.off('close-layer-manager', this.handleCloseLayerManager)
+    document.removeEventListener(
+      'pointerdown',
+      this.handleDocumentPointerDown,
+      true
+    )
+    document.removeEventListener('keydown', this.handleDocumentKeyDown, true)
     this.editor.events.documentActivated.removeEventListener(
       this.handleDocumentActivated
     )
@@ -378,174 +449,230 @@ export class AcExLayerManager {
   }
 
   /**
-   * Enables drag-to-move on the panel header.
+   * Positions the popover adjacent to the anchor, flipping when near viewport edges.
+   * On compact (mobile) layouts, uses a bottom sheet within the viewer host.
    *
-   * @param header - Header element receiving pointer events.
+   * @param anchor - Reference button bounding box.
    */
-  private bindDrag(header: HTMLElement) {
-    header.addEventListener('pointerdown', event => {
-      if (!(event.target instanceof HTMLElement)) return
-      if (event.target.closest('.ml-ex-ui-layer-manager-close')) return
-
-      const rect = this.root.getBoundingClientRect()
-      this.dragState = {
-        pointerId: event.pointerId,
-        offsetX: event.clientX - rect.left,
-        offsetY: event.clientY - rect.top
-      }
-      header.setPointerCapture(event.pointerId)
-    })
-
-    header.addEventListener('pointermove', event => {
-      if (!this.dragState || event.pointerId !== this.dragState.pointerId) return
-      this.hasUserPosition = true
-      this.setPosition(
-        event.clientX - this.dragState.offsetX,
-        event.clientY - this.dragState.offsetY
-      )
-    })
-
-    const endDrag = (event: PointerEvent) => {
-      if (!this.dragState || event.pointerId !== this.dragState.pointerId) return
-      this.dragState = undefined
-      header.releasePointerCapture(event.pointerId)
+  private positionNear(anchor: HTMLElement) {
+    this.resetPopoverInlineSize()
+    if (this.isCompactLayout()) {
+      this.root.classList.add('is-compact')
+      this.positionCompact()
+      return
     }
 
-    header.addEventListener('pointerup', endDrag)
-    header.addEventListener('pointercancel', endDrag)
+    this.root.classList.remove('is-compact')
+    this.positionNearAnchor(anchor)
   }
 
   /**
-   * Enables vertical resize via the bottom handle.
+   * Positions the popover beside the toolbar anchor on desktop layouts.
    *
-   * @param handle - Resize handle element.
+   * For vertical toolbars, height and vertical edges align with the toolbar;
+   * {@link LAYER_POPOVER_MIN_HEIGHT} applies when the toolbar is shorter.
+   *
+   * @param anchor - Reference button bounding box.
    */
-  private bindResize(handle: HTMLElement) {
-    handle.addEventListener('pointerdown', event => {
-      event.preventDefault()
-      this.resizeState = {
-        pointerId: event.pointerId,
-        startY: event.clientY,
-        startHeight: this.root.offsetHeight
-      }
-      handle.setPointerCapture(event.pointerId)
-    })
+  private positionNearAnchor(anchor: HTMLElement) {
+    const inset = LAYER_POPOVER_VIEWPORT_INSET
+    const rect = anchor.getBoundingClientRect()
+    const hostRect = this.host.getBoundingClientRect()
+    const panelWidth = this.constrainPopoverWidth(inset)
+    const toolbarRect = this.getToolbarRect()
+    const verticalToolbar =
+      this.toolbarPlacement === 'left' || this.toolbarPlacement === 'right'
 
-    handle.addEventListener('pointermove', event => {
-      if (!this.resizeState || event.pointerId !== this.resizeState.pointerId) {
-        return
-      }
-      const delta = event.clientY - this.resizeState.startY
-      const maxHeight = this.getResizeMaxPanelHeight()
-      const nextHeight = Math.max(
-        LAYER_MANAGER_MIN_HEIGHT,
-        Math.min(maxHeight, this.resizeState.startHeight + delta)
-      )
-      this.hasUserResize = true
-      this.root.style.height = `${nextHeight}px`
-      this.root.style.maxHeight = `${nextHeight}px`
-    })
+    let top: number
+    let left: number
+    let panelHeight: number
 
-    const endResize = (event: PointerEvent) => {
-      if (!this.resizeState || event.pointerId !== this.resizeState.pointerId) {
-        return
+    if (verticalToolbar && toolbarRect) {
+      const preferredHeight = Math.max(LAYER_POPOVER_MIN_HEIGHT, toolbarRect.height)
+      panelHeight = this.applyPopoverHeight(preferredHeight)
+
+      if (panelHeight >= toolbarRect.height) {
+        top = toolbarRect.top + (toolbarRect.height - panelHeight) / 2
+      } else {
+        top = toolbarRect.top
       }
-      this.resizeState = undefined
-      handle.releasePointerCapture(event.pointerId)
+
+      if (this.toolbarPlacement === 'right') {
+        left = rect.left - panelWidth - LAYER_POPOVER_GAP
+      } else {
+        left = rect.right + LAYER_POPOVER_GAP
+      }
+    } else {
+      panelHeight = this.applyPopoverHeight(LAYER_POPOVER_MIN_HEIGHT)
+
+      if (this.toolbarPlacement === 'right') {
+        left = rect.left - panelWidth - LAYER_POPOVER_GAP
+        top = rect.top
+      } else if (this.toolbarPlacement === 'left') {
+        left = rect.right + LAYER_POPOVER_GAP
+        top = rect.top
+      } else if (this.toolbarPlacement === 'top') {
+        top = rect.bottom + LAYER_POPOVER_GAP
+        left = rect.left
+      } else {
+        top = rect.top - panelHeight - LAYER_POPOVER_GAP
+        left = rect.left
+      }
     }
 
-    handle.addEventListener('pointerup', endResize)
-    handle.addEventListener('pointercancel', endResize)
+    if (left + panelWidth > hostRect.right - inset) {
+      left = hostRect.right - panelWidth - inset
+    }
+    if (left < hostRect.left + inset) {
+      left = hostRect.left + inset
+    }
+
+    ;({ top, panelHeight } = this.clampPopoverVerticalBounds(
+      top,
+      panelHeight,
+      hostRect,
+      inset
+    ))
+
+    this.root.style.top = `${top - hostRect.top}px`
+    this.root.style.left = `${left - hostRect.left}px`
+  }
+
+  /** Positions the popover as a bottom sheet on compact layouts. */
+  private positionCompact() {
+    const inset = LAYER_POPOVER_VIEWPORT_INSET
+    const width = Math.max(0, this.host.clientWidth - inset * 2)
+    const maxHeight = this.getMaxPopoverHeight()
+    const preferredHeight = Math.min(
+      LAYER_POPOVER_COMPACT_MAX_HEIGHT,
+      Math.max(
+        LAYER_POPOVER_ABSOLUTE_MIN_HEIGHT,
+        Math.round(this.host.clientHeight * LAYER_POPOVER_COMPACT_HEIGHT_RATIO)
+      )
+    )
+    const height = this.applyPopoverHeight(preferredHeight, maxHeight)
+
+    this.root.style.width = `${width}px`
+    this.root.style.left = `${inset}px`
+    this.root.style.top = `${Math.max(
+      inset,
+      this.host.clientHeight - height - inset
+    )}px`
   }
 
   /**
-   * Default panel height: canvas height minus 150px top and bottom margins.
+   * Applies popover height constraints and returns the resolved height.
+   *
+   * @param preferredHeight - Desired height before clamping.
+   * @param maxHeight - Optional maximum height override.
    */
-  private getDefaultPanelHeight(): number {
-    if (this.allowMoveOutsideCanvas) {
-      return Math.max(
-        LAYER_MANAGER_MIN_HEIGHT,
-        window.innerHeight - LAYER_MANAGER_VERTICAL_MARGIN * 2
-      )
+  private applyPopoverHeight(
+    preferredHeight: number,
+    maxHeight = this.getMaxPopoverHeight()
+  ): number {
+    const height = Math.min(preferredHeight, maxHeight)
+    this.root.style.maxHeight = `${maxHeight}px`
+    this.root.style.height = `${height}px`
+    return height
+  }
+
+  /** Clears inline size overrides so CSS defaults can apply on desktop. */
+  private resetPopoverInlineSize() {
+    this.root.style.width = ''
+    this.root.style.height = ''
+    this.root.style.maxHeight = ''
+  }
+
+  /**
+   * Clamps popover width so it never exceeds the viewer host.
+   *
+   * @param inset - Edge inset used for width calculation.
+   */
+  private constrainPopoverWidth(inset: number): number {
+    const maxWidth = Math.max(0, this.host.clientWidth - inset * 2)
+    if (maxWidth > 0 && this.root.offsetWidth > maxWidth) {
+      this.root.style.width = `${maxWidth}px`
     }
+    return this.root.offsetWidth || maxWidth
+  }
+
+  /** Whether the viewer host is narrow enough to use compact layout. */
+  private isCompactLayout(): boolean {
+    return this.host.clientWidth <= LAYER_POPOVER_COMPACT_BREAKPOINT
+  }
+
+  /**
+   * Clamps popover vertical position and height within the host.
+   */
+  private clampPopoverVerticalBounds(
+    top: number,
+    panelHeight: number,
+    hostRect: DOMRect,
+    inset: number
+  ): { top: number; panelHeight: number } {
+    const maxBottom = hostRect.bottom - inset
+    const minTop = hostRect.top + inset
+
+    if (top + panelHeight > maxBottom) {
+      top = maxBottom - panelHeight
+    }
+    if (top < minTop) {
+      top = minTop
+      const availableHeight = maxBottom - top
+      if (availableHeight < panelHeight) {
+        panelHeight = this.applyPopoverHeight(
+          Math.max(LAYER_POPOVER_ABSOLUTE_MIN_HEIGHT, availableHeight)
+        )
+      }
+    }
+    return { top, panelHeight }
+  }
+
+  /** Maximum popover height based on the viewer host size. */
+  private getMaxPopoverHeight(): number {
     return Math.max(
-      LAYER_MANAGER_MIN_HEIGHT,
-      this.host.clientHeight - LAYER_MANAGER_VERTICAL_MARGIN * 2
+      LAYER_POPOVER_ABSOLUTE_MIN_HEIGHT,
+      this.host.clientHeight - LAYER_POPOVER_VIEWPORT_INSET * 2
     )
   }
 
-  /**
-   * Maximum height while the user is resizing (full canvas; no 150px margin).
-   */
-  private getResizeMaxPanelHeight(): number {
-    if (this.allowMoveOutsideCanvas) {
-      return Math.max(LAYER_MANAGER_MIN_HEIGHT, window.innerHeight)
-    }
-    return Math.max(LAYER_MANAGER_MIN_HEIGHT, this.host.clientHeight)
+  /** Returns the toolbar bounding box in viewport coordinates, when present. */
+  private getToolbarRect(): DOMRect | undefined {
+    const toolbar = this.host.querySelector<HTMLElement>('.ml-ex-ui-toolbar')
+    return toolbar?.getBoundingClientRect()
   }
 
-  /**
-   * Centers the panel vertically and places it on the side opposite the toolbar.
-   */
-  private applyDefaultPosition() {
-    if (!this.hasUserResize) {
-      const defaultHeight = this.getDefaultPanelHeight()
-      this.root.style.height = `${defaultHeight}px`
-      this.root.style.maxHeight = `${defaultHeight}px`
-    }
+  /** Finds the layer toolbar button in the host, when the toolbar is present. */
+  private findLayerButtonAnchor(): HTMLElement | undefined {
+    return this.resolveLayerAnchor?.() ?? this.queryLayerButtonAnchor()
+  }
 
-    const hostWidth = this.host.clientWidth
-    const hostHeight = this.host.clientHeight
-    const panelWidth = this.root.offsetWidth
-    const panelHeight = this.root.offsetHeight
-    const availableHeight = hostHeight - LAYER_MANAGER_VERTICAL_MARGIN * 2
-    const top =
-      LAYER_MANAGER_VERTICAL_MARGIN +
-      Math.max(0, (availableHeight - panelHeight) / 2)
+  /** Queries the host for the layer toolbar button without expanding the toolbar. */
+  private queryLayerButtonAnchor(): HTMLElement | undefined {
+    const button = this.host.querySelector<HTMLElement>(
+      '[data-toolbar-item-id="layer"]'
+    )
+    return button ?? undefined
+  }
 
-    let left: number
-    if (this.toolbarPlacement === 'right') {
-      left = LAYER_MANAGER_HORIZONTAL_MARGIN
-    } else {
-      left = Math.max(
-        LAYER_MANAGER_HORIZONTAL_MARGIN,
-        hostWidth - panelWidth - LAYER_MANAGER_HORIZONTAL_MARGIN
+  /** Moves focus to the first interactive control inside the popover. */
+  private focusInitialControl() {
+    requestAnimationFrame(() => {
+      if (!this.visible) return
+      const focusable = this.root.querySelector<HTMLElement>(
+        'input:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
       )
-    }
-
-    if (this.allowMoveOutsideCanvas) {
-      const hostRect = this.host.getBoundingClientRect()
-      this.root.style.left = `${hostRect.left + left}px`
-      this.root.style.top = `${hostRect.top + top}px`
-      return
-    }
-
-    this.root.style.left = `${left}px`
-    this.root.style.top = `${top}px`
+      focusable?.focus()
+    })
   }
 
   /**
-   * Sets panel position in viewport or host-local coordinates.
+   * Stops pointer events from bubbling so canvas handlers do not close the popover.
    *
-   * @param clientLeft - Desired left edge in viewport coordinates.
-   * @param clientTop - Desired top edge in viewport coordinates.
+   * @param element - Popover section to guard.
    */
-  private setPosition(clientLeft: number, clientTop: number) {
-    if (this.allowMoveOutsideCanvas) {
-      this.root.style.left = `${clientLeft}px`
-      this.root.style.top = `${clientTop}px`
-      return
-    }
-
-    const hostRect = this.host.getBoundingClientRect()
-    let left = clientLeft - hostRect.left
-    let top = clientTop - hostRect.top
-    const maxLeft = Math.max(0, this.host.clientWidth - this.root.offsetWidth)
-    const maxTop = Math.max(0, this.host.clientHeight - this.root.offsetHeight)
-    left = Math.max(0, Math.min(left, maxLeft))
-    top = Math.max(0, Math.min(top, maxTop))
-    this.root.style.left = `${left}px`
-    this.root.style.top = `${top}px`
+  private bindPopoverPointerGuard(element: HTMLElement) {
+    element.addEventListener('pointerdown', event => event.stopPropagation())
   }
 
   /**

--- a/packages/cad-simple-ui-plugin/src/ui/AcExToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExToolbar.ts
@@ -1,6 +1,12 @@
 import { AcApDocManager, AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
 
-import { createIconElement } from '../assets/icons'
+import {
+  createIconElement,
+  ICON_CHEVRON_DOWN,
+  ICON_CHEVRON_LEFT,
+  ICON_CHEVRON_RIGHT,
+  ICON_CHEVRON_UP
+} from '../assets/icons'
 import {
   filterVisibleToolbarItems,
   isToolbarItemDisabled,
@@ -25,6 +31,12 @@ export interface AcExToolbarOptions {
   i18n: AcExI18n
   /** Invoked when a leaf item with a `command` is activated. */
   onCommand: (command: string) => void
+  /** When true, append a collapse/expand toggle at the end of the toolbar. */
+  collapsible?: boolean
+  /** Initial collapsed state when {@link collapsible} is true. */
+  defaultCollapsed?: boolean
+  /** Invoked when the toolbar is collapsed (e.g. close anchored popovers). */
+  onCollapse?: () => void
 }
 
 /**
@@ -48,12 +60,14 @@ export class AcExToolbar {
   private items: AcExToolbarItem[]
   /** Runtime submenu selection for parents with {@link AcExToolbarItem.childIcon} `'selected'`. */
   private selectedChildByParent = new Map<string, string>()
+  /** Whether the toolbar is collapsed to show only the toggle button. */
+  private collapsed: boolean
 
   /** Re-renders buttons when a document becomes active. */
   private handleDocumentActivated = () => {
     this.hasDocument = Boolean(AcApDocManager.instance.curDocument)
     this.isDisabled = false
-    this.root.classList.remove('is-disabled')
+    this.syncRootClasses()
     this.openMode =
       AcApDocManager.instance.curDocument?.openMode ?? AcEdOpenMode.Read
     this.renderButtons()
@@ -62,7 +76,7 @@ export class AcExToolbar {
   /** Disables the toolbar while a document is opening. */
   private handleDocumentToBeOpened = () => {
     this.isDisabled = true
-    this.root.classList.add('is-disabled')
+    this.syncRootClasses()
   }
 
   /**
@@ -71,10 +85,12 @@ export class AcExToolbar {
   constructor(private options: AcExToolbarOptions) {
     ensureUiStyles()
     this.items = options.items
+    this.collapsed =
+      Boolean(options.collapsible) && Boolean(options.defaultCollapsed)
     this.seedSelectedChildren(options.items)
 
     this.root = document.createElement('div')
-    this.root.className = `ml-ex-ui-toolbar is-${this.getOrientationClass()} is-${options.placement}`
+    this.syncRootClasses()
     this.root.setAttribute('role', 'toolbar')
     options.host.appendChild(this.root)
 
@@ -115,7 +131,7 @@ export class AcExToolbar {
     if (this.options.placement === placement) return
     this.options.placement = placement
     this.selectedChildByParent.set('toolbar-placement', `placement-${placement}`)
-    this.root.className = `ml-ex-ui-toolbar is-${this.getOrientationClass()} is-${placement}`
+    this.syncRootClasses()
     this.renderButtons()
   }
 
@@ -132,6 +148,41 @@ export class AcExToolbar {
   /** Current toolbar edge placement. */
   get placement() {
     return this.options.placement
+  }
+
+  /** Whether the toolbar is collapsed to the toggle button only. */
+  get isCollapsed() {
+    return this.collapsed
+  }
+
+  /**
+   * Returns the layer toolbar button, expanding a collapsed toolbar first.
+   */
+  getLayerButtonAnchor(): HTMLElement | undefined {
+    if (this.options.collapsible && this.collapsed) {
+      this.setCollapsed(false)
+    }
+    return (
+      this.root.querySelector<HTMLElement>('[data-toolbar-item-id="layer"]') ??
+      undefined
+    )
+  }
+
+  /**
+   * Sets collapsed state without toggling.
+   *
+   * @param collapsed - Target collapsed state.
+   */
+  setCollapsed(collapsed: boolean) {
+    if (!this.options.collapsible || this.collapsed === collapsed) return
+    this.collapsed = collapsed
+    if (collapsed) {
+      this.openDropdown?.close()
+      this.openDropdown = undefined
+      this.options.onCollapse?.()
+    }
+    this.syncRootClasses()
+    this.syncCollapseToggleButton()
   }
 
   /** Removes listeners, closes dropdowns, and detaches the toolbar DOM. */
@@ -156,6 +207,73 @@ export class AcExToolbar {
       this.options.placement === 'right'
       ? 'vertical'
       : 'horizontal'
+  }
+
+  /** Applies placement, collapsed, and disabled classes on the root element. */
+  private syncRootClasses() {
+    const classes = [
+      'ml-ex-ui-toolbar',
+      `is-${this.getOrientationClass()}`,
+      `is-${this.options.placement}`
+    ]
+    if (this.collapsed) classes.push('is-collapsed')
+    if (this.isDisabled) classes.push('is-disabled')
+    this.root.className = classes.join(' ')
+  }
+
+  /** Toggles collapsed state when {@link AcExToolbarOptions.collapsible} is enabled. */
+  private toggleCollapsed() {
+    this.setCollapsed(!this.collapsed)
+  }
+
+  /**
+   * Chevron for the collapse toggle: vertical placements use up/down;
+   * horizontal placements (top/bottom) use left/right.
+   */
+  private getCollapseToggleIcon() {
+    const horizontal =
+      this.options.placement === 'top' || this.options.placement === 'bottom'
+    if (horizontal) {
+      return this.collapsed ? ICON_CHEVRON_RIGHT : ICON_CHEVRON_LEFT
+    }
+    return this.collapsed ? ICON_CHEVRON_DOWN : ICON_CHEVRON_UP
+  }
+
+  /** Updates collapse toggle icon and labels after locale or state changes. */
+  private syncCollapseToggleButton(button?: HTMLButtonElement) {
+    const target =
+      button ??
+      this.root.querySelector<HTMLButtonElement>(
+        '[data-toolbar-item-id="toolbar-collapse"]'
+      )
+    if (!target) return
+
+    const labelKey = this.collapsed ? 'toolbar.expand' : 'toolbar.collapse'
+    target.replaceChildren(createIconElement(this.getCollapseToggleIcon()))
+    target.title = this.options.i18n.t(labelKey)
+    target.setAttribute('aria-label', target.title)
+    target.setAttribute('aria-expanded', String(!this.collapsed))
+  }
+
+  /** Appends separator and collapse toggle when collapsible mode is enabled. */
+  private appendCollapseToggle() {
+    if (!this.options.collapsible) return
+
+    const separator = document.createElement('div')
+    separator.className = 'ml-ex-ui-toolbar-separator'
+    separator.setAttribute('role', 'separator')
+    this.root.appendChild(separator)
+
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'ml-ex-ui-toolbar-btn ml-ex-ui-toolbar-collapse-btn'
+    button.dataset.toolbarItemId = 'toolbar-collapse'
+    this.syncCollapseToggleButton(button)
+    button.addEventListener('click', event => {
+      event.stopPropagation()
+      this.toggleCollapsed()
+    })
+    this.root.appendChild(button)
   }
 
   /** Rebuilds all toolbar buttons from {@link items}. */
@@ -188,6 +306,7 @@ export class AcExToolbar {
         ? this.options.i18n.t(effective.label)
         : effective.id
       button.setAttribute('aria-label', button.title)
+      button.dataset.toolbarItemId = effective.id
 
       if (effective.children?.length) {
         button.classList.add('has-children')
@@ -249,7 +368,9 @@ export class AcExToolbar {
           return
         }
 
-        if (effective.action) {
+        if (effective.anchorAction) {
+          effective.anchorAction(button)
+        } else if (effective.action) {
           effective.action()
         } else if (effective.command) {
           this.options.onCommand(effective.command)
@@ -261,6 +382,8 @@ export class AcExToolbar {
 
       this.root.appendChild(button)
     })
+
+    this.appendCollapseToggle()
   }
 
   /** Seeds submenu selection from {@link AcExToolbarItem.selectedChildId}. */

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -22,6 +22,7 @@ export function ensureUiStyles() {
       box-shadow: var(--ml-ui-shadow, 0 2px 6px rgba(0, 0, 0, 0.12));
       border-radius: 6px;
       box-sizing: border-box;
+      --ml-ex-ui-toolbar-btn-size: 32px;
     }
 
     .ml-ex-ui-toolbar.is-horizontal {
@@ -42,6 +43,40 @@ export function ensureUiStyles() {
     .ml-ex-ui-toolbar.is-disabled {
       opacity: 0.55;
       pointer-events: none;
+    }
+
+    .ml-ex-ui-toolbar.is-collapsed .ml-ex-ui-toolbar-btn:not(.ml-ex-ui-toolbar-collapse-btn),
+    .ml-ex-ui-toolbar.is-collapsed .ml-ex-ui-toolbar-separator {
+      display: none;
+    }
+
+    .ml-ex-ui-toolbar-collapse-btn {
+      box-sizing: border-box;
+      padding: 0;
+      flex-shrink: 0;
+    }
+
+    .ml-ex-ui-toolbar.is-vertical .ml-ex-ui-toolbar-collapse-btn {
+      min-width: var(--ml-ex-ui-toolbar-btn-size);
+      width: auto;
+      min-height: calc(var(--ml-ex-ui-toolbar-btn-size) / 2);
+      height: calc(var(--ml-ex-ui-toolbar-btn-size) / 2);
+      margin-top: -4px;
+      margin-bottom: -4px;
+    }
+
+    .ml-ex-ui-toolbar.is-horizontal .ml-ex-ui-toolbar-collapse-btn {
+      min-height: var(--ml-ex-ui-toolbar-btn-size);
+      height: auto;
+      min-width: calc(var(--ml-ex-ui-toolbar-btn-size) / 2);
+      width: calc(var(--ml-ex-ui-toolbar-btn-size) / 2);
+      margin-left: -4px;
+      margin-right: -4px;
+    }
+
+    .ml-ex-ui-toolbar-collapse-btn .ml-ex-ui-icon svg {
+      width: calc(var(--ml-ex-ui-toolbar-btn-size) / 2);
+      height: calc(var(--ml-ex-ui-toolbar-btn-size) / 2);
     }
 
     .ml-ex-ui-toolbar-separator {
@@ -68,8 +103,9 @@ export function ensureUiStyles() {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-width: 32px;
-      min-height: 32px;
+      box-sizing: border-box;
+      min-width: var(--ml-ex-ui-toolbar-btn-size);
+      min-height: var(--ml-ex-ui-toolbar-btn-size);
       padding: 4px;
       border: 1px solid var(--ml-ui-border, #dcdfe6);
       border-radius: 4px;
@@ -173,10 +209,12 @@ export function ensureUiStyles() {
     }
 
     .ml-ex-ui-layer-manager {
-      position: fixed;
-      z-index: 90;
-      width: min(280px, calc(100vw - 24px));
+      position: absolute;
+      z-index: 100;
+      width: min(280px, calc(100% - 16px));
+      max-width: calc(100% - 16px);
       min-height: 120px;
+      box-sizing: border-box;
       display: flex;
       flex-direction: column;
       background: var(--ml-ui-bg, #ffffff);
@@ -188,10 +226,23 @@ export function ensureUiStyles() {
       font-size: 12px;
     }
 
-    .ml-ex-ui-layer-manager.is-contained {
-      position: absolute;
-      width: min(280px, calc(100% - 16px));
-      max-height: 100%;
+    .ml-ex-ui-layer-manager.is-compact {
+      width: calc(100% - 16px);
+      max-width: none;
+      border-radius: 12px 12px 8px 8px;
+    }
+
+    .ml-ex-ui-layer-manager.is-compact .ml-ex-ui-layer-table th:first-child,
+    .ml-ex-ui-layer-manager.is-compact .ml-ex-ui-layer-table td:first-child {
+      width: 100%;
+      max-width: 0;
+    }
+
+    .ml-ex-ui-layer-manager.is-compact .ml-ex-ui-layer-name {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .ml-ex-ui-layer-manager.is-hidden {
@@ -204,19 +255,9 @@ export function ensureUiStyles() {
       justify-content: space-between;
       padding: 8px 10px;
       border-bottom: 1px solid var(--ml-ui-border, #dcdfe6);
-      cursor: move;
       user-select: none;
       font-weight: 600;
-    }
-
-    .ml-ex-ui-layer-manager-close {
-      border: none;
-      background: transparent;
-      color: var(--ml-ui-text-muted, #606266);
-      cursor: pointer;
-      font-size: 16px;
-      line-height: 1;
-      padding: 2px 6px;
+      flex: 0 0 auto;
     }
 
     .ml-ex-ui-layer-table-wrap {
@@ -262,17 +303,6 @@ export function ensureUiStyles() {
 
     .ml-ex-ui-layer-header-on input[type='checkbox'] {
       margin: 0;
-    }
-
-    .ml-ex-ui-layer-manager-resize {
-      flex: 0 0 auto;
-      height: 6px;
-      cursor: ns-resize;
-      background: transparent;
-    }
-
-    .ml-ex-ui-layer-manager-resize:hover {
-      background: var(--ml-ui-border, rgba(0, 0, 0, 0.06));
     }
 
     .ml-ex-ui-layer-name {

--- a/packages/cad-simple-viewer-example/index.html
+++ b/packages/cad-simple-viewer-example/index.html
@@ -11,18 +11,26 @@
         box-sizing: border-box;
       }
 
+      html {
+        height: 100%;
+      }
+
       body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         background: #111827;
         color: #e5e7eb;
-        height: 100vh;
+        width: 100%;
+        height: 100%;
         overflow: hidden;
       }
 
       .app-shell {
         display: flex;
-        width: 100vw;
-        height: 100vh;
+        width: 100%;
+        height: 100%;
+        max-width: 100%;
+        min-height: 0;
+        overflow: hidden;
       }
 
       .file-sidebar {
@@ -52,6 +60,7 @@
         font-size: 0.82rem;
         color: #9ca3af;
         line-height: 1.4;
+        margin-bottom: 0.75rem;
       }
 
       .file-list {
@@ -89,6 +98,8 @@
         display: flex;
         flex-direction: column;
         min-width: 0;
+        min-height: 0;
+        overflow: hidden;
         background: #111827;
       }
 
@@ -96,11 +107,20 @@
         position: relative;
         flex: 1;
         min-height: 0;
+        min-width: 0;
+        overflow: hidden;
       }
 
       #cad-container {
         position: absolute;
         inset: 0;
+        overflow: hidden;
+      }
+
+      #cad-container canvas {
+        display: block;
+        max-width: 100%;
+        max-height: 100%;
       }
 
       .empty-state {
@@ -140,15 +160,18 @@
       @media (max-width: 960px) {
         .app-shell {
           flex-direction: column;
+          min-height: 0;
         }
 
         .file-sidebar {
           flex: 0 0 auto;
-          max-width: none;
+          flex-shrink: 0;
+          max-width: 100%;
           min-width: 0;
+          width: 100%;
           height: auto;
           padding: 0;
-          overflow: visible;
+          overflow: hidden;
           border-right: none;
           border-bottom: 1px solid #1f2937;
         }
@@ -204,20 +227,28 @@
 
         .file-sidebar-body {
           display: none;
-          flex-direction: column;
-          gap: 0.65rem;
-          padding: 0 0.85rem 0.75rem;
-          max-height: min(42vh, 320px);
-          overflow: auto;
         }
 
-        .file-sidebar.expanded .file-sidebar-body {
+        .file-sidebar-body.file-sidebar-popover {
           display: flex;
+          flex-direction: column;
+          gap: 0.65rem;
+          position: fixed;
+          z-index: 200;
+          left: 8px;
+          right: 8px;
+          padding: 0.75rem 0.85rem;
+          overflow: auto;
+          background: #0f172a;
+          border: 1px solid #374151;
+          border-radius: 8px;
+          box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
         }
 
         .viewer-pane {
           flex: 1;
           min-height: 0;
+          min-width: 0;
         }
       }
     </style>

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -23,6 +23,7 @@ class CadViewerApp {
   private emptyState: HTMLDivElement
   private predefinedButtons: NodeListOf<HTMLButtonElement>
   private fileSidebar: HTMLElement
+  private fileSidebarBody: HTMLElement
   private fileSidebarToggle: HTMLButtonElement
   private fileSidebarSubtitle: HTMLSpanElement
   private isInitialized = false
@@ -42,6 +43,9 @@ class CadViewerApp {
       '#predefinedFileList .file-list-item'
     ) as NodeListOf<HTMLButtonElement>
     this.fileSidebar = document.getElementById('fileSidebar') as HTMLElement
+    this.fileSidebarBody = document.getElementById(
+      'fileSidebarBody'
+    ) as HTMLElement
     this.fileSidebarToggle = document.getElementById(
       'fileSidebarToggle'
     ) as HTMLButtonElement
@@ -81,9 +85,9 @@ class CadViewerApp {
         host: this.viewerPane,
         toolbar: {
           placement: 'right',
-          items: 'default'
-        },
-        layerManager: { enabled: true }
+          items: 'default',
+          collapsible: true
+        }
       })
 
       AcApDocManager.instance.events.documentActivated.addEventListener(
@@ -131,29 +135,32 @@ class CadViewerApp {
 
   private setupMobileSidebar() {
     this.fileSidebarToggle.addEventListener('click', () => {
-      this.setFileSidebarExpanded(
-        !this.fileSidebar.classList.contains('expanded')
-      )
+      this.setFileSidebarExpanded(!this.isFileSidebarOpen())
     })
 
-    document.addEventListener('click', event => {
-      if (
-        !this.isMobileLayout() ||
-        !this.fileSidebar.classList.contains('expanded')
-      ) {
+    document.addEventListener('pointerdown', event => {
+      if (!this.isMobileLayout() || !this.isFileSidebarOpen()) {
         return
       }
 
       const target = event.target
       if (!(target instanceof Node)) return
-      if (!this.fileSidebar.contains(target)) {
-        this.setFileSidebarExpanded(false)
+      if (
+        this.fileSidebarToggle.contains(target) ||
+        this.fileSidebarBody.contains(target)
+      ) {
+        return
       }
+      this.setFileSidebarExpanded(false)
     })
 
     window.addEventListener('resize', () => {
       if (!this.isMobileLayout()) {
         this.setFileSidebarExpanded(false)
+        return
+      }
+      if (this.isFileSidebarOpen()) {
+        this.positionMobileFilePopover()
       }
     })
   }
@@ -162,9 +169,42 @@ class CadViewerApp {
     return window.matchMedia('(max-width: 960px)').matches
   }
 
+  private isFileSidebarOpen(): boolean {
+    return this.isMobileLayout()
+      ? this.fileSidebarBody.classList.contains('file-sidebar-popover')
+      : this.fileSidebar.classList.contains('expanded')
+  }
+
   private setFileSidebarExpanded(expanded: boolean) {
+    if (this.isMobileLayout()) {
+      this.fileSidebar.classList.toggle('expanded', expanded)
+      this.fileSidebarToggle.setAttribute('aria-expanded', String(expanded))
+      this.fileSidebarBody.classList.toggle('file-sidebar-popover', expanded)
+      if (expanded) {
+        this.positionMobileFilePopover()
+      } else {
+        this.fileSidebarBody.style.top = ''
+        this.fileSidebarBody.style.maxHeight = ''
+      }
+      return
+    }
+
     this.fileSidebar.classList.toggle('expanded', expanded)
     this.fileSidebarToggle.setAttribute('aria-expanded', String(expanded))
+  }
+
+  private positionMobileFilePopover() {
+    const rect = this.fileSidebarToggle.getBoundingClientRect()
+    const gap = 4
+    const viewportInset = 8
+    const top = rect.bottom + gap
+    const maxHeight = Math.max(
+      120,
+      Math.min(window.innerHeight * 0.5, 360, window.innerHeight - top - viewportInset)
+    )
+
+    this.fileSidebarBody.style.top = `${top}px`
+    this.fileSidebarBody.style.maxHeight = `${maxHeight}px`
   }
 
   private updateFileSidebarSubtitle(label: string) {

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -427,10 +427,17 @@ export class AcApDocManager {
     }
     const callback: AcEdCalculateSizeCallback = () => {
       if (options.autoResize) {
+        const container = options.container
+        if (container) {
+          return {
+            width: Math.max(1, Math.floor(container.clientWidth)),
+            height: Math.max(1, Math.floor(container.clientHeight))
+          }
+        }
         const box = options.container?.getBoundingClientRect()
         return {
-          width: box?.width ?? initialSize.width,
-          height: box?.height ?? initialSize.height
+          width: Math.max(1, Math.floor(box?.width ?? initialSize.width)),
+          height: Math.max(1, Math.floor(box?.height ?? initialSize.height))
         }
       } else {
         return {

--- a/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
@@ -291,7 +291,11 @@ export abstract class AcEdBaseView {
       trailing: true
     })
     const resizeObserver = new ResizeObserver(debouncedWindowResize)
-    resizeObserver.observe(this._canvas.parentElement as Element)
+    resizeObserver.observe(this._container)
+    const containerParent = this._container.parentElement
+    if (containerParent) {
+      resizeObserver.observe(containerParent)
+    }
 
     this._selectionBoxSize = 4
 
@@ -962,11 +966,11 @@ export abstract class AcEdBaseView {
   protected onWindowResize() {
     if (this._calculateSizeCallback) {
       const { width, height } = this._calculateSizeCallback()
-      this._width = width
-      this._height = height
+      this._width = Math.max(1, Math.floor(width))
+      this._height = Math.max(1, Math.floor(height))
     } else {
-      this._width = this._canvas.clientWidth
-      this._height = this._canvas.clientHeight
+      this._width = Math.max(1, Math.floor(this._canvas.clientWidth))
+      this._height = Math.max(1, Math.floor(this._canvas.clientHeight))
     }
     this.events.viewResize.dispatch({
       width: this._width,

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -229,12 +229,16 @@ export class AcTrView2d extends AcEdBaseView {
 
     const container = mergedOptions.container ?? document.createElement('div')
     mergedOptions.container = container
+    container.style.overflow = 'hidden'
 
     const renderer = new THREE.WebGLRenderer({
       antialias: true,
       alpha: true
     })
     container.appendChild(renderer.domElement)
+    renderer.domElement.style.display = 'block'
+    renderer.domElement.style.maxWidth = '100%'
+    renderer.domElement.style.maxHeight = '100%'
 
     super(renderer.domElement, container)
     this._gripManager = new AcEdGripManager(this)
@@ -473,6 +477,8 @@ export class AcTrView2d extends AcEdBaseView {
     this._css2dRenderer.domElement.style.left = '0px'
     this._css2dRenderer.domElement.style.pointerEvents = 'none'
     this._css2dRenderer.domElement.style.zIndex = '99998'
+    this._css2dRenderer.domElement.style.maxWidth = '100%'
+    this._css2dRenderer.domElement.style.maxHeight = '100%'
     container.appendChild(this._css2dRenderer.domElement)
 
     this._missedImages = new Map()


### PR DESCRIPTION
## Summary

- Refactor the layer manager from a draggable floating panel into a popover anchored to the toolbar layer button, with outside-click/Escape dismissal, compact bottom-sheet layout on narrow hosts, and automatic enablement when the toolbar includes a layer button (removes the separate `layerManager` plugin option).
- Add optional collapsible toolbar mode (`toolbar.collapsible` / `defaultCollapsed`) with chevron toggle, plus `anchorAction` support for popover-style toolbar buttons.
- Fix viewer resize behavior for constrained layouts (container-based sizing, expanded ResizeObserver targets, canvas max dimensions) and update the example app with collapsible toolbar and mobile file-sidebar popover.

## Test plan

- [ ] Open the example app on desktop; click the layer toolbar button and verify the popover opens beside the toolbar and closes on outside click or Escape.
- [ ] Run the `layer` command and confirm it toggles the same popover.
- [ ] Enable `toolbar.collapsible: true` and verify collapse/expand hides tool buttons while keeping the chevron toggle; confirm layer popover closes when collapsing.
- [ ] Resize the viewer host below 640px width and verify the layer popover uses the bottom-sheet layout.
- [ ] On mobile (≤960px), verify the file sidebar opens as a positioned popover and closes on outside tap.
- [ ] Open a drawing and resize the viewer pane; confirm the canvas stays within bounds without overflow or zero-size glitches.
