### PR TITLE
feat(cad-agent-plugin): add DeepSeek VL provider and improve agent UX

### DIFF
--- a/packages/cad-agent-plugin/src/agent/createCadAgent.ts
+++ b/packages/cad-agent-plugin/src/agent/createCadAgent.ts
@@ -9,6 +9,7 @@ import {
 
 import type { LlmSettings } from '../storage/LlmSettingsStore'
 import { createCadTools } from '../tools/cadTools'
+import { formatChatError } from '../ui/formatChatError'
 import { createModelFromSettings } from './createModel'
 import { CAD_AGENT_SYSTEM_PROMPT } from './systemPrompt'
 
@@ -56,7 +57,9 @@ export function createAgentChatTransport(
       })
       // Return UI message chunks directly — not HTTP SSE from respond().body.
       return result.toUIMessageStream({
-        originalMessages: validatedMessages
+        originalMessages: validatedMessages,
+        onError: error =>
+          error instanceof Error ? formatChatError(error) : String(error)
       })
     },
     /** In-process transport does not support stream reconnection. */

--- a/packages/cad-agent-plugin/src/agent/createModel.ts
+++ b/packages/cad-agent-plugin/src/agent/createModel.ts
@@ -37,8 +37,8 @@ export function createModelFromSettings(settings: LlmSettings): LanguageModel {
     return openai.chat(settings.model)
   }
 
