### PR TITLE
feat(cad-agent-plugin): add natural-language CAD drawing agent

### DIFF
--- a/packages/cad-agent-plugin/README.md
+++ b/packages/cad-agent-plugin/README.md
@@ -1,0 +1,26 @@
+# @mlightcad/cad-agent-plugin
+
+Natural-language CAD drawing agent for [cad-viewer](https://github.com/mlightcad/cad-viewer).
+
+## Features
+
+- Lazy-loaded `AcApPlugin` (trigger command: `agent`)
+- Vercel AI SDK `Experimental_Agent` with CAD tool calling
+- Vue chat panel (`@ai-sdk/vue` `Chat` + custom transport)
+- Browser-side API key (OpenAI / Anthropic / OpenAI-compatible)
+
+## Usage in cad-viewer
+
+```typescript
+import { registerLazyAgentPlugin } from '@mlightcad/cad-agent-plugin/register'
+
+registerLazyAgentPlugin(AcApDocManager.instance.pluginManager)
+```
+
+Run `agent` from the ribbon or command line to open the panel.
+
+## CAD tools (Phase 1)
+
+- `get_drawing_context`
+- `draw_line`, `draw_circle`, `draw_arc`, `draw_rectangle`, `draw_polyline`, `draw_text`
+- `set_current_layer`, `create_layer`, `zoom_extents`

--- a/packages/cad-agent-plugin/package.json
+++ b/packages/cad-agent-plugin/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@mlightcad/cad-agent-plugin",
+  "version": "1.5.7",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mlightcad/cad-viewer.git"
+  },
+  "files": [
+    "dist",
+    "lib",
+    "README.md",
+    "package.json"
+  ],
+  "main": "./dist/cad-agent-plugin.umd.cjs",
+  "module": "./dist/cad-agent-plugin.js",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "types": "./lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "register": [
+        "lib/register.d.ts"
+      ]
+    }
+  },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./dist/cad-agent-plugin.js",
+      "require": "./dist/cad-agent-plugin.umd.cjs"
+    },
+    "./register": {
+      "types": "./lib/register.d.ts",
+      "import": "./dist/cad-agent-plugin-register.js",
+      "require": "./dist/cad-agent-plugin-register.umd.cjs"
+    },
+    "./style.css": "./dist/style.css"
+  },
+  "scripts": {
+    "clean": "rimraf dist lib tsconfig.tsbuildinfo",
+    "build:types": "node scripts/copy-typings.mjs",
+    "build": "pnpm build:types && vite build",
+    "lint": "eslint src/",
+    "lint:fix": "eslint --fix --quiet src/"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^2.0.0",
+    "@ai-sdk/openai": "^2.0.0",
+    "@ai-sdk/vue": "^2.0.0",
+    "ai": "^5.0.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@mlightcad/cad-simple-viewer": "workspace:*",
+    "@mlightcad/data-model": "^1.10.0",
+    "@vitejs/plugin-vue": "^5.1.3",
+    "vue": "^3.4.21",
+    "vue-tsc": "^2.1.6"
+  },
+  "peerDependencies": {
+    "@mlightcad/cad-simple-viewer": "workspace:*",
+    "@mlightcad/data-model": "^1.10.0",
+    "vue": "^3.4.21"
+  }
+}

--- a/packages/cad-agent-plugin/project.json
+++ b/packages/cad-agent-plugin/project.json
@@ -1,0 +1,39 @@
+{
+  "name": "@mlightcad/cad-agent-plugin",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/cad-agent-plugin/src",
+  "projectType": "library",
+  "tags": ["npm:private"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm build",
+        "cwd": "packages/cad-agent-plugin"
+      },
+      "dependsOn": ["^build"],
+      "cache": true
+    },
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "rimraf dist lib tsconfig.tsbuildinfo",
+        "cwd": "packages/cad-agent-plugin"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint src/",
+        "cwd": "packages/cad-agent-plugin"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint --fix --quiet src/",
+        "cwd": "packages/cad-agent-plugin"
+      }
+    }
+  }
+}

--- a/packages/cad-agent-plugin/scripts/copy-typings.mjs
+++ b/packages/cad-agent-plugin/scripts/copy-typings.mjs
@@ -1,0 +1,18 @@
+/**
+ * Copies hand-maintained public API declarations from `typings/` into `lib/`.
+ *
+ * Why not `tsc` like the other export plugins?
+ * - `package.json` exposes types at `lib/index.d.ts` and `lib/register.d.ts`.
+ * - Running `tsc` or `vue-tsc` over this package pulls in the `ai` / `@ai-sdk/*`
+ *   dependency graph, which is large enough to hang or OOM during declaration emit.
+ * - `vite-plugin-dts` hit the same memory limit in practice.
+ *
+ * Instead we keep a small, curated surface in `typings/` (only what consumers
+ * need) and copy it here before `vite build`. Update those files when the
+ * public API changes.
+ */
+import { cpSync, mkdirSync, rmSync } from 'node:fs'
+
+rmSync('lib', { recursive: true, force: true })
+mkdirSync('lib', { recursive: true })
+cpSync('typings', 'lib', { recursive: true })

--- a/packages/cad-agent-plugin/src/AcApAgentPlugin.ts
+++ b/packages/cad-agent-plugin/src/AcApAgentPlugin.ts
@@ -1,0 +1,49 @@
+import { AcApContext, AcApPlugin, AcEdCommandStack } from '@mlightcad/cad-simple-viewer'
+
+import packageJson from '../package.json'
+import { AcApAgentCmd } from './command/AcApAgentCmd'
+
+/** Registered name of the CAD Agent plugin in the plugin manager. */
+export const AGENT_PLUGIN_NAME = 'AgentPlugin'
+
+/**
+ * CAD Agent plugin: natural-language drawing via LLM tool calling.
+ *
+ * Registers the `agent` command, which opens the agent chat panel in the tool palette.
+ */
+export class AcApAgentPlugin implements AcApPlugin {
+  /** Plugin identifier used by {@link AcApPluginManager}. */
+  name = AGENT_PLUGIN_NAME
+  /** Semantic version from `package.json`. */
+  version = packageJson.version
+  /** Short human-readable description shown in plugin listings. */
+  description = 'Natural-language CAD drawing agent'
+
+  /** Commands registered in {@link onLoad} for removal in {@link onUnload}. */
+  private registeredCommands: Array<{ group: string; name: string }> = []
+
+  /**
+   * Registers the `agent` system command that opens the agent palette tab.
+   *
+   * @param _context - Application context (unused).
+   * @param commandManager - Command stack used to register {@link AcApAgentCmd}.
+   */
+  onLoad(_context: AcApContext, commandManager: AcEdCommandStack): void {
+    const group = AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME
+    commandManager.addCommand(group, 'agent', 'agent', new AcApAgentCmd())
+    this.registeredCommands.push({ group, name: 'agent' })
+  }
+
+  /**
+   * Removes commands registered during {@link onLoad}.
+   *
+   * @param _context - Application context (unused).
+   * @param commandManager - Command stack used to unregister agent commands.
+   */
+  onUnload(_context: AcApContext, commandManager: AcEdCommandStack): void {
+    for (const cmd of this.registeredCommands) {
+      commandManager.removeCmd(cmd.group, cmd.name)
+    }
+    this.registeredCommands = []
+  }
+}

--- a/packages/cad-agent-plugin/src/agent/createCadAgent.ts
+++ b/packages/cad-agent-plugin/src/agent/createCadAgent.ts
@@ -1,0 +1,65 @@
+import {
+  type ChatTransport,
+  convertToModelMessages,
+  Experimental_Agent as Agent,
+  stepCountIs,
+  type UIMessage,
+  validateUIMessages
+} from 'ai'
+
+import type { LlmSettings } from '../storage/LlmSettingsStore'
+import { createCadTools } from '../tools/cadTools'
+import { createModelFromSettings } from './createModel'
+import { CAD_AGENT_SYSTEM_PROMPT } from './systemPrompt'
+
+/**
+ * Builds an AI SDK agent configured for CAD drawing with tool calling.
+ *
+ * @param settings - LLM provider credentials and model selection.
+ * @returns An agent that streams responses and can invoke {@link createCadTools}.
+ */
+export function createCadAgent(settings: LlmSettings) {
+  return new Agent({
+    model: createModelFromSettings(settings),
+    system: CAD_AGENT_SYSTEM_PROMPT,
+    tools: createCadTools(),
+    stopWhen: stepCountIs(10)
+  })
+}
+
+/**
+ * Creates a {@link ChatTransport} that runs the agent in-process (no HTTP server).
+ *
+ * Validates UI messages, converts them to model messages, and streams UI chunks
+ * directly from the agent rather than over SSE.
+ *
+ * @param getAgent - Factory invoked per request so settings changes take effect after reset.
+ * @returns A transport compatible with `@ai-sdk/vue` {@link Chat}.
+ */
+export function createAgentChatTransport(
+  getAgent: () => Agent
+): ChatTransport<UIMessage> {
+  return {
+    /** Validates messages, streams the agent, and yields UI message chunks. */
+    sendMessages: async ({ messages, abortSignal }) => {
+      const agent = getAgent()
+      const validatedMessages = await validateUIMessages({
+        messages,
+        tools: agent.tools
+      })
+      const modelMessages = await convertToModelMessages(validatedMessages, {
+        tools: agent.tools
+      })
+      const result = agent.stream({
+        prompt: modelMessages,
+        abortSignal
+      })
+      // Return UI message chunks directly — not HTTP SSE from respond().body.
+      return result.toUIMessageStream({
+        originalMessages: validatedMessages
+      })
+    },
+    /** In-process transport does not support stream reconnection. */
+    reconnectToStream: async () => null
+  }
+}

--- a/packages/cad-agent-plugin/src/agent/createModel.ts
+++ b/packages/cad-agent-plugin/src/agent/createModel.ts
@@ -1,0 +1,49 @@
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { createOpenAI } from '@ai-sdk/openai'
+import type { LanguageModel } from 'ai'
+
+import type { LlmSettings } from '../storage/LlmSettingsStore'
+import { createOpenAiCompatibleFetch } from './openAiCompatibleFetch'
+
+/**
+ * Instantiates an AI SDK language model from persisted LLM settings.
+ *
+ * Selects the Anthropic, OpenAI, or OpenAI-compatible provider implementation
+ * based on {@link LlmSettings.provider}.
+ *
+ * @param settings - Provider, API key, base URL, and model id.
+ * @returns A configured {@link LanguageModel}.
+ * @throws When {@link LlmSettings.apiKey} is empty.
+ */
+export function createModelFromSettings(settings: LlmSettings): LanguageModel {
+  if (!settings.apiKey.trim()) {
+    throw new Error('API key is required. Open Agent settings to configure it.')
+  }
+
+  if (settings.provider === 'anthropic') {
+    const anthropic = createAnthropic({
+      apiKey: settings.apiKey,
+      baseURL: settings.baseUrl || undefined
+    })
+    return anthropic(settings.model)
+  }
+
+  if (settings.provider === 'openai') {
+    const openai = createOpenAI({
+      apiKey: settings.apiKey,
+      baseURL: settings.baseUrl || undefined,
+      compatibility: 'strict'
+    })
+    return openai.chat(settings.model)
+  }
+
+  // DeepSeek and other OpenAI-compatible endpoints use /chat/completions
+  // and reject the `developer` role that AI SDK 5 may emit for system prompts.
+  const openai = createOpenAI({
+    apiKey: settings.apiKey,
+    baseURL: settings.baseUrl || undefined,
+    compatibility: 'compatible',
+    fetch: createOpenAiCompatibleFetch()
+  })
+  return openai.chat(settings.model)
+}

--- a/packages/cad-agent-plugin/src/agent/openAiCompatibleFetch.ts
+++ b/packages/cad-agent-plugin/src/agent/openAiCompatibleFetch.ts
@@ -1,0 +1,47 @@
+/** Minimal chat message shape used when rewriting request bodies. */
+type MessageLike = { role?: string; [key: string]: unknown }
+
+/**
+ * Rewrites `developer` roles to `system` in place for OpenAI-compatible APIs.
+ *
+ * @param items - Message array from a chat request body, if present.
+ */
+function convertDeveloperRoles(items: MessageLike[] | undefined): void {
+  if (!items) return
+  for (const item of items) {
+    if (item.role === 'developer') {
+      item.role = 'system'
+    }
+  }
+}
+
+/**
+ * Wraps `fetch` so OpenAI-compatible providers accept AI SDK 5 request bodies.
+ *
+ * AI SDK 5 may emit `developer` roles for system prompts on chat models.
+ * Most OpenAI-compatible APIs (DeepSeek, etc.) only accept `system`.
+ *
+ * @param baseFetch - Underlying fetch implementation (defaults to `globalThis.fetch`).
+ * @returns A fetch function that normalizes message roles before sending.
+ */
+export function createOpenAiCompatibleFetch(
+  baseFetch: typeof fetch = globalThis.fetch.bind(globalThis)
+): typeof fetch {
+  return async (input, init) => {
+    if (!init?.body || typeof init.body !== 'string') {
+      return baseFetch(input, init)
+    }
+
+    try {
+      const body = JSON.parse(init.body) as {
+        messages?: MessageLike[]
+        input?: MessageLike[]
+      }
+      convertDeveloperRoles(body.messages)
+      convertDeveloperRoles(body.input)
+      return baseFetch(input, { ...init, body: JSON.stringify(body) })
+    } catch {
+      return baseFetch(input, init)
+    }
+  }
+}

