### PR TITLE
feat(cad-simple-viewer): add entout command for entity preview PNG export

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
@@ -125,6 +125,7 @@ jest.mock('../src/command', () => {
     'AcApClearMeasurementsCmd',
     'AcApConvertToDxfCmd',
     'AcApConvertToPngCmd',
+    'AcApEntityPreviewCmd',
     'AcApCopyCmd',
     'AcApDimLinearCmd',
     'AcApEllipseCmd',

--- a/packages/cad-simple-viewer/__tests__/AcApEntityPreviewConvertor.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApEntityPreviewConvertor.spec.ts
@@ -1,0 +1,57 @@
+import { AcGeBox2d, AcGePoint2d } from '@mlightcad/data-model'
+
+jest.mock('../src/app', () => ({
+  AcApDocManager: {
+    instance: {
+      curView: null
+    }
+  }
+}))
+
+jest.mock('../src/view', () => ({
+  AcTrView2d: class AcTrView2d {}
+}))
+
+import { AcApEntityPreviewConvertor } from '../src/command/convert/AcApEntityPreviewConvertor'
+
+type EntityPreviewConvertorTestApi = {
+  resolveOutputSize: (
+    longSide: number,
+    aspect: number
+  ) => { width: number; height: number }
+  getBoundsAspect: (bounds: AcGeBox2d) => number
+}
+
+function convertorApi(): EntityPreviewConvertorTestApi {
+  return new AcApEntityPreviewConvertor() as unknown as EntityPreviewConvertorTestApi
+}
+
+describe('AcApEntityPreviewConvertor sizing helpers', () => {
+  it('resolveOutputSize keeps long side on width for landscape aspect', () => {
+    const api = convertorApi()
+
+    expect(api.resolveOutputSize(512, 2)).toEqual({
+      width: 512,
+      height: 256
+    })
+  })
+
+  it('resolveOutputSize keeps long side on height for portrait aspect', () => {
+    const api = convertorApi()
+
+    expect(api.resolveOutputSize(512, 0.5)).toEqual({
+      width: 256,
+      height: 512
+    })
+  })
+
+  it('getBoundsAspect uses absolute box dimensions', () => {
+    const api = convertorApi()
+    const bounds = new AcGeBox2d(
+      new AcGePoint2d(0, 0),
+      new AcGePoint2d(200, 50)
+    )
+
+    expect(api.getBoundsAspect(bounds)).toBeCloseTo(4)
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcTrLayout.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrLayout.spec.ts
@@ -413,3 +413,78 @@ describe('AcTrLayout spatial index', () => {
     ])
   })
 })
+
+describe('AcTrLayout entity preview helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRemoveEntity.mockReturnValue(false)
+    lastCapturedExclude = undefined
+  })
+
+  it('canCreateEntityPreview requires every entity when requireAllEntities is true', () => {
+    const layout = new AcTrLayout()
+    const group = layout.addLayer(createLayerInfo()).internalObject as unknown as {
+      hasEntity: jest.Mock
+      computeBoundingBox: jest.Mock
+    }
+    group.hasEntity = jest
+      .fn()
+      .mockImplementation((id: string) => id === 'line-1' || id === 'line-2')
+    group.computeBoundingBox = jest.fn(
+      (
+        target: THREE.Box3,
+        options?: { includeObjectIds?: ReadonlySet<string> }
+      ) => {
+        target.makeEmpty()
+        if (options?.includeObjectIds?.has('line-1')) {
+          target.min.set(0, 0, 0)
+          target.max.set(10, 10, 0)
+        }
+        if (options?.includeObjectIds?.has('line-2')) {
+          target.min.set(20, 0, 0)
+          target.max.set(30, 10, 0)
+        }
+        return target
+      }
+    )
+
+    expect(
+      layout.canCreateEntityPreview(['line-1', 'line-2'], {
+        requireAllEntities: true
+      })
+    ).toBe(true)
+    expect(
+      layout.canCreateEntityPreview(['line-1', 'missing'], {
+        requireAllEntities: true
+      })
+    ).toBe(false)
+  })
+
+  it('findPreviewableEntityIds returns only ids with batch bounds in this layout', () => {
+    const layout = new AcTrLayout()
+    const group = layout.addLayer(createLayerInfo()).internalObject as unknown as {
+      hasEntity: jest.Mock
+      computeBoundingBox: jest.Mock
+    }
+    group.hasEntity = jest
+      .fn()
+      .mockImplementation((id: string) => id === 'line-1' || id === 'line-2')
+    group.computeBoundingBox = jest.fn(
+      (
+        target: THREE.Box3,
+        options?: { includeObjectIds?: ReadonlySet<string> }
+      ) => {
+        target.makeEmpty()
+        if (options?.includeObjectIds?.has('line-1')) {
+          target.min.set(0, 0, 0)
+          target.max.set(10, 10, 0)
+        }
+        return target
+      }
+    )
+
+    expect(layout.findPreviewableEntityIds(['line-1', 'line-2', 'missing'])).toEqual(
+      ['line-1']
+    )
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcTrSceneEntityPreview.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrSceneEntityPreview.spec.ts
@@ -142,6 +142,26 @@ describe('AcTrScene entity preview layout policy', () => {
     )
   })
 
+  it('findPreviewableEntityIds reports skipped ids across layouts', () => {
+    const scene = new AcTrScene()
+    const active = createStubLayout({
+      'line-1': { min: [0, 0, 0], max: [10, 10, 0] }
+    })
+    const model = createStubLayout({
+      'line-2': { min: [50, 0, 0], max: [60, 10, 0] }
+    })
+
+    registerLayout(scene, 'active', active, { active: true })
+    registerLayout(scene, 'model', model, { model: true })
+
+    expect(
+      scene.findPreviewableEntityIds(
+        ['line-1', 'line-2', 'missing'],
+        'all'
+      )
+    ).toEqual(['line-1', 'line-2'])
+  })
+
   it('createPreview only uses the active layout with strict entity policy', () => {
     const scene = new AcTrScene()
     const active = createStubLayout({

--- a/packages/cad-simple-viewer/__tests__/AcTrSceneEntityPreview.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrSceneEntityPreview.spec.ts
@@ -1,0 +1,195 @@
+import * as THREE from 'three'
+
+jest.mock('@mlightcad/three-renderer', () => ({
+  AcTrEntityPreview: {
+    box3ToBounds2d: jest.fn()
+  },
+  AcTrHtmlTransientManager: class AcTrHtmlTransientManager {},
+  AcTrPreviewOverlayManager: class AcTrPreviewOverlayManager {},
+  AcTrTransientManager: class AcTrTransientManager {}
+}))
+
+import { AcTrLayout } from '../src/view/AcTrLayout'
+import { AcTrScene } from '../src/view/AcTrScene'
+
+type StubLayoutConfig = Record<
+  string,
+  { min: [number, number, number]; max: [number, number, number] } | 'missing'
+>
+
+function createStubLayout(
+  previewableIds: StubLayoutConfig
+): AcTrLayout {
+  const layout = {
+    computeEntityPreviewBoundsBox: jest.fn(
+      (entityIds: string[], target = new THREE.Box3()) => {
+        target.makeEmpty()
+        for (const id of entityIds) {
+          const bounds = previewableIds[id]
+          if (!bounds || bounds === 'missing') {
+            continue
+          }
+          target.union(
+            new THREE.Box3(
+              new THREE.Vector3(...bounds.min),
+              new THREE.Vector3(...bounds.max)
+            )
+          )
+        }
+        return target
+      }
+    ),
+    findPreviewableEntityIds: jest.fn((entityIds: string[]) =>
+      entityIds.filter(id => {
+        const bounds = previewableIds[id]
+        return bounds != null && bounds !== 'missing'
+      })
+    ),
+    createEntityPreviewRoot: jest.fn((entityIds: string[]) => {
+      const matched = entityIds.filter(id => {
+        const bounds = previewableIds[id]
+        return bounds != null && bounds !== 'missing'
+      })
+      if (matched.length === 0) {
+        return null
+      }
+      const root = new THREE.Group()
+      root.name = `PreviewStub:${matched.join(',')}`
+      return root
+    }),
+    canCreateEntityPreview: jest.fn(() => true)
+  }
+
+  return layout as unknown as AcTrLayout
+}
+
+function registerLayout(
+  scene: AcTrScene,
+  layoutId: string,
+  layout: AcTrLayout,
+  options?: { active?: boolean; model?: boolean }
+) {
+  const internal = scene as unknown as {
+    _layouts: Map<string, AcTrLayout>
+    _activeLayoutBtrId: string
+    _modelSpaceBtrId: string
+  }
+  internal._layouts.set(layoutId, layout)
+  if (options?.active) {
+    internal._activeLayoutBtrId = layoutId
+  }
+  if (options?.model) {
+    internal._modelSpaceBtrId = layoutId
+  }
+}
+
+describe('AcTrScene entity preview layout policy', () => {
+  it('active-first bounds use the first layout that matches', () => {
+    const scene = new AcTrScene()
+    const active = createStubLayout({
+      'line-a': { min: [0, 0, 0], max: [10, 10, 0] }
+    })
+    const model = createStubLayout({
+      'line-b': { min: [100, 100, 0], max: [120, 120, 0] }
+    })
+
+    registerLayout(scene, 'active', active, { active: true })
+    registerLayout(scene, 'model', model, { model: true })
+
+    const box = (
+      scene as unknown as {
+        computeEntityPreviewBoundsBox: (
+          ids: string[],
+          scope: 'active-first' | 'all'
+        ) => THREE.Box3
+      }
+    ).computeEntityPreviewBoundsBox(['line-a', 'line-b'], 'active-first')
+
+    expect(box.min.x).toBeCloseTo(0)
+    expect(box.max.x).toBeCloseTo(10)
+    expect(active.computeEntityPreviewBoundsBox).toHaveBeenCalled()
+    expect(model.computeEntityPreviewBoundsBox).not.toHaveBeenCalled()
+  })
+
+  it('scope all deduplicates entities across layouts', () => {
+    const scene = new AcTrScene()
+    const active = createStubLayout({
+      'shared': { min: [0, 0, 0], max: [10, 10, 0] },
+      'only-active': { min: [20, 0, 0], max: [30, 10, 0] }
+    })
+    const model = createStubLayout({
+      shared: { min: [0, 0, 0], max: [10, 10, 0] },
+      'only-model': { min: [100, 0, 0], max: [110, 10, 0] }
+    })
+
+    registerLayout(scene, 'active', active, { active: true })
+    registerLayout(scene, 'model', model, { model: true })
+
+    const root = scene.createEntityPreviewRoot(
+      ['shared', 'only-active', 'only-model'],
+      { scope: 'all' }
+    )
+
+    expect(root).not.toBeNull()
+    expect(root!.children).toHaveLength(2)
+    expect(active.createEntityPreviewRoot).toHaveBeenCalledWith(
+      ['shared', 'only-active'],
+      expect.objectContaining({ missingEntity: 'skip' })
+    )
+    expect(model.createEntityPreviewRoot).toHaveBeenCalledWith(
+      ['only-model'],
+      expect.objectContaining({ missingEntity: 'skip' })
+    )
+  })
+
+  it('createPreview only uses the active layout with strict entity policy', () => {
+    const scene = new AcTrScene()
+    const active = createStubLayout({
+      'line-1': { min: [0, 0, 0], max: [10, 10, 0] }
+    })
+    const model = createStubLayout({
+      'line-2': { min: [50, 0, 0], max: [60, 10, 0] }
+    })
+
+    registerLayout(scene, 'active', active, { active: true })
+    registerLayout(scene, 'model', model, { model: true })
+
+    const overlay = scene as unknown as {
+      _previewOverlayManager: { add: jest.Mock }
+    }
+    overlay._previewOverlayManager = {
+      add: jest.fn(() => ({ id: 'preview-handle' }))
+    }
+
+    scene.createPreview(['line-1'])
+    expect(active.createEntityPreviewRoot).toHaveBeenCalledWith(['line-1'], {
+      missingEntity: 'fail',
+      requireAllEntities: true
+    })
+    expect(model.createEntityPreviewRoot).not.toHaveBeenCalled()
+
+    jest.clearAllMocks()
+    expect(scene.createPreview(['line-2'])).toBeNull()
+    expect(active.createEntityPreviewRoot).toHaveBeenCalledWith(['line-2'], {
+      missingEntity: 'fail',
+      requireAllEntities: true
+    })
+    expect(model.createEntityPreviewRoot).not.toHaveBeenCalled()
+  })
+
+  it('canCreatePreview checks the active layout without building preview geometry', () => {
+    const scene = new AcTrScene()
+    const active = createStubLayout({
+      'line-1': { min: [0, 0, 0], max: [10, 10, 0] }
+    })
+    active.canCreateEntityPreview = jest.fn(() => true)
+
+    registerLayout(scene, 'active', active, { active: true })
+
+    expect(scene.canCreatePreview(['line-1'])).toBe(true)
+    expect(active.canCreateEntityPreview).toHaveBeenCalledWith(['line-1'], {
+      requireAllEntities: true
+    })
+    expect(active.createEntityPreviewRoot).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -24,6 +24,7 @@ import {
   AcApCopyCmd,
   AcApDimLinearCmd,
   AcApEllipseCmd,
+  AcApEntityPreviewCmd,
   AcApEraseCmd,
   AcApHatchCmd,
   AcApHideObjectsCmd,
@@ -1023,6 +1024,7 @@ export class AcApDocManager {
     addSystemCommand('circle', 'circle', new AcApCircleCmd())
     addSystemCommand('cdxf', 'cdxf', new AcApConvertToDxfCmd())
     addSystemCommand('pngout', 'pngout', new AcApConvertToPngCmd())
+    addSystemCommand('entout', 'entout', new AcApEntityPreviewCmd())
     addSystemCommand('ellipse', 'ellipse', new AcApEllipseCmd())
     addSystemCommand('erase', 'erase', new AcApEraseCmd())
     addSystemCommand('hideobjects', 'hideobjects', new AcApHideObjectsCmd())

--- a/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewCmd.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewCmd.ts
@@ -75,10 +75,11 @@ export class AcApEntityPreviewCmd extends AcEdCommand {
 
     const result = new AcApEntityPreviewConvertor().export(objectIds, longSide)
     if (result.ok) {
-      this.showMessage(
-        `${objectIds.length} ${AcApI18n.t('jig.entout.exported')}`,
-        'success'
-      )
+      let message = `${result.exportedCount} ${AcApI18n.t('jig.entout.exported')}`
+      if (result.skippedCount > 0) {
+        message += `, ${result.skippedCount} ${AcApI18n.t('jig.entout.skipped')}`
+      }
+      this.showMessage(message, 'success')
       return
     }
 

--- a/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewCmd.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewCmd.ts
@@ -1,0 +1,102 @@
+import { AcApContext, AcApDocManager } from '../../app'
+import {
+  AcEdCommand,
+  AcEdOpenMode,
+  AcEdPromptDoubleOptions,
+  AcEdPromptSelectionOptions,
+  AcEdPromptStatus
+} from '../../editor'
+import { AcApI18n } from '../../i18n'
+import { AcTrView2d } from '../../view'
+import { AcApEntityPreviewConvertor } from './AcApEntityPreviewConvertor'
+
+const DEFAULT_LONG_SIDE_PX = 512
+
+/**
+ * Command that exports a merged preview image for one or more selected entities.
+ */
+export class AcApEntityPreviewCmd extends AcEdCommand {
+  constructor() {
+    super()
+    this.mode = AcEdOpenMode.Read
+  }
+
+  /**
+   * Prompts for entity selection and preview size, then downloads the PNG.
+   *
+   * @param context - Current application context
+   */
+  async execute(context: AcApContext) {
+    const selectionSet = context.view.selectionSet
+    let objectIds = selectionSet.count > 0 ? selectionSet.ids : []
+
+    if (objectIds.length === 0) {
+      const options = new AcEdPromptSelectionOptions(
+        AcApI18n.sysCmdPrompt('entout')
+      )
+      const selectionResult =
+        await AcApDocManager.instance.editor.getSelection(options)
+      if (
+        selectionResult.status !== AcEdPromptStatus.OK ||
+        !selectionResult.value ||
+        selectionResult.value.count === 0
+      ) {
+        return
+      }
+      objectIds = selectionResult.value.ids
+    }
+
+    const longSidePrompt = new AcEdPromptDoubleOptions(
+      `${AcApI18n.t('jig.entout.longSidePrompt')} <${DEFAULT_LONG_SIDE_PX}>`
+    )
+    longSidePrompt.allowNone = true
+    longSidePrompt.allowNegative = false
+    longSidePrompt.allowZero = false
+    longSidePrompt.defaultValue = DEFAULT_LONG_SIDE_PX
+    longSidePrompt.useDefaultValue = true
+    const longSideResult =
+      await AcApDocManager.instance.editor.getDouble(longSidePrompt)
+
+    if (
+      longSideResult.status === AcEdPromptStatus.Cancel ||
+      longSideResult.status === AcEdPromptStatus.Error
+    ) {
+      return
+    }
+
+    const longSide =
+      longSideResult.status === AcEdPromptStatus.OK &&
+      longSideResult.value !== undefined
+        ? longSideResult.value
+        : DEFAULT_LONG_SIDE_PX
+
+    const view = AcApDocManager.instance.curView as AcTrView2d
+    this.syncActiveLayoutViewSize(view)
+
+    const result = new AcApEntityPreviewConvertor().export(objectIds, longSide)
+    if (result.ok) {
+      this.showMessage(
+        `${objectIds.length} ${AcApI18n.t('jig.entout.exported')}`,
+        'success'
+      )
+      return
+    }
+
+    this.showMessage(
+      AcApI18n.t(`jig.entout.failed.${result.reason}`),
+      'error'
+    )
+  }
+
+  /**
+   * Keeps active layout-view size in sync with current view size.
+   */
+  private syncActiveLayoutViewSize(view: AcTrView2d) {
+    const layoutView = view.activeLayoutView
+    if (!layoutView) {
+      return
+    }
+
+    layoutView.resize(view.width, view.height)
+  }
+}

--- a/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewConvertor.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewConvertor.ts
@@ -1,0 +1,154 @@
+import { AcDbObjectId, AcGeBox2d, AcGeVector2d } from '@mlightcad/data-model'
+import { disposePreviewSubset } from '@mlightcad/three-renderer'
+
+import { AcApDocManager } from '../../app'
+import { resolveExportDownloadName } from '../../util/AcApExportFileNameUtil'
+import { AcTrView2d } from '../../view'
+
+export type AcApEntityPreviewExportFailure =
+  | 'no-preview-root'
+  | 'no-bounds'
+  | 'capture-failed'
+  | 'download-failed'
+
+export type AcApEntityPreviewExportResult =
+  | { ok: true }
+  | { ok: false; reason: AcApEntityPreviewExportFailure }
+
+/**
+ * Exports one merged preview image for the specified entity ids.
+ *
+ * Reuses the same batch extraction path as MOVE/COPY/ROTATE jigs, then captures
+ * through {@link AcTrRenderer.renderEntityPreview}.
+ */
+export class AcApEntityPreviewConvertor {
+  /**
+   * Renders selected entities into one PNG and triggers a browser download.
+   *
+   * @param entityIds - Database object ids to include in the preview
+   * @param longSide - Maximum output width or height in pixels
+   */
+  export(
+    entityIds: AcDbObjectId[],
+    longSide: number
+  ): AcApEntityPreviewExportResult {
+    const view = AcApDocManager.instance.curView as AcTrView2d
+    const scene = view.cadScene
+
+    const bounds =
+      scene.computeEntityPreviewBounds2d(entityIds, 1.1, 'all') ?? null
+    if (!bounds) {
+      console.warn('[ENTPREVIEW] Failed to compute preview bounds', entityIds)
+      return { ok: false, reason: 'no-bounds' }
+    }
+
+    const outputSize = this.resolveOutputSize(
+      longSide,
+      this.getBoundsAspect(bounds)
+    )
+    const renderWidth = outputSize.width
+    const renderHeight = outputSize.height
+
+    const previewRoot = scene.createEntityPreviewRoot(entityIds, {
+      scope: 'all'
+    })
+    if (!previewRoot) {
+      console.warn(
+        '[ENTPREVIEW] Failed to build preview geometry',
+        `${entityIds.length} requested entity ids`
+      )
+      return { ok: false, reason: 'no-preview-root' }
+    }
+
+    const rendererWrapper = view.renderer
+    let downloaded = false
+
+    try {
+      const capture = rendererWrapper.renderEntityPreview(previewRoot, {
+        width: renderWidth,
+        height: renderHeight,
+        bounds,
+        margin: 1,
+        viewportSize: { width: view.width, height: view.height },
+        localLineResolutionOnly: true,
+        onRestored: () => {
+          view.isDirty = true
+        }
+      })
+
+      if (!capture) {
+        return { ok: false, reason: 'capture-failed' }
+      }
+
+      downloaded = this.downloadCanvas(capture.canvas)
+    } catch (error) {
+      console.error('[ENTPREVIEW] Failed to render preview image', error)
+      return { ok: false, reason: 'capture-failed' }
+    } finally {
+      disposePreviewSubset(previewRoot)
+    }
+
+    if (!downloaded) {
+      return { ok: false, reason: 'download-failed' }
+    }
+
+    return { ok: true }
+  }
+
+  /**
+   * Computes width and height from a target long side while preserving aspect ratio.
+   */
+  private resolveOutputSize(longSide: number, aspect: number) {
+    const clampedLongSide = Math.max(1, Math.round(longSide))
+    const safeAspect =
+      Number.isFinite(aspect) && aspect > Number.EPSILON ? aspect : 1
+
+    if (safeAspect >= 1) {
+      return {
+        width: clampedLongSide,
+        height: Math.max(1, Math.round(clampedLongSide / safeAspect))
+      }
+    }
+
+    return {
+      width: Math.max(1, Math.round(clampedLongSide * safeAspect)),
+      height: clampedLongSide
+    }
+  }
+
+  /**
+   * Returns the world-space aspect ratio of one 2D bounds box.
+   */
+  private getBoundsAspect(bounds: AcGeBox2d) {
+    const size = new AcGeVector2d()
+    bounds.getSize(size)
+    const width = Math.max(Math.abs(size.x), Number.EPSILON)
+    const height = Math.max(Math.abs(size.y), Number.EPSILON)
+    return width / height
+  }
+
+  /**
+   * Creates a downloadable PNG file and triggers the download.
+   */
+  private downloadCanvas(canvas: HTMLCanvasElement) {
+    try {
+      const doc = AcApDocManager.instance.curDocument
+      const downloadName = resolveExportDownloadName(
+        doc.fileName || doc.docTitle,
+        'png',
+        'entity-preview'
+      )
+      const dataUrl = canvas.toDataURL('image/png')
+      const downloadLink = document.createElement('a')
+      downloadLink.href = dataUrl
+      downloadLink.download = downloadName
+      document.body.appendChild(downloadLink)
+      downloadLink.click()
+      document.body.removeChild(downloadLink)
+      return true
+    } catch (error) {
+      console.error('[ENTPREVIEW] Failed to download preview PNG', error)
+      return false
+    }
+  }
+}

--- a/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewConvertor.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewConvertor.ts
@@ -12,7 +12,7 @@ export type AcApEntityPreviewExportFailure =
   | 'download-failed'
 
 export type AcApEntityPreviewExportResult =
-  | { ok: true }
+  | { ok: true; exportedCount: number; skippedCount: number }
   | { ok: false; reason: AcApEntityPreviewExportFailure }
 
 /**
@@ -34,6 +34,9 @@ export class AcApEntityPreviewConvertor {
   ): AcApEntityPreviewExportResult {
     const view = AcApDocManager.instance.curView as AcTrView2d
     const scene = view.cadScene
+    const previewableIds = scene.findPreviewableEntityIds(entityIds, 'all')
+    const exportedCount = previewableIds.length
+    const skippedCount = entityIds.length - exportedCount
 
     const bounds =
       scene.computeEntityPreviewBounds2d(entityIds, 1.1, 'all') ?? null
@@ -92,7 +95,7 @@ export class AcApEntityPreviewConvertor {
       return { ok: false, reason: 'download-failed' }
     }
 
-    return { ok: true }
+    return { ok: true, exportedCount, skippedCount }
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/convert/index.ts
+++ b/packages/cad-simple-viewer/src/command/convert/index.ts
@@ -1,4 +1,6 @@
 export * from './AcApConvertToDxfCmd'
 export * from './AcApConvertToPngCmd'
+export * from './AcApEntityPreviewCmd'
+export * from './AcApEntityPreviewConvertor'
 export * from './AcApPngConvertor'
 export * from './AcApDxfConvertor'

--- a/packages/cad-simple-viewer/src/i18n/en/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/command.ts
@@ -102,6 +102,10 @@ export default {
       description: 'Deletes selected entities from the drawing',
       prompt: 'Select entities'
     },
+    entout: {
+      description: 'Exports a merged preview image for selected entities',
+      prompt: 'Select entities'
+    },
     hideobjects: {
       description: 'Temporarily suppresses the display of selected objects',
       prompt: 'Select objects'

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -255,6 +255,7 @@ export default {
   entout: {
     longSidePrompt: 'Enter preview long side size in pixels',
     exported: 'object preview(s) exported',
+    skipped: 'object(s) skipped',
     failed: {
       'no-preview-root': 'Unable to build preview geometry for the selection',
       'no-bounds': 'Unable to compute preview bounds for the selection',

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -252,6 +252,16 @@ export default {
     restored: 'object(s) restored',
     nothingToRestore: 'No hidden objects to restore'
   },
+  entout: {
+    longSidePrompt: 'Enter preview long side size in pixels',
+    exported: 'object preview(s) exported',
+    failed: {
+      'no-preview-root': 'Unable to build preview geometry for the selection',
+      'no-bounds': 'Unable to compute preview bounds for the selection',
+      'capture-failed': 'Unable to render the entity preview image',
+      'download-failed': 'Preview rendered but the PNG download failed'
+    }
+  },
   layer: {
     main: 'Enter option',
     listSummary: 'Layer list was printed to browser console',

--- a/packages/cad-simple-viewer/src/i18n/zh/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/command.ts
@@ -92,6 +92,10 @@ export default {
       description: '从图纸中删除所选对象',
       prompt: '选择对象'
     },
+    entout: {
+      description: '导出所选对象的合并预览图',
+      prompt: '选择对象'
+    },
     hideobjects: {
       description: '临时隐藏所选对象的显示',
       prompt: '选择对象'

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -244,6 +244,16 @@ export default {
     restored: '个对象已恢复显示',
     nothingToRestore: '没有可恢复显示的对象'
   },
+  entout: {
+    longSidePrompt: '输入预览图长边像素尺寸',
+    exported: '个对象预览已导出',
+    failed: {
+      'no-preview-root': '无法为所选对象构建预览几何',
+      'no-bounds': '无法计算所选对象的预览范围',
+      'capture-failed': '无法渲染实体预览图',
+      'download-failed': '预览已渲染，但 PNG 下载失败'
+    }
+  },
   layer: {
     main: '输入选项',
     listSummary: '图层列表已输出到浏览器控制台',

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -247,6 +247,7 @@ export default {
   entout: {
     longSidePrompt: '输入预览图长边像素尺寸',
     exported: '个对象预览已导出',
+    skipped: '个对象已跳过',
     failed: {
       'no-preview-root': '无法为所选对象构建预览几何',
       'no-bounds': '无法计算所选对象的预览范围',

--- a/packages/cad-simple-viewer/src/view/AcTrLayer.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayer.ts
@@ -137,13 +137,17 @@ export class AcTrLayer {
    */
   computeBatchBoundingBox(
     target = new THREE.Box3(),
-    excludeObjectIds?: ReadonlySet<string>
+    excludeObjectIds?: ReadonlySet<string>,
+    includeObjectIds?: ReadonlySet<string>
   ) {
     if (!this.visible) {
       target.makeEmpty()
       return target
     }
-    return this._group.computeBoundingBox(target, { excludeObjectIds })
+    return this._group.computeBoundingBox(target, {
+      excludeObjectIds,
+      includeObjectIds
+    })
   }
 
   get visible() {
@@ -312,7 +316,7 @@ export class AcTrLayer {
    * Builds a preview subset for entities stored in this layer group.
    *
    * @param entityIds - Database object ids to extract from this layer
-   * @param options - Optional preview style and slot limits
+   * @param options - Optional preview style, slot limits, and missing-entity policy
    * @returns Preview subset group, or `null` when extraction failed
    */
   createPreviewSubset(

--- a/packages/cad-simple-viewer/src/view/AcTrLayout.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayout.ts
@@ -1,6 +1,7 @@
 import { AcDbObjectId, AcGeBox2d, AcGeBox3d } from '@mlightcad/data-model'
 import {
   AcTrEntity,
+  AcTrEntityPreview,
   AcTrGroup,
   disposePreviewSubset
 } from '@mlightcad/three-renderer'
@@ -11,6 +12,19 @@ import { unionSpatialQueryItems } from '../editor/view/AcEdSpatialQueryResult'
 import { AcTrHierarchicalSpatialIndex } from '../spatialIndex'
 import type { AcTrSpatialSearchOptions } from '../spatialIndex/AcTrSpatialIndex'
 import { AcTrLayer, AcTrLayerStats } from './AcTrLayer'
+
+/** Options for {@link AcTrLayout.createEntityPreviewRoot}. */
+export interface AcTrEntityPreviewRootOptions {
+  /**
+   * Behavior when one entity id cannot be extracted from a layer batch group.
+   *
+   * - `fail` (default): dispose the partial preview and return `null`
+   * - `skip`: ignore that id and continue with the remaining ids
+   */
+  missingEntity?: 'fail' | 'skip'
+  /** When true, every requested id must exist in this layout. */
+  requireAllEntities?: boolean
+}
 
 /**
  * Interface representing statistics for a layout.
@@ -425,55 +439,166 @@ export class AcTrLayout {
   }
 
   /**
-   * Returns true when every requested entity is present in this layout.
+   * Returns true when requested entities can be previewed in this layout.
+   *
+   * Uses batch bounds only and does not clone preview geometry.
    *
    * @param entityIds - Database object ids required for preview creation
+   * @param options - When {@link AcTrEntityPreviewRootOptions.requireAllEntities} is
+   *   true (default), every id must be present; otherwise at least one id is enough
    */
-  canCreateEntityPreview(entityIds: AcDbObjectId[]): boolean {
+  canCreateEntityPreview(
+    entityIds: AcDbObjectId[],
+    options?: Pick<AcTrEntityPreviewRootOptions, 'requireAllEntities'>
+  ): boolean {
     if (entityIds.length === 0) {
       return false
     }
-    const root = this.createEntityPreviewRoot(entityIds)
-    if (!root) {
-      return false
+
+    const requireAllEntities = options?.requireAllEntities ?? true
+    if (requireAllEntities) {
+      for (const id of entityIds) {
+        if (!this.hasEntity(id)) {
+          return false
+        }
+        const scratch = new THREE.Box3()
+        this.computeEntityPreviewBoundsBox([id], scratch)
+        if (scratch.isEmpty()) {
+          return false
+        }
+      }
+      return true
     }
-    disposePreviewSubset(root)
-    return true
+
+    return !this.computeEntityPreviewBoundsBox(entityIds).isEmpty()
+  }
+
+  /**
+   * Returns entity ids that have drawable batch bounds in this layout.
+   *
+   * @param entityIds - Database object ids to check
+   */
+  findPreviewableEntityIds(entityIds: AcDbObjectId[]): AcDbObjectId[] {
+    const previewable: AcDbObjectId[] = []
+    for (const id of entityIds) {
+      if (!this.hasEntity(id)) {
+        continue
+      }
+      const scratch = new THREE.Box3()
+      this.computeEntityPreviewBoundsBox([id], scratch)
+      if (!scratch.isEmpty()) {
+        previewable.push(id)
+      }
+    }
+    return previewable
+  }
+
+  /**
+   * Computes world-space bounds for the requested entities from packed batch data.
+   *
+   * This avoids building a preview subset or traversing cloned drawables.
+   *
+   * @param entityIds - Database object ids to measure
+   * @param target - Optional output box
+   * @returns Axis-aligned bounds box, empty when nothing matched
+   */
+  computeEntityPreviewBoundsBox(
+    entityIds: AcDbObjectId[],
+    target = new THREE.Box3()
+  ) {
+    target.makeEmpty()
+    if (entityIds.length === 0) {
+      return target
+    }
+
+    const includeObjectIds = new Set(entityIds)
+    const scratch = new THREE.Box3()
+    for (const layer of this._layers.values()) {
+      layer.computeBatchBoundingBox(scratch, undefined, includeObjectIds)
+      if (!scratch.isEmpty()) {
+        target.union(scratch)
+      }
+    }
+    return target
+  }
+
+  /**
+   * Computes a 2D preview framing box for the requested entities in this layout.
+   *
+   * @param entityIds - Database object ids to measure
+   * @param margin - Margin multiplier applied around the raw bounds
+   */
+  computeEntityPreviewBounds2d(
+    entityIds: AcDbObjectId[],
+    margin = 1.1
+  ): AcGeBox2d | null {
+    const box = this.computeEntityPreviewBoundsBox(entityIds)
+    return AcTrEntityPreview.box3ToBounds2d(box, margin)
   }
 
   /**
    * Builds one preview root group by extracting GPU-resident geometry from layer batches.
    *
+   * Entities that are missing from this layout or cannot be extracted are skipped.
+   * Returns `null` only when no drawable geometry could be collected.
+   *
    * @param entityIds - Database object ids to include in the preview overlay
-   * @returns Preview root group, or `null` when any entity could not be extracted
+   * @returns Preview root group, or `null` when no preview geometry was extracted
    */
-  createEntityPreviewRoot(entityIds: AcDbObjectId[]): THREE.Group | null {
-    const idsByLayer = new Map<AcTrLayer, AcDbObjectId[]>()
+  createEntityPreviewRoot(
+    entityIds: AcDbObjectId[],
+    options?: AcTrEntityPreviewRootOptions
+  ): THREE.Group | null {
+    const missingEntity = options?.missingEntity ?? 'fail'
+    const requireAllEntities = options?.requireAllEntities ?? false
+
+    if (requireAllEntities) {
+      for (const id of entityIds) {
+        if (!this.hasEntity(id)) {
+          return null
+        }
+      }
+    }
+
+    const idsByLayer = new Map<AcTrLayer, Set<AcDbObjectId>>()
 
     for (const id of entityIds) {
       const layers = this.getLayersByObjectId(id)
       if (layers.length === 0) {
-        return null
+        if (requireAllEntities || missingEntity === 'fail') {
+          return null
+        }
+        continue
       }
       for (const layer of layers) {
         let layerIds = idsByLayer.get(layer)
         if (!layerIds) {
-          layerIds = []
+          layerIds = new Set()
           idsByLayer.set(layer, layerIds)
         }
-        if (!layerIds.includes(id)) {
-          layerIds.push(id)
-        }
+        layerIds.add(id)
       }
+    }
+
+    if (idsByLayer.size === 0) {
+      return null
     }
 
     const previewRoot = new THREE.Group()
     previewRoot.name = 'EntityPreviewRoot'
     for (const [layer, ids] of idsByLayer) {
-      const subset = layer.createPreviewSubset(ids)
-      if (!subset) {
-        disposePreviewSubset(previewRoot)
-        return null
+      const idList = [...ids]
+      const subset = layer.createPreviewSubset(idList, {
+        // Complex blocks/hatches may need several drawable slots per entity.
+        maxSlots: Math.max(10000, idList.length * 8),
+        missingEntity
+      })
+      if (!subset || subset.children.length === 0) {
+        if (missingEntity === 'fail') {
+          disposePreviewSubset(previewRoot)
+          return null
+        }
+        continue
       }
       previewRoot.add(subset)
     }

--- a/packages/cad-simple-viewer/src/view/AcTrScene.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrScene.ts
@@ -1,16 +1,23 @@
 import { AcDbObjectId, AcGeBox2d, AcGeBox3d, log } from '@mlightcad/data-model'
 import {
   AcTrEntity,
+  AcTrEntityPreview,
   AcTrHtmlTransientManager,
   AcTrPreviewOverlayManager,
   AcTrTransientManager
 } from '@mlightcad/three-renderer'
-import { AcEdLayerInfo } from 'editor'
 import * as THREE from 'three'
 
+import { AcEdLayerInfo } from '../editor'
 import type { AcTrSpatialSearchOptions } from '../spatialIndex/AcTrSpatialIndex'
 import { AcTrLayer } from './AcTrLayer'
-import { AcTrLayout, AcTrLayoutStats } from './AcTrLayout'
+import {
+  type AcTrEntityPreviewRootOptions,
+  AcTrLayout,
+  AcTrLayoutStats} from './AcTrLayout'
+
+/** Layout search order when building entity preview geometry. */
+export type AcTrEntityPreviewScope = 'active-first' | 'all'
 
 export interface AcTrSceneStats {
   layouts: AcTrLayoutStats[]
@@ -438,7 +445,9 @@ export class AcTrScene {
   }
 
   /**
-   * Returns true when every requested entity exists in the active layout.
+   * Returns true when every requested entity can be previewed in the active layout.
+   *
+   * Uses batch bounds only and does not clone preview geometry.
    *
    * @param entityIds - Database object ids required for preview creation
    */
@@ -447,11 +456,184 @@ export class AcTrScene {
     if (!layout) {
       return false
     }
-    return layout.canCreateEntityPreview(entityIds)
+    return layout.canCreateEntityPreview(entityIds, { requireAllEntities: true })
+  }
+
+  /**
+   * Computes a 2D framing box for preview export without cloning drawables.
+   *
+   * @param entityIds - Database object ids to measure
+   * @param margin - Margin multiplier applied around the raw bounds
+   * @param scope - Layout search order; defaults to {@link AcTrEntityPreviewScope active-first}
+   */
+  computeEntityPreviewBounds2d(
+    entityIds: AcDbObjectId[],
+    margin = 1.1,
+    scope: AcTrEntityPreviewScope = 'active-first'
+  ): AcGeBox2d | null {
+    const box = this.computeEntityPreviewBoundsBox(entityIds, scope)
+    return AcTrEntityPreview.box3ToBounds2d(box, margin)
+  }
+
+  /**
+   * Builds one merged preview root, searching layouts in priority order.
+   *
+   * Entities that are missing from a layout or cannot be extracted are skipped.
+   * With {@link AcTrEntityPreviewScope.all}, each entity is taken from the first
+   * layout that can preview it so geometry is not duplicated.
+   *
+   * @param entityIds - Database object ids to include in the preview overlay
+   * @param options - Optional layout search order and per-layout extraction policy
+   * @returns Preview root group, or `null` when no preview geometry was extracted
+   */
+  createEntityPreviewRoot(
+    entityIds: AcDbObjectId[],
+    options?: {
+      scope?: AcTrEntityPreviewScope
+      layoutOptions?: AcTrEntityPreviewRootOptions
+    }
+  ): THREE.Group | null {
+    if (entityIds.length === 0) {
+      return null
+    }
+
+    const scope = options?.scope ?? 'active-first'
+    const layoutOptions: AcTrEntityPreviewRootOptions = {
+      missingEntity: 'skip',
+      ...options?.layoutOptions
+    }
+
+    if (scope === 'all') {
+      return this.mergeEntityPreviewRoots(
+        entityIds,
+        this.getOrderedLayouts('all'),
+        layoutOptions
+      )
+    }
+
+    for (const layout of this.getOrderedLayouts('active-first')) {
+      const root = layout.createEntityPreviewRoot(entityIds, layoutOptions)
+      if (root) {
+        return root
+      }
+    }
+    return null
+  }
+
+  /**
+   * Merges preview roots from the given layouts into one group.
+   *
+   * Each entity id is assigned to the first layout that can preview it.
+   */
+  private mergeEntityPreviewRoots(
+    entityIds: AcDbObjectId[],
+    layouts: Iterable<AcTrLayout>,
+    layoutOptions: AcTrEntityPreviewRootOptions
+  ): THREE.Group | null {
+    const pending = new Set(entityIds)
+    const previewRoot = new THREE.Group()
+    previewRoot.name = 'EntityPreviewRoot'
+
+    for (const layout of layouts) {
+      if (pending.size === 0) {
+        break
+      }
+
+      const claimable = layout.findPreviewableEntityIds([...pending])
+      if (claimable.length === 0) {
+        continue
+      }
+
+      const layoutRoot = layout.createEntityPreviewRoot(claimable, layoutOptions)
+      if (!layoutRoot) {
+        continue
+      }
+
+      previewRoot.add(layoutRoot)
+      for (const id of claimable) {
+        pending.delete(id)
+      }
+    }
+
+    return previewRoot.children.length > 0 ? previewRoot : null
+  }
+
+  /**
+   * Returns layouts in priority order for preview lookup.
+   */
+  private getOrderedLayouts(scope: AcTrEntityPreviewScope): AcTrLayout[] {
+    if (scope === 'all') {
+      return [...this._layouts.values()]
+    }
+
+    const ordered: AcTrLayout[] = []
+    const active = this.activeLayout
+    const model = this.modelSpaceLayout
+
+    if (active) {
+      ordered.push(active)
+    }
+    if (model && model !== active) {
+      ordered.push(model)
+    }
+    for (const layout of this._layouts.values()) {
+      if (layout !== active && layout !== model) {
+        ordered.push(layout)
+      }
+    }
+    return ordered
+  }
+
+  /**
+   * Computes batch bounds for requested entities using the same layout policy as
+   * {@link createEntityPreviewRoot}.
+   */
+  private computeEntityPreviewBoundsBox(
+    entityIds: AcDbObjectId[],
+    scope: AcTrEntityPreviewScope = 'active-first'
+  ) {
+    const target = new THREE.Box3()
+    const scratch = new THREE.Box3()
+
+    if (scope === 'all') {
+      const pending = new Set(entityIds)
+      for (const layout of this.getOrderedLayouts('all')) {
+        if (pending.size === 0) {
+          break
+        }
+
+        const claimable = layout.findPreviewableEntityIds([...pending])
+        if (claimable.length === 0) {
+          continue
+        }
+
+        layout.computeEntityPreviewBoundsBox(claimable, scratch)
+        if (!scratch.isEmpty()) {
+          target.union(scratch)
+        }
+        for (const id of claimable) {
+          pending.delete(id)
+        }
+      }
+      return target
+    }
+
+    for (const layout of this.getOrderedLayouts('active-first')) {
+      layout.computeEntityPreviewBoundsBox(entityIds, scratch)
+      if (!scratch.isEmpty()) {
+        target.copy(scratch)
+        return target
+      }
+    }
+
+    target.makeEmpty()
+    return target
   }
 
   /**
    * Creates one batched preview overlay for command jigs.
+   *
+   * Only the active layout is searched and every requested entity must be present.
    *
    * @param entityIds - Database object ids to include in the preview overlay
    * @returns Preview handle id, or `null` when preview creation failed
@@ -461,7 +643,11 @@ export class AcTrScene {
     if (!layout) {
       return null
     }
-    const root = layout.createEntityPreviewRoot(entityIds)
+
+    const root = layout.createEntityPreviewRoot(entityIds, {
+      missingEntity: 'fail',
+      requireAllEntities: true
+    })
     if (!root) {
       return null
     }

--- a/packages/cad-simple-viewer/src/view/AcTrScene.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrScene.ts
@@ -476,6 +476,51 @@ export class AcTrScene {
   }
 
   /**
+   * Returns entity ids that can be previewed using the same layout policy as
+   * {@link createEntityPreviewRoot}.
+   *
+   * @param entityIds - Database object ids to check
+   * @param scope - Layout search order; defaults to {@link AcTrEntityPreviewScope active-first}
+   */
+  findPreviewableEntityIds(
+    entityIds: AcDbObjectId[],
+    scope: AcTrEntityPreviewScope = 'active-first'
+  ): AcDbObjectId[] {
+    if (entityIds.length === 0) {
+      return []
+    }
+
+    if (scope === 'all') {
+      const previewable: AcDbObjectId[] = []
+      const pending = new Set(entityIds)
+      for (const layout of this.getOrderedLayouts('all')) {
+        if (pending.size === 0) {
+          break
+        }
+
+        const claimable = layout.findPreviewableEntityIds([...pending])
+        if (claimable.length === 0) {
+          continue
+        }
+
+        previewable.push(...claimable)
+        for (const id of claimable) {
+          pending.delete(id)
+        }
+      }
+      return previewable
+    }
+
+    for (const layout of this.getOrderedLayouts('active-first')) {
+      const claimable = layout.findPreviewableEntityIds(entityIds)
+      if (claimable.length > 0) {
+        return claimable
+      }
+    }
+    return []
+  }
+
+  /**
    * Builds one merged preview root, searching layouts in priority order.
    *
    * Entities that are missing from a layout or cannot be extracted are skipped.

--- a/packages/three-renderer/__tests__/AcTrBatchedGroupPreview.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupPreview.spec.ts
@@ -114,6 +114,25 @@ describe('AcTrBatchedGroup preview subset', () => {
     expect(group.hasEntity('line-1')).toBe(true)
   })
 
+  it('skips entity ids that cannot be extracted when missingEntity is skip', () => {
+    const group = new AcTrBatchedGroup()
+    group.addEntity(
+      createEntity(
+        'line-1',
+        createLineSegments({ x: 0, y: 0, z: 0 }, { x: 5, y: 0, z: 0 })
+      )
+    )
+
+    const subset = group.createPreviewSubset(['line-1', 'missing-id'], {
+      missingEntity: 'skip'
+    })
+    expect(subset).not.toBeNull()
+    expect(subset!.children.length).toBe(1)
+    expect(group.hasEntity('line-1')).toBe(true)
+
+    disposePreviewSubset(subset!)
+  })
+
   it('disposes each cloned material only once', () => {
     const group = new AcTrBatchedGroup()
     const line = createLineSegments({ x: 0, y: 0, z: 0 }, { x: 10, y: 0, z: 0 })

--- a/packages/three-renderer/__tests__/AcTrEntityPreview.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrEntityPreview.spec.ts
@@ -1,0 +1,84 @@
+import { AcGeBox2d, AcGePoint2d } from '@mlightcad/data-model'
+import * as THREE from 'three'
+
+import { AcTrEntity } from '../src/object/AcTrEntity'
+import { AcTrLine } from '../src/object/AcTrLine'
+import { AcTrEntityPreview } from '../src/renderer/AcTrEntityPreview'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { AcTrSubEntityTraitsUtil } from '../src/util'
+
+const defaultTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+
+function createLine(
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+  context: AcTrRenderContext
+) {
+  const line = new AcTrLine(
+    [
+      { x: start.x, y: start.y, z: 0 },
+      { x: end.x, y: end.y, z: 0 }
+    ],
+    defaultTraits,
+    context,
+    false
+  )
+  line.updateMatrixWorld(true)
+  return line
+}
+
+function getVisibleWorldExtents(camera: THREE.OrthographicCamera) {
+  const worldWidth = (camera.right - camera.left) / camera.zoom
+  const worldHeight = (camera.top - camera.bottom) / camera.zoom
+
+  return {
+    worldWidth,
+    worldHeight,
+    minX: camera.position.x - worldWidth / 2,
+    maxX: camera.position.x + worldWidth / 2,
+    minY: camera.position.y - worldHeight / 2,
+    maxY: camera.position.y + worldHeight / 2
+  }
+}
+
+function getVisibleWorldExtentsFromBox2d(box: AcGeBox2d) {
+  return {
+    minX: box.min.x,
+    minY: box.min.y,
+    maxX: box.max.x,
+    maxY: box.max.y
+  }
+}
+
+describe('AcTrEntityPreview', () => {
+  it('computeObjectBounds2d unions drawable geometry bounds', () => {
+    const context = new AcTrRenderContext()
+    const entity = new AcTrEntity(context)
+    entity.add(createLine({ x: 10, y: 20 }, { x: 110, y: 70 }, context))
+
+    const bounds = AcTrEntityPreview.computeObjectBounds2d(entity, 1)
+
+    expect(bounds).not.toBeNull()
+    const visible = getVisibleWorldExtentsFromBox2d(bounds!)
+    expect(visible.minX).toBeCloseTo(10, 5)
+    expect(visible.minY).toBeCloseTo(20, 5)
+    expect(visible.maxX).toBeCloseTo(110, 5)
+    expect(visible.maxY).toBeCloseTo(70, 5)
+  })
+
+  it('fitExportCamera matches export framing rules', () => {
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 1000)
+    const bounds = new AcGeBox2d(
+      new AcGePoint2d(10, 20),
+      new AcGePoint2d(110, 70)
+    )
+
+    AcTrEntityPreview.fitExportCamera(camera, bounds, 800, 400)
+
+    const visible = getVisibleWorldExtents(camera)
+    expect(camera.position.x).toBeCloseTo(60)
+    expect(camera.position.y).toBeCloseTo(45)
+    expect(visible.worldWidth).toBeCloseTo(100, 5)
+    expect(visible.worldHeight).toBeCloseTo(50, 5)
+  })
+})

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -176,6 +176,13 @@ export interface AcTrPreviewSubsetOptions {
   style?: 'normal' | 'dashed'
   /** Maximum number of drawable slots to extract. */
   maxSlots?: number
+  /**
+   * Behavior when one entity id cannot be extracted from this batch group.
+   *
+   * - `fail` (default): dispose the partial subset and return `null`
+   * - `skip`: ignore that id and continue with the remaining ids
+   */
+  missingEntity?: 'fail' | 'skip'
 }
 
 /**
@@ -416,7 +423,10 @@ export class AcTrBatchedGroup extends THREE.Group {
    */
   computeBoundingBox(
     target = new THREE.Box3(),
-    options?: { excludeObjectIds?: ReadonlySet<string> }
+    options?: {
+      excludeObjectIds?: ReadonlySet<string>
+      includeObjectIds?: ReadonlySet<string>
+    }
   ) {
     target.makeEmpty()
     const scratch = new THREE.Box3()
@@ -439,6 +449,12 @@ export class AcTrBatchedGroup extends THREE.Group {
 
     this._unbatchedEntities.forEach((objects, objectId) => {
       if (options?.excludeObjectIds?.has(objectId)) {
+        return
+      }
+      if (
+        options?.includeObjectIds &&
+        !options.includeObjectIds.has(objectId)
+      ) {
         return
       }
       for (const child of objects) {
@@ -1350,6 +1366,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     }
 
     const maxSlots = options?.maxSlots ?? 10000
+    const missingEntity = options?.missingEntity ?? 'fail'
     const container = new THREE.Group()
     container.name = 'PreviewSubset'
     container.userData.previewSubsetGroup = true
@@ -1366,13 +1383,16 @@ export class AcTrBatchedGroup extends THREE.Group {
         previewStyle: options?.style ?? 'normal'
       })
       if (added === 0) {
+        if (missingEntity === 'skip') {
+          continue
+        }
         disposePreviewSubset(container)
         return null
       }
       slotCount += added
     }
 
-    return container
+    return slotCount > 0 ? container : null
   }
 
   /**

--- a/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
@@ -823,7 +823,10 @@ export function createAcTrBatchedMixin<
      */
     unionActiveVisibleBoundingBoxInto(
       target: THREE.Box3,
-      options?: { excludeObjectIds?: ReadonlySet<string> }
+      options?: {
+        excludeObjectIds?: ReadonlySet<string>
+        includeObjectIds?: ReadonlySet<string>
+      }
     ) {
       const self = this as unknown as THREE.Object3D
       self.updateMatrixWorld(true)
@@ -836,6 +839,13 @@ export function createAcTrBatchedMixin<
           options?.excludeObjectIds &&
           info.objectId &&
           options.excludeObjectIds.has(info.objectId)
+        ) {
+          continue
+        }
+        if (
+          options?.includeObjectIds &&
+          info.objectId &&
+          !options.includeObjectIds.has(info.objectId)
         ) {
           continue
         }

--- a/packages/three-renderer/src/renderer/AcTrEntityPreview.ts
+++ b/packages/three-renderer/src/renderer/AcTrEntityPreview.ts
@@ -1,0 +1,587 @@
+import {
+  AcGeBox2d,
+  AcGePoint2d,
+  AcGeVector2d
+} from '@mlightcad/data-model'
+import * as THREE from 'three'
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
+
+import { AcTrMaterialManager } from '../style/AcTrMaterialManager'
+import { AcTrCamera } from '../viewport/AcTrCamera'
+import type { AcTrRenderer } from './AcTrRenderer'
+
+/** Options for {@link AcTrEntityPreview.capture}. */
+export interface AcTrEntityPreviewOptions {
+  /** Output width in pixels. */
+  width: number
+  /** Output height in pixels. */
+  height: number
+  /**
+   * World-space bounds used to frame the preview.
+   * When omitted, bounds are computed from drawable geometry in `object`.
+   */
+  bounds?: AcGeBox2d
+  /** Margin multiplier applied around computed or supplied bounds. Default `1.1`. */
+  margin?: number
+  /** Background colour; defaults to {@link AcTrRenderer.currentBackgroundColor}. */
+  backgroundColor?: number
+  /** Background alpha; defaults to {@link AcTrRenderer.clearAlpha}. */
+  backgroundAlpha?: number
+  /** When true, only preview-cloned line materials receive export resolution. */
+  localLineResolutionOnly?: boolean
+  /**
+   * Called after WebGL state is restored. Use this to repaint the interactive
+   * view when capture temporarily adjusts renderer uniforms or canvas state.
+   */
+  onRestored?: () => void
+  /**
+   * Main viewport size to restore after capture.
+   *
+   * Required when sharing the interactive renderer so the canvas buffer and line
+   * resolution match the live view again (same rule as PNG export).
+   */
+  viewportSize?: { width: number; height: number }
+}
+
+/** Result of {@link AcTrEntityPreview.capture}. */
+export interface AcTrEntityPreviewResult {
+  /** Canvas containing the rendered preview image. */
+  canvas: HTMLCanvasElement
+  /** World-space bounds used to frame the preview. */
+  bounds: AcGeBox2d
+}
+
+/** Saved WebGL renderer state restored after offscreen preview capture. */
+interface AcTrEntityPreviewRendererState {
+  pixelRatio: number
+  renderTarget: THREE.WebGLRenderTarget | null
+  scissorTest: boolean
+  viewport: THREE.Vector4
+  size: THREE.Vector2
+  clearColor: THREE.Color
+  clearAlpha: number
+  autoClear: boolean
+  cameraZoom: number
+  viewportSize?: { width: number; height: number }
+  localLineResolutionOnly?: boolean
+}
+
+/**
+ * Offscreen renderer for entity and block preview thumbnails.
+ *
+ * Stateless helpers are exposed as static methods. Capture requires one
+ * instance bound to an {@link AcTrRenderer}.
+ */
+export class AcTrEntityPreview {
+  private readonly _renderer: AcTrRenderer
+
+  /**
+   * Creates a preview capture bound to one renderer.
+   *
+   * @param renderer - Renderer used for offscreen capture
+   */
+  constructor(renderer: AcTrRenderer) {
+    this._renderer = renderer
+  }
+
+  /**
+   * Renders one standalone object subtree to an offscreen canvas.
+   *
+   * The input should be a detached preview root (for example from
+   * {@link AcTrBatchedGroup.createPreviewSubset}) or any other THREE.js object
+   * graph that is safe to reparent temporarily. When `object` already belongs to
+   * another scene, a deep clone is rendered and disposed afterward.
+   *
+   * @param object - Entity, block, or preview subset root to render
+   * @param options - Output size and optional framing overrides
+   * @returns Rendered canvas and framing bounds, or `null` when bounds cannot be resolved
+   */
+  capture(
+    object: THREE.Object3D,
+    options: AcTrEntityPreviewOptions
+  ): AcTrEntityPreviewResult | null {
+    const width = Math.max(1, Math.round(options.width))
+    const height = Math.max(1, Math.round(options.height))
+    const margin = options.margin ?? 1.1
+
+    const bounds = AcTrEntityPreview.resolvePreviewBounds(
+      object,
+      options.bounds,
+      margin
+    )
+    if (!bounds) {
+      return null
+    }
+
+    const renderer = this._renderer
+    const webgl = renderer.internalRenderer
+    const savedState = AcTrEntityPreview.saveRendererState(
+      renderer,
+      webgl,
+      options
+    )
+
+    const backgroundColor =
+      options.backgroundColor ?? renderer.currentBackgroundColor
+    const backgroundAlpha = options.backgroundAlpha ?? renderer.clearAlpha
+
+    const { drawable, ownsClone } = AcTrEntityPreview.prepareDrawable(object)
+
+    const scene = new THREE.Scene()
+    scene.add(drawable)
+
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 1000)
+    camera.position.z = 10
+    AcTrEntityPreview.fitExportCamera(camera, bounds, width, height)
+
+    let renderTarget: THREE.WebGLRenderTarget | undefined
+    let canvas: HTMLCanvasElement | undefined
+
+    try {
+      // Match PNG export: force 1:1 pixels while reading from a render target.
+      webgl.setPixelRatio(1)
+      renderer.autoClear = true
+      if (!options.localLineResolutionOnly) {
+        renderer.updateLineResolution(width, height)
+      }
+      renderer.setClearColor(backgroundColor, backgroundAlpha)
+      AcTrEntityPreview.syncDrawableLineResolution(drawable, width, height)
+
+      renderTarget = new THREE.WebGLRenderTarget(width, height, {
+        minFilter: THREE.LinearFilter,
+        magFilter: THREE.LinearFilter,
+        format: THREE.RGBAFormat,
+        type: THREE.UnsignedByteType
+      })
+
+      webgl.setRenderTarget(renderTarget)
+      webgl.setViewport(0, 0, width, height)
+      webgl.setScissorTest(false)
+
+      renderer.render(scene, new AcTrCamera(camera))
+
+      const pixels = new Uint8Array(width * height * 4)
+      webgl.readRenderTargetPixels(renderTarget, 0, 0, width, height, pixels)
+
+      canvas = AcTrEntityPreview.createCanvasFromPixels(
+        AcTrEntityPreview.flipPixelsVertically(pixels, width, height),
+        width,
+        height
+      )
+    } finally {
+      scene.remove(drawable)
+      if (ownsClone) {
+        AcTrEntityPreview.disposeObjectTree(drawable)
+      }
+
+      renderTarget?.dispose()
+      AcTrEntityPreview.restoreRendererState(renderer, webgl, savedState)
+      options.onRestored?.()
+    }
+
+    if (!canvas) {
+      return null
+    }
+
+    return { canvas, bounds }
+  }
+
+  static box3ToBounds2d(box: THREE.Box3, margin = 1.1): AcGeBox2d | null {
+    if (box.isEmpty() || !AcTrEntityPreview.isFiniteBox3(box)) {
+      return null
+    }
+    return AcTrEntityPreview.expandBox3ToBox2d(box, margin)
+  }
+
+  /**
+   * Computes a 2D axis-aligned bounding box from drawable geometry under `object`.
+   *
+   * @param object - Root object to measure (preview subset, {@link AcTrGroup}, etc.)
+   * @param margin - Margin multiplier applied around the raw bounds
+   * @returns Framed bounds, or `null` when no finite geometry is found
+   */
+  static computeObjectBounds2d(
+    object: THREE.Object3D,
+    margin = 1.1
+  ): AcGeBox2d | null {
+    object.updateMatrixWorld(true)
+
+    const box3 = new THREE.Box3()
+    const scratch = new THREE.Box3()
+
+    object.traverse(child => {
+      if (!AcTrEntityPreview.isLeafDrawable(child)) {
+        return
+      }
+      const geometry = (child as THREE.Mesh).geometry as
+        | THREE.BufferGeometry
+        | undefined
+      if (!geometry) {
+        return
+      }
+      if (!geometry.boundingBox) {
+        geometry.computeBoundingBox()
+      }
+      if (
+        !geometry.boundingBox ||
+        !AcTrEntityPreview.isFiniteBox3(geometry.boundingBox)
+      ) {
+        return
+      }
+      scratch.copy(geometry.boundingBox).applyMatrix4(child.matrixWorld)
+      box3.union(scratch)
+    })
+
+    if (box3.isEmpty() || !AcTrEntityPreview.isFiniteBox3(box3)) {
+      return null
+    }
+
+    return AcTrEntityPreview.expandBox3ToBox2d(box3, margin)
+  }
+
+  /**
+   * Computes a 2D axis-aligned bounding box from the full object hierarchy.
+   *
+   * Use as a fallback when {@link computeObjectBounds2d} finds no leaf drawables.
+   *
+   * @param object - Root object to measure
+   * @param margin - Margin multiplier applied around the raw bounds
+   * @returns Framed bounds, or `null` when no finite geometry is found
+   */
+  static computeObjectBounds2dFromObject(
+    object: THREE.Object3D,
+    margin = 1.1
+  ): AcGeBox2d | null {
+    object.updateMatrixWorld(true)
+    const box3 = new THREE.Box3().setFromObject(object)
+    if (box3.isEmpty() || !AcTrEntityPreview.isFiniteBox3(box3)) {
+      return null
+    }
+    return AcTrEntityPreview.expandBox3ToBox2d(box3, margin)
+  }
+
+  /**
+   * Fits an orthographic camera to a 2D world box using export pixel dimensions.
+   *
+   * Mirrors {@link AcTrBaseView.applyExportCamera} so offscreen previews use the
+   * same framing rules as PNG export.
+   *
+   * @param camera - Orthographic camera to update in place
+   * @param box - World-space bounds to fit
+   * @param pixelWidth - Output width in pixels
+   * @param pixelHeight - Output height in pixels
+   */
+  static fitExportCamera(
+    camera: THREE.OrthographicCamera,
+    box: AcGeBox2d,
+    pixelWidth: number,
+    pixelHeight: number
+  ) {
+    const size = new AcGeVector2d()
+    box.getSize(size)
+
+    const center = new AcGeVector2d()
+    box.getCenter(center)
+
+    const fitWidth = Math.max(Math.abs(size.x), Number.EPSILON)
+    const fitHeight = Math.max(Math.abs(size.y), Number.EPSILON)
+    const aspect = pixelWidth / Math.max(pixelHeight, 1)
+    const frustum = pixelHeight / 2
+    const scale = Math.min(
+      (2 * aspect * frustum) / fitWidth,
+      (2 * frustum) / fitHeight
+    )
+
+    camera.left = -aspect * frustum
+    camera.right = aspect * frustum
+    camera.top = frustum
+    camera.bottom = -frustum
+    camera.position.set(center.x, center.y, camera.position.z)
+    camera.zoom = scale
+    camera.updateProjectionMatrix()
+  }
+
+  /**
+   * Resolves the world-space bounds used to frame one preview capture.
+   *
+   * @param object - Drawable root passed to {@link capture}
+   * @param bounds - Optional caller-supplied bounds
+   * @param margin - Margin multiplier applied around computed or supplied bounds
+   * @returns Framed bounds, or `null` when no finite geometry is found
+   */
+  private static resolvePreviewBounds(
+    object: THREE.Object3D,
+    bounds: AcGeBox2d | undefined,
+    margin: number
+  ): AcGeBox2d | null {
+    let resolved =
+      bounds ?? AcTrEntityPreview.computeObjectBounds2d(object, margin)
+    if (!resolved) {
+      return null
+    }
+    if (bounds && margin !== 1) {
+      resolved = AcTrEntityPreview.expandBox2d(bounds, margin)
+    }
+    return resolved
+  }
+
+  /**
+   * Returns a drawable root that is safe to reparent into a temporary scene.
+   *
+   * @param object - Original drawable root supplied by the caller
+   * @returns Drawable root and whether this capture owns a cloned copy
+   */
+  private static prepareDrawable(object: THREE.Object3D): {
+    drawable: THREE.Object3D
+    ownsClone: boolean
+  } {
+    const ownsClone = object.parent != null
+    return {
+      drawable: ownsClone ? object.clone(true) : object,
+      ownsClone
+    }
+  }
+
+  /**
+   * Updates wide-line resolution uniforms on one preview drawable subtree.
+   *
+   * @param object - Preview drawable root rendered offscreen
+   * @param width - Output width in pixels
+   * @param height - Output height in pixels
+   */
+  static syncLineMaterialsResolution(
+    object: THREE.Object3D,
+    width: number,
+    height: number
+  ) {
+    AcTrEntityPreview.syncDrawableLineResolution(object, width, height)
+  }
+
+  /**
+   * Updates wide-line shader resolution on preview-cloned materials only.
+   *
+   * @param object - Preview drawable root rendered offscreen
+   * @param width - Output width in pixels
+   * @param height - Output height in pixels
+   */
+  private static syncDrawableLineResolution(
+    object: THREE.Object3D,
+    width: number,
+    height: number
+  ) {
+    const resolution = new THREE.Vector2(width, height)
+    object.traverse(child => {
+      const materials = (child as THREE.Mesh).material
+      if (!materials) {
+        return
+      }
+      if (Array.isArray(materials)) {
+        materials.forEach(material => {
+          if (material instanceof LineMaterial) {
+            material.resolution.copy(resolution)
+          }
+        })
+        return
+      }
+      if (materials instanceof LineMaterial) {
+        materials.resolution.copy(resolution)
+      }
+    })
+  }
+
+  /**
+   * Captures renderer and WebGL state before offscreen preview rendering.
+   *
+   * @param renderer - CAD renderer wrapper whose flags must be restored later
+   * @param webgl - Internal THREE.js renderer used for the capture pass
+   * @returns Snapshot of values to pass to {@link restoreRendererState}
+   */
+  private static saveRendererState(
+    renderer: AcTrRenderer,
+    webgl: THREE.WebGLRenderer,
+    options: AcTrEntityPreviewOptions
+  ): AcTrEntityPreviewRendererState {
+    const clearColor = new THREE.Color()
+    webgl.getClearColor(clearColor)
+
+    return {
+      pixelRatio: webgl.getPixelRatio(),
+      renderTarget: webgl.getRenderTarget(),
+      scissorTest: webgl.getScissorTest(),
+      viewport: webgl.getViewport(new THREE.Vector4()),
+      size: webgl.getSize(new THREE.Vector2()),
+      clearColor,
+      clearAlpha: webgl.getClearAlpha(),
+      autoClear: renderer.autoClear,
+      cameraZoom: AcTrMaterialManager.CameraZoomUniform.value,
+      viewportSize: options.viewportSize,
+      localLineResolutionOnly: options.localLineResolutionOnly
+    }
+  }
+
+  /**
+   * Restores renderer and WebGL state after offscreen preview rendering.
+   *
+   * @param renderer - CAD renderer wrapper whose flags should be restored
+   * @param webgl - Internal THREE.js renderer used for the capture pass
+   * @param state - Snapshot previously returned by {@link saveRendererState}
+   */
+  private static restoreRendererState(
+    renderer: AcTrRenderer,
+    webgl: THREE.WebGLRenderer,
+    state: AcTrEntityPreviewRendererState
+  ) {
+    webgl.setRenderTarget(state.renderTarget)
+    renderer.setClearColor(state.clearColor.getHex(), state.clearAlpha)
+    renderer.autoClear = state.autoClear
+    webgl.setPixelRatio(state.pixelRatio)
+
+    if (state.viewportSize) {
+      renderer.setSize(state.viewportSize.width, state.viewportSize.height)
+    } else if (!state.localLineResolutionOnly) {
+      renderer.updateLineResolution(state.size.x, state.size.y)
+    }
+
+    renderer.syncCameraZoom(state.cameraZoom)
+    webgl.setViewport(
+      state.viewport.x,
+      state.viewport.y,
+      state.viewport.z,
+      state.viewport.w
+    )
+    webgl.setScissorTest(state.scissorTest)
+  }
+
+  /**
+   * Returns true for drawable leaf nodes that should contribute preview bounds.
+   *
+   * Container entities may also expose placeholder geometry; those are skipped
+   * when they already own rendered child drawables.
+   *
+   * @param child - Candidate node encountered during bounds traversal
+   */
+  private static isLeafDrawable(child: THREE.Object3D) {
+    const mesh = child as THREE.Mesh
+    if (!mesh.geometry || !mesh.material) {
+      return false
+    }
+    return !child.children.some(
+      descendant => !!(descendant as THREE.Mesh).material
+    )
+  }
+
+  /**
+   * Returns true when all XY components of `box` are finite numbers.
+   *
+   * @param box - Candidate axis-aligned bounds in world space
+   */
+  private static isFiniteBox3(box: THREE.Box3) {
+    return (
+      Number.isFinite(box.min.x) &&
+      Number.isFinite(box.min.y) &&
+      Number.isFinite(box.max.x) &&
+      Number.isFinite(box.max.y)
+    )
+  }
+
+  /**
+   * Expands one 3D axis-aligned box into a 2D world box with margin applied.
+   *
+   * @param box - Source bounds measured from drawable geometry
+   * @param margin - Margin multiplier applied around the raw bounds
+   */
+  private static expandBox3ToBox2d(box: THREE.Box3, margin: number) {
+    const center = box.getCenter(new THREE.Vector3())
+    const size = box.getSize(new THREE.Vector3())
+    const halfWidth = (Math.max(Math.abs(size.x), Number.EPSILON) * margin) / 2
+    const halfHeight = (Math.max(Math.abs(size.y), Number.EPSILON) * margin) / 2
+
+    return new AcGeBox2d(
+      new AcGePoint2d(center.x - halfWidth, center.y - halfHeight),
+      new AcGePoint2d(center.x + halfWidth, center.y + halfHeight)
+    )
+  }
+
+  /**
+   * Expands one 2D world box by a margin multiplier around its center.
+   *
+   * @param box - Source bounds supplied by the caller
+   * @param margin - Margin multiplier applied around the raw bounds
+   */
+  private static expandBox2d(box: AcGeBox2d, margin: number) {
+    const size = new AcGeVector2d()
+    box.getSize(size)
+    const center = new AcGeVector2d()
+    box.getCenter(center)
+
+    const halfWidth = (Math.max(Math.abs(size.x), Number.EPSILON) * margin) / 2
+    const halfHeight = (Math.max(Math.abs(size.y), Number.EPSILON) * margin) / 2
+
+    return new AcGeBox2d(
+      new AcGePoint2d(center.x - halfWidth, center.y - halfHeight),
+      new AcGePoint2d(center.x + halfWidth, center.y + halfHeight)
+    )
+  }
+
+  /**
+   * Flips RGBA pixel rows vertically to match browser canvas coordinates.
+   *
+   * WebGL render targets use a bottom-left origin, while canvas image data uses
+   * a top-left origin.
+   *
+   * @param pixels - Raw RGBA bytes read from a render target
+   * @param width - Image width in pixels
+   * @param height - Image height in pixels
+   */
+  private static flipPixelsVertically(
+    pixels: Uint8Array,
+    width: number,
+    height: number
+  ) {
+    const flippedPixels = new Uint8Array(width * height * 4)
+    for (let y = 0; y < height; y++) {
+      const srcRow = (height - 1 - y) * width * 4
+      const dstRow = y * width * 4
+      flippedPixels.set(pixels.subarray(srcRow, srcRow + width * 4), dstRow)
+    }
+    return flippedPixels
+  }
+
+  /**
+   * Creates a canvas element from vertically oriented RGBA pixel data.
+   *
+   * @param pixels - RGBA bytes in top-left canvas order
+   * @param width - Image width in pixels
+   * @param height - Image height in pixels
+   */
+  private static createCanvasFromPixels(
+    pixels: Uint8Array,
+    width: number,
+    height: number
+  ) {
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      throw new Error('Failed to acquire 2D canvas context for entity preview')
+    }
+    const imageData = ctx.createImageData(width, height)
+    imageData.data.set(pixels)
+    ctx.putImageData(imageData, 0, 0)
+    return canvas
+  }
+
+  /**
+   * Disposes cloned preview geometry and removes it from the scene graph.
+   *
+   * @param object - Cloned drawable root created by {@link prepareDrawable}
+   */
+  private static disposeObjectTree(object: THREE.Object3D) {
+    object.traverse(child => {
+      const mesh = child as THREE.Mesh
+      mesh.geometry?.dispose()
+    })
+    object.removeFromParent()
+  }
+}

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -33,6 +33,11 @@ import {
 import { AcTrMaterialManager } from '../style/AcTrMaterialManager'
 import { AcTrSubEntityTraitsUtil } from '../util'
 import { AcTrCamera } from '../viewport'
+import {
+  AcTrEntityPreview,
+  type AcTrEntityPreviewOptions,
+  type AcTrEntityPreviewResult
+} from './AcTrEntityPreview'
 import { AcTrMTextRenderer } from './AcTrMTextRenderer'
 import { AcTrRenderContext } from './AcTrRenderContext'
 
@@ -400,6 +405,34 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    */
   image(blob: Blob, style: AcGiImageStyle) {
     return new AcTrImage(blob, style, this._context)
+  }
+
+  /**
+   * Renders one or more entities (or a block preview root) to an offscreen canvas.
+   *
+   * Pass a detached preview root such as the group returned by
+   * {@link AcTrBatchedGroup.createPreviewSubset} or an {@link AcTrGroup} built
+   * for a block definition. When the object is already attached to a scene, a
+   * deep clone is rendered internally.
+   *
+   * @param object - Drawable root to preview
+   * @param options - Output size and optional framing overrides
+   * @returns Preview canvas and framing bounds, or `null` when bounds cannot be resolved
+   *
+   * @example
+   * ```ts
+   * const subset = batchGroup.createPreviewSubset(['line-1', 'arc-2'])
+   * if (subset) {
+   *   const preview = renderer.renderEntityPreview(subset, { width: 128, height: 128 })
+   *   disposePreviewSubset(subset)
+   * }
+   * ```
+   */
+  renderEntityPreview(
+    object: THREE.Object3D,
+    options: AcTrEntityPreviewOptions
+  ): AcTrEntityPreviewResult | null {
+    return new AcTrEntityPreview(this).capture(object, options)
   }
 
   /**

--- a/packages/three-renderer/src/renderer/index.ts
+++ b/packages/three-renderer/src/renderer/index.ts
@@ -1,3 +1,4 @@
+export * from './AcTrEntityPreview'
 export * from './AcTrFontLoader'
 export * from './AcTrMTextRenderer'
 export * from './AcTrRenderContext'

--- a/packages/three-renderer/src/viewport/AcTrBaseView.ts
+++ b/packages/three-renderer/src/viewport/AcTrBaseView.ts
@@ -9,6 +9,7 @@ import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 
 import { AcTrRenderer } from '../renderer'
+import { AcTrEntityPreview } from '../renderer/AcTrEntityPreview'
 import { AcTrCamera } from './AcTrCamera'
 
 export interface AcTrBaseViewEventArgs {
@@ -182,28 +183,12 @@ export class AcTrBaseView {
    * Does not update OrbitControls target so interactive pan/zoom stay intact.
    */
   applyExportCamera(box: AcGeBox2d, pixelWidth: number, pixelHeight: number) {
-    const size = new AcGeVector2d()
-    box.getSize(size)
-
-    const center = new AcGeVector2d()
-    box.getCenter(center)
-
-    const fitWidth = Math.max(Math.abs(size.x), Number.EPSILON)
-    const fitHeight = Math.max(Math.abs(size.y), Number.EPSILON)
-    const aspect = pixelWidth / Math.max(pixelHeight, 1)
-    const frustum = pixelHeight / 2
-    const scale = Math.min(
-      (2 * aspect * frustum) / fitWidth,
-      (2 * frustum) / fitHeight
+    AcTrEntityPreview.fitExportCamera(
+      this._camera.internalCamera,
+      box,
+      pixelWidth,
+      pixelHeight
     )
-
-    this._camera.left = -aspect * frustum
-    this._camera.right = aspect * frustum
-    this._camera.top = frustum
-    this._camera.bottom = -frustum
-    this._camera.position.set(center.x, center.y, this._camera.position.z)
-    this._camera.zoom = scale
-    this._camera.updateProjectionMatrix()
   }
 
   zoomTo(box: AcGeBox2d, margin: number = 1.1) {


### PR DESCRIPTION
## Summary
- Add `entout` system command to export a merged PNG preview for selected entities with configurable long-side pixel size.
- Introduce `AcTrEntityPreview` offscreen capture in three-renderer, plus batch-bounds helpers (`includeObjectIds`, `missingEntity: skip`) to build previews without cloning geometry for feasibility checks.
- Extend `AcTrScene` and `AcTrLayout` with multi-layout preview lookup and add unit tests across cad-simple-viewer and three-renderer.

## Test plan
- [x] `pnpm test -- --testPathPatterns=AcApEntityPreviewConvertor|AcTrLayout|AcTrSceneEntityPreview|AcTrBatchedGroupPreview|AcTrEntityPreview` (30 tests passed)
- [ ] Open a drawing, select entities, run `entout`, confirm PNG download and framing
- [ ] Verify MOVE/COPY/ROTATE jig previews still work (active-layout strict policy unchanged)
- [ ] Test selection spanning multiple layouts with `scope: all` export path