### PR TITLE
feat(cad-viewer-example): add new drawing workflow from upload screen

### DIFF
--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -1,15 +1,19 @@
 <template>
   <div id="app-root">
-    <!-- Upload screen when no file is selected -->
-    <div v-if="!store.selectedFile" class="upload-screen">
-      <FileUpload @file-select="handleFileSelect" />
+    <!-- Upload screen when no drawing is open -->
+    <div v-if="!showViewer" class="upload-screen">
+      <FileUpload
+        @file-select="handleFileSelect"
+        @new-drawing="handleNewDrawing"
+      />
     </div>
 
-    <!-- CAD viewer when file is selected -->
+    <!-- CAD viewer when a file is selected or a new drawing is created -->
     <div v-else>
       <MlCadViewer
         locale="en"
-        :local-file="store.selectedFile"
+        :url="newDrawingUrl"
+        :local-file="store.selectedFile ?? undefined"
         :mode="selectedMode"
         :use-main-thread-draw="useMainThreadDraw"
         :draw-no-plot-layers="drawNoPlotLayers"
@@ -31,7 +35,7 @@ import {
   AcEdOpenMode
 } from '@mlightcad/cad-simple-viewer'
 import { MlCadViewer } from '@mlightcad/cad-viewer'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import { AcApQuitCmd } from './commands'
 import FileUpload from './components/FileUpload.vue'
@@ -67,11 +71,38 @@ const initialize = () => {
 // AcApSettingManager.instance.isShowStats = false
 // AcApSettingManager.instance.isShowCoordinate = false
 
+const BASE_URL = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/'
+const NEW_DRAWING_TEMPLATE_URL = `${BASE_URL}templates/acadiso.dxf`
+
+const showViewer = computed(
+  () => store.selectedFile != null || store.isNewDrawing
+)
+
+const newDrawingUrl = computed(() =>
+  store.isNewDrawing && store.selectedFile == null
+    ? NEW_DRAWING_TEMPLATE_URL
+    : undefined
+)
+
 const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Write)
 const useMainThreadDraw = ref(false)
 const drawNoPlotLayers = ref(false)
 const progressiveRendering = ref(false)
 const openViewMode = ref<AcApOpenViewMode | undefined>(undefined)
+
+const applyOpenOptions = (
+  mode: AcEdOpenMode,
+  mainThreadDraw: boolean,
+  showNoPlotLayers: boolean,
+  enableProgressiveRendering: boolean,
+  viewMode: AcApOpenViewMode | undefined
+) => {
+  selectedMode.value = mode
+  useMainThreadDraw.value = mainThreadDraw
+  drawNoPlotLayers.value = showNoPlotLayers
+  progressiveRendering.value = enableProgressiveRendering
+  openViewMode.value = viewMode
+}
 
 // Handle file selection from upload component
 const handleFileSelect = (
@@ -82,12 +113,33 @@ const handleFileSelect = (
   enableProgressiveRendering: boolean,
   viewMode: AcApOpenViewMode | undefined
 ) => {
+  store.isNewDrawing = false
   store.selectedFile = file
-  selectedMode.value = mode
-  useMainThreadDraw.value = mainThreadDraw
-  drawNoPlotLayers.value = showNoPlotLayers
-  progressiveRendering.value = enableProgressiveRendering
-  openViewMode.value = viewMode
+  applyOpenOptions(
+    mode,
+    mainThreadDraw,
+    showNoPlotLayers,
+    enableProgressiveRendering,
+    viewMode
+  )
+}
+
+const handleNewDrawing = (
+  mode: AcEdOpenMode,
+  mainThreadDraw: boolean,
+  showNoPlotLayers: boolean,
+  enableProgressiveRendering: boolean,
+  viewMode: AcApOpenViewMode | undefined
+) => {
+  store.selectedFile = null
+  store.isNewDrawing = true
+  applyOpenOptions(
+    mode,
+    mainThreadDraw,
+    showNoPlotLayers,
+    enableProgressiveRendering,
+    viewMode
+  )
 }
 </script>
 

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -20,7 +20,7 @@
         :progressive-rendering="progressiveRendering"
         :open-view-mode="openViewMode"
         @create="initialize"
-        base-url="https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/"
+        :base-url="BASE_URL"
       />
     </div>
   </div>

--- a/packages/cad-viewer-example/src/commands/quitCmd.ts
+++ b/packages/cad-viewer-example/src/commands/quitCmd.ts
@@ -8,5 +8,6 @@ import { store } from '../store'
 export class AcApQuitCmd extends AcEdCommand {
   async execute() {
     store.selectedFile = null
+    store.isNewDrawing = false
   }
 }

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -16,6 +16,14 @@
           </div>
         </section>
 
+        <button type="button" class="new-drawing-button" @click="handleNewDrawing">
+          New
+        </button>
+
+        <p class="upload-divider" aria-hidden="true">
+          <span>or</span>
+        </p>
+
         <el-upload
           class="upload-dropzone"
           drag
@@ -223,6 +231,13 @@ interface Props {
     progressiveRendering: boolean,
     openViewMode: AcApOpenViewMode | undefined
   ) => void
+  onNewDrawing?: (
+    mode: AcEdOpenMode,
+    useMainThreadDraw: boolean,
+    drawNoPlotLayers: boolean,
+    progressiveRendering: boolean,
+    openViewMode: AcApOpenViewMode | undefined
+  ) => void
 }
 
 const props = defineProps<Props>()
