### PR TITLE
feat(three-renderer): GPU slot-mask highlighting for batched geometry

### DIFF
--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -339,6 +339,20 @@ function readLineWidth(material: THREE.Material): number | undefined {
   return undefined
 }
 
+function readExportMaterial(object: THREE.Object3D): THREE.Material {
+  if ('material' in object) {
+    const originalMaterial = (
+      object.userData as { originalMaterial?: THREE.Material | THREE.Material[] }
+    ).originalMaterial
+    const material = originalMaterial ?? object.material
+    if (Array.isArray(material)) {
+      return material[0]!
+    }
+    return material as THREE.Material
+  }
+  return (object as THREE.Mesh).material as THREE.Material
+}
+
 function readMaterialStyle(material: THREE.Material): {
   color: number
   layer: string
@@ -557,7 +571,7 @@ export function collectBatchesFromObject3D(
       if (!shouldExportPlainDrawable(child)) return
       const rawSlice = exportLineSegments2Slice(child.geometry)
       if (rawSlice.positions.length === 0) return
-      const material = child.material as THREE.Material
+      const material = readExportMaterial(child)
       const { color, layer } = readMaterialStyle(material)
       const { offset, ...slice } = exportSceneDrawableSlice(child, rawSlice)
       lineBatches.push({
@@ -574,7 +588,7 @@ export function collectBatchesFromObject3D(
       if (!shouldExportPlainDrawable(child)) return
       const rawSlice = exportBufferGeometrySlice(child.geometry)
       if (rawSlice.positions.length === 0) return
-      const material = child.material as THREE.Material
+      const material = readExportMaterial(child)
       const { color, layer, linePattern } = readMaterialStyle(material)
       const { offset, ...slice } = exportSceneDrawableSlice(child, rawSlice)
       const lineDistances = linePattern
@@ -595,7 +609,7 @@ export function collectBatchesFromObject3D(
       if (!shouldExportPlainDrawable(child)) return
       const rawSlice = exportBufferGeometrySlice(child.geometry)
       if (rawSlice.positions.length === 0) return
-      const material = child.material as THREE.Material
+      const material = readExportMaterial(child)
       const style = readMaterialStyle(material)
       const { offset, ...slice } = exportSceneDrawableSlice(child, rawSlice, {
         preserveWorldSpaceForPatternFill: !!style.hatchPattern

--- a/packages/cad-simple-viewer/src/view/AcTrLayer.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayer.ts
@@ -392,35 +392,55 @@ export class AcTrLayer {
    * Hover the specified entities
    */
   hover(ids: AcDbObjectId[]) {
-    ids.forEach(id => {
-      this._group.hover(id)
-    })
+    if (ids.length === 0) {
+      return
+    }
+    if (ids.length === 1) {
+      this._group.hover(ids[0]!)
+      return
+    }
+    this._group.hoverMany(ids)
   }
 
   /**
    * Unhover the specified entities
    */
   unhover(ids: AcDbObjectId[]) {
-    ids.forEach(id => {
-      this._group.unhover(id)
-    })
+    if (ids.length === 0) {
+      return
+    }
+    if (ids.length === 1) {
+      this._group.unhover(ids[0]!)
+      return
+    }
+    this._group.unhoverMany(ids)
   }
 
   /**
    * Select the specified entities
    */
   select(ids: AcDbObjectId[]) {
-    ids.forEach(id => {
-      this._group.select(id)
-    })
+    if (ids.length === 0) {
+      return
+    }
+    if (ids.length === 1) {
+      this._group.select(ids[0]!)
+      return
+    }
+    this._group.selectMany(ids)
   }
 
   /**
    * Unselect the specified entities
    */
   unselect(ids: AcDbObjectId[]) {
-    ids.forEach(id => {
-      this._group.unselect(id)
-    })
+    if (ids.length === 0) {
+      return
+    }
+    if (ids.length === 1) {
+      this._group.unselect(ids[0]!)
+      return
+    }
+    this._group.unselectMany(ids)
   }
 }

--- a/packages/cad-simple-viewer/src/view/AcTrLayout.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayout.ts
@@ -536,10 +536,7 @@ export class AcTrLayout {
    * @param ids - Array of entity object IDs to hover
    */
   hover(ids: AcDbObjectId[]) {
-    ids.forEach(id => {
-      const layers = this.getLayersByObjectId(id)
-      layers.forEach(layer => layer.hover([id]))
-    })
+    this.applyHighlightToLayers(ids, (layer, entityIds) => layer.hover(entityIds))
   }
 
   /**
@@ -549,10 +546,9 @@ export class AcTrLayout {
    * @param ids - Array of entity object IDs to unhover
    */
   unhover(ids: AcDbObjectId[]) {
-    ids.forEach(id => {
-      const layers = this.getLayersByObjectId(id)
-      layers.forEach(layer => layer.unhover([id]))
-    })
+    this.applyHighlightToLayers(ids, (layer, entityIds) =>
+      layer.unhover(entityIds)
+    )
   }
 
   /**
@@ -562,10 +558,9 @@ export class AcTrLayout {
    * @param ids - Array of entity object IDs to select
    */
   select(ids: AcDbObjectId[]) {
-    ids.forEach(id => {
-      const layers = this.getLayersByObjectId(id)
-      layers.forEach(layer => layer.select([id]))
-    })
+    this.applyHighlightToLayers(ids, (layer, entityIds) =>
+      layer.select(entityIds)
+    )
   }
 
   /**
@@ -575,10 +570,34 @@ export class AcTrLayout {
    * @param ids - Array of entity object IDs to unselect
    */
   unselect(ids: AcDbObjectId[]) {
-    ids.forEach(id => {
+    this.applyHighlightToLayers(ids, (layer, entityIds) =>
+      layer.unselect(entityIds)
+    )
+  }
+
+  /**
+   * Groups entity ids by render layer and applies one bulk highlight call per layer.
+   *
+   * @param ids - Entity object ids whose highlight state should change.
+   * @param apply - Layer callback invoked once per layer with its grouped entity ids.
+   */
+  private applyHighlightToLayers(
+    ids: AcDbObjectId[],
+    apply: (layer: AcTrLayer, entityIds: AcDbObjectId[]) => void
+  ) {
+    const layerToIds = new Map<AcTrLayer, AcDbObjectId[]>()
+    for (const id of ids) {
       const layers = this.getLayersByObjectId(id)
-      layers.forEach(layer => layer.unselect([id]))
-    })
+      for (const layer of layers) {
+        const bucket = layerToIds.get(layer)
+        if (bucket) {
+          bucket.push(id)
+        } else {
+          layerToIds.set(layer, [id])
+        }
+      }
+    }
+    layerToIds.forEach((entityIds, layer) => apply(layer, entityIds))
   }
 
   /**

--- a/packages/three-renderer/__tests__/AcTrBatchedGroupHighlight.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupHighlight.spec.ts
@@ -1,0 +1,225 @@
+import * as THREE from 'three'
+
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import { AcTrBatchedLine } from '../src/batch/AcTrBatchedLine'
+import { AcTrBatchHighlightState, BATCH_SLOT_ID_ATTRIBUTE } from '../src/batch/highlight'
+import { AcTrEntity } from '../src/object/AcTrEntity'
+import { AcTrLine } from '../src/object/AcTrLine'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import {
+  AcTrSubEntityTraitsUtil
+} from '../src/util'
+import {
+  HIGHLIGHT_HOVER_COLOR,
+  HIGHLIGHT_SELECT_COLOR
+} from '../src/util/AcTrMaterialUtil'
+import { getObjectUserData } from '../src/util/AcTrObjectUserData'
+
+const defaultTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+
+function createBatchedLineEntity(objectId: string) {
+  const context = new AcTrRenderContext()
+  const line = new AcTrLine(
+    [
+      { x: 0, y: 0, z: 0 },
+      { x: 100, y: 0, z: 0 }
+    ],
+    defaultTraits,
+    context,
+    false
+  )
+  const entity = new AcTrEntity(context)
+  entity.objectId = objectId
+  entity.visible = true
+  entity.add(line)
+  return entity
+}
+
+function findBatchedLine(group: AcTrBatchedGroup): AcTrBatchedLine | undefined {
+  let result: AcTrBatchedLine | undefined
+  group.traverse(child => {
+    if (!result && child instanceof AcTrBatchedLine) {
+      result = child
+    }
+  })
+  return result
+}
+
+describe('AcTrBatchedGroup slot-mask highlight', () => {
+  it('writes slotId when batching line geometry', () => {
+    const group = new AcTrBatchedGroup()
+    group.addEntity(createBatchedLineEntity('line-1'))
+
+    const batchedLine = findBatchedLine(group)
+    expect(batchedLine).toBeDefined()
+    const slotId = batchedLine!.geometry.getAttribute(BATCH_SLOT_ID_ATTRIBUTE)
+    expect(slotId).toBeDefined()
+    expect(slotId.getX(0)).toBe(0)
+  })
+
+  it('selects batched entities without creating overlay drawables', () => {
+    const group = new AcTrBatchedGroup()
+    group.addEntity(createBatchedLineEntity('line-1'))
+
+    group.select('line-1')
+
+    const selectedGroup = group.children[1] as THREE.Group
+    expect(selectedGroup.children).toHaveLength(0)
+
+    const batchedLine = findBatchedLine(group)!
+    expect(batchedLine._highlightState.selectedMask[0]).toBe(1)
+  })
+
+  it('selectMany keeps overlay groups empty for batched entities', () => {
+    const group = new AcTrBatchedGroup()
+    for (let index = 0; index < 100; index++) {
+      group.addEntity(createBatchedLineEntity(`line-${index}`))
+    }
+
+    group.selectMany(Array.from({ length: 100 }, (_, index) => `line-${index}`))
+
+    const selectedGroup = group.children[1] as THREE.Group
+    expect(selectedGroup.children).toHaveLength(0)
+    expect(group.entityCount).toBe(100)
+  })
+
+  it('clears batched highlight state on unselect', () => {
+    const group = new AcTrBatchedGroup()
+    group.addEntity(createBatchedLineEntity('line-1'))
+
+    group.select('line-1')
+    group.unselect('line-1')
+
+    const batchedLine = findBatchedLine(group)!
+    expect(batchedLine._highlightState.selectedMask[0]).toBe(0)
+  })
+
+  it('uploads large highlight masks as a 2D texture within GPU limits', () => {
+    const state = new AcTrBatchHighlightState()
+    state.setAddressableSlotCount(65536)
+    state.setHighlight(65535, 'select', true)
+
+    state.uploadMaskTexture()
+
+    expect(state.maskTextureWidth).toBe(4096)
+    expect(state.maskTextureHeight).toBe(16)
+    expect(state.maskTexture?.image.width).toBe(4096)
+    expect(state.maskTexture?.image.height).toBe(16)
+  })
+
+  it('sizes mask texture to all addressable slots when only low slots are highlighted', () => {
+    const state = new AcTrBatchHighlightState()
+    state.setAddressableSlotCount(500)
+    state.setHighlight(0, 'select', true)
+
+    state.uploadMaskTexture()
+
+    expect(state.maskTextureWidth).toBe(500)
+    expect(state.maskTextureHeight).toBe(1)
+    expect(state.selectedMask[499]).toBe(0)
+  })
+
+  it('skips redundant mask uploads when highlight state is unchanged', () => {
+    const state = new AcTrBatchHighlightState()
+    state.setHighlight(0, 'select', true)
+    const firstTexture = state.uploadMaskTexture()
+    const firstData = firstTexture.image.data as Uint8Array
+
+    const secondTexture = state.uploadMaskTexture()
+
+    expect(secondTexture).toBe(firstTexture)
+    expect(secondTexture.image.data).toBe(firstData)
+  })
+
+  it('uses hover highlight color for unbatched drawables', () => {
+    const group = new AcTrBatchedGroup()
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 10, 0, 0], 3)
+    )
+    const material = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const line = new THREE.Line(geometry, material)
+    getObjectUserData(line).noBatch = true
+
+    const entity = new AcTrEntity(new AcTrRenderContext())
+    entity.objectId = 'unbatched-hover'
+    entity.visible = true
+    entity.add(line)
+    group.addEntity(entity)
+
+    group.hover('unbatched-hover')
+
+    const clonedLine = [...group.children[0].children].find(
+      child => child instanceof THREE.Line
+    ) as THREE.Line
+    expect((clonedLine.material as THREE.LineBasicMaterial).color.getHex()).toBe(
+      HIGHLIGHT_HOVER_COLOR.getHex()
+    )
+  })
+
+  it('keeps hover highlight after unselect when both were active', () => {
+    const group = new AcTrBatchedGroup()
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 10, 0, 0], 3)
+    )
+    const material = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const line = new THREE.Line(geometry, material)
+    getObjectUserData(line).noBatch = true
+
+    const entity = new AcTrEntity(new AcTrRenderContext())
+    entity.objectId = 'unbatched-both'
+    entity.visible = true
+    entity.add(line)
+    group.addEntity(entity)
+
+    group.select('unbatched-both')
+    group.hover('unbatched-both')
+    group.unselect('unbatched-both')
+
+    const clonedLine = [...group.children[0].children].find(
+      child => child instanceof THREE.Line
+    ) as THREE.Line
+    expect((clonedLine.material as THREE.LineBasicMaterial).color.getHex()).toBe(
+      HIGHLIGHT_HOVER_COLOR.getHex()
+    )
+  })
+
+  it('uses in-place material swap for unbatched drawables', () => {
+    const group = new AcTrBatchedGroup()
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 10, 0, 0], 3)
+    )
+    const material = new THREE.LineBasicMaterial({ color: 0xff0000 })
+    const line = new THREE.Line(geometry, material)
+    getObjectUserData(line).noBatch = true
+
+    const entity = new AcTrEntity(new AcTrRenderContext())
+    entity.objectId = 'unbatched-1'
+    entity.visible = true
+    entity.add(line)
+    group.addEntity(entity)
+
+    group.select('unbatched-1')
+
+    const selectedGroup = group.children[1] as THREE.Group
+    expect(selectedGroup.children).toHaveLength(0)
+
+    const clonedLine = [...group.children[0].children].find(
+      child => child instanceof THREE.Line
+    ) as THREE.Line
+    expect(clonedLine).toBeDefined()
+    expect(getObjectUserData(clonedLine).originalMaterial).toBe(material)
+    expect((clonedLine.material as THREE.LineBasicMaterial).color.getHex()).toBe(
+      HIGHLIGHT_SELECT_COLOR.getHex()
+    )
+
+    group.unselect('unbatched-1')
+    expect(clonedLine.material).toBe(material)
+    expect(getObjectUserData(clonedLine).originalMaterial).toBeUndefined()
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrBatchedGroupUnbatchedOps.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupUnbatchedOps.spec.ts
@@ -4,8 +4,9 @@ import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
 import { RTE_REBASE_THRESHOLD } from '../src/draw/AcTrBatchDrawPolicy'
 import { AcTrEntity } from '../src/object/AcTrEntity'
 import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { HIGHLIGHT_SELECT_COLOR } from '../src/util/AcTrMaterialUtil'
 import {
-  getHighlightUserData,
+  getObjectUserData,
   getSceneDrawableUserData
 } from '../src/util/AcTrObjectUserData'
 
@@ -85,7 +86,7 @@ function findUnbatchedPlacementClone(group: AcTrBatchedGroup) {
 }
 
 describe('AcTrBatchedGroup unbatched operations', () => {
-  it('selects and unselects an unbatched placement root', () => {
+  it('selects and unselects an unbatched placement root in place', () => {
     const group = new AcTrBatchedGroup()
     const placementRoot = createPlacementRoot(
       { x: RTE_REBASE_THRESHOLD + 100, y: 3_000_000, z: 0 },
@@ -98,16 +99,21 @@ describe('AcTrBatchedGroup unbatched operations', () => {
     group.select('mtext-1')
 
     const selectedGroup = group.children[1] as THREE.Group
-    expect(selectedGroup.children).toHaveLength(1)
-    expect(getHighlightUserData(selectedGroup.children[0]).objectId).toBe(
-      'mtext-1'
+    expect(selectedGroup.children).toHaveLength(0)
+    const clonedRoot = findUnbatchedPlacementClone(group)
+    expect(clonedRoot).toBeDefined()
+    const mesh = clonedRoot!.children[0] as THREE.Mesh
+    expect(getObjectUserData(mesh).originalMaterial).toBeDefined()
+    expect((mesh.material as THREE.MeshBasicMaterial).color.getHex()).toBe(
+      HIGHLIGHT_SELECT_COLOR.getHex()
     )
 
     group.unselect('mtext-1')
     expect(selectedGroup.children).toHaveLength(0)
+    expect(getObjectUserData(mesh).originalMaterial).toBeUndefined()
   })
 
-  it('disposes highlight materials for unbatched subtree children on unselect', () => {
+  it('restores unbatched materials on unselect without disposing shared highlight materials', () => {
     const group = new AcTrBatchedGroup()
     const placementRoot = createPlacementRoot(
       { x: RTE_REBASE_THRESHOLD + 100, y: 3_000_000, z: 0 },
@@ -118,20 +124,15 @@ describe('AcTrBatchedGroup unbatched operations', () => {
     group.addEntity(createEntity('mtext-1', placementRoot))
     group.select('mtext-1')
 
-    const selectedGroup = group.children[1] as THREE.Group
-    const highlightRoot = selectedGroup.children[0]
-    const highlightMeshes = highlightRoot.children.filter(
-      child => child instanceof THREE.Mesh
-    ) as THREE.Mesh[]
-    expect(highlightMeshes.length).toBeGreaterThan(0)
+    const clonedRoot = findUnbatchedPlacementClone(group)
+    const mesh = clonedRoot!.children[0] as THREE.Mesh
+    const originalMaterial = getObjectUserData(mesh).originalMaterial as
+      | THREE.Material
+      | undefined
+    expect(originalMaterial).toBeDefined()
 
-    const disposeSpy = jest.spyOn(THREE.Material.prototype, 'dispose')
     group.unselect('mtext-1')
-
-    expect(disposeSpy.mock.calls.length).toBeGreaterThanOrEqual(
-      highlightMeshes.length
-    )
-    disposeSpy.mockRestore()
+    expect(mesh.material).toBe(originalMaterial)
   })
 
   it('removes unbatched entities and clears selection highlights', () => {

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -21,9 +21,14 @@ import {
   AcTrSubEntityTraitsUtil
 } from '../util'
 import {
+  HIGHLIGHT_HOVER_COLOR,
+  HIGHLIGHT_SELECT_COLOR
+} from '../util/AcTrMaterialUtil'
+import {
   type AcTrHighlightOverlayGroup,
   copyHighlightObjectFlags,
   getHighlightUserData,
+  getObjectUserData,
   getSceneDrawableUserData,
   markHighlightOverlayGroup,
   patchDrawableMaterialFromCache,
@@ -35,6 +40,7 @@ import { AcTrBatchedLine } from './AcTrBatchedLine'
 import { AcTrBatchedLine2 } from './AcTrBatchedLine2'
 import { AcTrBatchedMesh } from './AcTrBatchedMesh'
 import { AcTrBatchedPoint } from './AcTrBatchedPoint'
+import { type AcTrBatchHighlightKind } from './highlight'
 
 /**
  * Union of batch container classes resolved by {@link THREE.Object3D.getObjectById}
@@ -188,6 +194,21 @@ export class AcTrBatchedGroup extends THREE.Group {
   private static readonly INITIAL_MESH_INDEX_CAPACITY = 256
   private static readonly INITIAL_POINT_VERTEX_CAPACITY = 16
   /**
+   * Cached highlight material clones keyed by source material and highlight kind.
+   *
+   * Shared across all {@link AcTrBatchedGroup} instances for unbatched drawables.
+   * Entries are evicted when the source material is disposed.
+   */
+  private static readonly sharedHighlightMaterialsBySource = new WeakMap<
+    THREE.Material,
+    Map<AcTrBatchHighlightKind, THREE.Material>
+  >()
+  private static readonly onSourceMaterialDisposed = (event: THREE.Event) => {
+    AcTrBatchedGroup.releaseSharedHighlightMaterials(
+      event.target as THREE.Material
+    )
+  }
+  /**
    * Batched line map for line segments without vertex index.
    * - the key is material id
    * - the value is one or more batched lines split by world origin
@@ -230,13 +251,20 @@ export class AcTrBatchedGroup extends THREE.Group {
    */
   private _pointSymbolBatches: AcTrOriginBatchMap<AcTrBatchedLine>
   /**
-   * The group to store all of selected entities
+   * Legacy overlay container retained for {@link createPreviewSubset} and
+   * {@link appendEntityOverlayDrawables}. Slot-mask and in-place material swap
+   * no longer populate this group for selection or hover.
    */
   private _selectedObjects: AcTrHighlightOverlayGroup
   /**
-   * The group to store all of entities hovering on them
+   * Legacy overlay container retained for preview extraction. Hover and selection
+   * use slot-mask or in-place material swap instead of overlay drawables.
    */
   private _hoverObjects: AcTrHighlightOverlayGroup
+  /** Entity ids whose unbatched drawables are currently selection-highlighted. */
+  private _unbatchedSelectedIds = new Set<string>()
+  /** Entity ids whose unbatched drawables are currently hover-highlighted. */
+  private _unbatchedHoveredIds = new Set<string>()
   /**
    * Non-batched objects (for render paths that cannot be merged, e.g. fat lines).
    */
@@ -442,6 +470,8 @@ export class AcTrBatchedGroup extends THREE.Group {
     })
     this._unbatchedObjects.clear()
     this._unbatchedEntities.clear()
+    this._unbatchedSelectedIds.clear()
+    this._unbatchedHoveredIds.clear()
     this._entitiesMap.clear()
     return this
   }
@@ -841,8 +871,8 @@ export class AcTrBatchedGroup extends THREE.Group {
     })
 
     if (!visible) {
-      this.unhighlight(objectId, this._selectedObjects)
-      this.unhighlight(objectId, this._hoverObjects)
+      this.unselect(objectId)
+      this.unhover(objectId)
     }
 
     return true
@@ -998,13 +1028,14 @@ export class AcTrBatchedGroup extends THREE.Group {
         }
       }
       batchedObjects.forEach(batchedObject => batchedObject.optimize())
-      this.unhighlight(objectId, this._selectedObjects)
+      this.unselect(objectId)
+      this.unhover(objectId)
       this._entitiesMap.delete(objectId)
     }
     const unbatchedObjects = this._unbatchedEntities.get(objectId)
     if (unbatchedObjects) {
-      this.unhighlight(objectId, this._selectedObjects)
-      this.unhighlight(objectId, this._hoverObjects)
+      this.unselect(objectId)
+      this.unhover(objectId)
       unbatchedObjects.forEach(object => {
         this.disposeObject(object)
         this._unbatchedObjects.remove(object)
@@ -1051,30 +1082,253 @@ export class AcTrBatchedGroup extends THREE.Group {
 
   /**
    * Adds hover highlight for one entity id.
+   *
+   * @param objectId - Database object id to hover.
    */
   hover(objectId: string) {
-    this.highlight(objectId, this._hoverObjects)
+    this.setEntityHighlight([objectId], 'hover', true)
   }
 
   /**
    * Removes hover highlight for one entity id.
+   *
+   * @param objectId - Database object id to unhover.
    */
   unhover(objectId: string) {
-    this.unhighlight(objectId, this._hoverObjects)
+    this.setEntityHighlight([objectId], 'hover', false)
   }
 
   /**
    * Adds selection highlight for one entity id.
+   *
+   * @param objectId - Database object id to select.
    */
   select(objectId: string) {
-    this.highlight(objectId, this._selectedObjects)
+    this.setEntityHighlight([objectId], 'select', true)
   }
 
   /**
    * Removes selection highlight for one entity id.
+   *
+   * @param objectId - Database object id to unselect.
    */
   unselect(objectId: string) {
-    this.unhighlight(objectId, this._selectedObjects)
+    this.setEntityHighlight([objectId], 'select', false)
+  }
+
+  /**
+   * Adds hover highlight for many entity ids with one mask flush pass.
+   *
+   * @param objectIds - Database object ids to hover.
+   */
+  hoverMany(objectIds: string[]) {
+    this.setEntityHighlight(objectIds, 'hover', true)
+  }
+
+  /**
+   * Removes hover highlight for many entity ids with one mask flush pass.
+   *
+   * @param objectIds - Database object ids to unhover.
+   */
+  unhoverMany(objectIds: string[]) {
+    this.setEntityHighlight(objectIds, 'hover', false)
+  }
+
+  /**
+   * Adds selection highlight for many entity ids with one mask flush pass.
+   *
+   * @param objectIds - Database object ids to select.
+   */
+  selectMany(objectIds: string[]) {
+    this.setEntityHighlight(objectIds, 'select', true)
+  }
+
+  /**
+   * Removes selection highlight for many entity ids with one mask flush pass.
+   *
+   * @param objectIds - Database object ids to unselect.
+   */
+  unselectMany(objectIds: string[]) {
+    this.setEntityHighlight(objectIds, 'select', false)
+  }
+
+  /**
+   * Applies or clears batched/unbatched highlight state for entity ids.
+   *
+   * @param objectIds - Database object ids whose highlight state should change.
+   * @param kind - Whether to update selection or hover state.
+   * @param enabled - `true` to highlight the entities, `false` to clear them.
+   */
+  private setEntityHighlight(
+    objectIds: string[],
+    kind: AcTrBatchHighlightKind,
+    enabled: boolean
+  ) {
+    if (objectIds.length === 0) {
+      return
+    }
+
+    const dirtyBatches = new Set<AcTrOriginBatch>()
+    for (const objectId of objectIds) {
+      const entityInfo = this._entitiesMap.get(objectId)
+      entityInfo?.forEach(item => {
+        const batchedObject = this.getObjectById(
+          item.batchedObjectId
+        ) as AcTrOriginBatch | null
+        if (
+          batchedObject &&
+          batchedObject.setHighlightAt(item.batchId, kind, enabled)
+        ) {
+          dirtyBatches.add(batchedObject)
+        }
+      })
+
+      const unbatchedObjects = this._unbatchedEntities.get(objectId)
+      if (unbatchedObjects) {
+        if (kind === 'select') {
+          if (enabled) {
+            this._unbatchedSelectedIds.add(objectId)
+          } else {
+            this._unbatchedSelectedIds.delete(objectId)
+          }
+        } else if (enabled) {
+          this._unbatchedHoveredIds.add(objectId)
+        } else {
+          this._unbatchedHoveredIds.delete(objectId)
+        }
+
+        for (const object of unbatchedObjects) {
+          this.refreshUnbatchedHighlight(object, objectId)
+        }
+      }
+    }
+
+    dirtyBatches.forEach(batch => batch.flushHighlightMask())
+  }
+
+  /**
+   * Applies the effective unbatched highlight material for one entity id.
+   *
+   * Selection takes precedence over hover, matching batched slot-mask behavior.
+   *
+   * @param object - Root of an unbatched drawable subtree.
+   * @param objectId - Database object id owning the drawable subtree.
+   */
+  private refreshUnbatchedHighlight(object: THREE.Object3D, objectId: string) {
+    if (this._unbatchedSelectedIds.has(objectId)) {
+      this.applyUnbatchedHighlightMaterial(object, 'select')
+      return
+    }
+    if (this._unbatchedHoveredIds.has(objectId)) {
+      this.applyUnbatchedHighlightMaterial(object, 'hover')
+      return
+    }
+    this.unhighlightUnbatchedObject(object)
+  }
+
+  /**
+   * Recursively swaps unbatched drawables to shared highlight materials.
+   *
+   * @param object - Root of an unbatched drawable subtree.
+   * @param kind - Whether to apply selection or hover tinting.
+   */
+  private applyUnbatchedHighlightMaterial(
+    object: THREE.Object3D,
+    kind: AcTrBatchHighlightKind
+  ) {
+    if ('material' in object) {
+      const material = object.material as THREE.Material | THREE.Material[]
+      const objectData = getObjectUserData(object)
+      if (objectData.originalMaterial == null) {
+        objectData.originalMaterial = material
+      }
+      object.material = this.getSharedHighlightMaterial(material, kind)
+      return
+    }
+
+    for (const child of object.children) {
+      this.applyUnbatchedHighlightMaterial(child, kind)
+    }
+  }
+
+  /**
+   * Restores original materials on one unbatched drawable subtree.
+   *
+   * @param object - Root of an unbatched drawable subtree.
+   */
+  private unhighlightUnbatchedObject(object: THREE.Object3D) {
+    if ('material' in object) {
+      const objectData = getObjectUserData(object)
+      if (objectData.originalMaterial != null) {
+        object.material = objectData.originalMaterial
+        delete objectData.originalMaterial
+      }
+      return
+    }
+
+    for (const child of object.children) {
+      this.unhighlightUnbatchedObject(child)
+    }
+  }
+
+  /**
+   * Returns one cached highlight material per source material and highlight kind.
+   *
+   * @param material - Source material or material array from an unbatched drawable.
+   * @param kind - Whether to tint for selection or hover.
+   * @returns Highlight material clone suitable for in-place tinting.
+   */
+  private getSharedHighlightMaterial(
+    material: THREE.Material | THREE.Material[],
+    kind: AcTrBatchHighlightKind
+  ): THREE.Material | THREE.Material[] {
+    if (Array.isArray(material)) {
+      return material.map(
+        entry =>
+          this.getSharedHighlightMaterial(entry, kind) as THREE.Material
+      )
+    }
+
+    let cache = AcTrBatchedGroup.sharedHighlightMaterialsBySource.get(material)
+    if (!cache) {
+      cache = new Map()
+      AcTrBatchedGroup.sharedHighlightMaterialsBySource.set(material, cache)
+      material.addEventListener(
+        'dispose',
+        AcTrBatchedGroup.onSourceMaterialDisposed
+      )
+    }
+
+    const cached = cache.get(kind)
+    if (cached) {
+      return cached
+    }
+
+    const highlightMaterial = AcTrMaterialUtil.cloneMaterial(material)
+    if (!Array.isArray(highlightMaterial)) {
+      AcTrMaterialUtil.setMaterialColor(
+        highlightMaterial,
+        kind === 'hover' ? HIGHLIGHT_HOVER_COLOR : HIGHLIGHT_SELECT_COLOR
+      )
+      cache.set(kind, highlightMaterial)
+      return highlightMaterial
+    }
+
+    return highlightMaterial
+  }
+
+  /**
+   * Disposes cached highlight clones when a source unbatched material is disposed.
+   *
+   * @param source - Source material whose highlight clones should be released.
+   */
+  private static releaseSharedHighlightMaterials(source: THREE.Material) {
+    const cache = AcTrBatchedGroup.sharedHighlightMaterialsBySource.get(source)
+    if (!cache) {
+      return
+    }
+    cache.forEach(highlightMaterial => highlightMaterial.dispose())
+    AcTrBatchedGroup.sharedHighlightMaterialsBySource.delete(source)
   }
 
   /**
@@ -1137,13 +1391,19 @@ export class AcTrBatchedGroup extends THREE.Group {
   }
 
   /**
-   * Creates highlight draw objects for one entity id.
+   * Removes batched slot-mask or unbatched material highlight for one entity id.
+   *
+   * @param objectId - Database object id whose highlight should be cleared.
+   * @param containerGroup - Legacy overlay group that maps to select or hover state.
    */
-  protected highlight(objectId: string, containerGroup: THREE.Group) {
-    this.appendEntityOverlayDrawables(objectId, containerGroup, {
-      maxSlots: 1000,
-      mode: 'highlight'
-    })
+  protected unhighlight(objectId: string, containerGroup: THREE.Group) {
+    if (containerGroup === this._selectedObjects) {
+      this.unselect(objectId)
+      return
+    }
+    if (containerGroup === this._hoverObjects) {
+      this.unhover(objectId)
+    }
   }
 
   /**
@@ -1272,18 +1532,6 @@ export class AcTrBatchedGroup extends THREE.Group {
     target: THREE.Object3D
   ) {
     copyHighlightObjectFlags(source, target)
-  }
-
-  /**
-   * Removes and disposes highlight objects for one entity id.
-   */
-  protected unhighlight(objectId: string, containerGroup: THREE.Group) {
-    const objects: THREE.Object3D[] = []
-    containerGroup.children.forEach(obj => {
-      if (getHighlightUserData(obj).objectId === objectId) objects.push(obj)
-    })
-    objects.forEach(obj => this.disposeHighlightObject(obj))
-    containerGroup.remove(...objects)
   }
 
   /**

--- a/packages/three-renderer/src/batch/AcTrBatchedLine.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine.ts
@@ -451,7 +451,7 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
 
     const batchGeometry = this.geometry
     const geometryInfo = this._geometryInfo[geometryId]
-    applyGeometryAt(geometryInfo, batchGeometry, geometry, 'AcTrBatchedLine')
+    applyGeometryAt(geometryInfo, batchGeometry, geometry, 'AcTrBatchedLine', geometryId)
 
     return geometryId
   }

--- a/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
@@ -22,6 +22,7 @@ import {
   resolveReservedCount
 } from './AcTrBatchedMixin'
 import { syncBatchDrawVisibilityAfterOptimize } from './drawVisibility'
+import { ensureSlotIdAttribute, writeSlotIdRange } from './highlight'
 
 type AcTrBatchedLine2GeometryInfo = AcTrVertexBatchGeometryInfo
 
@@ -88,6 +89,7 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     ;(this.geometry as LineSegmentsGeometry).setPositions(
       new Float32Array(this._maxSegmentCount * 6)
     )
+    ensureSlotIdAttribute(this.geometry, this._maxSegmentCount)
     this._copyStaticAttributes(reference)
     this._geometryInitialized = true
   }
@@ -103,7 +105,13 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     }
 
     for (const key in reference.attributes) {
-      if (key === 'instanceStart' || key === 'instanceEnd') continue
+      if (
+        key === 'instanceStart' ||
+        key === 'instanceEnd' ||
+        key === 'slotId'
+      ) {
+        continue
+      }
       dstGeometry.setAttribute(key, reference.getAttribute(key).clone())
     }
   }
@@ -310,6 +318,13 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     geometryInfo.vertexCount = segmentCount
     geometryInfo.boundingBox = null
 
+    writeSlotIdRange(
+      this.geometry,
+      segmentStart,
+      geometryInfo.reservedVertexCount,
+      geometryId
+    )
+
     return geometryId
   }
 
@@ -334,6 +349,18 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
           oldStart * 6,
           (oldStart + count) * 6
         )
+        const slotIdAttr = this.geometry.getAttribute('slotId') as
+          | THREE.BufferAttribute
+          | undefined
+        if (slotIdAttr) {
+          slotIdAttr.array.copyWithin(
+            nextSegmentStart,
+            oldStart,
+            oldStart + count
+          )
+          slotIdAttr.addUpdateRange(nextSegmentStart, count)
+          slotIdAttr.needsUpdate = true
+        }
       }
       info.vertexStart = nextSegmentStart
       nextSegmentStart += count

--- a/packages/three-renderer/src/batch/AcTrBatchedMesh.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMesh.ts
@@ -378,7 +378,7 @@ export class AcTrBatchedMesh extends AcTrBatchedMeshBase {
 
     const batchGeometry = this.geometry
     const geometryInfo = this._geometryInfo[geometryId]
-    applyGeometryAt(geometryInfo, batchGeometry, geometry, 'AcTrBatchedMesh')
+    applyGeometryAt(geometryInfo, batchGeometry, geometry, 'AcTrBatchedMesh', geometryId)
 
     return geometryId
   }

--- a/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
@@ -16,6 +16,15 @@ import {
   type AcTrBatchDrawVisibilityInfo,
   applyBatchSlotDrawVisibility
 } from './drawVisibility'
+import {
+  type AcTrBatchHighlightKind,
+  AcTrBatchHighlightState,
+  BATCH_SLOT_ID_ATTRIBUTE,
+  bindBatchHighlightUniforms,
+  ensureSlotIdAttribute,
+  installBatchHighlightRenderer,
+  writeSlotIdRange
+} from './highlight'
 
 /**
  * Generic constructor type used to parameterize the batched mixin factory.
@@ -118,6 +127,9 @@ export function initializeGeometry(
   maxIndexCount: number | null
 ) {
   for (const attributeName in reference.attributes) {
+    if (attributeName === BATCH_SLOT_ID_ATTRIBUTE) {
+      continue
+    }
     const srcAttribute = reference.getAttribute(attributeName)
     const { array, itemSize, normalized } = srcAttribute
 
@@ -130,6 +142,8 @@ export function initializeGeometry(
     )
     geometry.setAttribute(attributeName, dstAttribute)
   }
+
+  ensureSlotIdAttribute(geometry, maxVertexCount)
 
   if (maxIndexCount != null && reference.getIndex() !== null) {
     const indexArray =
@@ -170,6 +184,9 @@ export function validateGeometry(
   }
 
   for (const attributeName in batchGeometry.attributes) {
+    if (attributeName === BATCH_SLOT_ID_ATTRIBUTE) {
+      continue
+    }
     if (!geometry.hasAttribute(attributeName)) {
       throw new Error(
         `${typeName}: Added geometry missing "${attributeName}". All geometries must have consistent attributes.`
@@ -402,6 +419,9 @@ export function copyGeometryAttributes(
   reservedVertexCount: number
 ) {
   for (const attributeName in batchGeometry.attributes) {
+    if (attributeName === BATCH_SLOT_ID_ATTRIBUTE) {
+      continue
+    }
     const srcAttribute = geometry.getAttribute(attributeName)
     const dstAttribute = batchGeometry.getAttribute(
       attributeName
@@ -474,13 +494,15 @@ export function copyGeometryIndices(
  * @param batchGeometry - Combined destination geometry.
  * @param geometry - Source geometry payload to write.
  * @param typeName - Batch class name included in error messages.
+ * @param slotId - Geometry slot id written into the `slotId` vertex attribute.
  * @throws {Error} When the source geometry exceeds the slot's reserved capacity.
  */
 export function applyGeometryAt<T extends AcTrBatchGeometryLike>(
   geometryInfo: T,
   batchGeometry: THREE.BufferGeometry,
   geometry: THREE.BufferGeometry,
-  typeName: string
+  typeName: string,
+  slotId: number
 ) {
   const hasIndex = batchGeometry.getIndex() !== null
   const srcIndex = geometry.getIndex()
@@ -532,6 +554,13 @@ export function applyGeometryAt<T extends AcTrBatchGeometryLike>(
       )
     }
   }
+
+  writeSlotIdRange(
+    batchGeometry,
+    vertexStart,
+    reservedVertexCount,
+    slotId
+  )
 }
 
 /**
@@ -741,6 +770,8 @@ export function createAcTrBatchedMixin<
     > = this._batchIntersects as Array<
       THREE.Intersection & { batchId?: number; objectId?: string }
     >
+    /** CPU/GPU highlight mask for packed geometry slots in this batch. */
+    readonly _highlightState = new AcTrBatchHighlightState()
 
     /**
      * Estimated memory footprint and slot count of `_geometryInfo` records.
@@ -882,6 +913,77 @@ export function createAcTrBatchedMixin<
     }
 
     /**
+     * Marks one geometry slot as selected or hovered without copying geometry.
+     *
+     * @param geometryId - Slot index within the batch container.
+     * @param kind - Whether to update selection or hover state.
+     * @param enabled - `true` to highlight the slot, `false` to clear it.
+     * @returns `true` when the slot mask changed.
+     */
+    setHighlightAt(
+      geometryId: number,
+      kind: AcTrBatchHighlightKind,
+      enabled: boolean
+    ) {
+      try {
+        this.validateGeometryId(geometryId)
+      } catch {
+        return false
+      }
+
+      const changed = this._highlightState.setHighlight(
+        geometryId,
+        kind,
+        enabled
+      )
+      if (changed) {
+        installBatchHighlightRenderer(this, this._highlightState)
+      }
+      return changed
+    }
+
+    /**
+     * Uploads the batch highlight mask texture after bulk selection updates.
+     *
+     * @returns This instance for chaining.
+     */
+    flushHighlightMask() {
+      this._highlightState.setAddressableSlotCount(this._geometryInfo.length)
+      if (this._highlightState.dirty) {
+        this._highlightState.uploadMaskTexture()
+      }
+      if (this._highlightState.hasAnyHighlight() && this.material) {
+        bindBatchHighlightUniforms(this.material, this._highlightState)
+      }
+      return this
+    }
+
+    /**
+     * Clears highlight state for one geometry slot.
+     *
+     * @param geometryId - Slot index whose selection and hover flags are cleared.
+     * @returns This instance for chaining.
+     */
+    clearHighlightSlot(geometryId: number) {
+      if (this._highlightState.clearSlot(geometryId)) {
+        installBatchHighlightRenderer(this, this._highlightState)
+      }
+      return this
+    }
+
+    /**
+     * Clears all highlight state owned by this batch.
+     *
+     * @returns This instance for chaining.
+     */
+    clearHighlightState() {
+      if (this._highlightState.clearAll()) {
+        installBatchHighlightRenderer(this, this._highlightState)
+      }
+      return this
+    }
+
+    /**
      * Soft-deletes one geometry slot and registers its id for reuse.
      *
      * Does not compact buffer memory; call `optimize()` on the concrete batch
@@ -900,6 +1002,7 @@ export function createAcTrBatchedMixin<
         return this
       }
 
+      this.clearHighlightSlot(geometryId)
       return this
     }
 

--- a/packages/three-renderer/src/batch/AcTrBatchedPoint.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedPoint.ts
@@ -352,7 +352,7 @@ export class AcTrBatchedPoint extends AcTrBatchedPointBase {
     const batchGeometry = this.geometry
     const geometryInfo = this._geometryInfo[geometryId]
 
-    applyGeometryAt(geometryInfo, batchGeometry, geometry, 'AcTrBatchedPoint')
+    applyGeometryAt(geometryInfo, batchGeometry, geometry, 'AcTrBatchedPoint', geometryId)
 
     return geometryId
   }

--- a/packages/three-renderer/src/batch/highlight/AcTrBatchHighlightShaders.ts
+++ b/packages/three-renderer/src/batch/highlight/AcTrBatchHighlightShaders.ts
@@ -1,0 +1,388 @@
+import * as THREE from 'three'
+
+import {
+  HIGHLIGHT_HOVER_COLOR,
+  HIGHLIGHT_SELECT_COLOR
+} from '../../util/AcTrMaterialUtil'
+import { getMaterialRuntimeUserData } from '../../util/AcTrObjectUserData'
+import { AcTrBatchHighlightState } from './AcTrBatchHighlightState'
+
+/** Uniform bag injected into batch highlight shader programs. */
+export type AcTrBatchHighlightUniforms = {
+  /** RGBA mask texture: R = selected, G = hovered. */
+  u_highlightMask: { value: THREE.Texture }
+  /** Mask texture width and height in pixels. */
+  u_highlightMaskSize: { value: THREE.Vector2 }
+  /** Fragment color applied when the slot is selected. */
+  u_highlightSelectColor: { value: THREE.Color }
+  /** Fragment color applied when the slot is hovered. */
+  u_highlightHoverColor: { value: THREE.Color }
+}
+
+const HIGHLIGHT_FRAGMENT_DECL = /* glsl */ `
+uniform sampler2D u_highlightMask;
+uniform vec2 u_highlightMaskSize;
+uniform vec3 u_highlightSelectColor;
+uniform vec3 u_highlightHoverColor;
+varying float vBatchSlotId;
+
+vec3 applyBatchHighlight(vec3 color) {
+  if (u_highlightMaskSize.x <= 0.0 || u_highlightMaskSize.y <= 0.0) {
+    return color;
+  }
+  vec2 maskUv = vec2(
+    (mod(vBatchSlotId, u_highlightMaskSize.x) + 0.5) / u_highlightMaskSize.x,
+    (floor(vBatchSlotId / u_highlightMaskSize.x) + 0.5) / u_highlightMaskSize.y
+  );
+  vec4 mask = texture2D(u_highlightMask, maskUv);
+  if (mask.r > 0.5) {
+    return u_highlightSelectColor;
+  }
+  if (mask.g > 0.5) {
+    return u_highlightHoverColor;
+  }
+  return color;
+}
+`
+
+const EMPTY_HIGHLIGHT_MASK = /*@__PURE__*/ (() => {
+  const texture = new THREE.DataTexture(new Uint8Array(4), 1, 1, THREE.RGBAFormat)
+  texture.minFilter = THREE.NearestFilter
+  texture.magFilter = THREE.NearestFilter
+  texture.needsUpdate = true
+  return texture
+})()
+
+const warnedUnpatchedMaterials = new Set<string>()
+
+/**
+ * Creates default highlight uniform values backed by a 1×1 empty mask texture.
+ *
+ * @returns Fresh uniform bag for one material instance.
+ */
+function createHighlightUniforms(): AcTrBatchHighlightUniforms {
+  return {
+    u_highlightMask: { value: EMPTY_HIGHLIGHT_MASK },
+    u_highlightMaskSize: { value: new THREE.Vector2(1, 1) },
+    u_highlightSelectColor: { value: HIGHLIGHT_SELECT_COLOR.clone() },
+    u_highlightHoverColor: { value: HIGHLIGHT_HOVER_COLOR.clone() }
+  }
+}
+
+/**
+ * Returns persistent highlight uniforms stored on material runtime userData.
+ *
+ * @param material - Material whose compiled program receives highlight uniforms.
+ * @returns Shared uniform bag for the material.
+ */
+function getOrCreateHighlightUniforms(
+  material: THREE.Material
+): AcTrBatchHighlightUniforms {
+  const runtime = getMaterialRuntimeUserData(material)
+  if (!runtime.batchHighlightUniforms) {
+    runtime.batchHighlightUniforms = createHighlightUniforms()
+  }
+  return runtime.batchHighlightUniforms as AcTrBatchHighlightUniforms
+}
+
+/**
+ * Injects the `slotId` attribute and `vBatchSlotId` varying into a vertex shader.
+ *
+ * @param source - Original vertex shader source.
+ * @returns Patched vertex shader that forwards the batch slot id to the fragment stage.
+ */
+function injectVertexSlotId(source: string) {
+  if (source.includes('vBatchSlotId')) {
+    return source
+  }
+
+  let vertexShader = source
+  if (vertexShader.includes('#include <common>')) {
+    vertexShader = vertexShader.replace(
+      '#include <common>',
+      `#include <common>
+attribute float slotId;
+varying float vBatchSlotId;`
+    )
+  } else {
+    vertexShader = `attribute float slotId;
+varying float vBatchSlotId;
+${vertexShader}`
+  }
+
+  if (vertexShader.includes('#include <begin_vertex>')) {
+    return vertexShader.replace(
+      '#include <begin_vertex>',
+      `#include <begin_vertex>
+vBatchSlotId = slotId;`
+    )
+  }
+
+  if (vertexShader.includes('void main() {')) {
+    return vertexShader.replace(
+      'void main() {',
+      `void main() {
+vBatchSlotId = slotId;`
+    )
+  }
+
+  return vertexShader
+}
+
+/**
+ * Injects highlight sampling helpers and applies tinting before final color output.
+ *
+ * @param source - Original fragment shader source.
+ * @returns Patched fragment shader and whether highlight application was wired in.
+ */
+function injectFragmentHighlight(source: string): {
+  source: string
+  injected: boolean
+} {
+  if (
+    source.includes('applyBatchHighlight(gl_FragColor.rgb)') ||
+    source.includes('applyBatchHighlight(diffuseColor.rgb)')
+  ) {
+    return { source, injected: true }
+  }
+
+  const fragmentShader = source.includes('applyBatchHighlight')
+    ? source
+    : HIGHLIGHT_FRAGMENT_DECL + source
+
+  const applySnippet = 'gl_FragColor.rgb = applyBatchHighlight(gl_FragColor.rgb);'
+
+  if (fragmentShader.includes('#include <dithering_fragment>')) {
+    return {
+      source: fragmentShader.replace(
+        '#include <dithering_fragment>',
+        `${applySnippet}
+#include <dithering_fragment>`
+      ),
+      injected: true
+    }
+  }
+
+  if (fragmentShader.includes('#include <colorspace_fragment>')) {
+    return {
+      source: fragmentShader.split('#include <colorspace_fragment>').join(
+        `${applySnippet}
+#include <colorspace_fragment>`
+      ),
+      injected: true
+    }
+  }
+
+  if (fragmentShader.includes('#include <tonemapping_fragment>')) {
+    return {
+      source: fragmentShader.replace(
+        '#include <tonemapping_fragment>',
+        `${applySnippet}
+#include <tonemapping_fragment>`
+      ),
+      injected: true
+    }
+  }
+
+  if (fragmentShader.includes('gl_FragColor = vec4( diffuseColor.rgb, alpha );')) {
+    return {
+      source: fragmentShader.replace(
+        'gl_FragColor = vec4( diffuseColor.rgb, alpha );',
+        'gl_FragColor = vec4( applyBatchHighlight(diffuseColor.rgb), alpha );'
+      ),
+      injected: true
+    }
+  }
+
+  if (fragmentShader.includes('gl_FragColor = vec4( diffuseColor.rgb, opacity );')) {
+    return {
+      source: fragmentShader.replace(
+        'gl_FragColor = vec4( diffuseColor.rgb, opacity );',
+        'gl_FragColor = vec4( applyBatchHighlight(diffuseColor.rgb), opacity );'
+      ),
+      injected: true
+    }
+  }
+
+  return { source, injected: false }
+}
+
+/**
+ * Logs a one-time development warning when highlight injection fails.
+ *
+ * @param material - Material whose fragment shader could not be patched.
+ */
+function warnUnpatchedHighlightMaterial(material: THREE.Material) {
+  if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'production') {
+    return
+  }
+
+  const key = material.type
+  if (warnedUnpatchedMaterials.has(key)) {
+    return
+  }
+  warnedUnpatchedMaterials.add(key)
+  console.warn(
+    `[AcTrBatchHighlight] Could not inject highlight shader for material type "${key}". Highlight tinting may be skipped.`
+  )
+}
+
+/**
+ * Merges persistent highlight uniforms into one compiled shader parameter bag.
+ *
+ * @param shader - Shader parameters produced by Three.js compilation.
+ * @param uniforms - Highlight uniform bag owned by the source material.
+ */
+function mergeShaderUniforms(
+  shader: THREE.WebGLProgramParametersWithUniforms,
+  uniforms: AcTrBatchHighlightUniforms
+) {
+  shader.uniforms.u_highlightMask = uniforms.u_highlightMask
+  shader.uniforms.u_highlightMaskSize = uniforms.u_highlightMaskSize
+  shader.uniforms.u_highlightSelectColor = uniforms.u_highlightSelectColor
+  shader.uniforms.u_highlightHoverColor = uniforms.u_highlightHoverColor
+}
+
+/**
+ * Copies highlight uniforms onto a {@link THREE.ShaderMaterial} instance.
+ *
+ * @param material - Shader material receiving direct uniform references.
+ * @param uniforms - Highlight uniform bag to bind.
+ */
+function attachHighlightUniforms(
+  material: THREE.Material,
+  uniforms: AcTrBatchHighlightUniforms
+) {
+  if (material instanceof THREE.ShaderMaterial) {
+    material.uniforms.u_highlightMask = uniforms.u_highlightMask
+    material.uniforms.u_highlightMaskSize = uniforms.u_highlightMaskSize
+    material.uniforms.u_highlightSelectColor = uniforms.u_highlightSelectColor
+    material.uniforms.u_highlightHoverColor = uniforms.u_highlightHoverColor
+  }
+}
+
+/**
+ * Forces Three.js to recompile or refresh uniforms for a patched material.
+ *
+ * @param material - Material whose GPU program must be rebuilt or updated.
+ */
+function markMaterialProgramDirty(material: THREE.Material) {
+  material.needsUpdate = true
+  if (material instanceof THREE.ShaderMaterial) {
+    material.uniformsNeedUpdate = true
+  }
+}
+
+/**
+ * Patches one material so batched draw calls can tint highlighted slots via
+ * a per-batch mask texture bound in {@link bindBatchHighlightUniforms}.
+ *
+ * @param material - Drawable material compiled for batched geometry rendering.
+ */
+export function patchMaterialForBatchHighlight(material: THREE.Material) {
+  const runtime = getMaterialRuntimeUserData(material)
+  const uniforms = getOrCreateHighlightUniforms(material)
+
+  if (!runtime.batchHighlightPatched) {
+    runtime.batchHighlightPatched = true
+
+    if (material instanceof THREE.ShaderMaterial) {
+      material.vertexShader = injectVertexSlotId(material.vertexShader)
+      const fragmentPatch = injectFragmentHighlight(material.fragmentShader)
+      material.fragmentShader = fragmentPatch.source
+      if (!fragmentPatch.injected) {
+        warnUnpatchedHighlightMaterial(material)
+      }
+    } else {
+      const previousOnBeforeCompile = material.onBeforeCompile
+      material.onBeforeCompile = (shader, renderer) => {
+        previousOnBeforeCompile?.call(material, shader, renderer)
+        mergeShaderUniforms(shader, uniforms)
+        shader.vertexShader = injectVertexSlotId(shader.vertexShader)
+        const fragmentPatch = injectFragmentHighlight(shader.fragmentShader)
+        shader.fragmentShader = fragmentPatch.source
+        if (!fragmentPatch.injected) {
+          warnUnpatchedHighlightMaterial(material)
+        }
+      }
+
+      const previousCacheKey = material.customProgramCacheKey
+      material.customProgramCacheKey = () =>
+        `${previousCacheKey.call(material)}|batchHighlight`
+    }
+
+    attachHighlightUniforms(material, uniforms)
+    markMaterialProgramDirty(material)
+    return
+  }
+
+  attachHighlightUniforms(material, uniforms)
+}
+
+/**
+ * Binds one batch highlight mask to the compiled material uniforms.
+ *
+ * @param material - One material or material array used by the batch drawable.
+ * @param state - CPU/GPU highlight mask owned by the batch container.
+ */
+export function bindBatchHighlightUniforms(
+  material: THREE.Material | THREE.Material[],
+  state: AcTrBatchHighlightState
+) {
+  const materials = Array.isArray(material) ? material : [material]
+  const texture = state.uploadMaskTexture()
+
+  for (const entry of materials) {
+    patchMaterialForBatchHighlight(entry)
+    const uniforms = getOrCreateHighlightUniforms(entry)
+    uniforms.u_highlightMask.value = texture
+    const dimensions = state.getMaskTextureDimensions()
+    uniforms.u_highlightMaskSize.value.set(dimensions.width, dimensions.height)
+    uniforms.u_highlightSelectColor.value.copy(HIGHLIGHT_SELECT_COLOR)
+    uniforms.u_highlightHoverColor.value.copy(HIGHLIGHT_HOVER_COLOR)
+    if (entry instanceof THREE.ShaderMaterial) {
+      entry.uniformsNeedUpdate = true
+    }
+  }
+}
+
+/**
+ * Installs an `onBeforeRender` hook that uploads the batch highlight mask
+ * before each draw call sharing the batch material.
+ *
+ * @param object - Batch drawable whose draw calls should refresh highlight uniforms.
+ * @param state - CPU/GPU highlight mask owned by the batch container.
+ */
+export function installBatchHighlightRenderer(
+  object: THREE.Object3D,
+  state: AcTrBatchHighlightState
+) {
+  const runtime = object.userData as { batchHighlightRendererInstalled?: boolean }
+  if (runtime.batchHighlightRendererInstalled) {
+    return
+  }
+  runtime.batchHighlightRendererInstalled = true
+
+  const previousOnBeforeRender = object.onBeforeRender
+  object.onBeforeRender = (
+    renderer,
+    scene,
+    camera,
+    geometry,
+    material,
+    group
+  ) => {
+    previousOnBeforeRender?.(
+      renderer,
+      scene,
+      camera,
+      geometry,
+      material,
+      group
+    )
+    if (!state.hasAnyHighlight() || !material) {
+      return
+    }
+    bindBatchHighlightUniforms(material, state)
+  }
+}

--- a/packages/three-renderer/src/batch/highlight/AcTrBatchHighlightState.ts
+++ b/packages/three-renderer/src/batch/highlight/AcTrBatchHighlightState.ts
@@ -1,0 +1,248 @@
+import * as THREE from 'three'
+
+/** Highlight interaction kind bound to one packed geometry slot. */
+export type AcTrBatchHighlightKind = 'select' | 'hover'
+
+/** Safe upper bound for one highlight mask texture dimension. */
+const MAX_MASK_TEXTURE_DIMENSION = 4096
+
+/**
+ * Computes a 2D mask texture layout that fits `slotCount` slots within GPU
+ * dimension limits.
+ *
+ * @param slotCount - Number of geometry slots to encode in the mask texture.
+ * @returns Pixel width and height of the highlight mask texture.
+ * @throws {Error} When the slot count exceeds the maximum mask texture capacity.
+ */
+function computeMaskTextureLayout(slotCount: number) {
+  const count = Math.max(slotCount, 1)
+  if (count <= MAX_MASK_TEXTURE_DIMENSION) {
+    return { width: count, height: 1 }
+  }
+
+  const width = MAX_MASK_TEXTURE_DIMENSION
+  const height = Math.ceil(count / width)
+  if (height > MAX_MASK_TEXTURE_DIMENSION) {
+    throw new Error(
+      `AcTrBatchHighlightState: slot count ${count} exceeds highlight mask capacity.`
+    )
+  }
+  return { width, height }
+}
+
+/**
+ * Per-batch CPU/GPU highlight mask for packed geometry slots.
+ *
+ * Selection and hover each occupy one channel in an RGBA `DataTexture`.
+ * Large batches use a 2D texture layout so width stays within GPU limits.
+ */
+export class AcTrBatchHighlightState {
+  /** CPU-side selection flags indexed by geometry slot id. */
+  selectedMask = new Uint8Array(0)
+  /** CPU-side hover flags indexed by geometry slot id. */
+  hoveredMask = new Uint8Array(0)
+  /** GPU mask texture uploaded from {@link selectedMask} and {@link hoveredMask}. */
+  maskTexture: THREE.DataTexture | null = null
+  /** Current width of {@link maskTexture} in pixels. */
+  maskTextureWidth = 0
+  /** Current height of {@link maskTexture} in pixels. */
+  maskTextureHeight = 0
+  /** Whether CPU mask data changed since the last texture upload. */
+  dirty = false
+  /**
+   * Highest slot index that may appear in vertex `slotId` attributes for this
+   * batch, regardless of whether that slot is currently highlighted.
+   */
+  addressableSlotCount = 0
+
+  /**
+   * Returns the number of slots the mask texture must cover for correct UV
+   * lookups from any packed geometry in the batch.
+   */
+  getTextureSlotCount() {
+    return Math.max(
+      this.selectedMask.length,
+      this.hoveredMask.length,
+      this.addressableSlotCount,
+      1
+    )
+  }
+
+  /**
+   * Grows CPU mask arrays when the batch needs to address more geometry slots.
+   *
+   * @param slotCount - Minimum number of slots that must be addressable.
+   */
+  ensureCapacity(slotCount: number) {
+    if (slotCount <= this.selectedMask.length) {
+      return
+    }
+    const newSize = Math.max(slotCount, this.selectedMask.length * 2, 16)
+    const selectedMask = new Uint8Array(newSize)
+    const hoveredMask = new Uint8Array(newSize)
+    selectedMask.set(this.selectedMask)
+    hoveredMask.set(this.hoveredMask)
+    this.selectedMask = selectedMask
+    this.hoveredMask = hoveredMask
+  }
+
+  /**
+   * Records how many geometry slots may appear in packed vertex attributes.
+   *
+   * Ensures the uploaded mask texture is large enough that unhighlighted slots
+   * sample zero rather than clamping to a highlighted edge texel.
+   *
+   * @param slotCount - One plus the highest geometry slot id in the batch.
+   */
+  setAddressableSlotCount(slotCount: number) {
+    if (slotCount <= this.addressableSlotCount) {
+      return
+    }
+
+    const previousLayout = computeMaskTextureLayout(this.getTextureSlotCount())
+    this.addressableSlotCount = slotCount
+    this.ensureCapacity(slotCount)
+
+    const nextLayout = computeMaskTextureLayout(this.getTextureSlotCount())
+    if (
+      this.maskTexture != null &&
+      (previousLayout.width !== nextLayout.width ||
+        previousLayout.height !== nextLayout.height)
+    ) {
+      this.dirty = true
+    }
+  }
+
+  /**
+   * Sets or clears one highlight flag for a geometry slot.
+   *
+   * @param slotId - Packed geometry slot index within the batch.
+   * @param kind - Whether to update selection or hover state.
+   * @param enabled - `true` to highlight the slot, `false` to clear it.
+   * @returns `true` when the mask value changed.
+   */
+  setHighlight(slotId: number, kind: AcTrBatchHighlightKind, enabled: boolean) {
+    this.ensureCapacity(slotId + 1)
+    const mask = kind === 'select' ? this.selectedMask : this.hoveredMask
+    const next = enabled ? 1 : 0
+    if (mask[slotId] === next) {
+      return false
+    }
+    mask[slotId] = next
+    this.dirty = true
+    return true
+  }
+
+  /**
+   * Clears both selection and hover flags for one geometry slot.
+   *
+   * @param slotId - Packed geometry slot index within the batch.
+   * @returns `true` when either mask channel changed.
+   */
+  clearSlot(slotId: number) {
+    let changed = false
+    if (this.selectedMask[slotId]) {
+      this.selectedMask[slotId] = 0
+      changed = true
+    }
+    if (this.hoveredMask[slotId]) {
+      this.hoveredMask[slotId] = 0
+      changed = true
+    }
+    if (changed) {
+      this.dirty = true
+    }
+    return changed
+  }
+
+  /**
+   * Clears all selection and hover flags owned by this batch.
+   *
+   * @returns `true` when any mask data existed before clearing.
+   */
+  clearAll() {
+    if (!this.hasAnyHighlight()) {
+      return false
+    }
+    this.selectedMask.fill(0)
+    this.hoveredMask.fill(0)
+    this.dirty = true
+    return true
+  }
+
+  /**
+   * Returns whether any geometry slot is currently selected or hovered.
+   *
+   * @returns `true` when at least one slot has a non-zero mask value.
+   */
+  hasAnyHighlight() {
+    for (let i = 0; i < this.selectedMask.length; i++) {
+      if (this.selectedMask[i] || this.hoveredMask[i]) {
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
+   * Uploads CPU mask arrays into {@link maskTexture}, reallocating when layout
+   * dimensions change.
+   *
+   * @param force - When `true`, rebuilds the texture even if {@link dirty} is false.
+   * @returns The mask texture bound by batch highlight shaders.
+   */
+  uploadMaskTexture(force = false) {
+    if (!force && !this.dirty && this.maskTexture != null) {
+      return this.maskTexture
+    }
+
+    const slotCount = this.getTextureSlotCount()
+    const { width, height } = computeMaskTextureLayout(slotCount)
+    const data = new Uint8Array(width * height * 4)
+
+    for (let slotId = 0; slotId < slotCount; slotId++) {
+      const x = slotId % width
+      const y = Math.floor(slotId / width)
+      const offset = (y * width + x) * 4
+      data[offset] = this.selectedMask[slotId] ? 255 : 0
+      data[offset + 1] = this.hoveredMask[slotId] ? 255 : 0
+    }
+
+    if (
+      this.maskTexture == null ||
+      this.maskTextureWidth !== width ||
+      this.maskTextureHeight !== height
+    ) {
+      this.maskTexture?.dispose()
+      this.maskTexture = new THREE.DataTexture(
+        data,
+        width,
+        height,
+        THREE.RGBAFormat
+      )
+      this.maskTexture.minFilter = THREE.NearestFilter
+      this.maskTexture.magFilter = THREE.NearestFilter
+      this.maskTexture.needsUpdate = true
+      this.maskTextureWidth = width
+      this.maskTextureHeight = height
+    } else {
+      this.maskTexture.image.data = data
+      this.maskTexture.needsUpdate = true
+    }
+
+    this.dirty = false
+    return this.maskTexture
+  }
+
+  /**
+   * Returns the pixel dimensions of the current highlight mask texture.
+   *
+   * @returns Width and height, each at least `1`.
+   */
+  getMaskTextureDimensions() {
+    return {
+      width: Math.max(this.maskTextureWidth, 1),
+      height: Math.max(this.maskTextureHeight, 1)
+    }
+  }
+}

--- a/packages/three-renderer/src/batch/highlight/AcTrBatchSlotId.ts
+++ b/packages/three-renderer/src/batch/highlight/AcTrBatchSlotId.ts
@@ -1,0 +1,59 @@
+import * as THREE from 'three'
+
+/** Buffer attribute name storing the packed geometry slot id per vertex/instance. */
+export const BATCH_SLOT_ID_ATTRIBUTE = 'slotId'
+
+/**
+ * Ensures the batch geometry owns a `slotId` float attribute with at least
+ * `capacity` entries.
+ *
+ * @param geometry - Combined batch geometry receiving slot id attributes.
+ * @param capacity - Minimum number of vertex or instance entries required.
+ * @returns The existing or newly allocated `slotId` buffer attribute.
+ */
+export function ensureSlotIdAttribute(
+  geometry: THREE.BufferGeometry,
+  capacity: number
+) {
+  const existing = geometry.getAttribute(BATCH_SLOT_ID_ATTRIBUTE) as
+    | THREE.BufferAttribute
+    | undefined
+  if (existing) {
+    if (existing.count >= capacity) {
+      return existing
+    }
+    const next = new THREE.Float32BufferAttribute(capacity, 1)
+    next.array.set(existing.array.subarray(0, existing.count))
+    geometry.setAttribute(BATCH_SLOT_ID_ATTRIBUTE, next)
+    return next
+  }
+
+  const attribute = new THREE.Float32BufferAttribute(capacity, 1)
+  geometry.setAttribute(BATCH_SLOT_ID_ATTRIBUTE, attribute)
+  return attribute
+}
+
+/**
+ * Writes one slot id across a contiguous vertex/instance range.
+ *
+ * @param geometry - Combined batch geometry whose `slotId` attribute is updated.
+ * @param start - First vertex or instance index in the range.
+ * @param count - Number of consecutive entries to write.
+ * @param slotId - Packed geometry slot id stored in each entry.
+ */
+export function writeSlotIdRange(
+  geometry: THREE.BufferGeometry,
+  start: number,
+  count: number,
+  slotId: number
+) {
+  if (count <= 0) {
+    return
+  }
+
+  const attribute = ensureSlotIdAttribute(geometry, start + count)
+  const array = attribute.array as Float32Array
+  array.fill(slotId, start, start + count)
+  attribute.addUpdateRange(start, count)
+  attribute.needsUpdate = true
+}

--- a/packages/three-renderer/src/batch/highlight/index.ts
+++ b/packages/three-renderer/src/batch/highlight/index.ts
@@ -1,0 +1,14 @@
+export {
+  BATCH_SLOT_ID_ATTRIBUTE,
+  ensureSlotIdAttribute,
+  writeSlotIdRange
+} from './AcTrBatchSlotId'
+export {
+  AcTrBatchHighlightState,
+  type AcTrBatchHighlightKind
+} from './AcTrBatchHighlightState'
+export {
+  bindBatchHighlightUniforms,
+  installBatchHighlightRenderer,
+  patchMaterialForBatchHighlight
+} from './AcTrBatchHighlightShaders'

--- a/packages/three-renderer/src/index.ts
+++ b/packages/three-renderer/src/index.ts
@@ -34,6 +34,7 @@ export {
   getSceneDrawableUserData,
   isHighlightCloneDrawable,
   isHighlightOverlayDescendant,
+  resolveDrawableExportMaterial,
   markHighlightOverlayGroup,
   patchDrawableMaterialFromCache,
   resolveCachedMaterialRemap,

--- a/packages/three-renderer/src/util/AcTrMaterialUtil.ts
+++ b/packages/three-renderer/src/util/AcTrMaterialUtil.ts
@@ -3,9 +3,23 @@ import * as THREE from 'three'
 import { getMaterialRuntimeUserData } from './AcTrObjectUserData'
 
 /**
- * Highlight color.
+ * Selection highlight color.
+ *
+ * Replace with a system-variable-driven value when CAD sysvars are wired in.
  */
-export const HIGHLIGHT_COLOR = new THREE.Color(0x08e8de)
+export const HIGHLIGHT_SELECT_COLOR = new THREE.Color(0x08e8de)
+
+/**
+ * Hover highlight color.
+ *
+ * Replace with a system-variable-driven value when CAD sysvars are wired in.
+ */
+export const HIGHLIGHT_HOVER_COLOR = new THREE.Color(0x66fff8)
+
+/**
+ * @deprecated Use {@link HIGHLIGHT_SELECT_COLOR} instead.
+ */
+export const HIGHLIGHT_COLOR = HIGHLIGHT_SELECT_COLOR
 
 /**
  * Type for materials that have color property
@@ -49,7 +63,7 @@ export class AcTrMaterialUtil {
 
   public static setMaterialColor(
     material: THREE.Material | THREE.Material[],
-    color: THREE.Color = HIGHLIGHT_COLOR
+    color: THREE.Color = HIGHLIGHT_SELECT_COLOR
   ) {
     if (Array.isArray(material)) {
       material.forEach(mat => this.setMaterialColor(mat, color))
@@ -115,6 +129,8 @@ export class AcTrMaterialUtil {
     const materialData = getMaterialRuntimeUserData(material)
     delete materialData.relativeToEyePatchVersion
     delete materialData.relativeToEyeCompiledShader
+    delete materialData.batchHighlightPatched
+    delete materialData.batchHighlightUniforms
     material.onBeforeCompile = THREE.Material.prototype.onBeforeCompile
     material.customProgramCacheKey =
       THREE.Material.prototype.customProgramCacheKey

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -338,6 +338,27 @@ export function isHighlightCloneDrawable(object: THREE.Object3D): boolean {
   return true
 }
 
+/**
+ * Returns the drawable material to use for HTML/export snapshots.
+ *
+ * Unbatched selection and hover tinting swaps materials in place while
+ * preserving the source material on {@link AcTrObjectUserDataFields.originalMaterial}.
+ */
+export function resolveDrawableExportMaterial(
+  object: THREE.Object3D
+): THREE.Material | THREE.Material[] | undefined {
+  if (!('material' in object)) {
+    return undefined
+  }
+
+  const originalMaterial = getObjectUserData(object).originalMaterial
+  if (originalMaterial != null) {
+    return originalMaterial
+  }
+
+  return object.material as THREE.Material | THREE.Material[]
+}
+
 export function getBatchedContainerUserData(
   object: THREE.Object3D
 ): AcTrBatchedContainerUserData {

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -27,6 +27,10 @@ export interface AcTrMaterialRuntimeUserData {
   relativeToEyePatchVersion?: string
   /** Compiled shader instance from the latest `onBeforeCompile`. */
   relativeToEyeCompiledShader?: unknown
+  /** Batch slot-mask highlight shader patch installed on this material. */
+  batchHighlightPatched?: boolean
+  /** Persistent highlight uniform bag shared by compiled shader programs. */
+  batchHighlightUniforms?: Record<string, { value: unknown }>
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace per-entity overlay drawables with shader-based slot-mask highlighting for batched lines, meshes, and points, using a per-batch `slotId` vertex attribute and RGBA mask texture (select/hover channels).
- Add `hoverMany`,  `selectMany` bulk APIs on `AcTrBatchedGroup` and layer-level grouping in `AcTrLayout` to batch highlight updates and avoid redundant GPU uploads.
- Add highlight module (`AcTrBatchHighlightState`, shaders, slot-id helpers) with 2D mask texture layout for large batches (up to 4096x4096 slots) and tests covering mask uploads, bulk selection, and unbatched fallback behavior.

## Test plan
- [ ] Run `pnpm nx test three-renderer` and confirm `AcTrBatchedGroupHighlight.spec.ts` passes
- [ ] Open a drawing with many batched entities; verify hover and selection highlights render correctly
- [ ] Box-select or quick-select many entities at once; confirm no visual lag or missing highlights
- [ ] Toggle hover after selection and back; confirm hover color persists when selection is cleared