### PR TITLE
feat(cad-simple-viewer): add web worker readiness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ CAD-Viewer has some known limitations that users should be aware of:
   |-------|---------|
   | 0 | Do not save proxy graphics |
   | 1 | Save proxy graphics |
-
-These issues are being tracked and will be addressed in future releases.
+- **DWG File Size Limits**:
+  - Parsing DWG files with LibreDWG is memory-intensive and can easily exceed 2 GB of RAM. `libredwg-web` therefore enforces WASM heap memory limits; very large DWG files may fail to parse.
+  - We have developed a proprietary DWG parser with significantly lower memory usage, support for larger DWG files, and more accurate parsing. If the open-source `libredwg-web` stack cannot meet your requirements, please email [mlight.lee@outlook.com](mailto:mlight.lee@outlook.com) to discuss licensing the proprietary parser.
 
 ## Roadmap
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,8 +151,9 @@ CAD-Viewer 针对复杂图纸渲染进行了多项优化，可在保持高帧率
   |------|------|
   | 0 | 不保存 Proxy Graphics |
   | 1 | 保存 Proxy Graphics |
-
-上述限制将会在后续版本中逐步改进。
+- **DWG 文件大小限制**：
+  - 使用 LibreDWG 解析 DWG 文件时内存开销较大，很容易占用超过 2 GB 内存。因此 `libredwg-web` 对 WASM 堆内存做了限制，过大的 DWG 文件可能无法解析。
+  - 我们已开发闭源 DWG 解析器，具有更低的内存开销，支持解析更大的 DWG 文件，且解析结果更加正确。若开源项目 `libredwg-web` 无法满足您的需求，请发送邮件至 [mlight.lee@outlook.com](mailto:mlight.lee@outlook.com) 协商闭源 DWG 解析器授权。
 
 ## 路线图（Roadmap）
 

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -28,6 +28,7 @@ class CadViewerApp {
   private fileSidebarSubtitle: HTMLSpanElement
   private isInitialized = false
   private hasOpenedFile = false
+  private isLoadingFile = false
 
   constructor() {
     this.container = document.getElementById('cad-container') as HTMLDivElement
@@ -93,6 +94,12 @@ class CadViewerApp {
       AcApDocManager.instance.events.documentActivated.addEventListener(
         args => {
           document.title = args.doc.docTitle
+        }
+      )
+
+      AcApDocManager.instance.events.documentToBeOpened.addEventListener(
+        () => {
+          this.setLoadingState(true)
         }
       )
 
@@ -249,6 +256,8 @@ class CadViewerApp {
     } catch (error) {
       log.error('Error loading file:', error)
       this.showMessage(`Error loading file: ${error}`, 'error')
+    } finally {
+      this.finishLoadingState()
     }
   }
 
@@ -277,6 +286,8 @@ class CadViewerApp {
     } catch (error) {
       log.error('Error loading predefined file:', error)
       this.showMessage(`Error loading file: ${error}`, 'error')
+    } finally {
+      this.finishLoadingState()
     }
   }
 
@@ -285,8 +296,21 @@ class CadViewerApp {
     this.updateEmptyStateVisibility()
   }
 
+  private setLoadingState(loading: boolean) {
+    this.isLoadingFile = loading
+    this.updateEmptyStateVisibility()
+  }
+
+  private finishLoadingState() {
+    this.isLoadingFile = false
+    this.updateEmptyStateVisibility()
+  }
+
   private updateEmptyStateVisibility() {
-    this.emptyState.classList.toggle('hidden', this.hasOpenedFile)
+    this.emptyState.classList.toggle(
+      'hidden',
+      this.hasOpenedFile || this.isLoadingFile
+    )
   }
 
   private getFileNameFromUrl(url: string) {

--- a/packages/cad-simple-viewer/README.md
+++ b/packages/cad-simple-viewer/README.md
@@ -97,7 +97,7 @@ if (!(await manager.areWorkersReady())) {
 }
 ```
 
-`areWorkersReady()` and `checkWebworkerReadiness()` use HEAD requests internally. A successful result is cached for the current page lifecycle; failures are not cached, so a transient network error does not permanently block CAD opening.
+`areWorkersReady()` and `checkWebworkerReadiness()` use HEAD requests internally. Successful URL probes are cached for the current page lifecycle; failures are not cached at the probe layer, so a transient network error can succeed on a later `areWorkersReady()` call. After each check, `manager.workersReady` is `true` or `false` (`null` only before the first check).
 
 You can also enable automatic checks during initialization:
 

--- a/packages/cad-simple-viewer/README.md
+++ b/packages/cad-simple-viewer/README.md
@@ -70,6 +70,48 @@ Layer table mutations are centralized in `AcApLayerService`. UI integrations sho
 
 The `LockAndFade` isolation keyword matches AutoCAD naming but the viewer **locks** non-isolated layers only. It does not apply a visual fade; users are notified when selecting this mode in the `LAYISO` command.
 
+## Web Worker deployment
+
+The viewer loads three worker scripts for DXF parsing, DWG parsing, and MTEXT rendering. Host applications must deploy these files and point to them via `webworkerFileUrls` in `AcApDocManager.createInstance()`.
+
+Before calling `openDocument()`, verify that the workers are reachable. Use the built-in readiness API rather than downloading worker bodies with a plain GET request (the LibreDWG worker alone is ~12 MB):
+
+```typescript
+const workerUrls = {
+  dxfParser: './workers/dxf-parser-worker.js',
+  dwgParser: './workers/libredwg-parser-worker.js',
+  mtextRender: './workers/mtext-renderer-worker.js'
+}
+
+// Option 1: check before creating the manager
+const ready = await AcApDocManager.checkWebworkerReadiness(workerUrls)
+if (!ready) {
+  throw new Error('CAD worker scripts are missing or blocked')
+}
+
+const manager = AcApDocManager.createInstance({ webworkerFileUrls: workerUrls })
+
+// Option 2: check on an existing manager instance
+if (!(await manager.areWorkersReady())) {
+  throw new Error('CAD worker scripts are missing or blocked')
+}
+```
+
+`areWorkersReady()` and `checkWebworkerReadiness()` use HEAD requests internally. A successful result is cached for the current page lifecycle; failures are not cached, so a transient network error does not permanently block CAD opening.
+
+You can also enable automatic checks during initialization:
+
+```typescript
+AcApDocManager.createInstance({
+  webworkerFileUrls: workerUrls,
+  checkWorkersOnInit: true
+})
+
+manager.events.workersReady.addEventListener(({ ready }) => {
+  if (!ready) console.error('CAD workers are not reachable')
+})
+```
+
 ## Available Exports
 
 ### Core Classes

--- a/packages/cad-simple-viewer/__tests__/AcApWebworkerReadiness.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApWebworkerReadiness.spec.ts
@@ -1,0 +1,94 @@
+import {
+  checkWebworkerReadiness,
+  resetWebworkerReadinessCache
+} from '../src/app/AcApWebworkerReadiness'
+
+function mockFetch(
+  implementation: (...args: unknown[]) => unknown
+): typeof fetch {
+  return jest.fn(implementation) as unknown as typeof fetch
+}
+
+describe('checkWebworkerReadiness', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    resetWebworkerReadinessCache()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('uses HEAD requests and returns true when all workers respond ok', async () => {
+    global.fetch = mockFetch(() =>
+      Promise.resolve({ ok: true, status: 200 } as Response)
+    )
+
+    const ready = await checkWebworkerReadiness({
+      dxfParser: '/workers/dxf-parser-worker.js',
+      dwgParser: '/workers/libredwg-parser-worker.js',
+      mtextRender: '/workers/mtext-renderer-worker.js'
+    })
+
+    expect(ready).toBe(true)
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+    expect(global.fetch).toHaveBeenCalledWith('/workers/dxf-parser-worker.js', {
+      method: 'HEAD'
+    })
+  })
+
+  it('does not cache failures so a later retry can succeed', async () => {
+    global.fetch = mockFetch(() =>
+      Promise.resolve({ ok: true, status: 200 } as Response)
+    )
+    ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network error'))
+
+    const urls = {
+      dxfParser: '/workers/dxf-parser-worker.js',
+      dwgParser: '/workers/libredwg-parser-worker.js',
+      mtextRender: '/workers/mtext-renderer-worker.js'
+    }
+
+    expect(await checkWebworkerReadiness(urls)).toBe(false)
+    expect(await checkWebworkerReadiness(urls)).toBe(true)
+    expect(global.fetch).toHaveBeenCalledTimes(6)
+  })
+
+  it('caches a successful result for the current page lifecycle', async () => {
+    global.fetch = mockFetch(() =>
+      Promise.resolve({ ok: true, status: 200 } as Response)
+    )
+
+    const urls = {
+      dxfParser: '/workers/dxf-parser-worker.js',
+      dwgParser: '/workers/libredwg-parser-worker.js',
+      mtextRender: '/workers/mtext-renderer-worker.js'
+    }
+
+    expect(await checkWebworkerReadiness(urls)).toBe(true)
+    expect(await checkWebworkerReadiness(urls)).toBe(true)
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('falls back to a ranged GET when HEAD returns 405', async () => {
+    global.fetch = mockFetch(() =>
+      Promise.resolve({ ok: true, status: 200 } as Response)
+    )
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: false, status: 405 } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 206 } as Response)
+
+    const ready = await checkWebworkerReadiness({
+      dxfParser: '/workers/dxf-parser-worker.js'
+    })
+
+    expect(ready).toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith('/workers/dxf-parser-worker.js', {
+      method: 'HEAD'
+    })
+    expect(global.fetch).toHaveBeenCalledWith('/workers/dxf-parser-worker.js', {
+      headers: { Range: 'bytes=0-0' }
+    })
+  })
+})

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -76,11 +76,6 @@ import {
   AcApZoomCmd
 } from '../command'
 import {
-  checkWebworkerReadiness,
-  DEFAULT_WEBWORKER_FILE_URLS,
-  resetWebworkerReadinessCache
-} from './AcApWebworkerReadiness'
-import {
   AcEdCalculateSizeCallback,
   AcEdCommand,
   AcEdCommandStack,
@@ -94,6 +89,11 @@ import { AcApContext } from './AcApContext'
 import { AcApDocument } from './AcApDocument'
 import { AcApFontLoader } from './AcApFontLoader'
 import { AcApProgress } from './AcApProgress'
+import {
+  checkWebworkerReadiness,
+  DEFAULT_WEBWORKER_FILE_URLS,
+  resetWebworkerReadinessCache
+} from './AcApWebworkerReadiness'
 import {
   AcApOpenDatabaseOptions,
   AcApOpenViewMode
@@ -375,7 +375,7 @@ export class AcApDocManager {
   private static _instance?: AcApDocManager
   /** Worker URLs configured at initialization */
   private _webworkerFileUrls?: AcApWebworkerFiles
-  /** Cached worker readiness; null until checked, true when all workers are reachable */
+  /** Cached worker readiness; null until checked, then true or false */
   private _workersReady: boolean | null = null
   /** In-flight worker readiness check */
   private _workersReadyCheckPromise?: Promise<boolean>
@@ -561,9 +561,10 @@ export class AcApDocManager {
   /**
    * Returns true when all configured worker files are reachable.
    *
-   * Uses HEAD requests internally and caches a successful result for the
-   * current page lifecycle. Failures are not cached so transient network
-   * errors can be retried.
+   * Uses HEAD requests internally. A successful result is cached on this
+   * instance for fast subsequent calls; failures update {@link workersReady}
+   * to false but can be retried. The underlying URL probe does not cache
+   * failures, so transient network errors can recover on a later call.
    */
   areWorkersReady(): Promise<boolean> {
     if (this._workersReady === true) {
@@ -575,14 +576,13 @@ export class AcApDocManager {
         this._webworkerFileUrls
       )
         .then(ready => {
-          if (ready) {
-            this._workersReady = true
-          }
+          this._workersReady = ready
           this._workersReadyCheckPromise = undefined
           this.events.workersReady.dispatch({ ready })
           return ready
         })
         .catch(() => {
+          this._workersReady = false
           this._workersReadyCheckPromise = undefined
           this.events.workersReady.dispatch({ ready: false })
           return false

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -76,6 +76,11 @@ import {
   AcApZoomCmd
 } from '../command'
 import {
+  checkWebworkerReadiness,
+  DEFAULT_WEBWORKER_FILE_URLS,
+  resetWebworkerReadinessCache
+} from './AcApWebworkerReadiness'
+import {
   AcEdCalculateSizeCallback,
   AcEdCommand,
   AcEdCommandStack,
@@ -233,6 +238,13 @@ export interface AcApDocManagerOptions {
   webworkerFileUrls?: AcApWebworkerFiles
 
   /**
+   * When true, verify worker script URLs via HEAD requests after initialization.
+   * The result is exposed through {@link AcApDocManager.workersReady} and the
+   * `workersReady` event. Defaults to false.
+   */
+  checkWorkersOnInit?: boolean
+
+  /**
    * URL of the offline HTML viewer runtime bundle (`viewer-runtime.iife.js`).
    * Used by the HTML export plugin when packaging standalone HTML files.
    */
@@ -361,6 +373,12 @@ export class AcApDocManager {
   private _openFileProgressStage?: AcDbProgressdEventArgs['stage']
   /** Singleton instance */
   private static _instance?: AcApDocManager
+  /** Worker URLs configured at initialization */
+  private _webworkerFileUrls?: AcApWebworkerFiles
+  /** Cached worker readiness; null until checked, true when all workers are reachable */
+  private _workersReady: boolean | null = null
+  /** In-flight worker readiness check */
+  private _workersReadyCheckPromise?: Promise<boolean>
 
   /** Events fired during document lifecycle */
   public readonly events = {
@@ -369,7 +387,9 @@ export class AcApDocManager {
     /** Fired when a new document is created */
     documentCreated: new AcCmEventManager<AcDbDocumentEventArgs>(),
     /** Fired when a document becomes active */
-    documentActivated: new AcCmEventManager<AcDbDocumentEventArgs>()
+    documentActivated: new AcCmEventManager<AcDbDocumentEventArgs>(),
+    /** Fired when a worker readiness check completes */
+    workersReady: new AcCmEventManager<{ ready: boolean }>()
   }
 
   /**
@@ -470,7 +490,11 @@ export class AcApDocManager {
     if (!options.notLoadDefaultFonts) {
       this.loadDefaultFonts()
     }
+    this._webworkerFileUrls = options.webworkerFileUrls
     this.registerWorkers(options.webworkerFileUrls)
+    if (options.checkWorkersOnInit) {
+      void this.areWorkersReady()
+    }
     // Load plugins asynchronously (don't await to avoid blocking initialization)
     this.loadPlugins(options.plugins).catch(error => {
       log.error('[AcApDocManager] Error loading plugins:', error)
@@ -494,6 +518,16 @@ export class AcApDocManager {
   }
 
   /**
+   * Checks whether configured worker scripts are reachable without creating an
+   * {@link AcApDocManager} instance.
+   */
+  static checkWebworkerReadiness(
+    webworkerFileUrls?: AcApWebworkerFiles
+  ): Promise<boolean> {
+    return checkWebworkerReadiness(webworkerFileUrls)
+  }
+
+  /**
    * Gets the singleton instance of the document manager.
    * Throw one exception if the instance isn't created yet.
    *
@@ -513,7 +547,49 @@ export class AcApDocManager {
     await this._pluginManager.unloadAllPlugins()
     this.context.doc.destroy()
     AcTrMTextRenderer.resetInstance()
+    resetWebworkerReadinessCache()
     AcApDocManager._instance = undefined
+  }
+
+  /**
+   * Last worker readiness result for this manager, or null if not checked yet.
+   */
+  get workersReady(): boolean | null {
+    return this._workersReady
+  }
+
+  /**
+   * Returns true when all configured worker files are reachable.
+   *
+   * Uses HEAD requests internally and caches a successful result for the
+   * current page lifecycle. Failures are not cached so transient network
+   * errors can be retried.
+   */
+  areWorkersReady(): Promise<boolean> {
+    if (this._workersReady === true) {
+      return Promise.resolve(true)
+    }
+
+    if (!this._workersReadyCheckPromise) {
+      this._workersReadyCheckPromise = checkWebworkerReadiness(
+        this._webworkerFileUrls
+      )
+        .then(ready => {
+          if (ready) {
+            this._workersReady = true
+          }
+          this._workersReadyCheckPromise = undefined
+          this.events.workersReady.dispatch({ ready })
+          return ready
+        })
+        .catch(() => {
+          this._workersReadyCheckPromise = undefined
+          this.events.workersReady.dispatch({ ready: false })
+          return false
+        })
+    }
+
+    return this._workersReadyCheckPromise
   }
 
   /**
@@ -1423,9 +1499,7 @@ export class AcApDocManager {
         convertByEntityType: false,
         useWorker: true,
         parserWorkerUrl:
-          webworkerFileUrls && webworkerFileUrls.dxfParser
-            ? webworkerFileUrls.dxfParser
-            : './assets/dxf-parser-worker.js'
+          webworkerFileUrls?.dxfParser ?? DEFAULT_WEBWORKER_FILE_URLS.dxfParser
       })
       AcDbDatabaseConverterManager.instance.register(
         AcDbFileType.DXF,
@@ -1441,9 +1515,7 @@ export class AcApDocManager {
         convertByEntityType: false,
         useWorker: true,
         parserWorkerUrl:
-          webworkerFileUrls && webworkerFileUrls.dwgParser
-            ? webworkerFileUrls.dwgParser
-            : './assets/libredwg-parser-worker.js'
+          webworkerFileUrls?.dwgParser ?? DEFAULT_WEBWORKER_FILE_URLS.dwgParser
       })
       AcDbDatabaseConverterManager.instance.register(
         AcDbFileType.DWG,
@@ -1470,9 +1542,8 @@ export class AcApDocManager {
     this.registerConverters(webworkerFileUrls)
     const mtextRenderer = AcTrMTextRenderer.getInstance()
     mtextRenderer.initialize(
-      webworkerFileUrls && webworkerFileUrls.mtextRender
-        ? webworkerFileUrls.mtextRender
-        : './assets/mtext-renderer-worker.js'
+      webworkerFileUrls?.mtextRender ??
+        DEFAULT_WEBWORKER_FILE_URLS.mtextRender
     )
     void mtextRenderer.setDefaultFonts(DEFAULT_FONTS_PRESET)
   }

--- a/packages/cad-simple-viewer/src/app/AcApWebworkerReadiness.ts
+++ b/packages/cad-simple-viewer/src/app/AcApWebworkerReadiness.ts
@@ -1,0 +1,76 @@
+import type { AcApWebworkerFiles } from './AcApDocManager'
+
+/** Default worker script URLs used when `webworkerFileUrls` is omitted. */
+export const DEFAULT_WEBWORKER_FILE_URLS: Required<AcApWebworkerFiles> = {
+  dxfParser: './assets/dxf-parser-worker.js',
+  dwgParser: './assets/libredwg-parser-worker.js',
+  mtextRender: './assets/mtext-renderer-worker.js'
+}
+
+/**
+ * Resolves configured worker URLs to strings, falling back to {@link DEFAULT_WEBWORKER_FILE_URLS}.
+ */
+export function resolveWebworkerFileUrls(
+  webworkerFileUrls?: AcApWebworkerFiles
+): string[] {
+  return [
+    webworkerFileUrls?.dxfParser ?? DEFAULT_WEBWORKER_FILE_URLS.dxfParser,
+    webworkerFileUrls?.dwgParser ?? DEFAULT_WEBWORKER_FILE_URLS.dwgParser,
+    webworkerFileUrls?.mtextRender ?? DEFAULT_WEBWORKER_FILE_URLS.mtextRender
+  ].map(url => String(url))
+}
+
+let cachedReadinessKey: string | undefined
+let cachedReadinessResult: true | undefined
+
+/** Clears the module-level success cache (e.g. when the doc manager is destroyed). */
+export function resetWebworkerReadinessCache(): void {
+  cachedReadinessKey = undefined
+  cachedReadinessResult = undefined
+}
+
+async function isWorkerUrlReachable(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, { method: 'HEAD' })
+    if (response.ok) {
+      return true
+    }
+    // Some static hosts reject HEAD; probe with a minimal ranged GET instead.
+    if (response.status === 405) {
+      const fallback = await fetch(url, { headers: { Range: 'bytes=0-0' } })
+      return fallback.ok || fallback.status === 206
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Returns true when all configured worker scripts respond successfully.
+ *
+ * Uses HEAD requests to avoid downloading large worker bundles. Successful
+ * results are cached for the current page lifecycle; failures are not cached
+ * so transient network errors can be retried.
+ */
+export async function checkWebworkerReadiness(
+  webworkerFileUrls?: AcApWebworkerFiles
+): Promise<boolean> {
+  const urls = resolveWebworkerFileUrls(webworkerFileUrls)
+  const key = urls.join('|')
+  if (cachedReadinessKey === key && cachedReadinessResult === true) {
+    return true
+  }
+
+  try {
+    const results = await Promise.all(urls.map(isWorkerUrlReachable))
+    const ready = results.every(Boolean)
+    if (ready) {
+      cachedReadinessKey = key
+      cachedReadinessResult = true
+    }
+    return ready
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- Add `AcApWebworkerReadiness` module with `checkWebworkerReadiness()` that verifies worker script URLs via HEAD requests (with ranged GET fallback for hosts that reject HEAD), caching successes but not failures.
- Expose `AcApDocManager.checkWebworkerReadiness()`, `areWorkersReady()`, `workersReady` getter, `workersRead` event, and optional `checkWorkersOnInit` option.
- Centralize default worker URLs in `DEFAULT_WEBWORKER_FILE_URLS` and document deployment guidance in `cad-simple-viewer/README.md`.
- Hide the simple viewer example empty state while a document is opening via `documentToBeOpened`.
- Document DWG file size / memory limits in root README (EN + zh-CN).

## Test plan

- [x] `pnpm test -- packages/cad-simple-viewer/__tests__/AcApWebworkerReadiness.spec.ts` (4 tests pass)
- [ ] Open `cad-simple-viewer-example` and verify empty state hides when loading a DXF/DWG file
- [ ] Deploy with missing worker scripts and confirm `checkWebworkerReadiness` returns `false`