### PR TITLE
fix: normalize layer name lookups to fix stuck visibility toggle (#409)

### DIFF
--- a/packages/cad-simple-viewer/src/view/AcTrLayout.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayout.ts
@@ -339,7 +339,9 @@ export class AcTrLayout {
       throw new Error('Layer name is required to add one entity!')
     }
 
-    const layer = this._layers.get(entity.layerName)
+    const layer = this._layers.get(
+      AcTrLayout.normalizeLayerName(entity.layerName)
+    )
     if (!layer) {
       throw new Error(`layer '${entity.layerName}' doesn't exist!`)
     }
@@ -615,7 +617,7 @@ export class AcTrLayout {
    * @returns - The layer with the specified name in this layout
    */
   getLayer(name: string) {
-    return this._layers.get(name)
+    return this._layers.get(AcTrLayout.normalizeLayerName(name))
   }
 
   /**
@@ -626,11 +628,11 @@ export class AcTrLayout {
    * group already exists in this layout.
    */
   addLayer(info: AcEdLayerInfo) {
-    const name = info.name
-    let layer = this._layers.get(name)
+    const key = AcTrLayout.normalizeLayerName(info.name)
+    let layer = this._layers.get(key)
     if (layer === undefined) {
       layer = new AcTrLayer(info)
-      this._layers.set(name, layer)
+      this._layers.set(key, layer)
       this._group.add(layer.internalObject)
     }
     return layer
@@ -642,7 +644,7 @@ export class AcTrLayout {
    * @returns Returns the updated layer group.
    */
   updateLayer(info: AcEdLayerInfo) {
-    const layer = this._layers.get(info.name)
+    const layer = this._layers.get(AcTrLayout.normalizeLayerName(info.name))
     if (layer) {
       // TODO: Handle layer name changes
       const wasVisible = layer.visible
@@ -652,6 +654,22 @@ export class AcTrLayout {
       }
     }
     return layer
+  }
+
+  /**
+   * Normalizes a layer name for use as a lookup key.
+   *
+   * AutoCAD/DXF layer names are case-insensitive, and some DXF sources (e.g.
+   * merged blocks/xrefs) emit the same logical layer with inconsistent casing
+   * or stray whitespace. Without this, such variants create separate
+   * {@link AcTrLayer} groups, so toggling one leaves entities on the other
+   * unaffected — the layer's visibility checkbox then appears to do nothing.
+   *
+   * @param name - Input layer name
+   * @returns Normalized key used for {@link AcTrLayout._layers}
+   */
+  private static normalizeLayerName(name: string) {
+    return name.trim().toUpperCase()
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixes #409 — layer visibility checkbox permanently stuck for some layers (e.g. "PLATE").
- `AcTrLayout` keyed its internal layer `Map` (and all lookups: `getLayer`, `addLayer`, `updateLayer`, `addEntity`) by exact layer-name string.
- DXF files with duplicate LAYER records differing only by case or trailing whitespace (common after merging blocks/xrefs) created two separate `AcTrLayer` groups for what AutoCAD treats as one logical layer.
- Toggling the checkbox flipped visibility on one group while entities rendered on the other group kept showing — checkbox looked like a no-op.
- Fix: added `AcTrLayout.normalizeLayerName()` (trim + uppercase) and applied it consistently to every `_layers` Map key/lookup.

## Test plan
- [x] `tsc --noEmit` clean on `packages/cad-simple-viewer` (no new errors from this change)
- [x] `eslint` clean on the changed file
- [x] Manually verified via a script: adding layers named `"PLATE"` and `"plate "` now resolve to the same `AcTrLayer` instance, and `updateLayer` toggling visibility on any case variant correctly flips `.visible`
- [ ] Reporter's DXF file would help confirm the exact duplicate-layer-name root cause in their case