### PR TITLE
fix(three-renderer): align lineDistance with position after segment sanitization

### DIFF
--- a/packages/three-renderer/__tests__/AcTrBatchedLineDistance.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedLineDistance.spec.ts
@@ -1,0 +1,60 @@
+import * as THREE from 'three'
+
+import { copyAttributeData } from '../src/batch/AcTrBatchedGeometryInfo'
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import { AcTrEntity } from '../src/object/AcTrEntity'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { AcTrBufferGeometryUtil } from '../src/util/AcTrBufferGeometryUtil'
+
+describe('copyAttributeData', () => {
+  it('copies only src.count elements in the fast path', () => {
+    const srcArray = new Float32Array([1, 2, 3, 4, 5, 6, 99, 99, 99])
+    const src = new THREE.BufferAttribute(srcArray.subarray(0, 6), 3)
+
+    const targetArray = new Float32Array(12)
+    const target = new THREE.BufferAttribute(targetArray, 3)
+
+    copyAttributeData(src, target, 1)
+
+    expect(Array.from(targetArray)).toEqual([
+      0, 0, 0, 1, 2, 3, 4, 5, 6, 0, 0, 0
+    ])
+  })
+})
+
+describe('AcTrBatchedGroup lineDistance alignment', () => {
+  it('batches dashed line segments after sanitizing non-finite vertices', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute(
+        [0, 0, 0, Number.NaN, 1, 0, 2, 2, 0, 3, 3, 0],
+        3
+      )
+    )
+    geometry.setAttribute(
+      'lineDistance',
+      new THREE.Float32BufferAttribute([0, 1, 2, 3, 4, 5], 1)
+    )
+
+    const material = new THREE.ShaderMaterial()
+    const line = new THREE.LineSegments(geometry, material)
+    const entity = new AcTrEntity(new AcTrRenderContext())
+    entity.add(line)
+
+    const matrix = new THREE.Matrix4().makeTranslation(100, 0, 0)
+    const cloned = geometry.clone()
+    expect(
+      AcTrBufferGeometryUtil.safeApplyMatrix4(cloned, matrix, 2)
+    ).toBe(true)
+    AcTrBufferGeometryUtil.recomputeLineDistanceForLineSegments(cloned)
+
+    const position = cloned.getAttribute('position')
+    const lineDistance = cloned.getAttribute('lineDistance')
+    expect(position.count).toBe(2)
+    expect(lineDistance.count).toBe(position.count)
+
+    const group = new AcTrBatchedGroup()
+    expect(() => group.addEntity(entity)).not.toThrow()
+  })
+})

--- a/packages/three-renderer/__tests__/AcTrBufferGeometryUtil.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBufferGeometryUtil.spec.ts
@@ -48,4 +48,44 @@ describe('AcTrBufferGeometryUtil finite coordinate helpers', () => {
     expect(warn).not.toHaveBeenCalled()
     warn.mockRestore()
   })
+
+  it('rebuilds lineDistance when sanitizing dashed line segments', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute(
+        [0, 0, 0, Number.NaN, 1, 0, 2, 2, 0, 3, 3, 0],
+        3
+      )
+    )
+    geometry.setAttribute(
+      'lineDistance',
+      new THREE.Float32BufferAttribute([0, 1, 2, 3, 4, 5], 1)
+    )
+
+    const matrix = new THREE.Matrix4().makeTranslation(5, 0, 0)
+    expect(AcTrBufferGeometryUtil.safeApplyMatrix4(geometry, matrix, 2)).toBe(
+      true
+    )
+
+    const position = geometry.getAttribute('position')
+    const lineDistance = geometry.getAttribute('lineDistance')
+    expect(position.count).toBe(2)
+    expect(lineDistance.count).toBe(2)
+    expect(lineDistance.getX(0)).toBe(0)
+    expect(lineDistance.getX(1)).toBeGreaterThan(0)
+  })
+
+  it('keeps lineDistance length aligned for odd segment vertex counts', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 2, 0, 0], 3)
+    )
+
+    AcTrBufferGeometryUtil.recomputeLineDistanceForLineSegments(geometry)
+
+    expect(geometry.getAttribute('position').count).toBe(2)
+    expect(geometry.getAttribute('lineDistance').count).toBe(2)
+  })
 })