--- a/packages/cad-agent-plugin/src/agent/systemPrompt.ts
+++ b/packages/cad-agent-plugin/src/agent/systemPrompt.ts
@@ -1,0 +1,16 @@
+/**
+ * System prompt instructing the CAD agent how to use drawing tools and context.
+ *
+ * Embedded in {@link createCadAgent} and sent to the LLM on every conversation.
+ */
+export const CAD_AGENT_SYSTEM_PROMPT = `You are a CAD drawing assistant embedded in a 2D CAD viewer.
+
+Rules:
+- The user may attach reference images (sketches, screenshots, floor plans). Use them to infer geometry, dimensions, and layout when possible.
+- Work in WCS with Z=0 unless the user specifies otherwise.
+- Call get_drawing_context first to learn units (INSUNITS), layers, and drawing extents.
+- Use numeric coordinates and dimensions only.
+- Prefer simple primitives (line, circle, polyline, rectangle, text).
+- When a tool returns success:false, read the error field and retry with corrected input.
+- After creating geometry, briefly summarize what was drawn.
+- Do not invent layers; use existing layers or create_layer when needed.`

--- a/packages/cad-agent-plugin/src/command/AcApAgentCmd.ts
+++ b/packages/cad-agent-plugin/src/command/AcApAgentCmd.ts
@@ -1,0 +1,20 @@
+import { AcApContext, AcEdCommand } from '@mlightcad/cad-simple-viewer'
+import { log } from '@mlightcad/data-model'
+
+import { openAgentPalette } from '../palette/agentPaletteIntegration'
+
+/**
+ * Opens or toggles the CAD Agent tab in the tool palette.
+ */
+export class AcApAgentCmd extends AcEdCommand {
+  /**
+   * Invokes the registered palette opener, if cad-viewer has wired one in.
+   *
+   * @param _context - Application context (unused).
+   */
+  async execute(_context: AcApContext) {
+    if (!openAgentPalette()) {
+      log.warn('CAD Agent palette is not available.')
+    }
+  }
+}

--- a/packages/cad-agent-plugin/src/createAgentPlugin.ts
+++ b/packages/cad-agent-plugin/src/createAgentPlugin.ts
@@ -1,0 +1,10 @@
+import { AcApAgentPlugin } from './AcApAgentPlugin'
+
+/**
+ * Creates a CAD Agent plugin instance.
+ *
+ * @returns A promise that resolves to a new {@link AcApAgentPlugin}.
+ */
+export async function createAgentPlugin() {
+  return new AcApAgentPlugin()
+}

--- a/packages/cad-agent-plugin/src/i18n/en.ts
+++ b/packages/cad-agent-plugin/src/i18n/en.ts
@@ -1,0 +1,41 @@
+/**
+ * English UI strings for the CAD Agent panel.
+ *
+ * Flat keys under `main.toolPalette.agent` (merged into {@link AcApI18n}).
+ * Keys must stay in sync with {@link agentZh}.
+ */
+export const agentEn = {
+  tab: 'Agent',
+  title: 'CAD Agent',
+  settings: 'Settings',
+  clear: 'Clear',
+  close: 'Close',
+  provider: 'Provider',
+  providerDeepseek: 'DeepSeek',
+  providerOpenai: 'OpenAI',
+  providerAnthropic: 'Anthropic',
+  providerOpenaiCompatible: 'OpenAI Compatible',
+  baseUrl: 'Base URL',
+  model: 'Model',
+  visionModels: 'Vision models',
+  textModels: 'Text-only models',
+  customModel: 'Custom model…',
+  customModelName: 'Custom model name',
+  modelSupportsVision: 'Supports image input',
+  modelTextOnly: 'Text only — image attachments disabled',
+  apiKey: 'API Key',
+  saveSettings: 'Save settings',
+  emptyHint:
+    'Describe what to draw, or attach a reference image (sketch, screenshot, floor plan).',
+  toolPrefix: 'tool',
+  inputPlaceholder: 'Describe the geometry to create…',
+  attachImage: 'Attach image',
+  removeAttachment: 'Remove',
+  imageAlt: 'Attached image',
+  errorTitle: 'Something went wrong',
+  dismissError: 'Dismiss',
+  send: 'Send',
+  working: 'Working…',
+  unsavedSettings: 'Save settings before sending messages.',
+  missingApiKey: 'Configure an API key in settings before sending messages.'
+} as const

--- a/packages/cad-agent-plugin/src/i18n/index.ts
+++ b/packages/cad-agent-plugin/src/i18n/index.ts
@@ -1,0 +1,86 @@
+import { AcApI18n, type AcApLocale } from '@mlightcad/cad-simple-viewer'
+
+import { agentEn } from './en'
+import { agentZh } from './zh'
+
+/** Vue i18n key prefix for all agent UI strings (`main.toolPalette.agent`). */
+export const AGENT_I18N_PREFIX = 'main.toolPalette.agent'
+
+/** Union of keys in {@link agentEn} used for type-safe translations. */
+export type AgentChatLabelKey = keyof typeof agentEn
+
+/** Map of every agent UI label key to its translated string. */
+export type AgentChatLabels = Record<AgentChatLabelKey, string>
+
+/** Locale-specific flat message tables before nesting under `main.toolPalette.agent`. */
+const agentMessagesByLocale = {
+  en: agentEn,
+  zh: agentZh
+} as const satisfies Record<AcApLocale, AgentChatLabels>
+
+/** Guards {@link registerAgentI18n} against duplicate merges. */
+let isRegistered = false
+
+/**
+ * Builds the nested vue-i18n message object for one locale.
+ *
+ * @param locale - Target locale (`en` or `zh`).
+ * @returns Messages shaped for `mergeLocaleMessage`.
+ */
+function buildVueMessages(locale: AcApLocale) {
+  return {
+    main: {
+      toolPalette: {
+        agent: agentMessagesByLocale[locale]
+      }
+    }
+  }
+}
+
+/**
+ * Registers CAD Agent UI strings into {@link AcApI18n}.
+ * Safe to call multiple times; subsequent calls are no-ops.
+ */
+export function registerAgentI18n(): void {
+  if (isRegistered) return
+
+  AcApI18n.mergeLocaleMessage('en', buildVueMessages('en'))
+  AcApI18n.mergeLocaleMessage('zh', buildVueMessages('zh'))
+  isRegistered = true
+}
+
+/**
+ * Merges agent UI strings into a vue-i18n instance (e.g. cad-viewer).
+ *
+ * @param mergeLocaleMessage - Host app's `mergeLocaleMessage` callback.
+ */
+export function mergeAgentI18nIntoVueI18n(
+  mergeLocaleMessage: (locale: AcApLocale, message: object) => void
+): void {
+  registerAgentI18n()
+  mergeLocaleMessage('en', buildVueMessages('en'))
+  mergeLocaleMessage('zh', buildVueMessages('zh'))
+}
+
+/**
+ * Translates a single agent label via {@link AcApI18n}.
+ *
+ * @param key - Label key from {@link agentEn}.
+ * @returns Localized string, or the key as fallback.
+ */
+export function agentT(key: AgentChatLabelKey): string {
+  return AcApI18n.t(`${AGENT_I18N_PREFIX}.${key}`, { fallback: key })
+}
+
+/**
+ * Builds a reactive-friendly map of all agent labels for the current locale.
+ *
+ * All label keys are derived from {@link agentEn} — add new strings in en.ts/zh.ts only.
+ *
+ * @returns Every {@link AgentChatLabelKey} mapped to its translation.
+ */
+export function buildAgentLabels(): AgentChatLabels {
+  return Object.fromEntries(
+    (Object.keys(agentEn) as AgentChatLabelKey[]).map(key => [key, agentT(key)])
+  ) as AgentChatLabels
+}

--- a/packages/cad-agent-plugin/src/i18n/useAgentI18n.ts
+++ b/packages/cad-agent-plugin/src/i18n/useAgentI18n.ts
@@ -1,0 +1,47 @@
+import { AcApI18n } from '@mlightcad/cad-simple-viewer'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+
+import {
+  type AgentChatLabelKey,
+  agentT,
+  buildAgentLabels} from './index'
+
+/**
+ * Reactive agent UI strings that follow {@link AcApI18n} locale changes.
+ *
+ * @returns `labels` — computed map of all agent strings; `t` — translate one key.
+ */
+export function useAgentI18n() {
+  /** Bumped on locale change to invalidate computed labels. */
+  const localeVersion = ref(0)
+
+  /** Invalidates cached labels when {@link AcApI18n} fires `localeChanged`. */
+  const handleLocaleChanged = () => {
+    localeVersion.value++
+  }
+
+  onMounted(() => {
+    AcApI18n.events.localeChanged.addEventListener(handleLocaleChanged)
+  })
+
+  onUnmounted(() => {
+    AcApI18n.events.localeChanged.removeEventListener(handleLocaleChanged)
+  })
+
+  const labels = computed(() => {
+    void localeVersion.value
+    return buildAgentLabels()
+  })
+
+  /**
+   * Translates one agent label, re-evaluating when the locale changes.
+   *
+   * @param key - Label key from {@link agentEn}.
+   */
+  const t = (key: AgentChatLabelKey) => {
+    void localeVersion.value
+    return agentT(key)
+  }
+
+  return { labels, t }
+}

--- a/packages/cad-agent-plugin/src/i18n/zh.ts
+++ b/packages/cad-agent-plugin/src/i18n/zh.ts
@@ -1,0 +1,40 @@
+/**
+ * Chinese UI strings for the CAD Agent panel.
+ *
+ * Flat keys under `main.toolPalette.agent` (merged into {@link AcApI18n}).
+ * Keys must stay in sync with {@link agentEn}.
+ */
+export const agentZh = {
+  tab: '智能助手',
+  title: 'CAD 智能助手',
+  settings: '设置',
+  clear: '清空',
+  close: '关闭',
+  provider: '服务商',
+  providerDeepseek: 'DeepSeek',
+  providerOpenai: 'OpenAI',
+  providerAnthropic: 'Anthropic',
+  providerOpenaiCompatible: 'OpenAI 兼容',
+  baseUrl: '接口地址',
+  model: '模型',
+  visionModels: '视觉模型',
+  textModels: '纯文本模型',
+  customModel: '自定义模型…',
+  customModelName: '自定义模型名称',
+  modelSupportsVision: '支持图片输入',
+  modelTextOnly: '仅文本 — 已禁用图片附件',
+  apiKey: 'API 密钥',
+  saveSettings: '保存设置',
+  emptyHint: '描述要绘制的内容，或附加参考图片（草图、截图、平面图等）。',
+  toolPrefix: '工具',
+  inputPlaceholder: '描述要创建的几何图形…',
+  attachImage: '添加图片',
+  removeAttachment: '移除',
+  imageAlt: '附加图片',
+  errorTitle: '请求出错',
+  dismissError: '关闭',
+  send: '发送',
+  working: '处理中…',
+  unsavedSettings: '请先保存设置后再发送消息。',
+  missingApiKey: '请先在设置中配置 API Key 后再发送消息。'
+} as const

--- a/packages/cad-agent-plugin/src/index.ts
+++ b/packages/cad-agent-plugin/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * CAD Agent plugin for cad-viewer.
+ *
+ * @packageDocumentation
+ */
+
+import './ui/agent-panel.css'
+
+export { default as AgentChatPanel } from './ui/AgentChatPanel.vue'

--- a/packages/cad-agent-plugin/src/palette/agentPaletteIntegration.ts
+++ b/packages/cad-agent-plugin/src/palette/agentPaletteIntegration.ts
@@ -1,0 +1,27 @@
+/** Callback that opens or focuses the agent tab in the host tool palette. */
+export type AgentPaletteOpener = () => void
+
+/** Palette opener registered by cad-viewer at startup. */
+let paletteOpener: AgentPaletteOpener | undefined
+
+/**
+ * Registers the function cad-viewer calls when the `agent` command runs.
+ *
+ * @param opener - Palette opener, or `undefined` to clear the registration.
+ */
+export function setAgentPaletteOpener(opener: AgentPaletteOpener | undefined) {
+  paletteOpener = opener
+}
+
+/**
+ * Invokes the registered palette opener.
+ *
+ * @returns `true` if an opener was registered and called; otherwise `false`.
+ */
+export function openAgentPalette(): boolean {
+  if (!paletteOpener) {
+    return false
+  }
+  paletteOpener()
+  return true
+}

--- a/packages/cad-agent-plugin/src/register.ts
+++ b/packages/cad-agent-plugin/src/register.ts
@@ -1,0 +1,34 @@
+import type { AcApPluginManager } from '@mlightcad/cad-simple-viewer'
+
+import { AGENT_PLUGIN_NAME } from './AcApAgentPlugin'
+import { registerAgentI18n } from './i18n'
+
+/** Trigger commands handled by {@link AGENT_PLUGIN_NAME}. */
+export const AGENT_PLUGIN_TRIGGERS = ['agent'] as const
+
+/**
+ * Registers the CAD Agent plugin for lazy loading.
+ *
+ * Import from `@mlightcad/cad-agent-plugin/register` so the main bundle
+ * is not pulled into the application entry chunk.
+ */
+export function registerLazyAgentPlugin(pluginManager: AcApPluginManager): void {
+  registerAgentI18n()
+
+  pluginManager.registerLazyPlugin({
+    name: AGENT_PLUGIN_NAME,
+    triggers: [...AGENT_PLUGIN_TRIGGERS],
+    loader: async () => {
+      const { createAgentPlugin } = await import('./createAgentPlugin')
+      return createAgentPlugin()
+    }
+  })
+}
+
+export { AGENT_PLUGIN_NAME }
+export { mergeAgentI18nIntoVueI18n, registerAgentI18n } from './i18n'
+export {
+  openAgentPalette,
+  setAgentPaletteOpener
+} from './palette/agentPaletteIntegration'
+export type { AgentPaletteOpener } from './palette/agentPaletteIntegration'