-  // DeepSeek and other OpenAI-compatible endpoints use /chat/completions
-  // and reject the `developer` role that AI SDK 5 may emit for system prompts.
+  // DeepSeek text API, DeepSeek VL, and other OpenAI-compatible endpoints use
+  // /chat/completions and reject the `developer` role that AI SDK 5 may emit.
   const openai = createOpenAI({
     apiKey: settings.apiKey,
     baseURL: settings.baseUrl || undefined,

--- a/packages/cad-agent-plugin/src/i18n/en.ts
+++ b/packages/cad-agent-plugin/src/i18n/en.ts
@@ -12,6 +12,9 @@ export const agentEn = {
   close: 'Close',
   provider: 'Provider',
   providerDeepseek: 'DeepSeek',
+  providerDeepseekVl: 'DeepSeek VL (vision)',
+  providerDeepseekVlHint:
+    'Uses an OpenAI-compatible vision endpoint (default: SiliconFlow). For self-hosted vLLM, set Base URL to your server, e.g. http://127.0.0.1:8000/v1.',
   providerOpenai: 'OpenAI',
   providerAnthropic: 'Anthropic',
   providerOpenaiCompatible: 'OpenAI Compatible',

--- a/packages/cad-agent-plugin/src/i18n/zh.ts
+++ b/packages/cad-agent-plugin/src/i18n/zh.ts
@@ -12,6 +12,9 @@ export const agentZh = {
   close: '关闭',
   provider: '服务商',
   providerDeepseek: 'DeepSeek',
+  providerDeepseekVl: 'DeepSeek VL（视觉）',
+  providerDeepseekVlHint:
+    '使用 OpenAI 兼容的视觉接口（默认：SiliconFlow）。自托管 vLLM 时请将接口地址改为本地服务，例如 http://127.0.0.1:8000/v1。',
   providerOpenai: 'OpenAI',
   providerAnthropic: 'Anthropic',
   providerOpenaiCompatible: 'OpenAI 兼容',

--- a/packages/cad-agent-plugin/src/storage/LlmSettingsStore.ts
+++ b/packages/cad-agent-plugin/src/storage/LlmSettingsStore.ts
@@ -9,6 +9,7 @@ export type LlmProviderId =
   | 'anthropic'
   | 'openai-compatible'
   | 'deepseek'
+  | 'deepseek-vl'
 
 /**
  * Persisted LLM configuration for the CAD agent chat panel.
@@ -59,7 +60,11 @@ export const PROVIDER_DEFAULTS: Record<
   },
   deepseek: {
     baseUrl: 'https://api.deepseek.com/v1',
-    model: 'deepseek-chat'
+    model: 'deepseek-v4-flash'
+  },
+  'deepseek-vl': {
+    baseUrl: 'https://api.siliconflow.cn/v1',
+    model: 'deepseek-vl2'
   }
 }
 

--- a/packages/cad-agent-plugin/src/storage/modelCatalog.ts
+++ b/packages/cad-agent-plugin/src/storage/modelCatalog.ts
@@ -72,16 +72,54 @@ export const PROVIDER_MODEL_OPTIONS: Record<
   ],
   deepseek: [
     {
+      value: 'deepseek-v4-flash',
+      labelEn: 'DeepSeek V4 Flash',
+      labelZh: 'DeepSeek V4 Flash',
+      supportsVision: false
+    },
+    {
+      value: 'deepseek-v4-pro',
+      labelEn: 'DeepSeek V4 Pro',
+      labelZh: 'DeepSeek V4 Pro',
+      supportsVision: false
+    },
+    {
       value: 'deepseek-chat',
-      labelEn: 'DeepSeek Chat',
-      labelZh: 'DeepSeek Chat',
+      labelEn: 'DeepSeek Chat (legacy)',
+      labelZh: 'DeepSeek Chat（旧版别名）',
       supportsVision: false
     },
     {
       value: 'deepseek-reasoner',
-      labelEn: 'DeepSeek Reasoner',
-      labelZh: 'DeepSeek Reasoner',
+      labelEn: 'DeepSeek Reasoner (legacy)',
+      labelZh: 'DeepSeek Reasoner（旧版别名）',
       supportsVision: false
+    }
+  ],
+  'deepseek-vl': [
+    {
+      value: 'deepseek-vl2',
+      labelEn: 'DeepSeek VL2',
+      labelZh: 'DeepSeek VL2',
+      supportsVision: true
+    },
+    {
+      value: 'deepseek-ai/deepseek-vl2-small',
+      labelEn: 'DeepSeek VL2 Small',
+      labelZh: 'DeepSeek VL2 Small',
+      supportsVision: true
+    },
+    {
+      value: 'deepseek-ai/deepseek-vl2-tiny',
+      labelEn: 'DeepSeek VL2 Tiny',
+      labelZh: 'DeepSeek VL2 Tiny',
+      supportsVision: true
+    },
+    {
+      value: 'deepseek-ai/deepseek-vl2',
+      labelEn: 'DeepSeek VL2 (HuggingFace id)',
+      labelZh: 'DeepSeek VL2（HuggingFace 路径）',
+      supportsVision: true
     }
   ],
   'openai-compatible': [

--- a/packages/cad-agent-plugin/src/ui/AgentChatPanel.vue
+++ b/packages/cad-agent-plugin/src/ui/AgentChatPanel.vue
@@ -253,6 +253,15 @@ function clearPendingImages() {
   pendingImages.value = []
 }
 
+/** Builds a {@link FileList} so the AI SDK can convert attachments to file UI parts. */
+function toFileList(files: File[]): FileList {
+  const dataTransfer = new DataTransfer()
+  for (const file of files) {
+    dataTransfer.items.add(file)
+  }
+  return dataTransfer.files
+}
+
 /** Sends the current text and optional images to the CAD agent. */
 async function sendMessage() {
   const text = input.value.trim()
@@ -265,7 +274,7 @@ async function sendMessage() {
   try {
     await chat.value.sendMessage({
       ...(text ? { text } : {}),
-      ...(files.length > 0 ? { files } : {})
+      ...(files.length > 0 ? { files: toFileList(files) } : {})
     })
   } catch {
     // error surfaced via chat.error
@@ -389,6 +398,7 @@ function toolParts(message: UIMessage): string[] {
         {{ labels.provider }}
         <select v-model="settings.provider">
           <option value="deepseek">{{ labels.providerDeepseek }}</option>
+          <option value="deepseek-vl">{{ labels.providerDeepseekVl }}</option>
           <option value="openai">{{ labels.providerOpenai }}</option>
           <option value="anthropic">{{ labels.providerAnthropic }}</option>
           <option value="openai-compatible">
@@ -400,6 +410,9 @@ function toolParts(message: UIMessage): string[] {
         {{ labels.baseUrl }}
         <input v-model="settings.baseUrl" type="text" />
       </label>
+      <p v-if="settings.provider === 'deepseek-vl'" class="cad-agent-model-hint">
+        {{ labels.providerDeepseekVlHint }}
+      </p>
       <label>
         {{ labels.model }}
         <select v-model="modelSelection">
@@ -486,9 +499,15 @@ function toolParts(message: UIMessage): string[] {
             type="button"
             class="cad-agent-error-dismiss"
             :title="labels.dismissError"
+            :aria-label="labels.dismissError"
             @click="dismissError"
           >
-            脳
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
           </button>
         </div>
       </div>
@@ -509,9 +528,15 @@ function toolParts(message: UIMessage): string[] {
             type="button"
             class="cad-agent-attachment-remove"
             :title="labels.removeAttachment"
+            :aria-label="labels.removeAttachment"
             @click="removePendingImage(index)"
           >
-            脳
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
           </button>
         </div>
       </div>

--- a/packages/cad-agent-plugin/src/ui/agent-panel.css
+++ b/packages/cad-agent-plugin/src/ui/agent-panel.css
@@ -206,6 +206,9 @@
 }
 
 .cad-agent-error-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
   width: 24px;
   height: 24px;
@@ -214,9 +217,12 @@
   border-radius: 4px;
   background: transparent;
   color: #f48771;
-  font-size: 18px;
-  line-height: 1;
   cursor: pointer;
+}
+
+.cad-agent-error-dismiss svg {
+  width: 16px;
+  height: 16px;
 }
 
 .cad-agent-error-dismiss:hover {
@@ -382,6 +388,9 @@
 }
 
 .cad-agent-attachment-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
   top: 2px;
   right: 2px;
@@ -392,9 +401,12 @@
   border-radius: 4px;
   background: rgba(0, 0, 0, 0.65);
   color: #fff;
-  font-size: 14px;
-  line-height: 1;
   cursor: pointer;
+}
+
+.cad-agent-attachment-remove svg {
+  width: 14px;
+  height: 14px;
 }
 
 .cad-agent-attachment-remove:hover {

--- a/packages/cad-agent-plugin/src/ui/formatChatError.ts
+++ b/packages/cad-agent-plugin/src/ui/formatChatError.ts
@@ -1,3 +1,5 @@
+import { APICallError } from 'ai'
+
 /**
  * Extracts a human-readable message from a provider error payload.
  *
@@ -33,6 +35,11 @@ function extractApiMessage(value: unknown): string | undefined {
  * @returns A concise message suitable for the chat error banner.
  */
 export function formatChatError(error: Error): string {
+  if (APICallError.isInstance(error)) {
+    const fromBody = extractApiMessage(error.responseBody)
+    if (fromBody) return fromBody
+  }
+
   const responseBody = (error as Error & { responseBody?: unknown }).responseBody
   const fromBody = extractApiMessage(responseBody)
   if (fromBody) return fromBody


### PR DESCRIPTION
## Summary

- Add **DeepSeek VL (vision)** provider preset with SiliconFlow defaults and model catalog entries (VL2, VL2 Small/Tiny, HuggingFace ids).
- Update DeepSeek text provider defaults to V4 Flash/Pro; keep legacy `deepseek-chat` / `deepseek-reasoner` as aliases.
- Fix image attachment upload by converting `File[]` to `FileList` for the AI SDK.
- Improve error handling: use `APICallError` parsing in `formatChatError`, wire `onError` into the agent stream, and replace garbled dismiss buttons with SVG icons + `aria-label`.

## Test plan

- [ ] Open Agent settings, select **DeepSeek VL (vision)** — verify SiliconFlow base URL and VL2 model defaults appear with hint text.
- [ ] Attach an image on a vision-capable model and send a message — verify the image is included in the request.
- [ ] Trigger an API error (invalid key) — verify a readable error message appears in the chat banner.
- [ ] Confirm dismiss/remove buttons render as X icons (not garbled characters).
- [ ] Switch DeepSeek text provider — verify V4 Flash/Pro appear in the model dropdown.