### PR TITLE
feat(cad-html-plugin): add view-only export mode and gzip snapshot compression

### DIFF
--- a/packages/cad-html-exporter-cli/runner/main.ts
+++ b/packages/cad-html-exporter-cli/runner/main.ts
@@ -17,6 +17,7 @@ declare global {
         title?: string
         exportInvisibleLayers?: boolean
         initialView?: 'fit' | 'current'
+        viewerMode?: 'view' | 'measure'
       }
     ) => Promise<string>
   }
@@ -78,6 +79,7 @@ window.exportCadToHtml = async (fileName, bytes, options = {}) => {
       locale: options.locale,
       exportInvisibleLayers: resolved.exportInvisibleLayers,
       initialView: resolved.initialView,
+      viewerMode: resolved.viewerMode,
       viewState:
         resolved.initialView === 'current'
           ? captureAcApHtmlViewState(view)

--- a/packages/cad-html-exporter-cli/src/cli.ts
+++ b/packages/cad-html-exporter-cli/src/cli.ts
@@ -7,6 +7,15 @@ import { exportToHtml } from './exportToHtml.js'
 
 const program = new Command()
 
+function parseViewerMode(value: string): 'view' | 'measure' {
+  if (value === 'view' || value === 'measure') {
+    return value
+  }
+  throw new Error(
+    `Invalid --viewer-mode "${value}". Expected "view" or "measure".`
+  )
+}
+
 program
   .name('cad-html-exporter')
   .description(
@@ -28,17 +37,24 @@ program
     'Initial view when opening HTML: fit (zoom extents) or current',
     'fit'
   )
+  .option(
+    '--viewer-mode <mode>',
+    'Offline viewer mode: view (pan/zoom/layers only) or measure (includes measurement tools)',
+    'measure'
+  )
   .action(async (input: string, opts) => {
     try {
       const initialView =
         opts.initialView === 'current' ? 'current' : ('fit' as const)
+      const viewerMode = parseViewerMode(opts.viewerMode)
       const outputPath = await exportToHtml(path.resolve(input), {
         outputPath: opts.output ? path.resolve(opts.output) : undefined,
         locale: opts.locale,
         title: opts.title,
         exportInvisibleLayers:
           opts.exportInvisibleLayers === false ? false : undefined,
-        initialView
+        initialView,
+        viewerMode
       })
       console.log(`Wrote ${outputPath}`)
     } catch (error) {

--- a/packages/cad-html-exporter-cli/src/exportToHtml.ts
+++ b/packages/cad-html-exporter-cli/src/exportToHtml.ts
@@ -16,6 +16,7 @@ declare global {
         title?: string
         exportInvisibleLayers?: boolean
         initialView?: 'fit' | 'current'
+        viewerMode?: 'view' | 'measure'
       }
     ) => Promise<string>
   }
@@ -27,6 +28,7 @@ export interface ExportToHtmlOptions {
   title?: string
   exportInvisibleLayers?: boolean
   initialView?: 'fit' | 'current'
+  viewerMode?: 'view' | 'measure'
 }
 
 function runnerDistDir(): string {
@@ -140,7 +142,8 @@ export async function exportToHtml(
         locale,
         title,
         exportInvisibleLayers,
-        initialView
+        initialView,
+        viewerMode
       }) => {
         const binary = atob(data)
         const bytes = new Uint8Array(binary.length)
@@ -151,7 +154,8 @@ export async function exportToHtml(
           locale,
           title,
           exportInvisibleLayers,
-          initialView
+          initialView,
+          viewerMode
         })
       },
       {
@@ -160,7 +164,8 @@ export async function exportToHtml(
         locale: options.locale,
         title: options.title ?? fileName,
         exportInvisibleLayers: options.exportInvisibleLayers,
-        initialView: options.initialView
+        initialView: options.initialView,
+        viewerMode: options.viewerMode
       }
     )
 

--- a/packages/cad-html-plugin/__tests__/AcApExportHtmlCmd.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcApExportHtmlCmd.spec.ts
@@ -1,157 +1,412 @@
 jest.mock('@mlightcad/cad-simple-viewer', () => {
+
   class AcEdCommand {}
 
+
+
   class MockKeywordCollection {
+
     default: unknown
+
     add(display: string, global: string, local: string) {
+
       return { display, global, local, enabled: true, visible: true }
+
     }
+
   }
+
+
 
   class AcEdPromptKeywordOptions {
+
     allowNone = false
+
     keywords = new MockKeywordCollection()
 
+
+
     constructor(readonly message: string) {}
+
   }
+
+
 
   return {
+
     AcApContext: {},
+
     AcApDocManager: {
+
       instance: {
+
         editor: {
+
           getKeywords: jest.fn()
+
         }
+
       }
+
     },
+
     AcApI18n: {
+
       t: (key: string) => {
+
         const globals: Record<string, string> = {
+
           'jig.chtml.keywords.yes.global': 'Yes',
+
           'jig.chtml.keywords.no.global': 'No',
+
           'jig.chtml.keywords.extents.global': 'Extents',
-          'jig.chtml.keywords.current.global': 'Current'
+
+          'jig.chtml.keywords.current.global': 'Current',
+
+          'jig.chtml.keywords.view.global': 'View',
+
+          'jig.chtml.keywords.measure.global': 'Measure'
+
         }
+
         return globals[key] ?? key
+
       }
+
     },
+
     AcEdCommand,
+
     AcEdPromptKeywordOptions,
+
     AcEdPromptStatus: {
+
       Cancel: -5002,
+
       None: 0x1388,
+
       OK: 0x13ec,
+
       Keyword: -5005
+
     }
+
   }
+
 })
+
+
 
 jest.mock('../src/AcApHtmlConvertor', () => ({
+
   AcApHtmlConvertor: jest.fn().mockImplementation(() => ({
+
     convert: jest.fn(() => Promise.resolve())
+
   }))
+
 }))
 
+
+
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+
 import { AcEdPromptStatus } from '@mlightcad/cad-simple-viewer'
 
+
+
 import { AcApExportHtmlCmd } from '../src/AcApExportHtmlCmd'
+
 import { AcApHtmlConvertor } from '../src/AcApHtmlConvertor'
 
+
+
 const getKeywords = AcApDocManager.instance.editor.getKeywords as jest.Mock
+
 const convert = () =>
+
   (AcApHtmlConvertor as jest.MockedClass<typeof AcApHtmlConvertor>).mock
+
     .results[0]?.value.convert as jest.Mock
 
+
+
 describe('AcApExportHtmlCmd prompt defaults', () => {
+
   const cmd = new AcApExportHtmlCmd()
+
   const context = {
+
     doc: { fileName: 'drawing.dwg', docTitle: 'Drawing' },
+
     view: {}
+
   } as any
 
+
+
   beforeEach(() => {
+
     jest.clearAllMocks()
+
   })
 
-  test('accepts empty Enter (None) for both prompts and exports with defaults', async () => {
+
+
+  test('accepts empty Enter (None) for all prompts and exports with defaults', async () => {
+
     getKeywords
+
       .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
       .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+
 
     await cmd.execute(context)
 
-    expect(getKeywords).toHaveBeenCalledTimes(2)
+
+
+    expect(getKeywords).toHaveBeenCalledTimes(3)
+
     expect(getKeywords.mock.calls[0][0].allowNone).toBe(true)
+
     expect(getKeywords.mock.calls[1][0].allowNone).toBe(true)
+
+    expect(getKeywords.mock.calls[2][0].allowNone).toBe(true)
+
     expect(convert()).toHaveBeenCalledWith(
+
       'drawing.dwg',
+
       {
+
         exportInvisibleLayers: true,
-        initialView: 'fit'
+
+        initialView: 'fit',
+
+        viewerMode: 'measure'
+
       },
+
       context.view
+
     )
+
   })
 
-  test('accepts default keyword (OK) for both prompts and exports', async () => {
+
+
+  test('accepts default keyword (OK) for all prompts and exports', async () => {
+
     getKeywords
+
       .mockResolvedValueOnce({
+
         status: AcEdPromptStatus.OK,
+
         stringResult: 'Yes'
+
       })
+
       .mockResolvedValueOnce({
+
         status: AcEdPromptStatus.OK,
+
         stringResult: 'Extents'
+
       })
+
+      .mockResolvedValueOnce({
+
+        status: AcEdPromptStatus.OK,
+
+        stringResult: 'Measure'
+
+      })
+
+
 
     await cmd.execute(context)
 
+
+
     expect(convert()).toHaveBeenCalledWith(
+
       'drawing.dwg',
+
       {
+
         exportInvisibleLayers: true,
-        initialView: 'fit'
+
+        initialView: 'fit',
+
+        viewerMode: 'measure'
+
       },
+
       context.view
+
     )
+
   })
+
+
+
+  test('exports with view-only viewer mode when View keyword is selected', async () => {
+
+    getKeywords
+
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+      .mockResolvedValueOnce({
+
+        status: AcEdPromptStatus.OK,
+
+        stringResult: 'View'
+
+      })
+
+
+
+    await cmd.execute(context)
+
+
+
+    expect(convert()).toHaveBeenCalledWith(
+
+      'drawing.dwg',
+
+      {
+
+        exportInvisibleLayers: true,
+
+        initialView: 'fit',
+
+        viewerMode: 'view'
+
+      },
+
+      context.view
+
+    )
+
+  })
+
+
 
   test('cancels export when the first prompt is cancelled', async () => {
+
     getKeywords.mockResolvedValueOnce({ status: AcEdPromptStatus.Cancel })
 
+
+
     await cmd.execute(context)
+
+
 
     expect(getKeywords).toHaveBeenCalledTimes(1)
+
     expect(AcApHtmlConvertor).not.toHaveBeenCalled()
+
   })
+
+
 
   test('cancels export when the second prompt is cancelled', async () => {
+
     getKeywords
+
       .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
       .mockResolvedValueOnce({ status: AcEdPromptStatus.Cancel })
 
+
+
     await cmd.execute(context)
+
+
 
     expect(getKeywords).toHaveBeenCalledTimes(2)
+
     expect(AcApHtmlConvertor).not.toHaveBeenCalled()
+
   })
 
-  test('registers default keywords on prompt options', async () => {
+
+
+  test('cancels export when the viewer mode prompt is cancelled', async () => {
+
     getKeywords
+
       .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
       .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.Cancel })
+
+
 
     await cmd.execute(context)
 
+
+
+    expect(getKeywords).toHaveBeenCalledTimes(3)
+
+    expect(AcApHtmlConvertor).not.toHaveBeenCalled()
+
+  })
+
+
+
+  test('registers default keywords on prompt options', async () => {
+
+    getKeywords
+
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+      .mockResolvedValueOnce({ status: AcEdPromptStatus.None })
+
+
+
+    await cmd.execute(context)
+
+
+
     const invisibleLayersPrompt = getKeywords.mock.calls[0][0]
+
     const initialViewPrompt = getKeywords.mock.calls[1][0]
 
+    const viewerModePrompt = getKeywords.mock.calls[2][0]
+
+
+
     expect(invisibleLayersPrompt.keywords.default).toEqual(
+
       expect.objectContaining({ global: 'Yes' })
+
     )
+
     expect(initialViewPrompt.keywords.default).toEqual(
+
       expect.objectContaining({ global: 'Extents' })
+
     )
+
+    expect(viewerModePrompt.keywords.default).toEqual(
+
+      expect.objectContaining({ global: 'Measure' })
+
+    )
+
   })
+
 })
+

--- a/packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
@@ -148,7 +148,8 @@ describe('patterned hatch HTML export', () => {
       activeLayoutBtrId: 'ms'
     }
 
-    const decoded = decodeSnapshot(encodeSnapshot(snapshot))
+    const encoded = encodeSnapshot(snapshot)
+    const decoded = decodeSnapshot(encoded.payload)
     const decodedBatch = decoded.layouts[0]!.meshBatches[0]!
     expect(decodedBatch.hatchPattern).toEqual(batch.hatchPattern)
 

--- a/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
@@ -1,0 +1,34 @@
+jest.mock('@mlightcad/cad-simple-viewer', () => ({
+  ML_UI_MOBILE_MAX_WIDTH: 768
+}))
+
+import { buildAcExHtmlShellBody } from '../src/AcExHtmlShell'
+
+describe('buildAcExHtmlShellBody', () => {
+  it('omits measurement toolbar controls in view mode', () => {
+    const html = buildAcExHtmlShellBody('#000000', 'view')
+
+    expect(html).toContain('data-action="fit"')
+    expect(html).toContain('id="mlcad-layers-btn"')
+    expect(html).toContain('id="mlcad-lang-btn"')
+    expect(html).not.toContain('data-measure-mode=')
+    expect(html).not.toContain('id="mlcad-settings-btn"')
+    expect(html).not.toContain('id="mlcad-settings-wrap"')
+    expect(html).not.toContain('mlcad-tool-separator')
+    expect(html).not.toContain('id="mlcad-status-bar"')
+  })
+
+  it('includes measurement toolbar controls in measure mode', () => {
+    const html = buildAcExHtmlShellBody('#000000', 'measure')
+
+    expect(html).toContain('data-measure-mode="distance"')
+    expect(html).toContain('id="mlcad-settings-btn"')
+    expect(html).toContain('id="mlcad-settings-wrap"')
+    expect(html).toContain('id="mlcad-lang-btn"')
+    expect(html).toContain('id="mlcad-status-bar"')
+    expect(html.match(/mlcad-tool-separator/g)?.length).toBe(2)
+    expect(html.indexOf('id="mlcad-layers-btn"')).toBeLessThan(
+      html.indexOf('id="mlcad-settings-btn"')
+    )
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
@@ -38,7 +38,8 @@ describe('AcExSnapshotCodec', () => {
       activeLayoutBtrId: 'ms'
     }
     const encoded = encodeSnapshot(snapshot)
-    const decoded = decodeSnapshot(encoded)
+    expect(encoded.compression).toBe('gzip')
+    const decoded = decodeSnapshot(encoded.payload)
     expect(decoded.meta.extents.maxX).toBe(10)
     expect(decoded.layers[0]?.name).toBe('0')
   })
@@ -93,7 +94,8 @@ describe('AcExSnapshotCodec', () => {
       activeLayoutBtrId: 'ms'
     }
 
-    const decoded = decodeSnapshot(encodeSnapshot(snapshot))
+    const encoded = encodeSnapshot(snapshot)
+    const decoded = decodeSnapshot(encoded.payload)
     const line = decoded.layouts[0]!.lineBatches[0]!
     expect(Array.from(line.positions)).toEqual([0, 0, 0, 10, 0, 0])
     expect(Array.from(line.indices!)).toEqual([0, 1])
@@ -154,8 +156,8 @@ describe('AcExSnapshotCodec', () => {
       activeLayoutBtrId: 'ms'
     }
 
-    const line = decodeSnapshot(encodeSnapshot(snapshot)).layouts[0]!
-      .lineBatches[0]!
+    const encoded = encodeSnapshot(snapshot)
+    const line = decodeSnapshot(encoded.payload).layouts[0]!.lineBatches[0]!
     expect(line.offset[0]).toBe(largeOrigin)
     expect(line.offset[1]).toBe(largeOrigin + 100)
     expect(Array.from(line.positions)).toEqual([0.5, 1.25, 0, 10.5, 2.75, 0])
@@ -201,8 +203,8 @@ describe('AcExSnapshotCodec', () => {
       activeLayoutBtrId: 'ms'
     }
 
-    const line = decodeSnapshot(encodeSnapshot(snapshot)).layouts[0]!
-      .lineBatches[0]!
+    const encoded = encodeSnapshot(snapshot)
+    const line = decodeSnapshot(encoded.payload).layouts[0]!.lineBatches[0]!
     expect(line.lineWidth).toBe(2.5)
     expect(line.color).toBe(0x00ff00)
     expect(Array.from(line.positions)).toEqual([0, 0, 0, 100, 50, 0])

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCompression.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCompression.spec.ts
@@ -1,0 +1,16 @@
+import {
+  ACEX_SNAPSHOT_COMPRESSION,
+  compressSnapshotBinary,
+  decompressSnapshotBinary
+} from '../src/AcExSnapshotCompression'
+
+describe('AcExSnapshotCompression', () => {
+  it('compresses exports with gzip', () => {
+    const input = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+    const compressed = compressSnapshotBinary(input)
+    expect(compressed.compression).toBe(ACEX_SNAPSHOT_COMPRESSION)
+    expect(Array.from(decompressSnapshotBinary(compressed.bytes))).toEqual(
+      Array.from(input)
+    )
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExViewerMemory.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExViewerMemory.spec.ts
@@ -4,8 +4,6 @@ import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
 import {
-  canReleaseActiveLayoutBatches,
-  copyFloat32Buffer,
   releaseLayerGroupsGeometryCpuArrays,
   releaseSnapshotBatchBuffers,
   releaseSnapshotOsnapCatalogs
@@ -84,35 +82,10 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
 }
 
 describe('AcExViewerMemory', () => {
-  it('copyFloat32Buffer creates an independent array', () => {
-    const source = f32([1, 2, 3])
-    const copy = copyFloat32Buffer(source)
-    source[0] = 99
-    expect(copy[0]).toBe(1)
-  })
-
-  it('canReleaseActiveLayoutBatches requires analytic osnap primitives', () => {
-    const withOsnap = makeSnapshot().layouts[0]!
-    expect(canReleaseActiveLayoutBatches(withOsnap)).toBe(true)
-
-    const withoutOsnap = makeSnapshot({
-      layouts: [
-        {
-          btrId: 'ms',
-          name: 'Model',
-          isModelSpace: true,
-          lineBatches: [],
-          meshBatches: []
-        }
-      ]
-    }).layouts[0]!
-    expect(canReleaseActiveLayoutBatches(withoutOsnap)).toBe(false)
-  })
-
-  it('releaseSnapshotBatchBuffers clears inactive layouts always', () => {
+  it('releaseSnapshotBatchBuffers clears every layout', () => {
     const snapshot = makeSnapshot()
 
-    releaseSnapshotBatchBuffers(snapshot, 'ms')
+    releaseSnapshotBatchBuffers(snapshot)
 
     expect(snapshot.layouts[0]!.lineBatches).toHaveLength(0)
     expect(snapshot.layouts[1]!.lineBatches).toHaveLength(0)
@@ -129,33 +102,6 @@ describe('AcExViewerMemory', () => {
     expect(snapshot.layouts[1]!.osnap).toBeUndefined()
     expect(retained).toHaveLength(1)
     expect(retained[0]).toMatchObject({ kind: 'line', x0: 0, y0: 0, x1: 1, y1: 0 })
-  })
-
-  it('releaseSnapshotBatchBuffers keeps active layout batches without osnap catalog', () => {
-    const snapshot = makeSnapshot({
-      layouts: [
-        {
-          btrId: 'ms',
-          name: 'Model',
-          isModelSpace: true,
-          lineBatches: [
-            {
-              layer: '0',
-              color: 0xffffff,
-              offset: [0, 0, 0] as [number, number, number],
-              positions: f32([0, 0, 0, 1, 0, 0])
-            }
-          ],
-          meshBatches: []
-        }
-      ],
-      activeLayoutBtrId: 'ms'
-    })
-
-    releaseSnapshotBatchBuffers(snapshot, 'ms')
-
-    expect(snapshot.layouts[0]!.lineBatches).toHaveLength(1)
-    expect(snapshot.layouts[0]!.lineBatches[0]!.positions).toHaveLength(6)
   })
 
   it('releaseLayerGroupsGeometryCpuArrays empties geometry attribute arrays', () => {

--- a/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
+++ b/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
@@ -53,9 +53,15 @@ export class AcApExportHtmlCmd extends AcEdCommand {
       return undefined
     }
 
+    const viewerMode = await this.promptViewerMode()
+    if (viewerMode === undefined) {
+      return undefined
+    }
+
     return resolveAcApHtmlExportOptions({
       exportInvisibleLayers,
-      initialView
+      initialView,
+      viewerMode
     })
   }
 
@@ -137,6 +143,50 @@ export class AcApExportHtmlCmd extends AcEdCommand {
         return defaults.initialView
       }
       return result.stringResult === 'Current' ? 'current' : 'fit'
+    }
+    return undefined
+  }
+
+  private async promptViewerMode(): Promise<
+    AcApHtmlExportOptions['viewerMode'] | undefined
+  > {
+    const defaults = resolveAcApHtmlExportOptions()
+    const current =
+      defaults.viewerMode === 'view'
+        ? AcApI18n.t('jig.chtml.keywords.view.global')
+        : AcApI18n.t('jig.chtml.keywords.measure.global')
+    const prompt = new AcEdPromptKeywordOptions(
+      `${AcApI18n.t('jig.chtml.viewerMode')} <${current}>`
+    )
+    prompt.allowNone = true
+    const view = prompt.keywords.add(
+      AcApI18n.t('jig.chtml.keywords.view.display'),
+      AcApI18n.t('jig.chtml.keywords.view.global'),
+      AcApI18n.t('jig.chtml.keywords.view.local')
+    )
+    const measure = prompt.keywords.add(
+      AcApI18n.t('jig.chtml.keywords.measure.display'),
+      AcApI18n.t('jig.chtml.keywords.measure.global'),
+      AcApI18n.t('jig.chtml.keywords.measure.local')
+    )
+    prompt.keywords.default =
+      defaults.viewerMode === 'view' ? view : measure
+
+    const result = await AcApDocManager.instance.editor.getKeywords(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) {
+      return undefined
+    }
+    if (result.status === AcEdPromptStatus.None) {
+      return defaults.viewerMode
+    }
+    if (
+      result.status === AcEdPromptStatus.OK ||
+      result.status === AcEdPromptStatus.Keyword
+    ) {
+      if (!result.stringResult) {
+        return defaults.viewerMode
+      }
+      return result.stringResult === 'View' ? 'view' : 'measure'
     }
     return undefined
   }

--- a/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
@@ -103,6 +103,7 @@ export class AcApHtmlConvertor {
           background: exportView.backgroundColor,
           exportInvisibleLayers: resolved.exportInvisibleLayers,
           initialView: resolved.initialView,
+          viewerMode: resolved.viewerMode,
           viewState:
             resolved.initialView === 'current'
               ? captureAcApHtmlViewState(exportView)

--- a/packages/cad-html-plugin/src/AcApHtmlExportOptions.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlExportOptions.ts
@@ -1,6 +1,10 @@
 import type { AcTrView2d } from '@mlightcad/cad-simple-viewer'
 
-import type { AcExInitialViewMode, AcExViewState } from './AcExSnapshotTypes'
+import type {
+  AcExInitialViewMode,
+  AcExViewerMode,
+  AcExViewState
+} from './AcExSnapshotTypes'
 
 /** Matches the offline HTML viewer orthographic half-height in world units. */
 const HTML_VIEWER_CAMERA_FRUSTUM = 400
@@ -18,6 +22,11 @@ export interface AcApHtmlExportOptions {
    * Initial framing when the exported HTML is opened. Defaults to `'fit'`.
    */
   initialView?: AcExInitialViewMode
+  /**
+   * Offline viewer capability profile. `'view'` omits OSNAP data and measurement
+   * UI for a smaller, faster HTML file. Defaults to `'measure'`.
+   */
+  viewerMode?: AcExViewerMode
 }
 
 /**
@@ -28,10 +37,10 @@ export function resolveAcApHtmlExportOptions(
 ): Required<AcApHtmlExportOptions> {
   return {
     exportInvisibleLayers: options.exportInvisibleLayers !== false,
-    initialView: options.initialView ?? 'fit'
+    initialView: options.initialView ?? 'fit',
+    viewerMode: options.viewerMode ?? 'measure'
   }
 }
-
 /**
  * Captures the active 2D view as camera state understood by the offline viewer.
  */

--- a/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
@@ -16,6 +16,7 @@ import {
   type AcExLineBatch,
   type AcExMeshBatch,
   type AcExSnapshot,
+  type AcExViewerMode,
   type AcExViewState
 } from './AcExSnapshotTypes'
 import { buildViewerMetadata } from './AcExViewerMetadata'
@@ -53,6 +54,10 @@ export interface AcApHtmlSnapshotBuilderOptions {
    * is `'current'`.
    */
   viewState?: AcExViewState
+  /**
+   * Offline viewer capability profile. When `'view'`, OSNAP catalogs are omitted.
+   */
+  viewerMode?: AcExViewerMode
 }
 
 /**
@@ -140,7 +145,9 @@ export class AcApHtmlSnapshotBuilder {
         isModelSpace: btrId === scene.modelSpaceBtrId,
         lineBatches,
         meshBatches,
-        osnap: buildOsnapCatalog(database, btrId, { includeLayer })
+        osnap: shouldExportOsnap(options)
+          ? buildOsnapCatalog(database, btrId, { includeLayer })
+          : undefined
       })
       await yieldToMain()
     }
@@ -212,7 +219,9 @@ export class AcApHtmlSnapshotBuilder {
         isModelSpace: btrId === scene.modelSpaceBtrId,
         lineBatches,
         meshBatches,
-        osnap: buildOsnapCatalog(database, btrId, { includeLayer })
+        osnap: shouldExportOsnap(options)
+          ? buildOsnapCatalog(database, btrId, { includeLayer })
+          : undefined
       })
     })
 
@@ -262,8 +271,13 @@ function buildSnapshotMeta(
     background: meta.background,
     locale: options.locale ?? AcApI18n.currentLocale,
     initialView,
-    viewState: initialView === 'current' ? options.viewState : undefined
+    viewState: initialView === 'current' ? options.viewState : undefined,
+    viewerMode: options.viewerMode ?? 'measure'
   }
+}
+
+function shouldExportOsnap(options: AcApHtmlSnapshotBuilderOptions): boolean {
+  return (options.viewerMode ?? 'measure') === 'measure'
 }
 
 function shouldExportLayer(

--- a/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
@@ -140,6 +140,16 @@ function savePersistedSettings(state: AcExMeasureSettingsState): void {
 }
 
 /**
+ * Language toggle button shared by view-mode toolbar and measure settings strip.
+ */
+export function buildAcExLanguageToolbarButton(): string {
+  return `<button type="button" class="mlcad-tool-btn mlcad-lang-btn" id="mlcad-lang-btn" data-i18n-key="toolbar.languageSwitch" data-i18n-attr="title aria-label" title="Switch language" aria-label="Switch language">
+            ${acExHtmlIcons.language}
+            <span class="mlcad-lang-badge" id="mlcad-lang-badge">EN</span>
+          </button>`
+}
+
+/**
  * Builds the settings strip markup inserted beside the toolbar in {@link buildAcExHtmlShellBody}.
  */
 export function buildAcExHtmlSettingsStrip(): string {
@@ -167,10 +177,7 @@ export function buildAcExHtmlSettingsStrip(): string {
             'data-i18n-key': 'settings.polar',
             'data-i18n-attr': 'title aria-label'
           })}
-          <button type="button" class="mlcad-tool-btn mlcad-lang-btn" id="mlcad-lang-btn" data-i18n-key="toolbar.languageSwitch" data-i18n-attr="title aria-label" title="Switch language" aria-label="Switch language">
-            ${acExHtmlIcons.language}
-            <span class="mlcad-lang-badge" id="mlcad-lang-badge">EN</span>
-          </button>
+          ${buildAcExLanguageToolbarButton()}
         </div>
         <div id="mlcad-polar-angles" role="group" data-i18n-attr="aria-label" data-i18n-key="settings.polarAngles" aria-label="Polar tracking angles" hidden>
           ${polarAngleButtons}

--- a/packages/cad-html-plugin/src/AcExHtmlPackager.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlPackager.ts
@@ -20,7 +20,7 @@ export interface AcExPackHtmlOptions {
 }
 
 /**
- * Builds a self-contained HTML document with an embedded gzip-compressed snapshot
+ * Builds a self-contained HTML document with an embedded compressed snapshot
  * and inline viewer runtime.
  *
  * @param snapshot - Display snapshot to embed in a `<script id="mlcad-snapshot">` tag.
@@ -32,11 +32,13 @@ export function packHtml(
   options: AcExPackHtmlOptions
 ): string {
   const title = options.title ?? snapshot.meta.title ?? 'CAD Drawing'
-  const payload = encodeSnapshot(snapshot)
+  const encoded = encodeSnapshot(snapshot)
   const runtime = options.viewerRuntime
   const mime = snapshotMimeType()
+  const compression = encoded.compression
   const loadingBg = `#${snapshot.meta.background.toString(16).padStart(6, '0')}`
   const htmlLang = resolveAcExHtmlLocale(snapshot.meta.locale) ?? 'en'
+  const viewerMode = snapshot.meta.viewerMode ?? 'measure'
 
   return `<!DOCTYPE html>
 <html lang="${htmlLang}">
@@ -48,8 +50,8 @@ export function packHtml(
   <style>${ACEX_HTML_SHELL_CSS}</style>
 </head>
 <body>
-${buildAcExHtmlShellBody(loadingBg)}
-  <script id="mlcad-snapshot" type="${mime}+gzip;base64">${payload}</script>
+${buildAcExHtmlShellBody(loadingBg, viewerMode)}
+  <script id="mlcad-snapshot" type="${mime}+${compression};base64">${encoded.payload}</script>
   <script>${escapeInlineScript(runtime)}</script>
 </body>
 </html>`

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -1,7 +1,11 @@
 import { ML_UI_MOBILE_MAX_WIDTH } from '@mlightcad/cad-simple-viewer'
 
 import { acExHtmlIcons, acExToolbarButton } from './AcExHtmlIcons'
-import { buildAcExHtmlSettingsStrip } from './AcExHtmlMeasureSettings'
+import {
+  buildAcExHtmlSettingsStrip,
+  buildAcExLanguageToolbarButton
+} from './AcExHtmlMeasureSettings'
+import type { AcExViewerMode } from './AcExSnapshotTypes'
 
 /**
  * Shared CSS for the offline HTML viewer chrome (toolbar, layer drawer, status bar).
@@ -99,9 +103,10 @@ export const ACEX_HTML_SHELL_CSS = `
     width: calc(var(--mlcad-toolbar-width) / 2);
     height: calc(var(--mlcad-toolbar-width) / 2);
   }
-  #mlcad-toolbar > .mlcad-tool-separator:last-of-type {
-    margin-top: 0;
-    margin-bottom: 0;
+  .mlcad-tool-separator {
+    height: 1px;
+    margin: 4px 8px;
+    background: var(--mlcad-ui-border);
   }
   .mlcad-lang-btn { position: relative; }
   .mlcad-lang-badge {
@@ -211,17 +216,14 @@ export const ACEX_HTML_SHELL_CSS = `
     backdrop-filter: blur(10px);
     pointer-events: none;
   }
-  .mlcad-tool-separator {
-    height: 1px;
-    margin: 4px 8px;
-    background: var(--mlcad-ui-border);
-  }
 
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-settings-wrap,
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-layer-drawer {
     display: none !important;
   }
-  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-toolbar .mlcad-tool-btn:not(#mlcad-toolbar-toggle),
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-toolbar .mlcad-tool-btn:not(#mlcad-toolbar-toggle) {
+    display: none;
+  }
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-toolbar .mlcad-tool-separator {
     display: none;
   }
@@ -421,9 +423,20 @@ export const ACEX_HTML_SHELL_CSS = `
  * Excludes snapshot and runtime `<script>` tags — those are appended by {@link packHtml}.
  *
  * @param loadingBg - CSS color for the initial loading screen (matches drawing background).
+ * @param viewerMode - `'view'` shows pan/zoom/layers only; `'measure'` adds measurement tools.
  * @returns HTML fragment inserted inside `<body>`.
  */
-export function buildAcExHtmlShellBody(loadingBg: string): string {
+export function buildAcExHtmlShellBody(
+  loadingBg: string,
+  viewerMode: AcExViewerMode = 'measure'
+): string {
+  const measureToolbar =
+    viewerMode === 'measure' ? buildAcExMeasureToolbarSection() : ''
+  const settingsToolbar =
+    viewerMode === 'measure' ? buildAcExMeasureSettingsToolbarButton() : ''
+  const languageToolbar =
+    viewerMode === 'view' ? buildAcExLanguageToolbarButton() : ''
+
   return `
   <div id="mlcad-loading" aria-hidden="true" style="background:${loadingBg}">
     <div class="mlcad-loading-spinner"></div>
@@ -436,6 +449,52 @@ export function buildAcExHtmlShellBody(loadingBg: string): string {
           'data-i18n-key': 'toolbar.zoomExtents',
           'data-i18n-attr': 'title aria-label'
         })}
+        ${viewerMode === 'measure' ? buildAcExToolbarSeparator() : ''}
+        ${measureToolbar}
+        ${viewerMode === 'measure' ? buildAcExToolbarSeparator() : ''}
+        ${acExToolbarButton(acExHtmlIcons.layer, 'Layers', {
+          id: 'mlcad-layers-btn',
+          'aria-haspopup': 'dialog',
+          'aria-expanded': 'false',
+          'data-i18n-key': 'toolbar.layers',
+          'data-i18n-attr': 'title aria-label'
+        })}
+        ${settingsToolbar}
+        ${languageToolbar}
+        ${acExToolbarButton(acExHtmlIcons.chevronUp, 'Collapse toolbar', {
+          id: 'mlcad-toolbar-toggle',
+          'aria-expanded': 'true',
+          'data-i18n-key': 'toolbar.collapse',
+          'data-i18n-attr': 'title aria-label'
+        })}
+      </nav>
+      ${viewerMode === 'measure' ? buildAcExHtmlSettingsStrip() : ''}
+      <div id="mlcad-layer-drawer" role="dialog" data-i18n-attr="aria-label" data-i18n-key="layers.title" aria-label="Layers" hidden>
+        <div class="mlcad-drawer-header">
+          <span data-i18n-key="layers.title" data-i18n-text>Layers</span>
+          <button type="button" class="mlcad-drawer-close" id="mlcad-layer-close" data-i18n-key="layers.close" data-i18n-attr="aria-label" aria-label="Close layers">×</button>
+        </div>
+        <div class="mlcad-layer-actions">
+          <button type="button" class="mlcad-layer-action-btn" id="mlcad-layer-show-all">
+            ${acExHtmlIcons.layerOn}<span data-i18n-key="layers.showAll" data-i18n-text>Show all</span>
+          </button>
+          <button type="button" class="mlcad-layer-action-btn" id="mlcad-layer-hide-all">
+            ${acExHtmlIcons.layerOff}<span data-i18n-key="layers.hideAll" data-i18n-text>Hide all</span>
+          </button>
+        </div>
+        <div id="mlcad-layer-list"></div>
+      </div>
+    </aside>
+    ${viewerMode === 'measure' ? '<footer id="mlcad-status-bar" aria-live="polite"></footer>' : ''}
+  </div>`
+}
+
+function buildAcExToolbarSeparator(): string {
+  return '<div class="mlcad-tool-separator" aria-hidden="true"></div>'
+}
+
+function buildAcExMeasureToolbarSection(): string {
+  return `
         ${acExToolbarButton(acExHtmlIcons.measureDistance, 'Measure distance', {
           'data-action': 'measure',
           'data-measure-mode': 'distance',
@@ -478,47 +537,15 @@ export function buildAcExHtmlShellBody(loadingBg: string): string {
             'data-i18n-key': 'toolbar.clearMeasurements',
             'data-i18n-attr': 'title aria-label'
           }
-        )}
-        <div class="mlcad-tool-separator" aria-hidden="true"></div>
-        ${acExToolbarButton(acExHtmlIcons.layer, 'Layers', {
-          id: 'mlcad-layers-btn',
-          'aria-haspopup': 'dialog',
-          'aria-expanded': 'false',
-          'data-i18n-key': 'toolbar.layers',
-          'data-i18n-attr': 'title aria-label'
-        })}
-        ${acExToolbarButton(acExHtmlIcons.setting, 'Measure settings', {
-          id: 'mlcad-settings-btn',
-          'aria-haspopup': 'true',
-          'aria-expanded': 'false',
-          'data-i18n-key': 'toolbar.settings',
-          'data-i18n-attr': 'title aria-label'
-        })}
-        <div class="mlcad-tool-separator" aria-hidden="true"></div>
-        ${acExToolbarButton(acExHtmlIcons.chevronUp, 'Collapse toolbar', {
-          id: 'mlcad-toolbar-toggle',
-          'aria-expanded': 'true',
-          'data-i18n-key': 'toolbar.collapse',
-          'data-i18n-attr': 'title aria-label'
-        })}
-      </nav>
-      ${buildAcExHtmlSettingsStrip()}
-      <div id="mlcad-layer-drawer" role="dialog" data-i18n-attr="aria-label" data-i18n-key="layers.title" aria-label="Layers" hidden>
-        <div class="mlcad-drawer-header">
-          <span data-i18n-key="layers.title" data-i18n-text>Layers</span>
-          <button type="button" class="mlcad-drawer-close" id="mlcad-layer-close" data-i18n-key="layers.close" data-i18n-attr="aria-label" aria-label="Close layers">×</button>
-        </div>
-        <div class="mlcad-layer-actions">
-          <button type="button" class="mlcad-layer-action-btn" id="mlcad-layer-show-all">
-            ${acExHtmlIcons.layerOn}<span data-i18n-key="layers.showAll" data-i18n-text>Show all</span>
-          </button>
-          <button type="button" class="mlcad-layer-action-btn" id="mlcad-layer-hide-all">
-            ${acExHtmlIcons.layerOff}<span data-i18n-key="layers.hideAll" data-i18n-text>Hide all</span>
-          </button>
-        </div>
-        <div id="mlcad-layer-list"></div>
-      </div>
-    </aside>
-    <footer id="mlcad-status-bar" aria-live="polite"></footer>
-  </div>`
+        )}`
+}
+
+function buildAcExMeasureSettingsToolbarButton(): string {
+  return acExToolbarButton(acExHtmlIcons.setting, 'Measure settings', {
+    id: 'mlcad-settings-btn',
+    'aria-haspopup': 'true',
+    'aria-expanded': 'false',
+    'data-i18n-key': 'toolbar.settings',
+    'data-i18n-attr': 'title aria-label'
+  })
 }

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -26,11 +26,10 @@ import type {
   AcExExtents,
   AcExLineBatch,
   AcExMeshBatch,
-  AcExSnapshot
+  AcExSnapshot,
+  AcExViewerMode
 } from './AcExSnapshotTypes'
 import {
-  copyFloat32Buffer,
-  copyUint32Buffer,
   releaseLayerGroupsGeometryCpuArrays,
   releaseSnapshotBatchBuffers,
   releaseSnapshotOsnapCatalogs,
@@ -50,6 +49,20 @@ function hideLoading(): void {
   })
 }
 
+function showViewerError(message: string): void {
+  const loading = document.getElementById('mlcad-loading')
+  if (!loading) return
+  loading.innerHTML = `<div style="padding:24px;color:#e8eaed;text-align:center;max-width:480px;line-height:1.5">${message}</div>`
+}
+
+/** Fallback when view mode omits the footer status bar. */
+function createHiddenStatusSink(): HTMLElement {
+  const el = document.createElement('div')
+  el.hidden = true
+  el.setAttribute('aria-hidden', 'true')
+  return el
+}
+
 function bootstrap(): void {
   requestAnimationFrame(() => {
     requestAnimationFrame(() => startViewer())
@@ -58,12 +71,14 @@ function bootstrap(): void {
 
 function startViewer(): void {
   const root = document.getElementById('mlcad-root')
-  const statusEl = document.getElementById('mlcad-status-bar')
   const snapshotEl = document.getElementById('mlcad-snapshot')
-  if (!root || !statusEl || !snapshotEl) {
+  if (!root || !snapshotEl) {
     hideLoading()
     return
   }
+
+  const statusEl =
+    document.getElementById('mlcad-status-bar') ?? createHiddenStatusSink()
 
   const payload = snapshotEl.textContent?.trim() ?? ''
   let snapshot: AcExSnapshot
@@ -72,10 +87,12 @@ function startViewer(): void {
   } catch (error) {
     const i18n = new AcExHtmlI18n(detectAcExHtmlLocale())
     i18n.applyToDocument()
-    statusEl.textContent = i18n.t('status.loadFailed', { error: String(error) })
-    hideLoading()
+    showViewerError(i18n.t('status.loadFailed', { error: String(error) }))
     return
   }
+
+  const viewerMode: AcExViewerMode = snapshot.meta.viewerMode ?? 'measure'
+  const measureEnabled = viewerMode === 'measure'
 
   const i18n = new AcExHtmlI18n(detectAcExHtmlLocale())
   i18n.applyToDocument()
@@ -84,8 +101,7 @@ function startViewer(): void {
     snapshot.layouts.find(l => l.btrId === snapshot.activeLayoutBtrId) ??
     snapshot.layouts[0]
   if (!layout) {
-    statusEl.textContent = i18n.t('status.noLayout')
-    hideLoading()
+    showViewerError(i18n.t('status.noLayout'))
     return
   }
 
@@ -160,17 +176,32 @@ function startViewer(): void {
     snapshot.meta.viewExtents ?? snapshot.meta.extents
   )
 
-  const osnapIndex = new AcExOsnapIndex()
-  const osnapMarker = new AcExOsnapMarker(root)
-  osnapIndex.rebuild(layout)
-  for (const layer of snapshot.layers) {
-    if (!layer.visible) {
-      osnapIndex.setLayerHidden(layer.name, true)
-    }
+  let osnapIndex: AcExOsnapIndex | null = null
+  let osnapMarker: AcExOsnapMarker | null = null
+  let osnapThresholdWcs = 0
+  let snapCacheKey = 0
+  const recomputeOsnapThresholdWcs = () => {
+    if (!measureEnabled) return
+    const a = screenToWcs(0, 0)
+    const b = screenToWcs(osnapHitRadiusPx, 0)
+    osnapThresholdWcs = Math.abs(b.x - a.x)
+  }
+  const bumpSnapCacheKey = () => {
+    snapCacheKey++
   }
 
-  releaseSnapshotBatchBuffers(snapshot, snapshot.activeLayoutBtrId)
-  releaseSnapshotOsnapCatalogs(snapshot)
+  if (measureEnabled) {
+    osnapIndex = new AcExOsnapIndex()
+    osnapMarker = new AcExOsnapMarker(root)
+    osnapIndex.rebuild(layout)
+    for (const layer of snapshot.layers) {
+      if (!layer.visible) {
+        osnapIndex.setLayerHidden(layer.name, true)
+      }
+    }
+    releaseSnapshotOsnapCatalogs(snapshot)
+  }
+
   removeSnapshotElement(snapshotEl)
 
   const updateCameraFrustum = (width?: number, height?: number) => {
@@ -260,67 +291,64 @@ function startViewer(): void {
   }
 
   const osnapHitRadiusPx = 20
-  let osnapThresholdWcs = 0
-  const recomputeOsnapThresholdWcs = () => {
-    const a = screenToWcs(0, 0)
-    const b = screenToWcs(osnapHitRadiusPx, 0)
-    osnapThresholdWcs = Math.abs(b.x - a.x)
-  }
-  recomputeOsnapThresholdWcs()
-
-  let snapCacheKey = 0
-  const bumpSnapCacheKey = () => {
-    snapCacheKey++
+  if (measureEnabled) {
+    recomputeOsnapThresholdWcs()
   }
 
   const resolveMeasurePoint = (clientX: number, clientY: number) => {
     const raw = screenToWcs(clientX, clientY)
+    if (!osnapIndex) {
+      return { point: raw, snap: null }
+    }
     const snap = osnapIndex.findSnap(raw.x, raw.y, osnapThresholdWcs)
     const point = snap ? new THREE.Vector2(snap.x, snap.y) : raw
     return { point, snap: snap ?? null }
   }
 
-  const render = () => {
-    measure.syncOverlays()
-    renderer.render(scene, camera)
-  }
-
+  let measure: AcExMeasureController | null = null
   const measureSettingsRef: {
     current: ReturnType<typeof setupAcExHtmlMeasureSettings> | null
   } = { current: null }
 
-  const measure = new AcExMeasureController({
-    root,
-    scene,
-    i18n,
-    statusEl,
-    getReadyStatus: () => readyStatus,
-    onOsnapMarker: (snap, screen) => {
-      if (snap && screen) {
-        osnapMarker.show(screen.x, screen.y, snap.mode)
-      } else {
-        osnapMarker.hide()
-      }
-    },
-    getTrackingOptions: () =>
-      measureSettingsRef.current?.getTrackingOptions() ?? null,
-    view: {
-      screenToWcs,
-      wcsToScreen,
-      render,
-      getSnapCacheKey: () => snapCacheKey,
-      resolvePoint: resolveMeasurePoint,
-      formatLength,
-      formatAngle
-    }
-  })
+  const render = () => {
+    measure?.syncOverlays()
+    renderer.render(scene, camera)
+  }
 
-  measureSettingsRef.current = setupAcExHtmlMeasureSettings({
-    i18n,
-    measure,
-    angbase: snapshot.meta.units.angbase,
-    angdir: snapshot.meta.units.angdir
-  })
+  if (measureEnabled) {
+    measure = new AcExMeasureController({
+      root,
+      scene,
+      i18n,
+      statusEl,
+      getReadyStatus: () => readyStatus,
+      onOsnapMarker: (snap, screen) => {
+        if (snap && screen) {
+          osnapMarker?.show(screen.x, screen.y, snap.mode)
+        } else {
+          osnapMarker?.hide()
+        }
+      },
+      getTrackingOptions: () =>
+        measureSettingsRef.current?.getTrackingOptions() ?? null,
+      view: {
+        screenToWcs,
+        wcsToScreen,
+        render,
+        getSnapCacheKey: () => snapCacheKey,
+        resolvePoint: resolveMeasurePoint,
+        formatLength,
+        formatAngle
+      }
+    })
+
+    measureSettingsRef.current = setupAcExHtmlMeasureSettings({
+      i18n,
+      measure,
+      angbase: snapshot.meta.units.angbase,
+      angdir: snapshot.meta.units.angdir
+    })
+  }
 
   const toolbarCollapse = setupToolbarCollapse(i18n)
 
@@ -344,8 +372,8 @@ function startViewer(): void {
 
   i18n.setOnChange(() => {
     readyStatus = snapshot.meta.title ?? i18n.t('status.ready')
-    if (!measure.isActive) {
-      measure.refreshIdleStatus()
+    if (!measure?.isActive) {
+      measure?.refreshIdleStatus()
     }
     layerPanel?.refreshLayerLabels()
     measureSettingsRef.current?.refreshLabels()
@@ -366,7 +394,9 @@ function startViewer(): void {
     render()
   })
 
-  setupMeasurePointerInput(renderer.domElement, () => measure, render)
+  if (measureEnabled && measure) {
+    setupMeasurePointerInput(renderer.domElement, () => measure!, render)
+  }
 
   renderer.domElement.addEventListener('mousedown', event => {
     if (event.button === 1) renderer.domElement.style.cursor = 'grabbing'
@@ -386,27 +416,29 @@ function startViewer(): void {
         if (action === 'fit') {
           fit()
         } else if (action === 'clear-measurements') {
-          measure.clearAll()
+          measure?.clearAll()
         } else if (action === 'measure') {
           const mode = button.getAttribute(
             'data-measure-mode'
           ) as AcExMeasureMode | null
           if (mode) {
-            measure.setMode(mode)
+            measure?.setMode(mode)
           }
         }
       })
     })
 
-  window.addEventListener('keydown', event => {
-    if (measure.handleKeyDown(event.key)) {
-      event.preventDefault()
-      return
-    }
-    if (measure.handleSelectionKeyDown(event.key, event)) {
-      event.preventDefault()
-    }
-  })
+  if (measureEnabled && measure) {
+    window.addEventListener('keydown', event => {
+      if (measure!.handleKeyDown(event.key)) {
+        event.preventDefault()
+        return
+      }
+      if (measure!.handleSelectionKeyDown(event.key, event)) {
+        event.preventDefault()
+      }
+    })
+  }
 
   window.addEventListener('resize', () => {
     resize()
@@ -424,11 +456,11 @@ function startViewer(): void {
     fit()
   }
   releaseLayerGroupsGeometryCpuArrays(layerGroups)
-  measure.refreshIdleStatus()
+  releaseSnapshotBatchBuffers(snapshot)
+  measure?.refreshIdleStatus()
   hideLoading()
 }
 
-/** DOM handles for one layer row in the drawer (used when locale changes). */
 interface AcExLayerRowRefs {
   /** Layer name shown in the row. */
   name: string
@@ -510,7 +542,7 @@ interface AcExLayerPanelContext {
   layerGroups: Map<string, THREE.Group>
   /** Precomputed XY extents per layer for zoom-to-layer. */
   layerExtents: Map<string, AcExExtents | null>
-  /** Footer status bar element. */
+  /** Footer status bar element (hidden sink in view mode). */
   statusEl: HTMLElement
   /** I18n instance for drawer strings. */
   i18n: AcExHtmlI18n
@@ -519,7 +551,7 @@ interface AcExLayerPanelContext {
   /** Fits the camera to the given extents and redraws. */
   zoomToExtents: (extents: AcExExtents) => void
   /** Object-snap index updated when layer visibility changes. */
-  osnapIndex: AcExOsnapIndex
+  osnapIndex: AcExOsnapIndex | null
   /** Sorted layer names for bulk show/hide actions. */
   sortedLayerNames: string[]
 }
@@ -566,7 +598,7 @@ function setupLayerPanel(
     layerVisible.set(name, visible)
     const group = layerGroups.get(name)
     if (group) group.visible = visible
-    osnapIndex.setLayerHidden(name, !visible)
+    osnapIndex?.setLayerHidden(name, !visible)
   }
 
   const setAllLayersVisible = (visible: boolean) => {
@@ -576,9 +608,9 @@ function setupLayerPanel(
       if (group) group.visible = visible
     }
     if (visible) {
-      osnapIndex.showAllLayers()
+      osnapIndex?.showAllLayers()
     } else {
-      osnapIndex.hideAllLayers(sortedLayers)
+      osnapIndex?.hideAllLayers(sortedLayers)
     }
     for (const checkbox of checkboxes) {
       checkbox.checked = visible
@@ -682,7 +714,7 @@ function createLineObject(
 
   if (batch.lineWidth != null && batch.lineWidth > 0) {
     const geometry = new LineSegmentsGeometry()
-    geometry.setPositions(copyFloat32Buffer(batch.positions))
+    geometry.setPositions(batch.positions)
     const material = createViewerLineMaterial(
       batch,
       wideLineResolution
@@ -696,12 +728,10 @@ function createLineObject(
   const geometry = new THREE.BufferGeometry()
   geometry.setAttribute(
     'position',
-    new THREE.BufferAttribute(copyFloat32Buffer(batch.positions), 3)
+    new THREE.BufferAttribute(batch.positions, 3)
   )
   if (batch.indices && batch.indices.length > 0) {
-    geometry.setIndex(
-      new THREE.BufferAttribute(copyUint32Buffer(batch.indices), 1)
-    )
+    geometry.setIndex(new THREE.BufferAttribute(batch.indices, 1))
   }
   if (
     batch.linePattern &&
@@ -710,10 +740,7 @@ function createLineObject(
   ) {
     geometry.setAttribute(
       'lineDistance',
-      new THREE.Float32BufferAttribute(
-        copyFloat32Buffer(batch.lineDistances),
-        1
-      )
+      new THREE.BufferAttribute(batch.lineDistances, 1)
     )
   }
   const material = createViewerLineMaterial(batch)
@@ -794,7 +821,7 @@ function createPointObject(batch: AcExMeshBatch): THREE.Points | null {
   const geometry = new THREE.BufferGeometry()
   geometry.setAttribute(
     'position',
-    new THREE.BufferAttribute(copyFloat32Buffer(batch.positions), 3)
+    new THREE.BufferAttribute(batch.positions, 3)
   )
   const material = createViewerPointsMaterial(batch)
   const object = new THREE.Points(geometry, material)
@@ -809,11 +836,9 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
   const geometry = new THREE.BufferGeometry()
   geometry.setAttribute(
     'position',
-    new THREE.BufferAttribute(copyFloat32Buffer(batch.positions), 3)
+    new THREE.BufferAttribute(batch.positions, 3)
   )
-  geometry.setIndex(
-    new THREE.BufferAttribute(copyUint32Buffer(batch.indices), 1)
-  )
+  geometry.setIndex(new THREE.BufferAttribute(batch.indices, 1))
   if (
     batch.gradientFill &&
     batch.gradientPositions &&
@@ -821,10 +846,7 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
   ) {
     geometry.setAttribute(
       'gradientPosition',
-      new THREE.Float32BufferAttribute(
-        copyFloat32Buffer(batch.gradientPositions),
-        2
-      )
+      new THREE.BufferAttribute(batch.gradientPositions, 2)
     )
   }
   const material = createViewerMeshMaterial(batch)

--- a/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
@@ -310,6 +310,7 @@ class BinaryWriter {
   }
 
   writeFloat32Array(array: Float32Array): void {
+    this.alignTo(4)
     const bytes = new Uint8Array(
       array.buffer,
       array.byteOffset,
@@ -320,6 +321,7 @@ class BinaryWriter {
   }
 
   writeUint32Array(array: Uint32Array): void {
+    this.alignTo(4)
     const bytes = new Uint8Array(
       array.buffer,
       array.byteOffset,
@@ -327,6 +329,17 @@ class BinaryWriter {
     )
     this.writeU32(bytes.length)
     this.writeBytes(bytes)
+  }
+
+  private alignTo(alignment: number): void {
+    const remainder = this.length % alignment
+    if (remainder === 0) {
+      return
+    }
+    const pad = alignment - remainder
+    for (let i = 0; i < pad; i++) {
+      this.writeU8(0)
+    }
   }
 
   toUint8Array(): Uint8Array {
@@ -404,25 +417,55 @@ class BinaryReader {
     return JSON.parse(text) as T
   }
 
+  private alignTo(alignment: number): void {
+    const remainder = this.offset % alignment
+    if (remainder === 0) {
+      return
+    }
+    this.offset += alignment - remainder
+  }
+
   readFloat32Array(): Float32Array {
+    this.alignTo(4)
     const byteLength = this.readU32()
     if (byteLength === 0) {
       return new Float32Array(0)
     }
+    if (byteLength % 4 !== 0) {
+      throw new Error('Invalid float32 buffer length')
+    }
     const bytes = this.readBytes(byteLength)
-    const buffer = new ArrayBuffer(byteLength)
-    new Uint8Array(buffer).set(bytes)
-    return new Float32Array(buffer)
+    if (bytes.byteOffset % 4 === 0) {
+      return new Float32Array(
+        bytes.buffer,
+        bytes.byteOffset,
+        byteLength / 4
+      )
+    }
+    const copy = new ArrayBuffer(byteLength)
+    new Uint8Array(copy).set(bytes)
+    return new Float32Array(copy)
   }
 
   readUint32Array(): Uint32Array {
+    this.alignTo(4)
     const byteLength = this.readU32()
     if (byteLength === 0) {
       return new Uint32Array(0)
     }
+    if (byteLength % 4 !== 0) {
+      throw new Error('Invalid uint32 buffer length')
+    }
     const bytes = this.readBytes(byteLength)
-    const buffer = new ArrayBuffer(byteLength)
-    new Uint8Array(buffer).set(bytes)
-    return new Uint32Array(buffer)
+    if (bytes.byteOffset % 4 === 0) {
+      return new Uint32Array(
+        bytes.buffer,
+        bytes.byteOffset,
+        byteLength / 4
+      )
+    }
+    const copy = new ArrayBuffer(byteLength)
+    new Uint8Array(copy).set(bytes)
+    return new Uint32Array(copy)
   }
 }

--- a/packages/cad-html-plugin/src/AcExSnapshotCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotCodec.ts
@@ -1,28 +1,36 @@
-import { gunzipSync, gzipSync } from 'fflate'
-
 import {
   decodeSnapshotBinary,
   encodeSnapshotBinary
 } from './AcExSnapshotBinaryCodec'
+import {
+  type AcExEncodedSnapshot,
+  type AcExSnapshotCompression,
+  compressSnapshotBinary,
+  decompressSnapshotBinary} from './AcExSnapshotCompression'
 import { ACEX_SNAPSHOT_VERSION, type AcExSnapshot } from './AcExSnapshotTypes'
 
 const SNAPSHOT_MIME = 'application/vnd.mlightcad.acex-snapshot+binary'
+
+export type { AcExEncodedSnapshot, AcExSnapshotCompression }
 
 /**
  * Serializes a snapshot to a gzip-compressed base64 string for HTML embedding.
  *
  * @param snapshot - Snapshot to encode; {@link AcExSnapshot.version} must match
  *   {@link ACEX_SNAPSHOT_VERSION}.
- * @returns Base64-encoded gzip payload (no data-URL prefix).
+ * @returns Base64 payload and the compression format written into the HTML.
  * @throws When the snapshot version is unsupported.
  */
-export function encodeSnapshot(snapshot: AcExSnapshot): string {
+export function encodeSnapshot(snapshot: AcExSnapshot): AcExEncodedSnapshot {
   if (snapshot.version !== ACEX_SNAPSHOT_VERSION) {
     throw new Error(`Unsupported snapshot version: ${snapshot.version}`)
   }
   const binary = encodeSnapshotBinary(snapshot)
-  const compressed = gzipSync(binary)
-  return uint8ToBase64(compressed)
+  const compressed = compressSnapshotBinary(binary)
+  return {
+    payload: uint8ToBase64(compressed.bytes),
+    compression: compressed.compression
+  }
 }
 
 /**
@@ -34,7 +42,7 @@ export function encodeSnapshot(snapshot: AcExSnapshot): string {
  */
 export function decodeSnapshot(payload: string): AcExSnapshot {
   const bytes = base64ToUint8(payload.trim())
-  const binary = gunzipSync(bytes)
+  const binary = decompressSnapshotBinary(bytes)
   return decodeSnapshotBinary(binary)
 }
 

--- a/packages/cad-html-plugin/src/AcExSnapshotCompression.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotCompression.ts
@@ -1,0 +1,32 @@
+import { gunzipSync,gzipSync } from 'fflate'
+
+/** Snapshot payload compression stored on the HTML script `type` attribute. */
+export const ACEX_SNAPSHOT_COMPRESSION = 'gzip' as const
+
+export type AcExSnapshotCompression = typeof ACEX_SNAPSHOT_COMPRESSION
+
+export interface AcExCompressedSnapshotBinary {
+  bytes: Uint8Array
+  compression: AcExSnapshotCompression
+}
+
+/** Result of {@link encodeSnapshot} for HTML packaging. */
+export interface AcExEncodedSnapshot {
+  payload: string
+  compression: AcExSnapshotCompression
+}
+
+/** Compresses a snapshot binary payload with gzip for HTML export. */
+export function compressSnapshotBinary(
+  data: Uint8Array
+): AcExCompressedSnapshotBinary {
+  return {
+    bytes: gzipSync(data),
+    compression: ACEX_SNAPSHOT_COMPRESSION
+  }
+}
+
+/** Decompresses a gzip snapshot binary payload from an exported HTML file. */
+export function decompressSnapshotBinary(data: Uint8Array): Uint8Array {
+  return gunzipSync(data)
+}

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -239,6 +239,14 @@ export interface AcExViewState {
 export type AcExInitialViewMode = 'fit' | 'current'
 
 /**
+ * Offline viewer capability profile embedded at export time.
+ *
+ * - `view` — pan/zoom and layer visibility only (no measurement or OSNAP data).
+ * - `measure` — full viewer with measurement tools and analytic OSNAP catalog.
+ */
+export type AcExViewerMode = 'view' | 'measure'
+
+/**
  * Display-only snapshot embedded in exported HTML.
  * Does not contain DXF/DWG bytes, `AcDb` entity records, or editable drawing state.
  *
@@ -278,6 +286,11 @@ export interface AcExSnapshot {
      * `'current'`.
      */
     viewState?: AcExViewState
+    /**
+     * Viewer capability profile. Defaults to `'measure'` when omitted for
+     * snapshots produced before this option existed.
+     */
+    viewerMode?: AcExViewerMode
   }
   /** Layer table used by the layer drawer (visibility toggles, swatches). */
   layers: AcExLayerSnapshot[]

--- a/packages/cad-html-plugin/src/AcExViewerMemory.ts
+++ b/packages/cad-html-plugin/src/AcExViewerMemory.ts
@@ -2,49 +2,15 @@ import * as THREE from 'three'
 
 import type { AcExLayoutSnapshot, AcExSnapshot } from './AcExSnapshotTypes'
 
-/** Returns a shallow copy of a float vertex buffer. */
-export function copyFloat32Buffer(source: Float32Array): Float32Array {
-  return new Float32Array(source)
-}
-
-/** Returns a shallow copy of an index buffer. */
-export function copyUint32Buffer(source: Uint32Array): Uint32Array {
-  return new Uint32Array(source)
-}
-
 /**
- * Whether tessellated batch buffers on the active layout can be dropped after
- * the THREE scene is built.
+ * Clears tessellated batch typed arrays on every snapshot layout.
  *
- * When an analytic OSNAP catalog exists, layer visibility toggles filter
- * primitives only and never re-read {@link AcExLayoutSnapshot.lineBatches}.
+ * Call only after the THREE scene has uploaded geometry to the GPU and any
+ * OSNAP index has been built from analytic primitives or tessellated segments.
  */
-export function canReleaseActiveLayoutBatches(
-  layout: AcExLayoutSnapshot
-): boolean {
-  const osnap = layout.osnap
-  if (!osnap) {
-    return false
-  }
-  return (osnap.primitives?.length ?? 0) > 0
-}
-
-/**
- * Clears tessellated batch typed arrays on snapshot layouts to reclaim CPU memory.
- *
- * Inactive layouts are always cleared. The active layout is cleared only when
- * {@link canReleaseActiveLayoutBatches} is true so OSNAP can still fall back to
- * tessellated segments when no analytic catalog was exported.
- */
-export function releaseSnapshotBatchBuffers(
-  snapshot: AcExSnapshot,
-  activeLayoutBtrId: string
-): void {
+export function releaseSnapshotBatchBuffers(snapshot: AcExSnapshot): void {
   for (const layout of snapshot.layouts) {
-    const isActive = layout.btrId === activeLayoutBtrId
-    if (!isActive || canReleaseActiveLayoutBatches(layout)) {
-      clearLayoutBatchBuffers(layout)
-    }
+    clearLayoutBatchBuffers(layout)
   }
 }
 
@@ -67,7 +33,7 @@ export function releaseSnapshotOsnapCatalogs(snapshot: AcExSnapshot): void {
 /**
  * Removes the embedded snapshot script from the DOM after decode.
  *
- * The gzip/base64 payload is often the largest resident string in memory.
+ * The compressed/base64 payload is often the largest resident string in memory.
  */
 export function removeSnapshotElement(element: HTMLElement): void {
   element.textContent = ''

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -6,7 +6,9 @@
 
 /** Snapshot schema types, version constant, and geometry batch shapes. */
 export * from './AcExSnapshotTypes'
-/** Gzip/base64 encode and decode for embedded snapshot payloads. */
+/** Gzip encode and decode for embedded snapshot payloads. */
+export * from './AcExSnapshotCompression'
+/** Compressed/base64 encode and decode for embedded snapshot payloads. */
 export * from './AcExSnapshotCodec'
 /** Binary snapshot serialization used by {@link encodeSnapshot}. */
 export {

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -989,6 +989,7 @@ export default {
   chtml: {
     exportInvisibleLayers: 'Export invisible layers',
     initialView: 'Initial view when opening HTML',
+    viewerMode: 'Offline viewer mode',
     keywords: {
       yes: {
         display: 'Yes(Y)',
@@ -1009,6 +1010,16 @@ export default {
         display: 'Current(C)',
         local: 'Current',
         global: 'Current'
+      },
+      view: {
+        display: 'View(V)',
+        local: 'View',
+        global: 'View'
+      },
+      measure: {
+        display: 'Measure(M)',
+        local: 'Measure',
+        global: 'Measure'
       }
     }
   }

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -978,6 +978,7 @@ export default {
   chtml: {
     exportInvisibleLayers: '是否导出不可见图层',
     initialView: '打开 HTML 时的初始视图',
+    viewerMode: '离线查看器模式',
     keywords: {
       yes: {
         display: '是(Y)',
@@ -998,6 +999,16 @@ export default {
         display: '当前(C)',
         local: '当前',
         global: 'Current'
+      },
+      view: {
+        display: '查看(V)',
+        local: '查看',
+        global: 'View'
+      },
+      measure: {
+        display: '测量(M)',
+        local: '测量',
+        global: 'Measure'
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add **viewer mode** (iew | measure) to HTML export: view-only mode omits OSNAP catalog data and measurement UI for smaller, faster offline HTML files; measure mode remains the default.
- Compress snapshot binary payloads with **gzip** (via flate) and encode the compression type on the HTML script tag for smaller exported files.
- Extend the chtml command with a third interactive prompt for viewer mode, add --viewer-mode to the CLI exporter, and update shell/runtime to conditionally render toolbar, settings strip, and status bar.

## Test plan

- [ ] Run cad-html-plugin unit tests (AcApExportHtmlCmd, AcExHtmlShell, AcExSnapshotCompression, AcExSnapshotCodec, etc.)
- [ ] Export a drawing via chtml and verify View vs Measure keyword produces expected toolbar differences
- [ ] Export via CLI with --viewer-mode view and --viewer-mode measure; confirm offline HTML opens and behaves correctly
- [ ] Verify gzip-compressed HTML loads in browser and snapshot decompresses correctly
- [ ] Confirm backward compatibility: existing exports without viewer mode default to measure