--- a/packages/cad-agent-plugin/src/storage/LlmSettingsStore.ts
+++ b/packages/cad-agent-plugin/src/storage/LlmSettingsStore.ts
@@ -1,0 +1,144 @@
+import {
+  decryptApiKey,
+  encryptApiKey
+} from './apiKeyCrypto'
+
+/** Supported LLM API backends for the CAD agent. */
+export type LlmProviderId =
+  | 'openai'
+  | 'anthropic'
+  | 'openai-compatible'
+  | 'deepseek'
+
+/**
+ * Persisted LLM configuration for the CAD agent chat panel.
+ */
+export interface LlmSettings {
+  /** Selected API provider implementation. */
+  provider: LlmProviderId
+  /** Secret API key for the provider. */
+  apiKey: string
+  /** REST API base URL (provider-specific default when empty). */
+  baseUrl: string
+  /** Model identifier passed to the provider SDK. */
+  model: string
+}
+
+/** On-disk shape stored in `localStorage`. */
+interface PersistedLlmSettings {
+  provider?: LlmProviderId
+  baseUrl?: string
+  model?: string
+  /** Encrypted API key (preferred). */
+  apiKeyEnc?: string
+  /** Legacy plaintext API key, migrated on load/save. */
+  apiKey?: string
+}
+
+/** `localStorage` key for serialized {@link LlmSettings}. */
+const STORAGE_KEY = 'cad-agent-plugin.llm-settings'
+
+/**
+ * Default base URL and model id per provider, used when settings are first opened.
+ */
+export const PROVIDER_DEFAULTS: Record<
+  LlmProviderId,
+  Pick<LlmSettings, 'baseUrl' | 'model'>
+> = {
+  openai: {
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o-mini'
+  },
+  anthropic: {
+    baseUrl: 'https://api.anthropic.com/v1',
+    model: 'claude-3-5-haiku-latest'
+  },
+  'openai-compatible': {
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o-mini'
+  },
+  deepseek: {
+    baseUrl: 'https://api.deepseek.com/v1',
+    model: 'deepseek-chat'
+  }
+}
+
+/** Fallback settings when nothing is stored or parsing fails. */
+const DEFAULTS: LlmSettings = {
+  provider: 'openai-compatible',
+  apiKey: '',
+  ...PROVIDER_DEFAULTS['openai-compatible']
+}
+
+/**
+ * Returns the default base URL and model for a provider.
+ *
+ * @param provider - LLM provider id.
+ * @returns A shallow copy of the provider entry in {@link PROVIDER_DEFAULTS}.
+ */
+export function getProviderDefaults(
+  provider: LlmProviderId
+): Pick<LlmSettings, 'baseUrl' | 'model'> {
+  return { ...PROVIDER_DEFAULTS[provider] }
+}
+
+/**
+ * Restores the API key from persisted storage, including legacy plaintext values.
+ *
+ * @param persisted - Parsed JSON from `localStorage`.
+ * @returns Decrypted or legacy plaintext API key.
+ */
+async function restoreApiKey(
+  persisted: PersistedLlmSettings
+): Promise<string> {
+  if (persisted.apiKeyEnc) {
+    return decryptApiKey(persisted.apiKeyEnc)
+  }
+  if (typeof persisted.apiKey === 'string') {
+    return persisted.apiKey
+  }
+  return ''
+}
+
+/**
+ * Loads LLM settings from `localStorage`, merged over {@link DEFAULTS}.
+ *
+ * @returns Parsed settings with decrypted API key, or defaults when missing or invalid.
+ */
+export async function loadLlmSettings(): Promise<LlmSettings> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { ...DEFAULTS }
+
+    const persisted = JSON.parse(raw) as PersistedLlmSettings
+    const apiKey = await restoreApiKey(persisted)
+
+    return {
+      ...DEFAULTS,
+      ...persisted,
+      apiKey
+    }
+  } catch {
+    return { ...DEFAULTS }
+  }
+}
+
+/**
+ * Persists LLM settings to `localStorage` with an encrypted API key.
+ *
+ * @param settings - Full settings object to serialize.
+ */
+export async function saveLlmSettings(settings: LlmSettings): Promise<void> {
+  const apiKeyEnc = settings.apiKey
+    ? await encryptApiKey(settings.apiKey)
+    : ''
+
+  const persisted: PersistedLlmSettings = {
+    provider: settings.provider,
+    baseUrl: settings.baseUrl,
+    model: settings.model,
+    apiKeyEnc
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted))
+}

--- a/packages/cad-agent-plugin/src/storage/apiKeyCrypto.ts
+++ b/packages/cad-agent-plugin/src/storage/apiKeyCrypto.ts
@@ -1,0 +1,155 @@
+/** Encryption format version embedded in {@link ENCRYPTED_API_KEY_PREFIX}. */
+const CRYPTO_VERSION = 1
+
+/** Application-specific salt used for PBKDF2 key derivation. */
+const SALT = 'cad-agent-plugin-api-key-v1'
+
+/** AES-GCM initialization vector length in bytes. */
+const IV_LENGTH = 12
+
+/**
+ * Prefix that marks an API key value as encrypted in `localStorage`.
+ *
+ * Payloads use the form `enc:v{version}:{base64(iv + ciphertext)}`.
+ */
+export const ENCRYPTED_API_KEY_PREFIX = `enc:v${CRYPTO_VERSION}:`
+
+/**
+ * Builds the password material for PBKDF2 from the page origin and {@link SALT}.
+ *
+ * @returns A string bound to the current browsing origin (or `file://` when unavailable).
+ */
+function getEncryptionMaterial(): string {
+  const origin =
+    typeof globalThis.location?.origin === 'string'
+      ? globalThis.location.origin
+      : 'file://'
+  return `${origin}:${SALT}`
+}
+
+/**
+ * Derives the AES-GCM key used to encrypt and decrypt stored API keys.
+ *
+ * Uses PBKDF2 (SHA-256, 100k iterations) over {@link getEncryptionMaterial}.
+ *
+ * @returns A 256-bit {@link CryptoKey} suitable for AES-GCM.
+ */
+async function deriveCryptoKey(): Promise<CryptoKey> {
+  const encoder = new TextEncoder()
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(getEncryptionMaterial()),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  )
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: encoder.encode(SALT),
+      iterations: 100_000,
+      hash: 'SHA-256'
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+/**
+ * Encodes a byte array as a standard base64 string.
+ *
+ * @param bytes - Raw bytes to encode.
+ * @returns Base64 representation of `bytes`.
+ */
+function toBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+
+/**
+ * Decodes a standard base64 string into a byte array.
+ *
+ * @param value - Base64 text to decode.
+ * @returns Decoded bytes.
+ */
+function fromBase64(value: string): Uint8Array {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes
+}
+
+/**
+ * Encrypts an API key for storage in `localStorage`.
+ *
+ * Uses AES-GCM with a random {@link IV_LENGTH}-byte IV prepended to the ciphertext.
+ * Empty input returns an empty string without invoking Web Crypto.
+ *
+ * @param apiKey - Plaintext provider API key.
+ * @returns Encrypted payload prefixed with {@link ENCRYPTED_API_KEY_PREFIX}.
+ */
+export async function encryptApiKey(apiKey: string): Promise<string> {
+  if (!apiKey) {
+    return ''
+  }
+
+  const key = await deriveCryptoKey()
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
+  const encoded = new TextEncoder().encode(apiKey)
+  const cipherText = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    encoded
+  )
+
+  const payload = new Uint8Array(iv.length + cipherText.byteLength)
+  payload.set(iv, 0)
+  payload.set(new Uint8Array(cipherText), iv.length)
+
+  return `${ENCRYPTED_API_KEY_PREFIX}${toBase64(payload)}`
+}
+
+/**
+ * Decrypts an API key previously stored by {@link encryptApiKey}.
+ *
+ * Values without {@link ENCRYPTED_API_KEY_PREFIX} are returned unchanged so legacy
+ * plaintext entries can be migrated on the next save. Decryption failures yield
+ * an empty string.
+ *
+ * @param encryptedApiKey - Encrypted payload or legacy plaintext value.
+ * @returns Plaintext API key, or an empty string when input is empty or decryption fails.
+ */
+export async function decryptApiKey(encryptedApiKey: string): Promise<string> {
+  if (!encryptedApiKey) {
+    return ''
+  }
+
+  if (!encryptedApiKey.startsWith(ENCRYPTED_API_KEY_PREFIX)) {
+    return encryptedApiKey
+  }
+
+  try {
+    const key = await deriveCryptoKey()
+    const payload = fromBase64(
+      encryptedApiKey.slice(ENCRYPTED_API_KEY_PREFIX.length)
+    )
+    const iv = payload.slice(0, IV_LENGTH)
+    const cipherText = payload.slice(IV_LENGTH)
+    const plainBuffer = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      cipherText
+    )
+    return new TextDecoder().decode(plainBuffer)
+  } catch {
+    return ''
+  }
+}

--- a/packages/cad-agent-plugin/src/storage/modelCatalog.ts
+++ b/packages/cad-agent-plugin/src/storage/modelCatalog.ts
@@ -1,0 +1,186 @@
+import type { LlmProviderId } from './LlmSettingsStore'
+
+/**
+ * A selectable model entry in the agent settings dropdown.
+ */
+export interface LlmModelOption {
+  /** Model id sent to the provider API. */
+  value: string
+  /** English display label. */
+  labelEn: string
+  /** Chinese display label. */
+  labelZh: string
+  /** Whether the model accepts image attachments in chat. */
+  supportsVision: boolean
+}
+
+/** Sentinel select value when the user enters a custom model name. */
+export const CUSTOM_MODEL_VALUE = '__custom__'
+
+/**
+ * Preset model lists grouped by {@link LlmProviderId} for the settings UI.
+ */
+export const PROVIDER_MODEL_OPTIONS: Record<
+  LlmProviderId,
+  readonly LlmModelOption[]
+> = {
+  openai: [
+    {
+      value: 'gpt-4o',
+      labelEn: 'GPT-4o',
+      labelZh: 'GPT-4o',
+      supportsVision: true
+    },
+    {
+      value: 'gpt-4o-mini',
+      labelEn: 'GPT-4o Mini',
+      labelZh: 'GPT-4o Mini',
+      supportsVision: true
+    },
+    {
+      value: 'gpt-4-turbo',
+      labelEn: 'GPT-4 Turbo',
+      labelZh: 'GPT-4 Turbo',
+      supportsVision: true
+    },
+    {
+      value: 'gpt-3.5-turbo',
+      labelEn: 'GPT-3.5 Turbo',
+      labelZh: 'GPT-3.5 Turbo',
+      supportsVision: false
+    }
+  ],
+  anthropic: [
+    {
+      value: 'claude-3-5-sonnet-latest',
+      labelEn: 'Claude 3.5 Sonnet',
+      labelZh: 'Claude 3.5 Sonnet',
+      supportsVision: true
+    },
+    {
+      value: 'claude-3-5-haiku-latest',
+      labelEn: 'Claude 3.5 Haiku',
+      labelZh: 'Claude 3.5 Haiku',
+      supportsVision: true
+    },
+    {
+      value: 'claude-3-opus-latest',
+      labelEn: 'Claude 3 Opus',
+      labelZh: 'Claude 3 Opus',
+      supportsVision: true
+    }
+  ],
+  deepseek: [
+    {
+      value: 'deepseek-chat',
+      labelEn: 'DeepSeek Chat',
+      labelZh: 'DeepSeek Chat',
+      supportsVision: false
+    },
+    {
+      value: 'deepseek-reasoner',
+      labelEn: 'DeepSeek Reasoner',
+      labelZh: 'DeepSeek Reasoner',
+      supportsVision: false
+    }
+  ],
+  'openai-compatible': [
+    {
+      value: 'gpt-4o-mini',
+      labelEn: 'GPT-4o Mini',
+      labelZh: 'GPT-4o Mini',
+      supportsVision: true
+    },
+    {
+      value: 'gpt-4o',
+      labelEn: 'GPT-4o',
+      labelZh: 'GPT-4o',
+      supportsVision: true
+    },
+    {
+      value: 'gpt-3.5-turbo',
+      labelEn: 'GPT-3.5 Turbo',
+      labelZh: 'GPT-3.5 Turbo',
+      supportsVision: false
+    }
+  ]
+}
+
+/** Heuristic patterns for vision-capable models not listed in presets. */
+const VISION_MODEL_PATTERNS = [
+  /gpt-4o/i,
+  /gpt-4-turbo/i,
+  /gpt-4-vision/i,
+  /claude-3/i,
+  /claude-sonnet-4/i,
+  /claude-opus-4/i,
+  /claude-haiku-4/i,
+  /gemini/i,
+  /qwen.*vl/i,
+  /deepseek-vl/i,
+  /glm-4v/i,
+  /llava/i,
+  /pixtral/i
+]
+
+/**
+ * Finds a preset model option for the given provider and model id.
+ *
+ * @param provider - LLM provider id.
+ * @param model - Model id to look up.
+ * @returns The matching option, or `undefined` for custom models.
+ */
+export function findModelOption(
+  provider: LlmProviderId,
+  model: string
+): LlmModelOption | undefined {
+  return PROVIDER_MODEL_OPTIONS[provider].find(option => option.value === model)
+}
+
+/**
+ * Determines whether a model supports image input for the agent chat.
+ *
+ * Checks preset options first, then falls back to {@link VISION_MODEL_PATTERNS}.
+ *
+ * @param provider - LLM provider id.
+ * @param model - Model id to evaluate.
+ * @returns `true` when image attachments are allowed for this model.
+ */
+export function modelSupportsVision(
+  provider: LlmProviderId,
+  model: string
+): boolean {
+  const preset = findModelOption(provider, model)
+  if (preset) return preset.supportsVision
+  return VISION_MODEL_PATTERNS.some(pattern => pattern.test(model))
+}
+
+/**
+ * Maps a stored model id to a settings dropdown value.
+ *
+ * @param provider - LLM provider id.
+ * @param model - Current model id from settings.
+ * @returns The model id when preset, or {@link CUSTOM_MODEL_VALUE} otherwise.
+ */
+export function resolveModelSelection(
+  provider: LlmProviderId,
+  model: string
+): string {
+  return findModelOption(provider, model) ? model : CUSTOM_MODEL_VALUE
+}
+
+/**
+ * Returns preset models for a provider filtered by vision support.
+ *
+ * @param provider - LLM provider id.
+ * @param vision - When `true`, return vision models; otherwise text-only models.
+ * @returns Filtered copy of the provider's preset list.
+ */
+export function modelOptionsForProvider(
+  provider: LlmProviderId,
+  vision: boolean
+): LlmModelOption[] {
+  return PROVIDER_MODEL_OPTIONS[provider].filter(
+    option => option.supportsVision === vision
+  )
+}

