### PR TITLE
feat(cad-html-plugin): compute OSNAP lazily and release catalog memory

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
@@ -87,6 +87,67 @@ describe('AcExOsnapIndex', () => {
     expect(snap).toEqual({ x: 0, y: 0, mode: 'endpoint' })
   })
 
+  it('derives endpoint snap points from catalog primitives', () => {
+    const index = new AcExOsnapIndex(['endpoint', 'nearest'])
+    index.rebuild({
+      ...layout,
+      lineBatches: [],
+      osnap: {
+        primitives: [
+          {
+            kind: 'line',
+            layer: '0',
+            x0: 0,
+            y0: 0,
+            x1: 10,
+            y1: 0
+          }
+        ]
+      }
+    })
+    expect(index.findSnap(0.2, 0.1, 1)).toEqual({
+      x: 0,
+      y: 0,
+      mode: 'endpoint'
+    })
+    expect(index.findSnap(5, 0.1, 1)?.mode).toBe('nearest')
+  })
+
+  it('snaps to intersection from catalog primitives', () => {
+    const index = new AcExOsnapIndex(['intersection', 'endpoint'])
+    index.rebuild({
+      ...layout,
+      lineBatches: [],
+      osnap: {
+        primitives: [
+          {
+            kind: 'line',
+            layer: '0',
+            x0: 0,
+            y0: 0,
+            x1: 10,
+            y1: 10
+          },
+          {
+            kind: 'line',
+            layer: '0',
+            x0: 0,
+            y0: 10,
+            x1: 10,
+            y1: 0
+          }
+        ]
+      }
+    })
+    const snap = index.findSnap(5.1, 4.9, 1)
+    expect(snap).toEqual({ x: 5, y: 5, mode: 'intersection' })
+    expect(index.findSnap(0.2, 0.1, 1)).toEqual({
+      x: 0,
+      y: 0,
+      mode: 'endpoint'
+    })
+  })
+
   it('snaps to segment midpoint', () => {
     const index = new AcExOsnapIndex(['midpoint'])
     index.rebuild(layout)

--- a/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
@@ -4,6 +4,7 @@ import {
   AcDbBlockTableRecord,
   AcDbDatabase,
   AcDbDataGenerator,
+  AcDbEllipse,
   AcDbHatch,
   AcDbLeader,
   AcDbLine,
@@ -11,6 +12,7 @@ import {
   AcDbMLeaderContentType,
   AcDbMLine,
   AcDbPoint,
+  AcDbPolyline,
   AcDbRasterImage,
   AcDbRay,
   AcDbTable,
@@ -79,6 +81,43 @@ describe('buildOsnapCatalog', () => {
     expect(line?.y0).toBeCloseTo(0, 5)
     expect(line?.x1).toBeCloseTo(0, 5)
     expect(line?.y1).toBeCloseTo(10, 5)
+  })
+
+  it('exports all snap-capable primitives', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+    modelSpace.appendEntity(
+      new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(10, 0, 0))
+    )
+    modelSpace.appendEntity(
+      new AcDbEllipse(
+        new AcGePoint3d(20, 0, 0),
+        AcGeVector3d.Z_AXIS,
+        new AcGeVector3d(4, 0, 0),
+        4,
+        2,
+        0,
+        Math.PI * 2
+      )
+    )
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+
+    expect(catalog.primitives.some(prim => prim.kind === 'line')).toBe(true)
+    expect(catalog.primitives.some(prim => prim.kind === 'ellipse')).toBe(true)
+  })
+
+  it('exports polyline segments as line primitives', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+    const polyline = new AcDbPolyline()
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0))
+    polyline.addVertexAt(1, new AcGePoint2d(10, 0))
+    polyline.addVertexAt(2, new AcGePoint2d(10, 10))
+    modelSpace.appendEntity(polyline)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    expect(catalog.primitives.filter(p => p.kind === 'line').length).toBe(2)
   })
 
   it('exports snap primitives for dimension anonymous blocks', () => {

--- a/packages/cad-html-plugin/__tests__/AcExViewerMemory.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExViewerMemory.spec.ts
@@ -7,7 +7,8 @@ import {
   canReleaseActiveLayoutBatches,
   copyFloat32Buffer,
   releaseLayerGroupsGeometryCpuArrays,
-  releaseSnapshotBatchBuffers
+  releaseSnapshotBatchBuffers,
+  releaseSnapshotOsnapCatalogs
 } from '../src/AcExViewerMemory'
 import { ACEX_SNAPSHOT_VERSION } from '../src/AcExSnapshotTypes'
 
@@ -90,7 +91,7 @@ describe('AcExViewerMemory', () => {
     expect(copy[0]).toBe(1)
   })
 
-  it('canReleaseActiveLayoutBatches requires analytic osnap catalog', () => {
+  it('canReleaseActiveLayoutBatches requires analytic osnap primitives', () => {
     const withOsnap = makeSnapshot().layouts[0]!
     expect(canReleaseActiveLayoutBatches(withOsnap)).toBe(true)
 
@@ -115,6 +116,19 @@ describe('AcExViewerMemory', () => {
 
     expect(snapshot.layouts[0]!.lineBatches).toHaveLength(0)
     expect(snapshot.layouts[1]!.lineBatches).toHaveLength(0)
+  })
+
+  it('releaseSnapshotOsnapCatalogs clears layout catalogs without dropping retained primitives', () => {
+    const snapshot = makeSnapshot()
+    const activeLayout = snapshot.layouts[0]!
+    const retained = activeLayout.osnap!.primitives
+
+    releaseSnapshotOsnapCatalogs(snapshot)
+
+    expect(activeLayout.osnap).toBeUndefined()
+    expect(snapshot.layouts[1]!.osnap).toBeUndefined()
+    expect(retained).toHaveLength(1)
+    expect(retained[0]).toMatchObject({ kind: 'line', x0: 0, y0: 0, x1: 1, y1: 0 })
   })
 
   it('releaseSnapshotBatchBuffers keeps active layout batches without osnap catalog', () => {

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -33,6 +33,7 @@ import {
   copyUint32Buffer,
   releaseLayerGroupsGeometryCpuArrays,
   releaseSnapshotBatchBuffers,
+  releaseSnapshotOsnapCatalogs,
   removeSnapshotElement
 } from './AcExViewerMemory'
 
@@ -169,6 +170,7 @@ function startViewer(): void {
   }
 
   releaseSnapshotBatchBuffers(snapshot, snapshot.activeLayoutBtrId)
+  releaseSnapshotOsnapCatalogs(snapshot)
   removeSnapshotElement(snapshotEl)
 
   const updateCameraFrustum = (width?: number, height?: number) => {

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -15,10 +15,7 @@ import {
   intersectPrimitivePair,
   isIntersectionCapablePrimitive
 } from './AcExOsnapIntersections'
-import {
-  type AcExOsnapAcGeCurve,
-  primitiveToAcGeCurve
-} from './AcExOsnapPrimitiveToAcGe'
+import { primitiveToAcGeCurve } from './AcExOsnapPrimitiveToAcGe'
 import type {
   AcExOsnapMode,
   AcExOsnapPoint,
@@ -473,24 +470,6 @@ interface AcExRbushEntry {
   index: number
 }
 
-/** One pre-indexed discrete snap point (endpoint, center, etc.). @internal */
-interface AcExIndexedSnapPoint {
-  x: number
-  y: number
-  mode: AcExOsnapMode
-  layer: string
-}
-
-/** Source geometry for nearest snap and intersection queries. @internal */
-type AcExNearestSource =
-  | {
-      kind: 'primitive'
-      index: number
-      layer: string
-      geo?: AcExOsnapAcGeCurve
-    }
-  | { kind: 'segment'; index: number; layer: string }
-
 /** Squared distance from a point to an axis-aligned box exterior (0 when inside). @internal */
 function distSqToBounds(
   px: number,
@@ -570,19 +549,16 @@ function primitiveBounds(prim: AcExOsnapPrimitive): {
 /**
  * Spatial index for object snap in the offline HTML viewer.
  *
- * Discrete snap points (endpoint, midpoint, center, quadrant, node) are indexed
- * in an RBush tree at {@link AcExOsnapIndex.rebuild} so pointer queries avoid
- * rebuilding `AcGe*` curves. Nearest snap runs only when no discrete candidate
- * lies within the aperture.
+ * {@link AcExOsnapIndex.rebuild} loads analytic primitives and tessellated
+ * segments into RBush trees only. Discrete snap points, nearest, and
+ * intersection candidates are computed on pointer query from nearby geometry.
  */
 export class AcExOsnapIndex {
   private segments: AcExOsnapSegment[] = []
   private segmentLayers: string[] = []
   private primitives: AcExOsnapPrimitive[] = []
-  private snapPoints: AcExIndexedSnapPoint[] = []
-  private snapPointTree = new RBush<AcExRbushEntry>()
-  private nearestSources: AcExNearestSource[] = []
-  private nearestTree = new RBush<AcExRbushEntry>()
+  private primitiveTree = new RBush<AcExRbushEntry>()
+  private segmentTree = new RBush<AcExRbushEntry>()
   private modes: Set<AcExOsnapMode>
   private hiddenLayers = new Set<string>()
 
@@ -625,120 +601,53 @@ export class AcExOsnapIndex {
   }
 
   /**
-   * Builds the snap index from the active layout snapshot.
+   * Builds spatial indexes from the active layout snapshot.
    *
-   * Indexes all analytic and tessellated geometry once. Layer visibility is
-   * applied at query time via {@link setLayerHidden}, {@link showAllLayers}, and
-   * {@link hideAllLayers} so toggling many layers stays O(1).
+   * Loads analytic primitives and tessellated segments into RBush trees.
+   * Snap candidates are computed lazily during {@link findSnap}.
    *
    * @param layout - Active layout snapshot (batches + optional {@link AcExLayoutSnapshot.osnap}).
    */
   rebuild(layout: AcExLayoutSnapshot): void {
-    const catalog = layout.osnap
-    this.primitives = catalog?.primitives ?? []
-    if (this.primitives.length > 0) {
-      this.segments = []
-      this.segmentLayers = []
-    } else {
+    this.primitiveTree.clear()
+    this.segmentTree.clear()
+    this.hiddenLayers.clear()
+    this.segments = []
+    this.segmentLayers = []
+
+    this.primitives = layout.osnap?.primitives ?? []
+    if (this.primitives.length === 0) {
       const collected = collectBatchSegments(layout)
       this.segments = collected.segments
       this.segmentLayers = collected.segmentLayers
     }
 
-    this.snapPoints = []
-    this.snapPointTree.clear()
-    this.nearestSources = []
-    this.nearestTree.clear()
-    this.hiddenLayers.clear()
-
-    const discreteModes = new Set(this.modes)
-    discreteModes.delete('nearest')
-    discreteModes.delete('intersection')
-    const wantsNearest = this.modes.has('nearest')
-    const wantsIntersection = this.modes.has('intersection')
-    const wantsGeometryTree = wantsNearest || wantsIntersection
-
-    for (let i = 0; i < this.primitives.length; i++) {
-      const prim = this.primitives[i]!
-      const geo = wantsNearest ? primitiveToAcGeCurve(prim) : undefined
-      if (wantsGeometryTree && prim.kind !== 'point') {
-        this.nearestSources.push({
-          kind: 'primitive',
-          index: i,
-          layer: prim.layer,
-          geo
-        })
-      }
-      if (discreteModes.size > 0) {
-        for (const candidate of collectPrimitiveDiscreteSnapCandidates(
-          prim,
-          discreteModes,
-          geo
-        )) {
-          this.snapPoints.push({
-            x: candidate.x,
-            y: candidate.y,
-            mode: candidate.mode,
-            layer: prim.layer
-          })
-        }
-      }
-    }
-
-    for (let i = 0; i < this.segments.length; i++) {
-      const seg = this.segments[i]!
-      const layer = this.segmentLayers[i]!
-      if (wantsGeometryTree) {
-        this.nearestSources.push({ kind: 'segment', index: i, layer })
-      }
-      if (discreteModes.has('endpoint')) {
-        this.snapPoints.push(
-          { x: seg.x0, y: seg.y0, mode: 'endpoint', layer },
-          { x: seg.x1, y: seg.y1, mode: 'endpoint', layer }
-        )
-      }
-      if (discreteModes.has('midpoint')) {
-        this.snapPoints.push({
-          x: (seg.x0 + seg.x1) * 0.5,
-          y: (seg.y0 + seg.y1) * 0.5,
-          mode: 'midpoint',
-          layer
-        })
-      }
-    }
-
-    if (this.snapPoints.length === 0 && this.nearestSources.length === 0) {
+    if (this.primitives.length === 0 && this.segments.length === 0) {
       return
     }
 
-    const snapEntries: AcExRbushEntry[] = new Array(this.snapPoints.length)
-    for (let i = 0; i < this.snapPoints.length; i++) {
-      const point = this.snapPoints[i]!
-      snapEntries[i] = {
-        minX: point.x,
-        minY: point.y,
-        maxX: point.x,
-        maxY: point.y,
-        index: i
+    if (this.primitives.length > 0) {
+      const primitiveEntries: AcExRbushEntry[] = new Array(
+        this.primitives.length
+      )
+      for (let i = 0; i < this.primitives.length; i++) {
+        primitiveEntries[i] = {
+          ...primitiveBounds(this.primitives[i]!),
+          index: i
+        }
       }
-    }
-    if (snapEntries.length > 0) {
-      this.snapPointTree.load(snapEntries)
+      this.primitiveTree.load(primitiveEntries)
     }
 
-    const nearestEntries: AcExRbushEntry[] = new Array(
-      this.nearestSources.length
-    )
-    for (let i = 0; i < this.nearestSources.length; i++) {
-      const source = this.nearestSources[i]!
-      const b =
-        source.kind === 'primitive'
-          ? primitiveBounds(this.primitives[source.index]!)
-          : segmentBounds(this.segments[source.index]!)
-      nearestEntries[i] = { ...b, index: i }
-    }
-    if (nearestEntries.length > 0) {
-      this.nearestTree.load(nearestEntries)
+    if (this.segments.length > 0) {
+      const segmentEntries: AcExRbushEntry[] = new Array(this.segments.length)
+      for (let i = 0; i < this.segments.length; i++) {
+        segmentEntries[i] = {
+          ...segmentBounds(this.segments[i]!),
+          index: i
+        }
+      }
+      this.segmentTree.load(segmentEntries)
     }
   }
 
@@ -764,7 +673,7 @@ export class AcExOsnapIndex {
     threshold: number
   ): AcExOsnapPoint | undefined {
     if (threshold <= 0) return undefined
-    if (this.snapPoints.length === 0 && this.nearestSources.length === 0) {
+    if (this.primitives.length === 0 && this.segments.length === 0) {
       return undefined
     }
 
@@ -825,11 +734,10 @@ export class AcExOsnapIndex {
     py: number,
     threshold: number
   ): AcExOsnapPoint | undefined {
-    if (this.nearestSources.length === 0) return undefined
-
     const box = searchBox(px, py, threshold)
-    const hits = this.nearestTree.search(box)
-    if (hits.length === 0) return undefined
+    const primHits = this.primitiveTree.search(box)
+    const segHits = this.segmentTree.search(box)
+    if (primHits.length === 0 && segHits.length === 0) return undefined
 
     const threshSq = threshold * threshold
     const extent = Math.max(box.maxX - box.minX, box.maxY - box.minY, 1)
@@ -841,24 +749,23 @@ export class AcExOsnapIndex {
     const primSeen = new Set<number>()
     const segSeen = new Set<number>()
 
-    for (const hit of hits) {
-      const source = this.nearestSources[hit.index]!
-      if (this.hiddenLayers.has(source.layer)) continue
+    for (const hit of primHits) {
+      const prim = this.primitives[hit.index]!
+      if (this.hiddenLayers.has(prim.layer)) continue
+      if (!isIntersectionCapablePrimitive(prim)) continue
+      if (primSeen.has(hit.index)) continue
+      if (primIndices.length >= ACEX_MAX_INTERSECTION_SOURCES) continue
+      primSeen.add(hit.index)
+      primIndices.push(hit.index)
+    }
 
-      if (source.kind === 'primitive') {
-        const prim = this.primitives[source.index]!
-        if (!isIntersectionCapablePrimitive(prim)) continue
-        if (primSeen.has(source.index)) continue
-        if (primIndices.length >= ACEX_MAX_INTERSECTION_SOURCES) continue
-        primSeen.add(source.index)
-        primIndices.push(source.index)
-        continue
-      }
-
-      if (segSeen.has(source.index)) continue
+    for (const hit of segHits) {
+      const layer = this.segmentLayers[hit.index]!
+      if (this.hiddenLayers.has(layer)) continue
+      if (segSeen.has(hit.index)) continue
       if (segIndices.length >= ACEX_MAX_INTERSECTION_SOURCES) continue
-      segSeen.add(source.index)
-      segIndices.push(source.index)
+      segSeen.add(hit.index)
+      segIndices.push(hit.index)
     }
 
     let bestDistSq = threshSq
@@ -920,39 +827,112 @@ export class AcExOsnapIndex {
     return best
   }
 
+  private discreteModes(): Set<AcExOsnapMode> {
+    const discreteModes = new Set(this.modes)
+    discreteModes.delete('nearest')
+    discreteModes.delete('intersection')
+    return discreteModes
+  }
+
+  private considerDiscreteCandidate(
+    px: number,
+    py: number,
+    threshSq: number,
+    candidate: AcExOsnapPoint,
+    layer: string,
+    state: {
+      bestPriority: number
+      bestDistSq: number
+      best: AcExOsnapPoint | undefined
+    }
+  ): void {
+    if (!this.modes.has(candidate.mode)) return
+    if (this.hiddenLayers.has(layer)) return
+
+    const d2 = distSq(px, py, candidate.x, candidate.y)
+    if (d2 > threshSq) return
+    const priority = modePriority(candidate.mode)
+    if (
+      priority < state.bestPriority ||
+      (priority === state.bestPriority && d2 < state.bestDistSq)
+    ) {
+      state.bestPriority = priority
+      state.bestDistSq = d2
+      state.best = candidate
+    }
+  }
+
   private findDiscreteSnap(
     px: number,
     py: number,
     threshold: number
   ): AcExOsnapPoint | undefined {
-    if (this.snapPoints.length === 0) return undefined
+    const discreteModes = this.discreteModes()
+    if (discreteModes.size === 0) return undefined
 
     const threshSq = threshold * threshold
-    const hits = this.snapPointTree.search(searchBox(px, py, threshold))
+    const box = searchBox(px, py, threshold)
+    const state = {
+      bestPriority: Number.MAX_VALUE,
+      bestDistSq: Number.MAX_VALUE,
+      best: undefined as AcExOsnapPoint | undefined
+    }
 
-    let bestPriority = Number.MAX_VALUE
-    let bestDistSq = Number.MAX_VALUE
-    let best: AcExOsnapPoint | undefined
-
-    for (const hit of hits) {
-      const point = this.snapPoints[hit.index]!
-      if (!this.modes.has(point.mode)) continue
-      if (this.hiddenLayers.has(point.layer)) continue
-
-      const d2 = distSq(px, py, point.x, point.y)
-      if (d2 > threshSq) continue
-      const priority = modePriority(point.mode)
-      if (
-        priority < bestPriority ||
-        (priority === bestPriority && d2 < bestDistSq)
-      ) {
-        bestPriority = priority
-        bestDistSq = d2
-        best = { x: point.x, y: point.y, mode: point.mode }
+    for (const hit of this.primitiveTree.search(box)) {
+      const prim = this.primitives[hit.index]!
+      for (const candidate of collectPrimitiveDiscreteSnapCandidates(
+        prim,
+        discreteModes
+      )) {
+        this.considerDiscreteCandidate(
+          px,
+          py,
+          threshSq,
+          candidate,
+          prim.layer,
+          state
+        )
       }
     }
 
-    return best
+    for (const hit of this.segmentTree.search(box)) {
+      const seg = this.segments[hit.index]!
+      const layer = this.segmentLayers[hit.index]!
+      if (discreteModes.has('endpoint')) {
+        this.considerDiscreteCandidate(
+          px,
+          py,
+          threshSq,
+          { x: seg.x0, y: seg.y0, mode: 'endpoint' },
+          layer,
+          state
+        )
+        this.considerDiscreteCandidate(
+          px,
+          py,
+          threshSq,
+          { x: seg.x1, y: seg.y1, mode: 'endpoint' },
+          layer,
+          state
+        )
+      }
+      if (discreteModes.has('midpoint')) {
+        this.considerDiscreteCandidate(
+          px,
+          py,
+          threshSq,
+          {
+            x: (seg.x0 + seg.x1) * 0.5,
+            y: (seg.y0 + seg.y1) * 0.5,
+            mode: 'midpoint'
+          },
+          layer,
+          state
+        )
+      }
+    }
+
+    return state.best
   }
 
   private findNearestSnap(
@@ -960,15 +940,12 @@ export class AcExOsnapIndex {
     py: number,
     threshold: number
   ): AcExOsnapPoint | undefined {
-    if (this.nearestSources.length === 0) return undefined
-
     const threshSq = threshold * threshold
-    const hits = this.nearestTree.search(searchBox(px, py, threshold))
-
+    const box = searchBox(px, py, threshold)
     let bestDistSq = Number.MAX_VALUE
     let best: AcExOsnapPoint | undefined
 
-    for (const hit of hits) {
+    for (const hit of this.primitiveTree.search(box)) {
       if (
         distSqToBounds(px, py, hit.minX, hit.minY, hit.maxX, hit.maxY) >
         threshSq
@@ -976,23 +953,32 @@ export class AcExOsnapIndex {
         continue
       }
 
-      const source = this.nearestSources[hit.index]!
-      if (this.hiddenLayers.has(source.layer)) continue
+      const prim = this.primitives[hit.index]!
+      if (this.hiddenLayers.has(prim.layer)) continue
+      if (prim.kind === 'point') continue
 
-      if (source.kind === 'primitive') {
-        const prim = this.primitives[source.index]!
-        const geo = source.geo ?? primitiveToAcGeCurve(prim)
-        const nearest = collectPrimitiveNearestSnapCandidate(prim, px, py, geo)
-        if (!nearest) continue
-        const d2 = distSq(px, py, nearest.x, nearest.y)
-        if (d2 <= threshSq && d2 < bestDistSq) {
-          bestDistSq = d2
-          best = nearest
-        }
+      const geo = primitiveToAcGeCurve(prim)
+      const nearest = collectPrimitiveNearestSnapCandidate(prim, px, py, geo)
+      if (!nearest) continue
+      const d2 = distSq(px, py, nearest.x, nearest.y)
+      if (d2 <= threshSq && d2 < bestDistSq) {
+        bestDistSq = d2
+        best = nearest
+      }
+    }
+
+    for (const hit of this.segmentTree.search(box)) {
+      if (
+        distSqToBounds(px, py, hit.minX, hit.minY, hit.maxX, hit.maxY) >
+        threshSq
+      ) {
         continue
       }
 
-      const near = closestPointOnSegment(px, py, this.segments[source.index]!)
+      const layer = this.segmentLayers[hit.index]!
+      if (this.hiddenLayers.has(layer)) continue
+
+      const near = closestPointOnSegment(px, py, this.segments[hit.index]!)
       if (near.distSq <= threshSq && near.distSq < bestDistSq) {
         bestDistSq = near.distSq
         best = { x: near.x, y: near.y, mode: 'nearest' }
@@ -1007,7 +993,7 @@ export class AcExOsnapIndex {
  * Axis-aligned bounds of one tessellated snap segment in WCS.
  *
  * @param seg - Segment whose endpoints define the bounding box.
- * @returns `{ minX, minY, maxX, maxY }` used by the nearest-source RBush in
+ * @returns `{ minX, minY, maxX, maxY }` used by the segment RBush in
  *   {@link AcExOsnapIndex.rebuild}.
  * @internal
  */

--- a/packages/cad-html-plugin/src/AcExOsnapGeometry.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapGeometry.ts
@@ -51,7 +51,7 @@ export interface AcExOsnapCandidate {
 }
 
 /**
- * Collects discrete (non-nearest) snap points for one primitive at index build time.
+ * Collects discrete (non-nearest) snap points for one primitive during a snap query.
  *
  * @param prim - Exported primitive in WCS.
  * @param modes - Enabled OSNAP modes.

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
@@ -252,15 +252,11 @@ export type AcExOsnapPrimitive =
  * Per-layout catalog of analytic geometry used for object snap.
  *
  * Embedded on {@link AcExLayoutSnapshot.osnap} when exporting HTML. When
- * {@link AcExOsnapCatalog.primitives} is non-empty, {@link AcExOsnapIndex} ignores
- * tessellated `lineBatches` / `meshBatches` for snapping.
+ * {@link AcExOsnapCatalog.primitives} is non-empty, {@link AcExOsnapIndex}
+ * ignores tessellated `lineBatches` / `meshBatches` for snapping and derives
+ * discrete snap points from primitives at query time.
  */
 export interface AcExOsnapCatalog {
-  /**
-   * All snap-capable primitives for this layout in WCS.
-   *
-   * Includes entities nested inside block references (INSERT), each with an
-   * effective {@link AcExOsnapPrimitiveBase.layer}.
-   */
+  /** Analytic OSNAP geometry serialized into the HTML snapshot. */
   primitives: AcExOsnapPrimitive[]
 }

--- a/packages/cad-html-plugin/src/AcExViewerMemory.ts
+++ b/packages/cad-html-plugin/src/AcExViewerMemory.ts
@@ -22,7 +22,11 @@ export function copyUint32Buffer(source: Uint32Array): Uint32Array {
 export function canReleaseActiveLayoutBatches(
   layout: AcExLayoutSnapshot
 ): boolean {
-  return (layout.osnap?.primitives.length ?? 0) > 0
+  const osnap = layout.osnap
+  if (!osnap) {
+    return false
+  }
+  return (osnap.primitives?.length ?? 0) > 0
 }
 
 /**
@@ -41,6 +45,22 @@ export function releaseSnapshotBatchBuffers(
     if (!isActive || canReleaseActiveLayoutBatches(layout)) {
       clearLayoutBatchBuffers(layout)
     }
+  }
+}
+
+/**
+ * Drops {@link AcExLayoutSnapshot.osnap} from every layout after
+ * {@link AcExOsnapIndex.rebuild}.
+ *
+ * Call only after the index has copied or retained the catalog's
+ * `primitives` array (the runtime keeps that reference internally).
+ * Inactive layout catalogs become fully reclaimable; the active layout
+ * catalog wrapper is removed from the snapshot while primitive data
+ * remains alive for nearest / intersection snap queries.
+ */
+export function releaseSnapshotOsnapCatalogs(snapshot: AcExSnapshot): void {
+  for (const layout of snapshot.layouts) {
+    layout.osnap = undefined
   }
 }
 


### PR DESCRIPTION
## Summary

- Refactor `AcExOsnapIndex` to compute discrete snap points (endpoint, midpoint, center, etc.), nearest, and intersection candidates lazily during pointer queries instead of pre-indexing them at rebuild time.
- Simplify spatial indexing to two RBush trees (primitives + tessellated segments) and derive snap geometry from catalog primitives on demand.
- Add `releaseSnapshotOsnapCatalogs` so the HTML viewer can drop layout catalog wrappers after index rebuild while retaining primitive arrays for ongoing snap queries, reducing snapshot memory footprint.

## Test plan

- [x] Unit tests for lazy endpoint/intersection snap from catalog primitives (`AcExOsnap.spec.ts`)
- [x] Unit tests for polyline/ellipse primitive export (`AcExOsnapPrimitiveBuilder.spec.ts`)
- [x] Unit tests for catalog release without dropping retained primitives (`AcExViewerMemory.spec.ts`)
- [ ] Open an exported HTML viewer and verify OSNAP modes (endpoint, midpoint, nearest, intersection) still behave correctly
- [ ] Confirm memory is reclaimed after viewer startup when analytic OSNAP catalog is present