--- a/packages/three-renderer/src/batch/AcTrBatchedGeometryInfo.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGeometryInfo.ts
@@ -144,8 +144,12 @@ export function copyAttributeData(
       }
     }
   } else {
-    // faster copy approach using typed array set function
-    target.array.set(src.array, targetOffset * itemSize)
+    // Copy only active vertices (`src.count`), not the full backing store.
+    const srcLength = src.count * itemSize
+    target.array.set(
+      (src.array as THREE.TypedArray).subarray(0, srcLength),
+      targetOffset * itemSize
+    )
   }
 
   target.needsUpdate = true

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -1596,6 +1596,9 @@ export class AcTrBatchedGroup extends THREE.Group {
       geometry.dispose()
       return null
     }
+    if (geometry.hasAttribute('lineDistance')) {
+      AcTrBufferGeometryUtil.recomputeLineDistanceForLineSegments(geometry)
+    }
     const geometryId = batchedLine.addGeometry(geometry, -1, -1, worldOffset)
     batchedLine.setGeometryInfo(geometryId, userData)
     geometry.dispose()

--- a/packages/three-renderer/src/util/AcTrBufferGeometryUtil.ts
+++ b/packages/three-renderer/src/util/AcTrBufferGeometryUtil.ts
@@ -107,6 +107,69 @@ export class AcTrBufferGeometryUtil {
     return geometry
   }
 