--- a/packages/cad-agent-plugin/src/storage/settingsEquality.ts
+++ b/packages/cad-agent-plugin/src/storage/settingsEquality.ts
@@ -1,0 +1,20 @@
+import type { LlmSettings } from './LlmSettingsStore'
+
+/**
+ * Compares two LLM settings snapshots for chat/session equality.
+ *
+ * @param left - First settings object.
+ * @param right - Second settings object.
+ * @returns `true` when all persisted fields match.
+ */
+export function areLlmSettingsEqual(
+  left: LlmSettings,
+  right: LlmSettings
+): boolean {
+  return (
+    left.provider === right.provider &&
+    left.baseUrl === right.baseUrl &&
+    left.model === right.model &&
+    left.apiKey === right.apiKey
+  )
+}

--- a/packages/cad-agent-plugin/src/tools/CadActionExecutor.ts
+++ b/packages/cad-agent-plugin/src/tools/CadActionExecutor.ts
@@ -1,0 +1,521 @@
+import {
+  AcApDocManager,
+  acapRunDatabaseEdit
+} from '@mlightcad/cad-simple-viewer'
+import {
+  AcDbArc,
+  AcDbCircle,
+  AcDbEntity,
+  AcDbLine,
+  AcDbMText,
+  AcDbPolyline,
+  AcGePoint2d,
+  AcGePoint3d
+} from '@mlightcad/data-model'
+
+import { requireDocument, requireView } from './documentAccess'
+import type { DrawingContextSnapshot } from './DrawingContextProvider'
+import { getDrawingContext } from './DrawingContextProvider'
+
+/** 2D point in WCS used by agent tool inputs. */
+export interface Point2dInput {
+  x: number
+  y: number
+}
+
+/**
+ * Outcome of a CAD agent tool invocation.
+ *
+ * Serialized back to the LLM as JSON from each tool's `execute` handler.
+ */
+export interface ToolResult {
+  /** Whether the operation completed without error. */
+  success: boolean
+  /** Short human-readable summary for the model. */
+  message: string
+  /** Object ids of entities created, when applicable. */
+  entityIds?: string[]
+  /** Machine-readable error code or message when `success` is false. */
+  error?: string
+}
+
+/**
+ * Converts a 2D tool input to a 3D point with the given Z elevation.
+ *
+ * @param point - WCS x/y coordinates.
+ * @param z - Z coordinate (defaults to 0).
+ * @returns A new {@link AcGePoint3d}.
+ */
+function toPoint3d(point: Point2dInput, z = 0): AcGePoint3d {
+  return new AcGePoint3d(point.x, point.y, z)
+}
+
+/**
+ * Assigns a layer name to an entity when the tool input specifies one.
+ *
+ * @param entity - Entity about to be appended to model space.
+ * @param layer - Optional layer name from tool input.
+ */
+function applyLayer(entity: AcDbEntity, layer?: string): void {
+  if (layer) {
+    entity.layer = layer
+  }
+}
+
+/**
+ * Verifies that a layer exists before creating geometry on it.
+ *
+ * @param layer - Optional layer name from tool input.
+ * @returns A failed {@link ToolResult} when the layer is missing; otherwise `undefined`.
+ */
+function validateLayer(layer?: string): ToolResult | undefined {
+  if (!layer) {
+    return undefined
+  }
+  const layerNames = AcApDocManager.instance.curDocument.layerStore
+    .getLayers()
+    .map(entry => entry.name)
+  if (!layerNames.includes(layer)) {
+    return {
+      success: false,
+      message: `Layer not found: ${layer}`,
+      error: 'layer_not_found'
+    }
+  }
+  return undefined
+}
+
+/**
+ * Runs a database mutation inside an undoable edit transaction.
+ *
+ * @param label - Undo stack label shown in the editor.
+ * @param fn - Callback that performs the edit and returns a result.
+ * @returns The value returned by `fn`.
+ */
+function runEdit<T>(label: string, fn: () => T): T {
+  const db = AcApDocManager.instance.curDocument.database
+  let result!: T
+  acapRunDatabaseEdit(db, label, () => {
+    result = fn()
+  })
+  return result
+}
+
+/**
+ * Executes CAD drawing operations on behalf of the LLM agent tools.
+ *
+ * All geometry is created in model space of the active document.
+ */
+export class CadActionExecutor {
+  /**
+   * Returns a snapshot of the active drawing for the `get_drawing_context` tool.
+   *
+   * @returns Layer list, units, extents, and entity count.
+   */
+  getDrawingContext(): DrawingContextSnapshot | ToolResult {
+    const accessError = requireDocument(false)
+    if (accessError) {
+      return accessError
+    }
+    try {
+      return getDrawingContext()
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to read drawing context',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Creates a line entity between two WCS points.
+   *
+   * @param input - Start and end points and optional layer.
+   * @returns {@link ToolResult} with created entity ids on success.
+   */
+  drawLine(input: {
+    start: Point2dInput
+    end: Point2dInput
+    layer?: string
+  }): ToolResult {
+    const accessError = requireDocument(true)
+    if (accessError) {
+      return accessError
+    }
+    const layerError = validateLayer(input.layer)
+    if (layerError) {
+      return layerError
+    }
+    try {
+      const entityIds: string[] = []
+      runEdit('Agent: draw_line', () => {
+        const db = AcApDocManager.instance.curDocument.database
+        const line = new AcDbLine(
+          toPoint3d(input.start),
+          toPoint3d(input.end)
+        )
+        applyLayer(line, input.layer)
+        db.tables.blockTable.modelSpace.appendEntity(line)
+        entityIds.push(line.objectId)
+      })
+      return {
+        success: true,
+        message: 'Line created',
+        entityIds
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to draw line',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Creates a circle by center and radius.
+   *
+   * @param input - Center, radius, and optional layer.
+   * @returns {@link ToolResult} with created entity ids on success.
+   */
+  drawCircle(input: {
+    center: Point2dInput
+    radius: number
+    layer?: string
+  }): ToolResult {
+    const accessError = requireDocument(true)
+    if (accessError) {
+      return accessError
+    }
+    const layerError = validateLayer(input.layer)
+    if (layerError) {
+      return layerError
+    }
+    try {
+      const entityIds: string[] = []
+      runEdit('Agent: draw_circle', () => {
+        const db = AcApDocManager.instance.curDocument.database
+        const circle = new AcDbCircle(toPoint3d(input.center), input.radius)
+        applyLayer(circle, input.layer)
+        db.tables.blockTable.modelSpace.appendEntity(circle)
+        entityIds.push(circle.objectId)
+      })
+      return {
+        success: true,
+        message: 'Circle created',
+        entityIds
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to draw circle',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Creates an arc by center, radius, and start/end angles in degrees.
+   *
+   * @param input - Arc parameters and optional layer.
+   * @returns {@link ToolResult} with created entity ids on success.
+   */
+  drawArc(input: {
+    center: Point2dInput
+    radius: number
+    startAngleDeg: number
+    endAngleDeg: number
+    layer?: string
+  }): ToolResult {
+    const accessError = requireDocument(true)
+    if (accessError) {
+      return accessError
+    }
+    const layerError = validateLayer(input.layer)
+    if (layerError) {
+      return layerError
+    }
+    try {
+      const entityIds: string[] = []
+      runEdit('Agent: draw_arc', () => {
+        const db = AcApDocManager.instance.curDocument.database
+        const arc = new AcDbArc(
+          toPoint3d(input.center),
+          input.radius,
+          input.startAngleDeg,
+          input.endAngleDeg
+        )
+        applyLayer(arc, input.layer)
+        db.tables.blockTable.modelSpace.appendEntity(arc)
+        entityIds.push(arc.objectId)
+      })
+      return {
+        success: true,
+        message: 'Arc created',
+        entityIds
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to draw arc',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Creates a closed rectangular polyline from two opposite corners.
+   *
+   * @param input - Corner points and optional layer.
+   * @returns {@link ToolResult} with created entity ids on success.
+   */
+  drawRectangle(input: {
+    corner1: Point2dInput
+    corner2: Point2dInput
+    layer?: string
+  }): ToolResult {
+    const accessError = requireDocument(true)
+    if (accessError) {
+      return accessError
+    }
+    const layerError = validateLayer(input.layer)
+    if (layerError) {
+      return layerError
+    }
+    try {
+      const entityIds: string[] = []
+      runEdit('Agent: draw_rectangle', () => {
+        const db = AcApDocManager.instance.curDocument.database
+        const x1 = input.corner1.x
+        const y1 = input.corner1.y
+        const x2 = input.corner2.x
+        const y2 = input.corner2.y
+        const polyline = new AcDbPolyline()
+        const corners = [
+          new AcGePoint2d(x1, y1),
+          new AcGePoint2d(x2, y1),
+          new AcGePoint2d(x2, y2),
+          new AcGePoint2d(x1, y2)
+        ]
+        corners.forEach((point, index) => {
+          polyline.addVertexAt(index, point)
+        })
+        polyline.closed = true
+        applyLayer(polyline, input.layer)
+        db.tables.blockTable.modelSpace.appendEntity(polyline)
+        entityIds.push(polyline.objectId)
+      })
+      return {
+        success: true,
+        message: 'Rectangle created',
+        entityIds
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to draw rectangle',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Creates a polyline through an ordered list of vertices.
+   *
+   * @param input - Vertices, optional closed flag, and optional layer.
+   * @returns {@link ToolResult} with created entity ids on success.
+   */
+  drawPolyline(input: {
+    points: Point2dInput[]
+    closed?: boolean
+    layer?: string
+  }): ToolResult {
+    const accessError = requireDocument(true)
+    if (accessError) {
+      return accessError
+    }
+    if (input.points.length < 2) {
+      return {
+        success: false,
+        message: 'Polyline requires at least 2 points',
+        error: 'invalid_points'
+      }
+    }
+    const layerError = validateLayer(input.layer)
+    if (layerError) {
+      return layerError
+    }
+    try {
+      const entityIds: string[] = []
+      runEdit('Agent: draw_polyline', () => {
+        const db = AcApDocManager.instance.curDocument.database
+        const polyline = new AcDbPolyline()
+        input.points.forEach((point, index) => {
+          polyline.addVertexAt(index, new AcGePoint2d(point.x, point.y))
+        })
+        if (input.closed) {
+          polyline.closed = true
+        }
+        applyLayer(polyline, input.layer)
+        db.tables.blockTable.modelSpace.appendEntity(polyline)
+        entityIds.push(polyline.objectId)
+      })
+      return {
+        success: true,
+        message: 'Polyline created',
+        entityIds
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to draw polyline',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Creates MTEXT at a WCS position.
+   *
+   * @param input - Position, string contents, optional height, and optional layer.
+   * @returns {@link ToolResult} with created entity ids on success.
+   */
+  drawText(input: {
+    position: Point2dInput
+    text: string
+    height?: number
+    layer?: string
+  }): ToolResult {
+    const accessError = requireDocument(true)
+    if (accessError) {
+      return accessError
+    }
+    const layerError = validateLayer(input.layer)
+    if (layerError) {
+      return layerError
+    }
+    try {
+      const entityIds: string[] = []
+      runEdit('Agent: draw_text', () => {
+        const db = AcApDocManager.instance.curDocument.database
+        const mtext = new AcDbMText()
+        mtext.location = toPoint3d(input.position)
+        mtext.contents = input.text
+        mtext.textHeight = input.height ?? 2.5
+        applyLayer(mtext, input.layer)
+        db.tables.blockTable.modelSpace.appendEntity(mtext)
+        entityIds.push(mtext.objectId)
+      })
+      return {
+        success: true,
+        message: 'Text created',
+        entityIds
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to draw text',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Sets the document current layer (CLAYER).
+   *
+   * @param layerName - Existing layer name.
+   * @returns Success when the layer exists; otherwise `layer_not_found`.
+   */
+  setCurrentLayer(layerName: string): ToolResult {
+    const accessError = requireDocument(true)
+    if (accessError) {
+      return accessError
+    }
+    try {
+      const changed = runEdit('Agent: set_current_layer', () => {
+        return AcApDocManager.instance.curDocument.layerService.setCurrentLayer(
+          layerName
+        )
+      })
+      return changed
+        ? { success: true, message: `Current layer set to ${layerName}` }
+        : {
+            success: false,
+            message: `Layer not found: ${layerName}`,
+            error: 'layer_not_found'
+          }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to set current layer',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Creates a layer when it does not already exist.
+   *
+   * @param layerName - Name of the layer to create.
+   * @returns Success when created or already present.
+   */
+  createLayer(layerName: string): ToolResult {
+    const accessError = requireDocument(true)
+    if (accessError) {
+      return accessError
+    }
+    try {
+      const result = runEdit('Agent: create_layer', () => {
+        return AcApDocManager.instance.curDocument.layerService.createLayers([
+          layerName
+        ])
+      })
+      if (result.created > 0) {
+        return { success: true, message: `Layer created: ${layerName}` }
+      }
+      if (result.existed.includes(layerName)) {
+        return {
+          success: true,
+          message: `Layer already exists: ${layerName}`
+        }
+      }
+      return {
+        success: false,
+        message: `Failed to create layer: ${layerName}`,
+        error: 'create_layer_failed'
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to create layer',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  /**
+   * Zooms the active view to the full drawing extents.
+   *
+   * @returns Success when the view zoom completes.
+   */
+  zoomExtents(): ToolResult {
+    const accessError = requireView()
+    if (accessError) {
+      return accessError
+    }
+    try {
+      AcApDocManager.instance.context.view.zoomToFitDrawing()
+      return { success: true, message: 'Zoomed to drawing extents' }
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Failed to zoom extents',
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+}
+
+/** Shared singleton used by {@link createCadTools}. */
+export const cadActionExecutor = new CadActionExecutor()

--- a/packages/cad-agent-plugin/src/tools/DrawingContextProvider.ts
+++ b/packages/cad-agent-plugin/src/tools/DrawingContextProvider.ts
@@ -1,0 +1,55 @@
+import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+
+/**
+ * Snapshot of the active drawing passed to the LLM via `get_drawing_context`.
+ */
+export interface DrawingContextSnapshot {
+  /** Name of the current layer (CLAYER). */
+  currentLayer: string
+  /** All layer names in the document. */
+  layers: string[]
+  /** Drawing units code (INSUNITS). */
+  insunits: number
+  /** Number of entities in model space. */
+  entityCount: number
+  /** Axis-aligned bounding box of the database. */
+  extents: {
+    min: { x: number; y: number; z: number }
+    max: { x: number; y: number; z: number }
+    isEmpty: boolean
+  }
+  /** Human-readable document title. */
+  documentTitle: string
+}
+
+/**
+ * Collects layer, unit, extent, and entity metadata from the active document.
+ *
+ * @returns A JSON-serializable context object for agent tool calls.
+ */
+export function getDrawingContext(): DrawingContextSnapshot {
+  const doc = AcApDocManager.instance.curDocument
+  const db = doc.database
+  const modelSpace = db.tables.blockTable.modelSpace
+
+  let entityCount = 0
+  for (const _entity of modelSpace.newIterator()) {
+    entityCount++
+  }
+
+  const layers = doc.layerStore.getLayers().map(layer => layer.name)
+  const extents = db.extents
+
+  return {
+    currentLayer: doc.layerStore.getCurrentLayerName(),
+    layers,
+    insunits: db.insunits,
+    entityCount,
+    extents: {
+      min: { x: extents.min.x, y: extents.min.y, z: extents.min.z },
+      max: { x: extents.max.x, y: extents.max.y, z: extents.max.z },
+      isEmpty: extents.isEmpty()
+    },
+    documentTitle: doc.docTitle
+  }
+}

--- a/packages/cad-agent-plugin/src/tools/cadTools.ts
+++ b/packages/cad-agent-plugin/src/tools/cadTools.ts
@@ -1,0 +1,108 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import { cadActionExecutor } from './CadActionExecutor'
+
+/** Zod schema for 2D WCS points in agent tool arguments. */
+const pointSchema = z.object({
+  x: z.number(),
+  y: z.number()
+})
+
+/**
+ * Creates the tool set exposed to the CAD agent LLM.
+ *
+ * Each tool delegates to {@link cadActionExecutor} and returns a {@link ToolResult}.
+ *
+ * @returns AI SDK tool definitions keyed by tool name.
+ */
+export function createCadTools() {
+  return {
+    get_drawing_context: tool({
+      description:
+        'Get current drawing context: units, layers, extents, entity count',
+      inputSchema: z.object({}),
+      execute: async () => cadActionExecutor.getDrawingContext()
+    }),
+    draw_line: tool({
+      description: 'Draw a straight line segment in model space',
+      inputSchema: z.object({
+        start: pointSchema,
+        end: pointSchema,
+        layer: z.string().optional()
+      }),
+      execute: async input => cadActionExecutor.drawLine(input)
+    }),
+    draw_circle: tool({
+      description: 'Draw a circle by center and radius',
+      inputSchema: z.object({
+        center: pointSchema,
+        radius: z.number().positive(),
+        layer: z.string().optional()
+      }),
+      execute: async input => cadActionExecutor.drawCircle(input)
+    }),
+    draw_arc: tool({
+      description: 'Draw an arc by center, radius, and start/end angles in degrees',
+      inputSchema: z.object({
+        center: pointSchema,
+        radius: z.number().positive(),
+        startAngleDeg: z.number(),
+        endAngleDeg: z.number(),
+        layer: z.string().optional()
+      }),
+      execute: async input => cadActionExecutor.drawArc(input)
+    }),
+    draw_rectangle: tool({
+      description: 'Draw a rectangle from two opposite corners',
+      inputSchema: z.object({
+        corner1: pointSchema,
+        corner2: pointSchema,
+        layer: z.string().optional()
+      }),
+      execute: async input => cadActionExecutor.drawRectangle(input)
+    }),
+    draw_polyline: tool({
+      description: 'Draw a polyline through a list of points',
+      inputSchema: z.object({
+        points: z.array(pointSchema).min(2),
+        closed: z.boolean().optional(),
+        layer: z.string().optional()
+      }),
+      execute: async input => cadActionExecutor.drawPolyline(input)
+    }),
+    draw_text: tool({
+      description: 'Draw single-line MTEXT at a position',
+      inputSchema: z.object({
+        position: pointSchema,
+        text: z.string().min(1),
+        height: z.number().positive().optional(),
+        layer: z.string().optional()
+      }),
+      execute: async input => cadActionExecutor.drawText(input)
+    }),
+    set_current_layer: tool({
+      description: 'Set the current drawing layer (CLAYER)',
+      inputSchema: z.object({
+        layerName: z.string().min(1)
+      }),
+      execute: async input =>
+        cadActionExecutor.setCurrentLayer(input.layerName)
+    }),
+    create_layer: tool({
+      description: 'Create a new layer if it does not exist',
+      inputSchema: z.object({
+        layerName: z.string().min(1)
+      }),
+      execute: async input => cadActionExecutor.createLayer(input.layerName)
+    }),
+    zoom_extents: tool({
+      description: 'Zoom the view to show the full drawing extents',
+      inputSchema: z.object({}),
+      execute: async () => cadActionExecutor.zoomExtents()
+    })
+  }
+}
+
+/** Inferred tool map type returned by {@link createCadTools}. */
+export type CadTools = ReturnType<typeof createCadTools>

--- a/packages/cad-agent-plugin/src/tools/documentAccess.ts
+++ b/packages/cad-agent-plugin/src/tools/documentAccess.ts
@@ -1,0 +1,67 @@
+import { AcApDocManager, AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
+
+import type { ToolResult } from './CadActionExecutor'
+
+/**
+ * Verifies that an active drawing is available for agent tools.
+ *
+ * @param requireWrite - When true, rejects read-only documents.
+ * @returns A failed {@link ToolResult} when access is unavailable; otherwise `undefined`.
+ */
+export function requireDocument(requireWrite = false): ToolResult | undefined {
+  try {
+    const doc = AcApDocManager.instance?.curDocument
+    if (!doc?.database) {
+      return {
+        success: false,
+        message: 'No drawing is available. Open or create a drawing first.',
+        error: 'no_document'
+      }
+    }
+
+    if (requireWrite && doc.openMode !== AcEdOpenMode.Write) {
+      return {
+        success: false,
+        message: 'The drawing is open in read-only mode.',
+        error: 'read_only'
+      }
+    }
+
+    return undefined
+  } catch {
+    return {
+      success: false,
+      message: 'No drawing is available. Open or create a drawing first.',
+      error: 'no_document'
+    }
+  }
+}
+
+/**
+ * Verifies that the active drawing view is available for zoom operations.
+ *
+ * @returns A failed {@link ToolResult} when the view is unavailable; otherwise `undefined`.
+ */
+export function requireView(): ToolResult | undefined {
+  const documentError = requireDocument(false)
+  if (documentError) {
+    return documentError
+  }
+
+  try {
+    if (!AcApDocManager.instance.context?.view) {
+      return {
+        success: false,
+        message: 'Drawing view is not available.',
+        error: 'no_view'
+      }
+    }
+    return undefined
+  } catch {
+    return {
+      success: false,
+      message: 'Drawing view is not available.',
+      error: 'no_view'
+    }
+  }
+}

--- a/packages/cad-agent-plugin/src/ui/AgentChatPanel.vue
+++ b/packages/cad-agent-plugin/src/ui/AgentChatPanel.vue
@@ -1,0 +1,485 @@
+<script setup lang="ts">
+import '../ui/agent-panel.css'
+
+import { AcApI18n } from '@mlightcad/cad-simple-viewer'
+import type { UIMessage } from 'ai'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+
+import { useAgentI18n } from '../i18n/useAgentI18n'
+import {
+  getProviderDefaults,
+  type LlmProviderId,
+  type LlmSettings,
+  loadLlmSettings,
+  saveLlmSettings} from '../storage/LlmSettingsStore'
+import {
+  CUSTOM_MODEL_VALUE,
+  type LlmModelOption,
+  modelOptionsForProvider,
+  modelSupportsVision,
+  resolveModelSelection} from '../storage/modelCatalog'
+import { areLlmSettingsEqual } from '../storage/settingsEquality'
+import { formatChatError } from './formatChatError'
+import { useAgentChatRef } from './useAgentChat'
+
+/** Image file part on a {@link UIMessage} from the AI SDK. */
+type FilePart = {
+  type: 'file'
+  url: string
+  mediaType?: string
+  filename?: string
+}
+
+/**
+ * CAD Agent chat UI: settings, message history, image attachments, and tool-call display.
+ *
+ * Renders embedded in the tool palette or as a standalone overlay panel.
+ */
+withDefaults(
+  defineProps<{
+    /** When true, fills the tool palette tab (no overlay chrome). */
+    embedded?: boolean
+    /** Overlay mode only; ignored when embedded. */
+    visible?: boolean
+  }>(),
+  {
+    embedded: false,
+    visible: true
+  }
+)
+
+/** Emitted when the user closes the overlay panel (non-embedded mode). */
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { labels } = useAgentI18n()
+
+const settings = ref<LlmSettings>({
+  provider: 'openai-compatible',
+  apiKey: '',
+  baseUrl: '',
+  model: ''
+})
+const activeSettings = ref<LlmSettings>({
+  provider: 'openai-compatible',
+  apiKey: '',
+  baseUrl: '',
+  model: ''
+})
+const settingsReady = ref(false)
+const showSettings = ref(false)
+const input = ref('')
+const fileInputRef = ref<HTMLInputElement | null>(null)
+const pendingImages = ref<File[]>([])
+const pendingPreviewUrls = ref<string[]>([])
+const modelSelection = ref(
+  resolveModelSelection(settings.value.provider, settings.value.model)
+)
+
+watch(
+  () => settings.value.provider,
+  (provider: LlmProviderId) => {
+    const defaults = getProviderDefaults(provider)
+    settings.value.baseUrl = defaults.baseUrl
+    settings.value.model = defaults.model
+    modelSelection.value = resolveModelSelection(provider, defaults.model)
+  }
+)
+
+watch(modelSelection, selection => {
+  if (selection !== CUSTOM_MODEL_VALUE) {
+    settings.value.model = selection
+  }
+})
+
+watch(
+  pendingImages,
+  files => {
+    pendingPreviewUrls.value.forEach(url => URL.revokeObjectURL(url))
+    pendingPreviewUrls.value = files.map(file => URL.createObjectURL(file))
+  },
+  { deep: true }
+)
+
+onUnmounted(() => {
+  pendingPreviewUrls.value.forEach(url => URL.revokeObjectURL(url))
+})
+
+const { chat, resetChat } = useAgentChatRef(() => ({ ...activeSettings.value }))
+
+onMounted(async () => {
+  const loaded = await loadLlmSettings()
+  settings.value = { ...loaded }
+  activeSettings.value = { ...loaded }
+  modelSelection.value = resolveModelSelection(loaded.provider, loaded.model)
+  settingsReady.value = true
+  resetChat()
+})
+
+const settingsDirty = computed(
+  () => !areLlmSettingsEqual(settings.value, activeSettings.value)
+)
+
+const messages = computed(() => chat.value.messages)
+const status = computed(() => chat.value.status)
+const error = computed(() => chat.value.error)
+const errorMessage = computed(() =>
+  error.value ? formatChatError(error.value) : ''
+)
+
+const visionModelOptions = computed(() =>
+  modelOptionsForProvider(settings.value.provider, true)
+)
+const textModelOptions = computed(() =>
+  modelOptionsForProvider(settings.value.provider, false)
+)
+const supportsVision = computed(() =>
+  modelSupportsVision(
+    activeSettings.value.provider,
+    activeSettings.value.model
+  )
+)
+
+watch(supportsVision, supported => {
+  if (!supported) clearPendingImages()
+})
+
+const isBusy = computed(
+  () => status.value === 'streaming' || status.value === 'submitted'
+)
+
+const canSend = computed(
+  () =>
+    settingsReady.value &&
+    !settingsDirty.value &&
+    activeSettings.value.apiKey.trim().length > 0 &&
+    !isBusy.value &&
+    (input.value.trim().length > 0 ||
+      (supportsVision.value && pendingImages.value.length > 0))
+)
+
+const inputHint = computed(() => {
+  if (!settingsReady.value) {
+    return ''
+  }
+  if (settingsDirty.value) {
+    return labels.value.unsavedSettings
+  }
+  if (!activeSettings.value.apiKey.trim()) {
+    return labels.value.missingApiKey
+  }
+  return ''
+})
+
+/** Returns the localized display label for a model dropdown option. */
+function modelLabel(option: LlmModelOption): string {
+  return AcApI18n.currentLocale === 'zh' ? option.labelZh : option.labelEn
+}
+
+/** Clears the current chat error state without removing messages. */
+function dismissError() {
+  chat.value.clearError()
+}
+
+/** Persists LLM settings, hides the form, and resets the chat session. */
+async function applySettings() {
+  await saveLlmSettings(settings.value)
+  activeSettings.value = { ...settings.value }
+  showSettings.value = false
+  resetChat()
+}
+
+/** Opens the hidden file input for image attachments. */
+function openFilePicker() {
+  fileInputRef.value?.click()
+}
+
+/** Appends selected image files to the pending attachment list. */
+function onFilesSelected(event: Event) {
+  const target = event.target as HTMLInputElement
+  if (!target.files?.length) return
+  pendingImages.value = [
+    ...pendingImages.value,
+    ...Array.from(target.files).filter(file => file.type.startsWith('image/'))
+  ]
+  target.value = ''
+}
+
+/** Removes one pending image attachment by index. */
+function removePendingImage(index: number) {
+  pendingImages.value = pendingImages.value.filter((_, i) => i !== index)
+}
+
+/** Clears all pending image attachments before send. */
+function clearPendingImages() {
+  pendingImages.value = []
+}
+
+/** Sends the current text and optional images to the CAD agent. */
+async function sendMessage() {
+  const text = input.value.trim()
+  const files = supportsVision.value ? pendingImages.value : []
+  if ((!text && files.length === 0) || isBusy.value) return
+
+  input.value = ''
+  clearPendingImages()
+
+  try {
+    await chat.value.sendMessage({
+      ...(text ? { text } : {}),
+      ...(files.length > 0 ? { files } : {})
+    })
+  } catch {
+    // error surfaced via chat.error
+  }
+}
+
+/** Discards the conversation and starts a fresh agent session. */
+function clearChat() {
+  resetChat()
+}
+
+/** Concatenates all text parts of a UI message for display. */
+function partText(message: UIMessage): string {
+  if (!message.parts?.length) return ''
+  return message.parts
+    .filter(part => part?.type === 'text')
+    .map(part => (part.type === 'text' ? part.text : ''))
+    .join('')
+}
+
+/** Extracts image file parts from a UI message for inline preview. */
+function imageParts(message: UIMessage): FilePart[] {
+  if (!message.parts?.length) return []
+  return message.parts.filter(
+    (part): part is FilePart =>
+      part?.type === 'file' && !!part.mediaType?.startsWith('image/')
+  )
+}
+
+/** Returns tool names invoked in an assistant message (without the `tool-` prefix). */
+function toolParts(message: UIMessage): string[] {
+  if (!message.parts?.length) return []
+  return message.parts
+    .filter(
+      (part): part is { type: string } =>
+        typeof part?.type === 'string' && part.type.startsWith('tool-')
+    )
+    .map(part => part.type.replace(/^tool-/, ''))
+}
+</script>
+
+<template>
+  <div
+    class="cad-agent-panel-root"
+    :class="{
+      'cad-agent-panel-root--embedded': embedded,
+      'is-hidden': !embedded && !visible
+    }"
+  >
+    <div v-if="!embedded" class="cad-agent-panel-header">
+      <span class="cad-agent-panel-title">{{ labels.title }}</span>
+      <div class="cad-agent-panel-actions">
+        <button
+          type="button"
+          class="cad-agent-panel-btn"
+          @click="showSettings = !showSettings"
+        >
+          {{ labels.settings }}
+        </button>
+        <button type="button" class="cad-agent-panel-btn" @click="clearChat">
+          {{ labels.clear }}
+        </button>
+        <button type="button" class="cad-agent-panel-btn" @click="emit('close')">
+          {{ labels.close }}
+        </button>
+      </div>
+    </div>
+    <div v-else class="cad-agent-panel-toolbar">
+      <button
+        type="button"
+        class="cad-agent-panel-btn"
+        @click="showSettings = !showSettings"
+      >
+        {{ labels.settings }}
+      </button>
+      <button type="button" class="cad-agent-panel-btn" @click="clearChat">
+        {{ labels.clear }}
+      </button>
+    </div>
+
+    <div v-if="showSettings" class="cad-agent-settings">
+      <label>
+        {{ labels.provider }}
+        <select v-model="settings.provider">
+          <option value="deepseek">{{ labels.providerDeepseek }}</option>
+          <option value="openai">{{ labels.providerOpenai }}</option>
+          <option value="anthropic">{{ labels.providerAnthropic }}</option>
+          <option value="openai-compatible">
+            {{ labels.providerOpenaiCompatible }}
+          </option>
+        </select>
+      </label>
+      <label>
+        {{ labels.baseUrl }}
+        <input v-model="settings.baseUrl" type="text" />
+      </label>
+      <label>
+        {{ labels.model }}
+        <select v-model="modelSelection">
+          <optgroup v-if="visionModelOptions.length" :label="labels.visionModels">
+            <option
+              v-for="option in visionModelOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ modelLabel(option) }}
+            </option>
+          </optgroup>
+          <optgroup v-if="textModelOptions.length" :label="labels.textModels">
+            <option
+              v-for="option in textModelOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ modelLabel(option) }}
+            </option>
+          </optgroup>
+          <option :value="CUSTOM_MODEL_VALUE">{{ labels.customModel }}</option>
+        </select>
+      </label>
+      <label v-if="modelSelection === CUSTOM_MODEL_VALUE">
+        {{ labels.customModelName }}
+        <input v-model="settings.model" type="text" />
+      </label>
+      <p class="cad-agent-model-hint">
+        {{
+          supportsVision ? labels.modelSupportsVision : labels.modelTextOnly
+        }}
+      </p>
+      <label>
+        {{ labels.apiKey }}
+        <input v-model="settings.apiKey" type="password" autocomplete="off" />
+      </label>
+      <button type="button" class="cad-agent-panel-btn" @click="applySettings">
+        {{ labels.saveSettings }}
+      </button>
+    </div>
+
+    <div class="cad-agent-panel-messages">
+      <div v-if="messages.length === 0 && !error" class="cad-agent-panel-empty">
+        {{ labels.emptyHint }}
+      </div>
+      <div
+        v-for="message in messages"
+        :key="message.id"
+        class="cad-agent-msg"
+        :class="message.role"
+      >
+        <div>{{ partText(message) }}</div>
+        <div v-if="imageParts(message).length" class="cad-agent-msg-images">
+          <img
+            v-for="(part, index) in imageParts(message)"
+            :key="`${message.id}-img-${index}`"
+            class="cad-agent-msg-image"
+            :src="part.url"
+            :alt="part.filename ?? labels.imageAlt"
+          />
+        </div>
+        <div v-for="toolName in toolParts(message)" :key="toolName" class="cad-agent-tool">
+          {{ labels.toolPrefix }}: {{ toolName }}
+        </div>
+      </div>
+      <div v-if="error" class="cad-agent-msg error">
+        <div class="cad-agent-error-card">
+          <svg
+            class="cad-agent-error-icon"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+          <div class="cad-agent-error-body">
+            <div class="cad-agent-error-title">{{ labels.errorTitle }}</div>
+            <div class="cad-agent-error-message">{{ errorMessage }}</div>
+          </div>
+          <button
+            type="button"
+            class="cad-agent-error-dismiss"
+            :title="labels.dismissError"
+            @click="dismissError"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="cad-agent-panel-input">
+      <div v-if="pendingImages.length" class="cad-agent-attachments">
+        <div
+          v-for="(file, index) in pendingImages"
+          :key="`${file.name}-${file.lastModified}-${index}`"
+          class="cad-agent-attachment"
+        >
+          <img
+            :src="pendingPreviewUrls[index]"
+            :alt="file.name"
+          />
+          <button
+            type="button"
+            class="cad-agent-attachment-remove"
+            :title="labels.removeAttachment"
+            @click="removePendingImage(index)"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+      <textarea
+        v-model="input"
+        :placeholder="labels.inputPlaceholder"
+        @keydown.enter.exact.prevent="sendMessage"
+      />
+      <input
+        ref="fileInputRef"
+        class="cad-agent-file-input"
+        type="file"
+        accept="image/*"
+        multiple
+        @change="onFilesSelected"
+      />
+      <p v-if="inputHint" class="cad-agent-input-hint">{{ inputHint }}</p>
+      <div class="cad-agent-panel-input-row">
+        <div class="cad-agent-panel-input-actions">
+          <button
+            type="button"
+            class="cad-agent-icon-btn"
+            :disabled="isBusy || !supportsVision"
+            :title="labels.attachImage"
+            @click="openFilePicker"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"
+              />
+            </svg>
+          </button>
+        </div>
+        <button
+          type="button"
+          class="cad-agent-panel-btn"
+          :disabled="!canSend"
+          @click="sendMessage"
+        >
+          {{ isBusy ? labels.working : labels.send }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/cad-agent-plugin/src/ui/agent-panel.css
+++ b/packages/cad-agent-plugin/src/ui/agent-panel.css
@@ -1,0 +1,353 @@
+.cad-agent-panel-mount {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 40vw);
+  z-index: 25;
+  pointer-events: none;
+}
+
+.cad-agent-panel-root {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  pointer-events: auto;
+  background: #1e1e1e;
+  color: #e8e8e8;
+  border-left: 1px solid #3a3a3a;
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.35);
+  font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+  font-size: 13px;
+}
+
+.cad-agent-panel-root.is-hidden {
+  display: none;
+  pointer-events: none;
+}
+
+.cad-agent-panel-root--embedded {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border-left: none;
+  box-shadow: none;
+}
+
+.cad-agent-panel-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid #3a3a3a;
+  background: #252526;
+  flex-shrink: 0;
+}
+
+.cad-agent-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid #3a3a3a;
+  background: #252526;
+}
+
+.cad-agent-panel-title {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.cad-agent-panel-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.cad-agent-panel-btn {
+  border: 1px solid #4a4a4a;
+  background: #2d2d2d;
+  color: #e8e8e8;
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.cad-agent-panel-btn:hover {
+  background: #3a3a3a;
+}
+
+.cad-agent-panel-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cad-agent-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid #4a4a4a;
+  background: #2d2d2d;
+  color: #e8e8e8;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.cad-agent-icon-btn:hover:not(:disabled) {
+  background: #3a3a3a;
+}
+
+.cad-agent-icon-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.cad-agent-icon-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.cad-agent-panel-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cad-agent-msg {
+  border-radius: 8px;
+  padding: 8px 10px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.cad-agent-msg.user {
+  background: #264f78;
+  align-self: flex-end;
+  max-width: 92%;
+}
+
+.cad-agent-msg.assistant {
+  background: #2a2a2a;
+  align-self: flex-start;
+  max-width: 92%;
+}
+
+.cad-agent-msg.error {
+  align-self: stretch;
+  max-width: 100%;
+  background: rgba(244, 135, 113, 0.1);
+  border: 1px solid rgba(244, 135, 113, 0.35);
+  color: #f0c0b8;
+}
+
+.cad-agent-error-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.cad-agent-error-icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  color: #f48771;
+}
+
+.cad-agent-error-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.cad-agent-error-title {
+  font-weight: 600;
+  color: #f48771;
+  margin-bottom: 4px;
+}
+
+.cad-agent-error-message {
+  font-size: 12px;
+  line-height: 1.5;
+  color: #f0c0b8;
+  word-break: break-word;
+}
+
+.cad-agent-error-dismiss {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #f48771;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.cad-agent-error-dismiss:hover {
+  background: rgba(244, 135, 113, 0.15);
+}
+
+.cad-agent-tool {
+  font-size: 11px;
+  color: #9cdcfe;
+  margin-top: 4px;
+}
+
+.cad-agent-panel-empty {
+  color: #888;
+  text-align: center;
+  margin-top: 24px;
+}
+
+.cad-agent-panel-input {
+  border-top: 1px solid #3a3a3a;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cad-agent-panel-input textarea {
+  width: 100%;
+  min-height: 72px;
+  resize: vertical;
+  border: 1px solid #4a4a4a;
+  border-radius: 6px;
+  background: #1a1a1a;
+  color: #e8e8e8;
+  padding: 8px;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.cad-agent-panel-input-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.cad-agent-panel-input-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.cad-agent-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.cad-agent-attachment {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid #4a4a4a;
+  background: #1a1a1a;
+}
+
+.cad-agent-attachment img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.cad-agent-attachment-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.cad-agent-attachment-remove:hover {
+  background: rgba(0, 0, 0, 0.85);
+}
+
+.cad-agent-msg-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.cad-agent-msg-image {
+  max-width: 100%;
+  max-height: 200px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  object-fit: contain;
+}
+
+.cad-agent-file-input {
+  display: none;
+}
+
+.cad-agent-settings {
+  padding: 12px;
+  border-top: 1px solid #3a3a3a;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: #252526;
+}
+
+.cad-agent-settings label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #ccc;
+}
+
+.cad-agent-settings input,
+.cad-agent-settings select {
+  border: 1px solid #4a4a4a;
+  border-radius: 4px;
+  background: #1a1a1a;
+  color: #e8e8e8;
+  padding: 6px 8px;
+  font: inherit;
+}
+
+.cad-agent-model-hint {
+  margin: 0;
+  font-size: 11px;
+  color: #9a9a9a;
+  line-height: 1.4;
+}
+
+.cad-agent-input-hint {
+  margin: 6px 0 0;
+  font-size: 11px;
+  color: #c9a227;
+  line-height: 1.4;
+}

--- a/packages/cad-agent-plugin/src/ui/formatChatError.ts
+++ b/packages/cad-agent-plugin/src/ui/formatChatError.ts
@@ -1,0 +1,55 @@
+/**
+ * Extracts a human-readable message from a provider error payload.
+ *
+ * @param value - Parsed JSON body or nested `error` object from an API response.
+ * @returns Trimmed message string, or `undefined` when none is found.
+ */
+function extractApiMessage(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const record = value as Record<string, unknown>
+  const nestedError = record.error
+  if (nestedError && typeof nestedError === 'object') {
+    const nestedMessage = (nestedError as Record<string, unknown>).message
+    if (typeof nestedMessage === 'string' && nestedMessage.trim()) {
+      return nestedMessage.trim()
+    }
+  }
+
+  for (const key of ['message', 'detail', 'error']) {
+    const candidate = record[key]
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim()
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Turns provider/API errors into a short user-facing message.
+ *
+ * @param error - Error thrown by the AI SDK or transport layer.
+ * @returns A concise message suitable for the chat error banner.
+ */
+export function formatChatError(error: Error): string {
+  const responseBody = (error as Error & { responseBody?: unknown }).responseBody
+  const fromBody = extractApiMessage(responseBody)
+  if (fromBody) return fromBody
+
+  const message = error.message?.trim()
+  if (!message) return 'Unknown error'
+
+  const jsonMatch = message.match(/\{[\s\S]*\}/)
+  if (jsonMatch) {
+    try {
+      const parsed = JSON.parse(jsonMatch[0])
+      const fromJson = extractApiMessage(parsed)
+      if (fromJson) return fromJson
+    } catch {
+      // fall through to raw message
+    }
+  }
+
+  return message
+}

--- a/packages/cad-agent-plugin/src/ui/useAgentChat.ts
+++ b/packages/cad-agent-plugin/src/ui/useAgentChat.ts
@@ -1,0 +1,39 @@
+import { Chat } from '@ai-sdk/vue'
+import { shallowRef } from 'vue'
+
+import {
+  createAgentChatTransport,
+  createCadAgent
+} from '../agent/createCadAgent'
+import type { LlmSettings } from '../storage/LlmSettingsStore'
+
+/**
+ * Creates a Vue {@link Chat} instance wired to the in-process CAD agent.
+ *
+ * @param getSettings - Callback returning the saved LLM configuration for each request.
+ * @returns A new chat session with CAD drawing tools.
+ */
+export function createAgentChat(getSettings: () => LlmSettings) {
+  return new Chat({
+    transport: createAgentChatTransport(() =>
+      createCadAgent({ ...getSettings() })
+    )
+  })
+}
+
+/**
+ * Holds a replaceable chat ref so settings changes can reset the session.
+ *
+ * @param getSettings - Callback returning current LLM settings (e.g. from a Vue ref).
+ * @returns `chat` — shallow ref to the active session; `resetChat` — recreate after settings save.
+ */
+export function useAgentChatRef(getSettings: () => LlmSettings) {
+  const chat = shallowRef(createAgentChat(getSettings))
+
+  /** Discards the current session and builds a new agent from latest settings. */
+  const resetChat = () => {
+    chat.value = createAgentChat(getSettings)
+  }
+
+  return { chat, resetChat }
+}

--- a/packages/cad-agent-plugin/src/vue-shim.d.ts
+++ b/packages/cad-agent-plugin/src/vue-shim.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  /** Default export of a single-file Vue component. */
+  const component: DefineComponent<object, object, unknown>
+  export default component
+}

--- a/packages/cad-agent-plugin/tsconfig.build.json
+++ b/packages/cad-agent-plugin/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@mlightcad/cad-agent-plugin": ["./src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/vue-shim.d.ts"]
+}

--- a/packages/cad-agent-plugin/tsconfig.json
+++ b/packages/cad-agent-plugin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "paths": {
+      "@mlightcad/cad-agent-plugin": ["./src/index.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/cad-agent-plugin/typings/index.d.ts
+++ b/packages/cad-agent-plugin/typings/index.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Hand-maintained public API types for `@mlightcad/cad-agent-plugin`.
+ *
+ * Emitted to `lib/` by `pnpm build:types` (see `scripts/copy-typings.mjs`).
+ * Keep in sync with `src/index.ts` exports.
+ */
+import type { DefineComponent } from 'vue'
+
+export declare const AgentChatPanel: DefineComponent<object, object, unknown>

--- a/packages/cad-agent-plugin/typings/register.d.ts
+++ b/packages/cad-agent-plugin/typings/register.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Public API types for `@mlightcad/cad-agent-plugin/register`.
+ * Copied to `lib/` by `pnpm build:types`; keep in sync with `src/register.ts`.
+ */
+import type { AcApLocale, AcApPluginManager } from '@mlightcad/cad-simple-viewer'
+
+/** Registered name of the CAD Agent plugin in the plugin manager. */
+export declare const AGENT_PLUGIN_NAME: 'AgentPlugin'
+
+/** Trigger commands handled by {@link AGENT_PLUGIN_NAME}. */
+export declare const AGENT_PLUGIN_TRIGGERS: readonly ['agent']
+
+/**
+ * Registers the CAD Agent plugin for lazy loading.
+ *
+ * Import from `@mlightcad/cad-agent-plugin/register` so the main bundle
+ * is not pulled into the application entry chunk.
+ */
+export declare function registerLazyAgentPlugin(
+  pluginManager: AcApPluginManager
+): void
+
+export declare function registerAgentI18n(): void
+
+/**
+ * Merges agent UI strings into a vue-i18n instance (e.g. cad-viewer).
+ */
+export declare function mergeAgentI18nIntoVueI18n(
+  mergeLocaleMessage: (locale: AcApLocale, message: object) => void
+): void
+
+/** Callback that opens or focuses the agent tab in the host tool palette. */
+export type AgentPaletteOpener = () => void
+
+export declare function setAgentPaletteOpener(
+  opener: AgentPaletteOpener | undefined
+): void
+
+export declare function openAgentPalette(): boolean

--- a/packages/cad-agent-plugin/vite.config.ts
+++ b/packages/cad-agent-plugin/vite.config.ts
@@ -1,0 +1,31 @@
+import { resolve } from 'path'
+import vue from '@vitejs/plugin-vue'
+import peerDepsExternal from 'rollup-plugin-peer-deps-external'
+import { defineConfig, PluginOption } from 'vite'
+import {
+  createLibEntryFileName,
+  createLibRollupOutput
+} from '../vite-config/pluginRollupOutput'
+
+const packageId = 'cad-agent-plugin'
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    lib: {
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        register: resolve(__dirname, 'src/register.ts')
+      },
+      name: packageId,
+      fileName: (format, entryName) =>
+        createLibEntryFileName(packageId, format, entryName)
+    },
+    minify: true,
+    rollupOptions: {
+      output: createLibRollupOutput(packageId)
+    }
+  },
+  plugins: [vue(), peerDepsExternal() as PluginOption]
+})

--- a/packages/cad-viewer-example/package.json
+++ b/packages/cad-viewer-example/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",
+    "@mlightcad/cad-agent-plugin": "workspace:*",
     "@mlightcad/cad-html-plugin": "workspace:*",
     "@mlightcad/cad-pdf-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -43,6 +43,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "devDependencies": {
+    "@mlightcad/cad-agent-plugin": "workspace:*",
     "@mlightcad/cad-html-plugin": "workspace:*",
     "@mlightcad/cad-pdf-plugin": "workspace:*",
     "@mlightcad/cad-svg-plugin": "workspace:*",
@@ -68,6 +69,7 @@
     "vue-tsc": "^2.1.6"
   },
   "peerDependencies": {
+    "@mlightcad/cad-agent-plugin": "workspace:*",
     "@mlightcad/cad-html-plugin": "workspace:*",
     "@mlightcad/cad-pdf-plugin": "workspace:*",
     "@mlightcad/cad-svg-plugin": "workspace:*",
@@ -81,6 +83,9 @@
     "vue-i18n": "^11.4.4"
   },
   "peerDependenciesMeta": {
+    "@mlightcad/cad-agent-plugin": {
+      "optional": true
+    },
     "@mlightcad/cad-html-plugin": {
       "optional": true
     },

--- a/packages/cad-viewer/src/app/register.ts
+++ b/packages/cad-viewer/src/app/register.ts
@@ -2,9 +2,9 @@ import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin/register'
 import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin/register'
 import {
   AcApDocManager,
+  type AcApPluginManager,
   AcEdCommandStack,
-  AcEdMTextEditor
-} from '@mlightcad/cad-simple-viewer'
+  AcEdMTextEditor} from '@mlightcad/cad-simple-viewer'
 import { registerLazySvgPlugin } from '@mlightcad/cad-svg-plugin/register'
 import { markRaw } from 'vue'
 
@@ -27,6 +27,8 @@ import {
   MlTextStyleDlg
 } from '../component'
 import { useDialogManager } from '../composable'
+import { i18n } from '../locale'
+import { store } from './store'
 
 let isCommandRegistered = false
 export const registerCmds = () => {
@@ -129,13 +131,43 @@ export const registerMTextColorPicker = () => {
 }
 
 let isLazyPluginRegistered = false
+let isAgentIntegrationStarted = false
+
+const registerAgentIntegration = async (pluginManager: AcApPluginManager) => {
+  try {
+    await import('@mlightcad/cad-agent-plugin/style.css')
+    const agentRegister = await import('@mlightcad/cad-agent-plugin/register')
+
+    agentRegister.setAgentPaletteOpener(() => {
+      if (
+        store.dialogs.layerManager &&
+        store.dialogs.activePaletteTab === 'agent'
+      ) {
+        store.dialogs.layerManager = false
+        return
+      }
+
+      store.dialogs.activePaletteTab = 'agent'
+      store.dialogs.layerManager = true
+    })
+
+    agentRegister.mergeAgentI18nIntoVueI18n((locale, messages) => {
+      i18n.global.mergeLocaleMessage(locale, messages)
+    })
+
+    agentRegister.registerLazyAgentPlugin(pluginManager)
+    store.features.agentPlugin = true
+  } catch {
+    // Optional peer `@mlightcad/cad-agent-plugin` is not installed.
+  }
+}
 
 /**
  * Registers lazy plugins that load on first use of their trigger commands.
  *
  * Currently registers the PDF plugin (`cpdf`, `ipdf`), the HTML export
- * plugin (`chtml`), and the SVG export plugin (`csvg`), which are fetched
- * only when one of those commands runs.
+ * plugin (`chtml`), the SVG export plugin (`csvg`), and optionally the CAD
+ * Agent plugin (`agent`) when `@mlightcad/cad-agent-plugin` is installed.
  * Safe to call multiple times; registration runs once per application lifetime.
  */
 export const registerLazyPlugins = () => {
@@ -147,5 +179,11 @@ export const registerLazyPlugins = () => {
   registerLazyPdfPlugin(pluginManager)
   registerLazyHtmlPlugin(pluginManager)
   registerLazySvgPlugin(pluginManager)
+
+  if (!isAgentIntegrationStarted) {
+    isAgentIntegrationStarted = true
+    void registerAgentIntegration(pluginManager)
+  }
+
   isLazyPluginRegistered = true
 }

--- a/packages/cad-viewer/src/app/store.ts
+++ b/packages/cad-viewer/src/app/store.ts
@@ -4,5 +4,9 @@ export const store = reactive({
   dialogs: {
     layerManager: false,
     activePaletteTab: 'layerManager'
+  },
+  features: {
+    /** Set when `@mlightcad/cad-agent-plugin` is installed and registered. */
+    agentPlugin: false
   }
 })

--- a/packages/cad-viewer/src/component/palette/MlPaletteManager.vue
+++ b/packages/cad-viewer/src/component/palette/MlPaletteManager.vue
@@ -19,6 +19,11 @@
       <template #tab-entityProperties>
         <ml-entity-properties :entity-props-list="properties" />
       </template>
+      <template v-if="store.features.agentPlugin" #tab-agent>
+        <div class="ml-agent-palette-wrapper">
+          <agent-chat-panel embedded />
+        </div>
+      </template>
     </ml-tool-palette>
   </el-config-provider>
 </template>
@@ -28,13 +33,20 @@ import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { AcDbEntityProperties } from '@mlightcad/data-model'
 import { MlToolPalette, MlToolPaletteTab } from '@mlightcad/ui-components'
 import { ElConfigProvider } from 'element-plus'
-import { computed, nextTick, watch } from 'vue'
+import { computed, defineAsyncComponent, nextTick, watch } from 'vue'
 
 import { store } from '../../app'
 import { useSelectionSet, useViewerRect } from '../../composable'
 import { toolPaletteTabName, toolPaletteTitle } from '../../locale'
 import MlEntityProperties from './MlEntityProperties.vue'
 import MlLayerList from './MlLayerList.vue'
+
+const AgentChatPanel = defineAsyncComponent(() =>
+  Promise.all([
+    import('@mlightcad/cad-agent-plugin/style.css'),
+    import('@mlightcad/cad-agent-plugin')
+  ]).then(([, module]) => module.AgentChatPanel)
+)
 
 /**
  * Properties of palette manager component
@@ -121,9 +133,16 @@ const syncPaletteToContainer = () => {
   paletteElement.style.maxWidth = `${containerWidth}px`
 }
 
-const tabNames = ['layerManager', 'entityProperties']
+const baseTabNames = ['layerManager', 'entityProperties'] as const
+const tabNames = computed((): readonly string[] => {
+  if (store.features.agentPlugin) {
+    return [...baseTabNames, 'agent']
+  }
+  return baseTabNames
+})
+
 const tabs = computed<MlToolPaletteTab[]>(() => {
-  return tabNames.map(name => {
+  return tabNames.value.map(name => {
     return {
       name,
       label: toolPaletteTabName(name),
@@ -133,10 +152,10 @@ const tabs = computed<MlToolPaletteTab[]>(() => {
 })
 
 watch(
-  () => store.dialogs.activePaletteTab,
-  activeTab => {
-    if (!tabNames.includes(activeTab)) {
-      store.dialogs.activePaletteTab = tabNames[0]
+  [() => store.dialogs.activePaletteTab, tabNames],
+  ([activeTab, names]) => {
+    if (!names.includes(activeTab)) {
+      store.dialogs.activePaletteTab = names[0]
     }
   },
   { immediate: true }
@@ -182,5 +201,19 @@ const properties = computed(() => {
   display: flex;
   align-items: flex-start; /* Align items at the top */
   justify-content: flex-start; /* Align items to the left */
+}
+
+.ml-agent-palette-wrapper {
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.ml-agent-palette-wrapper :deep(.cad-agent-panel-root) {
+  flex: 1;
+  min-height: 0;
 }
 </style>

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -2,6 +2,7 @@
 import '@mlightcad/ribbon/style.css'
 
 import {
+  ChatDotRound,
   Delete,
   DocumentCopy,
   Hide,
@@ -38,6 +39,7 @@ import {
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { store } from '../../app'
 import type { LayerStateSnapshot, LayerStateToggleKey } from '../../composable'
 import {
   useDocument,
@@ -605,7 +607,8 @@ const handleRibbonLayerStateToggle = (payload: {
 const buildBaseTabs = (
   openMode: AcEdOpenMode,
   annotationVisible: boolean,
-  undoRedoState: { canUndo: boolean; canRedo: boolean }
+  undoRedoState: { canUndo: boolean; canRedo: boolean },
+  agentPluginEnabled: boolean
 ): RibbonTabModel[] => {
   const ribbonTooltips = {
     line: t('main.ribbon.tooltip.line'),
@@ -631,6 +634,7 @@ const buildBaseTabs = (
     properties: t('main.ribbon.tooltip.properties'),
     quickSelect: t('main.ribbon.tooltip.quickSelect'),
     drawingUnits: t('main.ribbon.tooltip.drawingUnits'),
+    agent: t('main.ribbon.tooltip.agent'),
     propertyColor: t('main.ribbon.tooltip.propertyColor'),
     propertyLineType: t('main.ribbon.tooltip.propertyLineType'),
     propertyLineWeight: t('main.ribbon.tooltip.propertyLineWeight')
@@ -1412,7 +1416,19 @@ const buildBaseTabs = (
                   tooltip: ribbonTooltips.drawingUnits,
                   size: 'large',
                   props: { icon: setting }
-                }
+                },
+                ...(agentPluginEnabled
+                  ? [
+                      {
+                        id: 'cmd-agent',
+                        type: 'button' as const,
+                        label: t('main.ribbon.command.agent'),
+                        tooltip: ribbonTooltips.agent,
+                        size: 'large' as const,
+                        props: { icon: ChatDotRound }
+                      }
+                    ]
+                  : [])
               ]
             }
           ]
@@ -1431,6 +1447,7 @@ const buildBaseTabs = (
 
 const ribbonData = computed(() => {
   locale.value
+  store.features.agentPlugin
   const openMode = docOpenMode.value
   const annotationVisible = isAnnotationVisible.value
   const commandByItemId = new Map<string, string>()
@@ -1484,6 +1501,9 @@ const ribbonData = computed(() => {
   commandByItemId.set('cmd-properties', 'properties')
   commandByItemId.set('cmd-qselect', 'qselect')
   commandByItemId.set('cmd-drawing-units', 'units')
+  if (store.features.agentPlugin) {
+    commandByItemId.set('cmd-agent', 'agent')
+  }
   commandByItemId.set('cmd-tool-rev-freehand', 'sketch')
   commandByItemId.set('cmd-tool-rev-rect', 'revrect')
   commandByItemId.set('cmd-tool-rev-cloud', 'revcloud')
@@ -1509,7 +1529,7 @@ const ribbonData = computed(() => {
   const tabs: RibbonTabModel[] = buildBaseTabs(openMode, annotationVisible, {
     canUndo: canUndo.value,
     canRedo: canRedo.value
-  })
+  }, store.features.agentPlugin)
   return {
     tabs,
     commandByItemId
@@ -1584,6 +1604,10 @@ const handleRibbonItemClick = (payload: {
   }
   const command = ribbonData.value.commandByItemId.get(payload.itemId)
   if (!command) return
+  if (command === 'agent') {
+    void runLazyCommand('agent')
+    return
+  }
   AcApDocManager.instance.sendStringToExecute(command)
 }
 

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -282,6 +282,8 @@ export default {
         'Open Quick Select to filter and select entities by criteria.',
       drawingUnits:
         'Open Drawing Units to set coordinate formats, precision, and insertion scale.',
+      agent:
+        'Open the CAD Agent palette tab to draw geometry using natural language.',
       propertyColor:
         'Set the color for newly created objects or selected entities.',
       propertyLineType:
@@ -378,7 +380,8 @@ export default {
       redo: 'Redo',
       properties: 'Properties',
       quickSelect: 'Quick Select',
-      drawingUnits: 'Drawing Units'
+      drawingUnits: 'Drawing Units',
+      agent: 'CAD Agent'
     }
   },
   verticalToolbar: {

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -276,6 +276,7 @@ export default {
       properties: '打开当前所选对象的属性面板。',
       quickSelect: '打开快速选择对话框，按条件筛选并选择图元。',
       drawingUnits: '打开图形单位对话框，设置坐标格式、精度与插入缩放单位。',
+      agent: '打开 CAD Agent 工具面板，使用自然语言描述并绘制图形。',
       propertyColor: '设置新建对象或当前选中对象使用的颜色。',
       propertyLineType: '设置新建对象或当前选中对象使用的线型。',
       propertyLineWeight: '设置新建对象或当前选中对象使用的线宽。',
@@ -349,7 +350,8 @@ export default {
       redo: '重做',
       properties: '属性',
       quickSelect: '快速选择',
-      drawingUnits: '图形单位'
+      drawingUnits: '图形单位',
+      agent: 'CAD Agent'
     }
   },
   verticalToolbar: {

--- a/packages/cad-viewer/src/types/vue.d.ts
+++ b/packages/cad-viewer/src/types/vue.d.ts
@@ -4,3 +4,8 @@ declare module '*.vue' {
   const component: DefineComponent<Record<string, any>, any, any>
   export default component
 }
+
+declare module '@mlightcad/cad-agent-plugin/style.css' {
+  const css: string
+  export default css
+}

--- a/packages/cad-viewer/vite.config.ts
+++ b/packages/cad-viewer/vite.config.ts
@@ -53,11 +53,14 @@ export default defineConfig(({ mode }: ConfigEnv) => {
       },
       minify: true,
       rollupOptions: {
-        // PDF/HTML plugins are peers; loaded at runtime via dynamic import in registerLazyPlugins
+        // PDF/HTML/SVG/Agent plugins are peers; loaded at runtime via dynamic import
         external: [
           '@mlightcad/cad-pdf-plugin',
           '@mlightcad/cad-html-plugin',
-          '@mlightcad/cad-svg-plugin'
+          '@mlightcad/cad-svg-plugin',
+          '@mlightcad/cad-agent-plugin',
+          '@mlightcad/cad-agent-plugin/register',
+          '@mlightcad/cad-agent-plugin/style.css'
         ],
         output: {
           chunkFileNames: `${packageId}-[name]-[hash].js`,

--- a/packages/vite-config/pluginRollupOutput.ts
+++ b/packages/vite-config/pluginRollupOutput.ts
@@ -5,7 +5,8 @@ export const PLUGIN_PACKAGE_IDS = [
   'cad-pdf-plugin',
   'cad-html-plugin',
   'cad-svg-plugin',
-  'cad-simple-ui-plugin'
+  'cad-simple-ui-plugin',
+  'cad-agent-plugin'
 ] as const
 
 /** Core viewer libraries shipped from this monorepo. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,40 @@ importers:
         specifier: ^3.1.1
         version: 3.4.0(vite@5.4.21(@types/node@24.12.4)(sass@1.98.0))
 
+  packages/cad-agent-plugin:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^2.0.0
+        version: 2.0.84(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^2.0.0
+        version: 2.0.110(zod@3.25.76)
+      '@ai-sdk/vue':
+        specifier: ^2.0.0
+        version: 2.0.208(vue@3.5.31(typescript@5.9.3))(zod@3.25.76)
+      ai:
+        specifier: ^5.0.0
+        version: 5.0.208(zod@3.25.76)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@mlightcad/cad-simple-viewer':
+        specifier: workspace:*
+        version: link:../cad-simple-viewer
+      '@mlightcad/data-model':
+        specifier: ^1.10.0
+        version: 1.10.0
+      '@vitejs/plugin-vue':
+        specifier: ^5.1.3
+        version: 5.2.4(vite@5.4.21(@types/node@24.12.4)(sass@1.98.0))(vue@3.5.31(typescript@5.9.3))
+      vue:
+        specifier: ^3.4.21
+        version: 3.5.31(typescript@5.9.3)
+      vue-tsc:
+        specifier: ^2.1.6
+        version: 2.2.12(typescript@5.9.3)
+
   packages/cad-html-exporter-cli:
     dependencies:
       '@mlightcad/cad-html-plugin':
@@ -302,6 +336,9 @@ importers:
       '@element-plus/icons-vue':
         specifier: ^2.3.1
         version: 2.3.2(vue@3.5.31(typescript@5.9.3))
+      '@mlightcad/cad-agent-plugin':
+        specifier: workspace:*
+        version: link:../cad-agent-plugin
       '@mlightcad/cad-html-plugin':
         specifier: workspace:*
         version: link:../cad-html-plugin
@@ -374,6 +411,9 @@ importers:
       '@element-plus/icons-vue':
         specifier: ^2.3.1
         version: 2.3.2(vue@3.5.31(typescript@5.9.3))
+      '@mlightcad/cad-agent-plugin':
+        specifier: workspace:*
+        version: link:../cad-agent-plugin
       '@mlightcad/cad-html-plugin':
         specifier: workspace:*
         version: link:../cad-html-plugin
@@ -465,6 +505,46 @@ importers:
         version: 0.172.0
 
 packages:
+
+  '@ai-sdk/anthropic@2.0.84':
+    resolution: {integrity: sha512-SoWiXMHinZA3hVD+jzAOHYcCizOxIBsmBfMiC6QagVdq+cqjxdgAdgDi7q+UsH/byZ8iTKJl77Ab8QXeG1oLCA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@2.0.107':
+    resolution: {integrity: sha512-4Yjo7U6KqcePqsMHL7g0NcwwQQh1IQ3gyW16LEXKlBX5C4pWxXM0qUyxRnNohyVAMKDW2VSWL4BViNNVqQoIDw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@2.0.110':
+    resolution: {integrity: sha512-PVbq0vXo6LVBCKeIOiDsOfrUIL2IOkMUipWP53SJZppDo594kbu5BFs/NdwnJMAX4q6EM6sGPVv751RN9PrZ9A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.28':
+    resolution: {integrity: sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/vue@2.0.208':
+    resolution: {integrity: sha512-FNxv844HPua9AfOTvQRmMHj2syFyVtBhx6asLX0zwzEphzZWt/KS+x9Tuvuu59LI3WSPlbOQBIlrOdcb/N8i3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      vue: ^3.4.21
+      zod: ^3.25.76 || ^4.1.8
+    peerDependenciesMeta:
+      vue:
+        optional: true
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -1844,6 +1924,10 @@ packages:
   '@nx/workspace@20.0.4':
     resolution: {integrity: sha512-aXlkpCPnci0MQoodooGEOXqhruDUdsOLpUn2kJMU6hiQ2QawhCdYerIMT9X5zsGoLLXk1/TBbItTm6Kp3eIxIQ==}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
     engines: {node: '>= 10.0.0'}
@@ -2148,6 +2232,9 @@ packages:
 
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@sxzz/popperjs-es@2.11.8':
     resolution: {integrity: sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ==}
@@ -2468,6 +2555,10 @@ packages:
   '@velipso/polybool@1.1.1':
     resolution: {integrity: sha512-HlWrm/wloLkUDHPQ1AgUdXysKL3y+rqV94udU5CVTtEPci5v6WjEfozNJTOOSwCsz50ySIxJK4gABqfbx1sD7A==}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2600,6 +2691,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@5.0.208:
+    resolution: {integrity: sha512-IiN5PCuUr4AcWhfFMJzirU6WVyZl3vrWbTN0BRnLWhrklNQ1W2VIoJ+H7mBLHzhC21kgv6dJkxsD6yc0M2lXNQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -3377,6 +3474,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -4016,6 +4117,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4912,6 +5016,11 @@ packages:
   svgpath@2.6.0:
     resolution: {integrity: sha512-OIWR6bKzXvdXYyO4DK/UWa1VA1JeKq8E+0ug2DG98Y/vOmMpfZNj+TIG988HjfYSqtcy/hFOtZq/n/j5GSESNg==}
 
+  swrv@1.2.0:
+    resolution: {integrity: sha512-lH/g4UcNyj+7lzK4eRGT4C68Q4EhQ6JtM9otPRIASfhhzfLWtbZPHcMuhuba7S9YVYuxkMUGImwMyGpfbkH07A==}
+    peerDependencies:
+      vue: ^3.4.21
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -5378,7 +5487,49 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
+
+  '@ai-sdk/anthropic@2.0.84(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.28(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@2.0.107(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.28(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/openai@2.0.110(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.28(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@3.0.28(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/vue@2.0.208(vue@3.5.31(typescript@5.9.3))(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 3.0.28(zod@3.25.76)
+      ai: 5.0.208(zod@3.25.76)
+      swrv: 1.2.0(vue@3.5.31(typescript@5.9.3))
+    optionalDependencies:
+      vue: 3.5.31(typescript@5.9.3)
+      zod: 3.25.76
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -7111,6 +7262,8 @@ snapshots:
       - '@swc/core'
       - debug
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
 
@@ -7333,6 +7486,8 @@ snapshots:
   '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@sxzz/popperjs-es@2.11.8': {}
 
@@ -7647,6 +7802,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@24.12.4)(sass@1.98.0))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       vite: 5.4.21(@types/node@24.12.4)(sass@1.98.0)
@@ -7827,6 +7984,14 @@ snapshots:
   address@1.2.2: {}
 
   agent-base@7.1.4: {}
+
+  ai@5.0.208(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.107(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.28(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
@@ -8639,6 +8804,8 @@ snapshots:
   esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.1.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -9479,6 +9646,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -10390,6 +10559,10 @@ snapshots:
 
   svgpath@2.6.0: {}
 
+  swrv@1.2.0(vue@3.5.31(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.31(typescript@5.9.3)
+
   symbol-tree@3.2.4: {}
 
   synckit@0.11.12:
@@ -10846,3 +11019,5 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary

- Add new @mlightcad/cad-agent-plugin package with Vercel AI SDK agent, CAD tool calling (draw primitives, layers, zoom), and a Vue chat panel with encrypted browser-side API key storage (OpenAI / Anthropic / OpenAI-compatible).
- Integrate into cad-viewer via lazy plugin registration, ribbon command, and tool palette tab; wire optional peer dependency in example app and Vite externals.

## Test plan

- [ ] pnpm install and build @mlightcad/cad-agent-plugin
- [ ] Run cad-viewer-example, open a drawing, run gent command from ribbon or CLI
- [ ] Configure LLM provider/API key in agent panel settings
- [ ] Verify natural-language requests execute CAD tools (e.g. draw line, create layer, zoom extents)
- [ ] Confirm i18n strings in EN/ZH and palette panel layout