@@ -287,6 +302,16 @@ const handleFileChange: UploadProps['onChange'] = (uploadFile: UploadFile) => {
       )
     }
   }
+}
+
+const handleNewDrawing = () => {
+  props.onNewDrawing?.(
+    selectedMode.value,
+    useMainThreadDraw.value,
+    drawNoPlotLayers.value,
+    progressiveRendering.value,
+    resolveOpenViewMode()
+  )
 }
 
 const beforeUpload: UploadProps['beforeUpload'] = (rawFile: File) => {
@@ -368,6 +393,55 @@ const isValidFile = (file: File): boolean => {
   font-size: 13px;
   color: #64748b;
   line-height: 1.4;
+}
+
+.new-drawing-button {
+  display: block;
+  width: 100%;
+  margin-bottom: 4px;
+  padding: 12px 16px;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #667eea 0%, #5b6fd6 100%);
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 8px 18px rgba(102, 126, 234, 0.28);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.2s ease,
+    filter 0.2s ease;
+}
+
+.new-drawing-button:hover {
+  filter: brightness(1.03);
+  box-shadow: 0 10px 22px rgba(102, 126, 234, 0.34);
+}
+
+.new-drawing-button:active {
+  transform: translateY(1px);
+}
+
+.upload-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 14px 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.upload-divider::before,
+.upload-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #e2e8f0;
 }
 
 .upload-dropzone {

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -17,7 +17,7 @@
         </section>
 
         <button type="button" class="new-drawing-button" @click="handleNewDrawing">
-          New
+          New Drawing
         </button>
 
         <p class="upload-divider" aria-hidden="true">

--- a/packages/cad-viewer-example/src/store.ts
+++ b/packages/cad-viewer-example/src/store.ts
@@ -2,6 +2,8 @@ import { reactive } from 'vue'
 
 export const store = reactive<{
   selectedFile: File | null
+  isNewDrawing: boolean
 }>({
-  selectedFile: null
+  selectedFile: null,
+  isNewDrawing: false
 })


### PR DESCRIPTION
## Summary
- Add a **New** button on the upload screen so users can open a blank drawing from the acadiso template without selecting a file
- Track `isNewDrawing` in the example store and wire it through App.vue, FileUpload.vue, and the quit command
- Load `templates/acadiso.dxf` from the CDN (same template used by `AcApQNewCmd`) when starting a new drawing

## Test plan
- [ ] Open cad-viewer-example and click **New** — viewer opens with an empty ISO template
- [ ] Run `quit` or `Exit` — returns to upload screen
- [ ] Upload a DWG/DXF after using **New** — file loads normally and `isNewDrawing` is cleared
- [ ] Verify open options (access mode, view mode, progressive rendering, etc.) apply to both file upload and new drawing flows