+  /**
+   * Rebuilds `lineDistance` for non-indexed {@link THREE.LineSegments} geometry.
+   *
+   * Uses only complete vertex pairs so the attribute length always matches
+   * `position.count`. Call after sanitizing or rebasing segment positions.
+   */
+  static recomputeLineDistanceForLineSegments(
+    geometry: THREE.BufferGeometry,
+    worldMatrix?: THREE.Matrix4
+  ) {
+    let positionAttribute = geometry.getAttribute(
+      'position'
+    ) as THREE.BufferAttribute
+    if (!positionAttribute || positionAttribute.count < 2) {
+      geometry.deleteAttribute('lineDistance')
+      return
+    }
+
+    const vertexCount = positionAttribute.count - (positionAttribute.count % 2)
+    if (vertexCount === 0) {
+      geometry.deleteAttribute('lineDistance')
+      return
+    }
+
+    if (vertexCount < positionAttribute.count) {
+      const trimmed = new Float32Array(vertexCount * positionAttribute.itemSize)
+      trimmed.set(
+        (positionAttribute.array as THREE.TypedArray).subarray(0, trimmed.length)
+      )
+      geometry.setAttribute(
+        'position',
+        new THREE.BufferAttribute(trimmed, positionAttribute.itemSize)
+      )
+      positionAttribute = geometry.getAttribute(
+        'position'
+      ) as THREE.BufferAttribute
+    }
+
+    const lineDistances = new Float32Array(vertexCount)
+    for (let i = 0; i < vertexCount; i += 2) {
+      if (worldMatrix) {
+        _vector1
+          .fromBufferAttribute(positionAttribute, i)
+          .applyMatrix4(worldMatrix)
+        _vector2
+          .fromBufferAttribute(positionAttribute, i + 1)
+          .applyMatrix4(worldMatrix)
+      } else {
+        _vector1.fromBufferAttribute(positionAttribute, i)
+        _vector2.fromBufferAttribute(positionAttribute, i + 1)
+      }
+
+      lineDistances[i] = i === 0 ? 0 : lineDistances[i - 1]
+      lineDistances[i + 1] =
+        lineDistances[i] + _vector1.distanceTo(_vector2)
+    }
+
+    geometry.setAttribute(
+      'lineDistance',
+      new THREE.Float32BufferAttribute(lineDistances, 1)
+    )
+  }
+
   // Calculates line distances in world space
   static computeLineDistance(line: THREE.Line) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -125,22 +188,14 @@ export class AcTrBufferGeometryUtil {
       if (!positionAttribute || positionAttribute.count === 0) {
         return
       }
-      const lineDistances: number[] = []
 
       if (isLineSegments) {
-        for (let i = 0, l = positionAttribute.count; i < l; i += 2) {
-          _vector1
-            .fromBufferAttribute(positionAttribute, i)
-            .applyMatrix4(worldMatrix)
-          _vector2
-            .fromBufferAttribute(positionAttribute, i + 1)
-            .applyMatrix4(worldMatrix)
-
-          lineDistances[i] = i === 0 ? 0 : lineDistances[i - 1]
-          lineDistances[i + 1] =
-            lineDistances[i] + _vector1.distanceTo(_vector2)
-        }
+        AcTrBufferGeometryUtil.recomputeLineDistanceForLineSegments(
+          geometry,
+          worldMatrix
+        )
       } else {
+        const lineDistances: number[] = []
         lineDistances[0] = 0
         for (let i = 1, l = positionAttribute.count; i < l; i++) {
           _vector1
@@ -153,12 +208,13 @@ export class AcTrBufferGeometryUtil {
           lineDistances[i] = lineDistances[i - 1]
           lineDistances[i] += _vector1.distanceTo(_vector2)
         }
+
+        geometry.setAttribute(
+          'lineDistance',
+          new THREE.Float32BufferAttribute(lineDistances, 1)
+        )
       }
 
-      geometry.setAttribute(
-        'lineDistance',
-        new THREE.Float32BufferAttribute(lineDistances, 1)
-      )
       line.geometry.dispose()
       line.geometry = geometry
     }
@@ -407,6 +463,32 @@ export class AcTrBufferGeometryUtil {
 
     const index = geometry.getIndex()
     if (!index) {
+      if (geometry.hasAttribute('lineDistance')) {
+        const segmentPositions: number[] = []
+        for (let vertex = 0; vertex + 1 < position.count; vertex += 2) {
+          if (!isFiniteVertex(vertex) || !isFiniteVertex(vertex + 1)) {
+            continue
+          }
+          const base1 = vertex * position.itemSize
+          const base2 = (vertex + 1) * position.itemSize
+          for (let component = 0; component < position.itemSize; component++) {
+            segmentPositions.push(position.array[base1 + component])
+          }
+          for (let component = 0; component < position.itemSize; component++) {
+            segmentPositions.push(position.array[base2 + component])
+          }
+        }
+        if (segmentPositions.length === 0) {
+          return false
+        }
+        geometry.setAttribute(
+          'position',
+          new THREE.Float32BufferAttribute(segmentPositions, position.itemSize)
+        )
+        AcTrBufferGeometryUtil.recomputeLineDistanceForLineSegments(geometry)
+        return true
+      }
+
       const validVertices: number[] = []
       for (let vertex = 0; vertex < position.count; vertex++) {
         if (isFiniteVertex(vertex)) {


### PR DESCRIPTION
## Summary

- Rebuild `lineDistance` for dashed `LineSegments` after sanitizing non-finite vertices so the attribute length always matches `position.count`.
- Recompute `lineDistance` when batching line geometries in `AcTrBatchedGroup`.
- Fix `copyAttributeData` fast path to copy only `src.count` elements instead of the full backing typed array.

## Test plan

- [x] `pnpm test -- --testPathPatterns="AcTrBufferGeometryUtil|AcTrBatchedLineDistance"` (7 tests pass)
- [ ] Open a drawing with dashed linetype lines and confirm they render correctly after batching
- [ ] Verify no WebGL attribute size mismatch errors in the browser console
