### PR TITLE
feat: add cad-mcp-server, an MCP server for CAD Agent drawing tools

### DIFF
--- a/packages/cad-agent-plugin/src/index.ts
+++ b/packages/cad-agent-plugin/src/index.ts
@@ -7,3 +7,14 @@
 import './ui/agent-panel.css'
 
 export { default as AgentChatPanel } from './ui/AgentChatPanel.vue'
+export {
+  CadActionExecutor,
+  cadActionExecutor,
+  type Point2dInput,
+  type ToolResult
+} from './tools/CadActionExecutor'
+export { createCadTools, type CadTools } from './tools/cadTools'
+export {
+  getDrawingContext,
+  type DrawingContextSnapshot
+} from './tools/DrawingContextProvider'

--- a/packages/cad-mcp-server/README.md
+++ b/packages/cad-mcp-server/README.md
@@ -1,0 +1,66 @@
+# @mlightcad/cad-mcp-server
+
+An [MCP](https://modelcontextprotocol.io) server that exposes cad-viewer's drawing tools to
+Claude Code, Codex, and other MCP-compatible clients.
+
+It reuses the exact tool set and execution logic already used by the in-app CAD Agent
+(`@mlightcad/cad-agent-plugin`'s `cadActionExecutor`). Under the hood, the server drives a
+headless Chromium session (via Playwright) that boots `@mlightcad/cad-simple-viewer` and
+runs drawing operations against a live in-memory document — the same way a user's browser
+tab would.
+
+## Setup
+
+```bash
+pnpm --filter @mlightcad/cad-mcp-server build
+pnpm --filter @mlightcad/cad-mcp-server install-browser  # one-time: installs headless Chromium
+```
+
+## Using with Claude Code
+
+Add the server to your MCP config (e.g. `.mcp.json` in the repo root, or via `claude mcp add`):
+
+```json
+{
+  "mcpServers": {
+    "cad-mcp-server": {
+      "command": "node",
+      "args": ["packages/cad-mcp-server/dist/cli.js"]
+    }
+  }
+}
+```
+
+## Using with Codex or other MCP clients
+
+Point the client at the same stdio command:
+
+```bash
+node packages/cad-mcp-server/dist/cli.js
+```
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `open_drawing` | Open a DXF or DWG file from a local path into the active session |
+| `get_drawing_context` | Get current layers, units, and drawing extents |
+| `draw_line` | Draw a straight line segment |
+| `draw_circle` | Draw a circle by center and radius |
+| `draw_arc` | Draw an arc by center, radius, and start/end angles |
+| `draw_rectangle` | Draw a rectangle from two opposite corners |
+| `draw_polyline` | Draw a polyline through a list of points |
+| `draw_text` | Draw single-line MTEXT at a position |
+| `set_current_layer` | Set the current drawing layer (CLAYER) |
+| `create_layer` | Create a new layer if it does not exist |
+| `zoom_extents` | Zoom the view to show the full drawing extents |
+
+One headless browser session is started lazily on the first tool call and kept alive for
+the lifetime of the MCP server process, so drawing state persists across calls within one
+session. Set `CAD_MCP_HEADLESS=false` to run the session in a visible browser window for
+debugging.
+
+## Scope
+
+This first version covers the same drawing/editing tool set as the in-app CAD Agent.
+Export tools (DXF/PNG/PDF/HTML) are not yet exposed here and are a natural follow-up.

--- a/packages/cad-mcp-server/package.json
+++ b/packages/cad-mcp-server/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@mlightcad/cad-mcp-server",
+  "version": "1.5.7",
+  "description": "MCP server exposing cad-viewer drawing tools to Claude Code, Codex, and other MCP clients",
+  "type": "module",
+  "bin": {
+    "cad-mcp-server": "./dist/cli.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mlightcad/cad-viewer.git"
+  },
+  "scripts": {
+    "build": "node --max-old-space-size=6144 ./node_modules/typescript/bin/tsc && vite build --config vite.runner.config.ts && node scripts/copy-runner-assets.mjs",
+    "install-browser": "playwright install chromium",
+    "clean": "rimraf dist dist-runner tsconfig.tsbuildinfo",
+    "start": "node ./dist/cli.js",
+    "lint": "eslint src/",
+    "lint:fix": "eslint --fix --quiet src/"
+  },
+  "dependencies": {
+    "@mlightcad/cad-agent-plugin": "workspace:*",
+    "@mlightcad/cad-simple-viewer": "workspace:*",
+    "@mlightcad/data-model": "^1.10.0",
+    "@mlightcad/dxf-json-converter": "^1.10.0",
+    "@mlightcad/libredwg-converter": "^3.10.0",
+    "@mlightcad/mtext-renderer": "^0.11.5",
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "playwright": "^1.49.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.5.2",
+    "vite": "^5.4.19"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/cad-mcp-server/project.json
+++ b/packages/cad-mcp-server/project.json
@@ -1,0 +1,49 @@
+{
+  "name": "@mlightcad/cad-mcp-server",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/cad-mcp-server/src",
+  "projectType": "application",
+  "tags": [
+    "npm:private"
+  ],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm build",
+        "cwd": "packages/cad-mcp-server"
+      },
+      "dependsOn": [
+        "^build",
+        {
+          "projects": [
+            "@mlightcad/cad-agent-plugin"
+          ],
+          "target": "build"
+        }
+      ],
+      "cache": true
+    },
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "rimraf dist dist-runner tsconfig.tsbuildinfo",
+        "cwd": "packages/cad-mcp-server"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint src/",
+        "cwd": "packages/cad-mcp-server"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint --fix --quiet src/",
+        "cwd": "packages/cad-mcp-server"
+      }
+    }
+  }
+}

--- a/packages/cad-mcp-server/runner/index.html
+++ b/packages/cad-mcp-server/runner/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>CAD MCP runner</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #1e1e1e;
+      }
+      #cad-root {
+        width: 1280px;
+        height: 720px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="cad-root"></div>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>

--- a/packages/cad-mcp-server/runner/main.ts
+++ b/packages/cad-mcp-server/runner/main.ts
@@ -1,0 +1,156 @@
+import {
+  cadActionExecutor,
+  getDrawingContext,
+  type Point2dInput,
+  type ToolResult
+} from '@mlightcad/cad-agent-plugin'
+import { AcApDocManager, AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
+
+declare global {
+  interface Window {
+    __cadMcp: {
+      ensure: () => Promise<void>
+      openDrawing: (fileName: string, base64: string) => Promise<ToolResult>
+      getDrawingContext: () => Promise<unknown>
+      drawLine: (input: {
+        start: Point2dInput
+        end: Point2dInput
+        layer?: string
+      }) => Promise<ToolResult>
+      drawCircle: (input: {
+        center: Point2dInput
+        radius: number
+        layer?: string
+      }) => Promise<ToolResult>
+      drawArc: (input: {
+        center: Point2dInput
+        radius: number
+        startAngleDeg: number
+        endAngleDeg: number
+        layer?: string
+      }) => Promise<ToolResult>
+      drawRectangle: (input: {
+        corner1: Point2dInput
+        corner2: Point2dInput
+        layer?: string
+      }) => Promise<ToolResult>
+      drawPolyline: (input: {
+        points: Point2dInput[]
+        closed?: boolean
+        layer?: string
+      }) => Promise<ToolResult>
+      drawText: (input: {
+        position: Point2dInput
+        text: string
+        height?: number
+        layer?: string
+      }) => Promise<ToolResult>
+      setCurrentLayer: (layerName: string) => Promise<ToolResult>
+      createLayer: (layerName: string) => Promise<ToolResult>
+      zoomExtents: () => Promise<ToolResult>
+    }
+  }
+}
+
+let ready = false
+
+async function ensureViewer(): Promise<void> {
+  if (ready) {
+    return
+  }
+  const container = document.getElementById('cad-root') as HTMLDivElement
+  AcApDocManager.createInstance({
+    container,
+    width: 1280,
+    height: 720,
+    autoResize: false,
+    baseUrl: 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/',
+    useMainThreadDraw: true,
+    webworkerFileUrls: {
+      dxfParser: './workers/dxf-parser-worker.js',
+      dwgParser: './workers/libredwg-parser-worker.js',
+      mtextRender: './workers/mtext-renderer-worker.js'
+    }
+  })
+  ready = true
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes.buffer
+}
+
+window.__cadMcp = {
+  ensure: ensureViewer,
+
+  async openDrawing(fileName, base64) {
+    await ensureViewer()
+    try {
+      const buffer = base64ToArrayBuffer(base64)
+      const opened = await AcApDocManager.instance.openDocument(
+        fileName,
+        buffer,
+        { mode: AcEdOpenMode.Write, minimumChunkSize: 1000 }
+      )
+      return opened
+        ? { success: true, message: `Opened "${fileName}"` }
+        : {
+            success: false,
+            message: `Failed to open "${fileName}"`,
+            error: 'open_failed'
+          }
+    } catch (error) {
+      return {
+        success: false,
+        message: `Failed to open "${fileName}"`,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  },
+
+  async getDrawingContext() {
+    await ensureViewer()
+    return getDrawingContext()
+  },
+
+  drawLine: async input => {
+    await ensureViewer()
+    return cadActionExecutor.drawLine(input)
+  },
+  drawCircle: async input => {
+    await ensureViewer()
+    return cadActionExecutor.drawCircle(input)
+  },
+  drawArc: async input => {
+    await ensureViewer()
+    return cadActionExecutor.drawArc(input)
+  },
+  drawRectangle: async input => {
+    await ensureViewer()
+    return cadActionExecutor.drawRectangle(input)
+  },
+  drawPolyline: async input => {
+    await ensureViewer()
+    return cadActionExecutor.drawPolyline(input)
+  },
+  drawText: async input => {
+    await ensureViewer()
+    return cadActionExecutor.drawText(input)
+  },
+  setCurrentLayer: async layerName => {
+    await ensureViewer()
+    return cadActionExecutor.setCurrentLayer(layerName)
+  },
+  createLayer: async layerName => {
+    await ensureViewer()
+    return cadActionExecutor.createLayer(layerName)
+  },
+  zoomExtents: async () => {
+    await ensureViewer()
+    return cadActionExecutor.zoomExtents()
+  }
+}

--- a/packages/cad-mcp-server/scripts/copy-runner-assets.mjs
+++ b/packages/cad-mcp-server/scripts/copy-runner-assets.mjs
@@ -1,0 +1,60 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const cliPackageRoot = fileURLToPath(new URL('..', import.meta.url))
+const outDir = join(cliPackageRoot, 'dist-runner')
+const workersDir = join(outDir, 'workers')
+
+function pkgRoot(name) {
+  const entry = require.resolve(name)
+  let dir = dirname(entry)
+  while (true) {
+    const pkgPath = join(dir, 'package.json')
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+      if (pkg.name === name) {
+        return dir
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      throw new Error(`Package root not found: ${name}`)
+    }
+    dir = parent
+  }
+}
+
+function copy(from, to) {
+  if (!existsSync(from)) {
+    throw new Error(`Missing asset: ${from}`)
+  }
+  copyFileSync(from, to)
+}
+
+mkdirSync(workersDir, { recursive: true })
+
+copy(
+  join(
+    pkgRoot('@mlightcad/dxf-json-converter'),
+    'dist',
+    'dxf-parser-worker.js'
+  ),
+  join(workersDir, 'dxf-parser-worker.js')
+)
+copy(
+  join(
+    pkgRoot('@mlightcad/libredwg-converter'),
+    'dist',
+    'libredwg-parser-worker.js'
+  ),
+  join(workersDir, 'libredwg-parser-worker.js')
+)
+copy(
+  join(pkgRoot('@mlightcad/mtext-renderer'), 'dist', 'mtext-renderer-worker.js'),
+  join(workersDir, 'mtext-renderer-worker.js')
+)
+
+console.log('Copied runner workers into dist-runner/')

--- a/packages/cad-mcp-server/src/browserSession.ts
+++ b/packages/cad-mcp-server/src/browserSession.ts
@@ -1,0 +1,252 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { createServer, type Server } from 'node:http'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { type Browser, chromium, type Page } from 'playwright'
+
+/** Result shape mirroring `@mlightcad/cad-agent-plugin`'s `ToolResult`. */
+export interface ToolResult {
+  success: boolean
+  message: string
+  entityIds?: string[]
+  error?: string
+}
+
+interface Point2dInput {
+  x: number
+  y: number
+}
+
+function runnerDistDir(): string {
+  const packageRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..'
+  )
+  return path.join(packageRoot, 'dist-runner')
+}
+
+function startStaticServer(root: string): Promise<{
+  url: string
+  close: () => Promise<void>
+}> {
+  return new Promise((resolve, reject) => {
+    const server: Server = createServer((req, res) => {
+      try {
+        const urlPath = decodeURIComponent((req.url ?? '/').split('?')[0])
+        const relative =
+          urlPath === '/' ? 'index.html' : urlPath.replace(/^\//, '')
+        const filePath = path.join(root, relative)
+
+        if (!filePath.startsWith(root)) {
+          res.writeHead(403)
+          res.end()
+          return
+        }
+        if (!existsSync(filePath)) {
+          res.writeHead(404)
+          res.end()
+          return
+        }
+
+        const ext = path.extname(filePath).toLowerCase()
+        const types: Record<string, string> = {
+          '.html': 'text/html; charset=utf-8',
+          '.js': 'text/javascript; charset=utf-8',
+          '.css': 'text/css; charset=utf-8',
+          '.json': 'application/json',
+          '.wasm': 'application/wasm'
+        }
+        res.setHeader('Content-Type', types[ext] ?? 'application/octet-stream')
+        void readFile(filePath).then(body => {
+          res.writeHead(200)
+          res.end(body)
+        })
+      } catch (error) {
+        res.writeHead(500)
+        res.end(String(error))
+      }
+    })
+
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to start static server for MCP runner.'))
+        return
+      }
+      resolve({
+        url: `http://127.0.0.1:${address.port}`,
+        close: () =>
+          new Promise((closeResolve, closeReject) => {
+            server.close(err => (err ? closeReject(err) : closeResolve()))
+          })
+      })
+    })
+  })
+}
+
+/**
+ * Owns a single headless-Chromium session running the cad-mcp-server runner page,
+ * which boots `@mlightcad/cad-simple-viewer` and executes drawing tool calls via
+ * `@mlightcad/cad-agent-plugin`'s {@link cadActionExecutor}.
+ *
+ * Lazily started on first tool call and kept alive for the lifetime of the MCP
+ * server process so that drawing state persists across tool calls in one session.
+ */
+export class CadBrowserSession {
+  private browser?: Browser
+  private page?: Page
+  private closeServer?: () => Promise<void>
+  private startPromise?: Promise<void>
+
+  private async ensureStarted(): Promise<void> {
+    if (this.page) {
+      return
+    }
+    if (!this.startPromise) {
+      this.startPromise = this.start()
+    }
+    await this.startPromise
+  }
+
+  private async start(): Promise<void> {
+    const runnerDir = runnerDistDir()
+    if (!existsSync(path.join(runnerDir, 'index.html'))) {
+      throw new Error(
+        'cad-mcp-server runner is not built. Run "pnpm --filter @mlightcad/cad-mcp-server build".'
+      )
+    }
+
+    const server = await startStaticServer(runnerDir)
+    this.closeServer = server.close
+
+    this.browser = await chromium.launch({
+      headless: process.env.CAD_MCP_HEADLESS !== 'false'
+    })
+    this.page = await this.browser.newPage()
+    await this.page.goto(`${server.url}/index.html`, {
+      waitUntil: 'networkidle'
+    })
+    await this.page.evaluate(() => window.__cadMcp.ensure())
+  }
+
+  /** Closes the browser and static server. Safe to call multiple times. */
+  async stop(): Promise<void> {
+    await this.page?.close().catch(() => undefined)
+    await this.browser?.close().catch(() => undefined)
+    await this.closeServer?.().catch(() => undefined)
+    this.page = undefined
+    this.browser = undefined
+    this.closeServer = undefined
+    this.startPromise = undefined
+  }
+
+  async openDrawing(fileName: string, filePath: string): Promise<ToolResult> {
+    await this.ensureStarted()
+    const absolute = path.resolve(filePath)
+    const bytes = await readFile(absolute)
+    return this.page!.evaluate(
+      ({ fileName, base64 }) => window.__cadMcp.openDrawing(fileName, base64),
+      { fileName, base64: bytes.toString('base64') }
+    )
+  }
+
+  async getDrawingContext(): Promise<unknown> {
+    await this.ensureStarted()
+    return this.page!.evaluate(() => window.__cadMcp.getDrawingContext())
+  }
+
+  async drawLine(input: {
+    start: Point2dInput
+    end: Point2dInput
+    layer?: string
+  }): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(
+      input => window.__cadMcp.drawLine(input),
+      input
+    )
+  }
+
+  async drawCircle(input: {
+    center: Point2dInput
+    radius: number
+    layer?: string
+  }): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(
+      input => window.__cadMcp.drawCircle(input),
+      input
+    )
+  }
+
+  async drawArc(input: {
+    center: Point2dInput
+    radius: number
+    startAngleDeg: number
+    endAngleDeg: number
+    layer?: string
+  }): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(input => window.__cadMcp.drawArc(input), input)
+  }
+
+  async drawRectangle(input: {
+    corner1: Point2dInput
+    corner2: Point2dInput
+    layer?: string
+  }): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(
+      input => window.__cadMcp.drawRectangle(input),
+      input
+    )
+  }
+
+  async drawPolyline(input: {
+    points: Point2dInput[]
+    closed?: boolean
+    layer?: string
+  }): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(
+      input => window.__cadMcp.drawPolyline(input),
+      input
+    )
+  }
+
+  async drawText(input: {
+    position: Point2dInput
+    text: string
+    height?: number
+    layer?: string
+  }): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(
+      input => window.__cadMcp.drawText(input),
+      input
+    )
+  }
+
+  async setCurrentLayer(layerName: string): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(
+      layerName => window.__cadMcp.setCurrentLayer(layerName),
+      layerName
+    )
+  }
+
+  async createLayer(layerName: string): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(
+      layerName => window.__cadMcp.createLayer(layerName),
+      layerName
+    )
+  }
+
+  async zoomExtents(): Promise<ToolResult> {
+    await this.ensureStarted()
+    return this.page!.evaluate(() => window.__cadMcp.zoomExtents())
+  }
+}

--- a/packages/cad-mcp-server/src/cli.ts
+++ b/packages/cad-mcp-server/src/cli.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+
+import { CadBrowserSession } from './browserSession.js'
+
+const session = new CadBrowserSession()
+
+const server = new McpServer({
+  name: 'cad-mcp-server',
+  version: '1.5.7'
+})
+
+const pointSchema = z.object({ x: z.number(), y: z.number() })
+
+function jsonResult(value: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value) }] }
+}
+
+// The `registerTool` overload's InputArgs/OutputArgs conditional generics hit
+// TypeScript's type-instantiation depth limit (TS2589) on some of these calls
+// under @modelcontextprotocol/sdk 1.29 + zod 3.25 + TS 5.9, independent of
+// schema complexity (even the empty-schema tool below can trip it). Runtime
+// behavior is unaffected; suppress until upstream resolves the generic depth.
+// @ts-expect-error TS2589: excessive type instantiation depth (SDK generics)
+server.registerTool(
+  'open_drawing',
+  {
+    description:
+      'Open a DXF or DWG file from a local path into the active CAD session',
+    inputSchema: {
+      filePath: z.string().min(1)
+    }
+  },
+  async ({ filePath }) => {
+    const fileName = filePath.split(/[/\\]/).pop() ?? filePath
+    const result = await session.openDrawing(fileName, filePath)
+    return jsonResult(result)
+  }
+)
+
+server.registerTool(
+  'get_drawing_context',
+  {
+    description: 'Get current drawing context: units, layers, and extents',
+    inputSchema: {}
+  },
+  async () => jsonResult(await session.getDrawingContext())
+)
+
+// @ts-expect-error TS2589: excessive type instantiation depth (SDK generics)
+server.registerTool(
+  'draw_line',
+  {
+    description: 'Draw a straight line segment in model space',
+    inputSchema: {
+      start: pointSchema,
+      end: pointSchema,
+      layer: z.string().optional()
+    }
+  },
+  async input => jsonResult(await session.drawLine(input))
+)
+
+server.registerTool(
+  'draw_circle',
+  {
+    description: 'Draw a circle by center and radius',
+    inputSchema: {
+      center: pointSchema,
+      radius: z.number().positive(),
+      layer: z.string().optional()
+    }
+  },
+  async input => jsonResult(await session.drawCircle(input))
+)
+
+server.registerTool(
+  'draw_arc',
+  {
+    description: 'Draw an arc by center, radius, and start/end angles in degrees',
+    inputSchema: {
+      center: pointSchema,
+      radius: z.number().positive(),
+      startAngleDeg: z.number(),
+      endAngleDeg: z.number(),
+      layer: z.string().optional()
+    }
+  },
+  async input => jsonResult(await session.drawArc(input))
+)
+
+server.registerTool(
+  'draw_rectangle',
+  {
+    description: 'Draw a rectangle from two opposite corners',
+    inputSchema: {
+      corner1: pointSchema,
+      corner2: pointSchema,
+      layer: z.string().optional()
+    }
+  },
+  async input => jsonResult(await session.drawRectangle(input))
+)
+
+// @ts-expect-error TS2589: excessive type instantiation depth (SDK generics)
+server.registerTool(
+  'draw_polyline',
+  {
+    description: 'Draw a polyline through a list of points',
+    inputSchema: {
+      points: z.array(pointSchema).min(2),
+      closed: z.boolean().optional(),
+      layer: z.string().optional()
+    }
+  },
+  async input => jsonResult(await session.drawPolyline(input))
+)
+
+// @ts-expect-error TS2589: excessive type instantiation depth (SDK generics)
+server.registerTool(
+  'draw_text',
+  {
+    description: 'Draw single-line MTEXT at a position',
+    inputSchema: {
+      position: pointSchema,
+      text: z.string().min(1),
+      height: z.number().positive().optional(),
+      layer: z.string().optional()
+    }
+  },
+  async input => jsonResult(await session.drawText(input))
+)
+
+server.registerTool(
+  'set_current_layer',
+  {
+    description: 'Set the current drawing layer (CLAYER)',
+    inputSchema: {
+      layerName: z.string().min(1)
+    }
+  },
+  async ({ layerName }) => jsonResult(await session.setCurrentLayer(layerName))
+)
+
+server.registerTool(
+  'create_layer',
+  {
+    description: 'Create a new layer if it does not exist',
+    inputSchema: {
+      layerName: z.string().min(1)
+    }
+  },
+  async ({ layerName }) => jsonResult(await session.createLayer(layerName))
+)
+
+server.registerTool(
+  'zoom_extents',
+  {
+    description: 'Zoom the view to show the full drawing extents',
+    inputSchema: {}
+  },
+  async () => jsonResult(await session.zoomExtents())
+)
+
+async function shutdown() {
+  await session.stop()
+  process.exit(0)
+}
+
+process.on('SIGINT', () => void shutdown())
+process.on('SIGTERM', () => void shutdown())
+
+const transport = new StdioServerTransport()
+await server.connect(transport)

--- a/packages/cad-mcp-server/src/global.d.ts
+++ b/packages/cad-mcp-server/src/global.d.ts
@@ -1,0 +1,54 @@
+import type { ToolResult } from './browserSession'
+
+interface Point2dInput {
+  x: number
+  y: number
+}
+
+declare global {
+  interface Window {
+    __cadMcp: {
+      ensure: () => Promise<void>
+      openDrawing: (fileName: string, base64: string) => Promise<ToolResult>
+      getDrawingContext: () => Promise<unknown>
+      drawLine: (input: {
+        start: Point2dInput
+        end: Point2dInput
+        layer?: string
+      }) => Promise<ToolResult>
+      drawCircle: (input: {
+        center: Point2dInput
+        radius: number
+        layer?: string
+      }) => Promise<ToolResult>
+      drawArc: (input: {
+        center: Point2dInput
+        radius: number
+        startAngleDeg: number
+        endAngleDeg: number
+        layer?: string
+      }) => Promise<ToolResult>
+      drawRectangle: (input: {
+        corner1: Point2dInput
+        corner2: Point2dInput
+        layer?: string
+      }) => Promise<ToolResult>
+      drawPolyline: (input: {
+        points: Point2dInput[]
+        closed?: boolean
+        layer?: string
+      }) => Promise<ToolResult>
+      drawText: (input: {
+        position: Point2dInput
+        text: string
+        height?: number
+        layer?: string
+      }) => Promise<ToolResult>
+      setCurrentLayer: (layerName: string) => Promise<ToolResult>
+      createLayer: (layerName: string) => Promise<ToolResult>
+      zoomExtents: () => Promise<ToolResult>
+    }
+  }
+}
+
+export {}

--- a/packages/cad-mcp-server/tsconfig.json
+++ b/packages/cad-mcp-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/cad-mcp-server/vite.runner.config.ts
+++ b/packages/cad-mcp-server/vite.runner.config.ts
@@ -1,0 +1,16 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vite'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  root: resolve(__dirname, 'runner'),
+  base: './',
+  build: {
+    outDir: resolve(__dirname, 'dist-runner'),
+    emptyOutDir: true,
+    minify: true
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,49 @@ importers:
         specifier: ^0.172.0
         version: 0.172.0
 
+  packages/cad-mcp-server:
+    dependencies:
+      '@mlightcad/cad-agent-plugin':
+        specifier: workspace:*
+        version: link:../cad-agent-plugin
+      '@mlightcad/cad-simple-viewer':
+        specifier: workspace:*
+        version: link:../cad-simple-viewer
+      '@mlightcad/data-model':
+        specifier: ^1.10.0
+        version: 1.10.0
+      '@mlightcad/dxf-json-converter':
+        specifier: ^1.10.0
+        version: 1.10.0(@mlightcad/data-model@1.10.0)
+      '@mlightcad/libredwg-converter':
+        specifier: ^3.10.0
+        version: 3.10.0(@mlightcad/data-model@1.10.0)
+      '@mlightcad/mtext-renderer':
+        specifier: ^0.11.5
+        version: 0.11.5(three@0.172.0)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.29.0(zod@3.25.76)
+      playwright:
+        specifier: ^1.49.1
+        version: 1.59.1
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.37
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.19
+        version: 5.4.21(@types/node@20.19.37)(sass@1.98.0)
+
   packages/cad-pdf-plugin:
     devDependencies:
       '@mlightcad/cad-simple-viewer':
@@ -1468,6 +1511,12 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1757,6 +1806,16 @@ packages:
     peerDependencies:
       element-plus: ^2.12.0
       vue: ^3.4.21
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/canvas-android-arm64@0.1.100':
     resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
@@ -2680,6 +2739,10 @@ packages:
     resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
     hasBin: true
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2898,6 +2961,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2947,6 +3014,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -3111,14 +3182,38 @@ packages:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig@6.0.0:
     resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
@@ -3225,6 +3320,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -3289,6 +3388,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -3314,6 +3416,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -3369,6 +3475,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -3481,11 +3590,19 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
@@ -3507,6 +3624,16 @@ packages:
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -3573,6 +3700,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3607,6 +3738,14 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   front-matter@4.0.2:
     resolution: {integrity: sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==}
@@ -3731,6 +3870,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -3745,6 +3888,10 @@ packages:
   html2canvas@1.4.1:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
     engines: {node: '>=8.0.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -3821,6 +3968,14 @@ packages:
   iobuffer@5.4.0:
     resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -3878,6 +4033,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -4091,6 +4249,9 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4127,6 +4288,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -4291,8 +4455,16 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4327,6 +4499,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -4406,6 +4582,10 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -4457,6 +4637,18 @@ packages:
         optional: true
       '@swc/core':
         optional: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   on-headers@1.1.0:
     resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
@@ -4548,6 +4740,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -4575,6 +4771,9 @@ packages:
 
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4613,6 +4812,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -4672,6 +4875,10 @@ packages:
     resolution: {integrity: sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -4686,6 +4893,10 @@ packages:
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -4702,6 +4913,14 @@ packages:
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rbush@4.0.1:
     resolution: {integrity: sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==}
@@ -4832,6 +5051,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
@@ -4871,13 +5094,24 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   serve@14.2.6:
     resolution: {integrity: sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==}
     engines: {node: '>= 14'}
     hasBin: true
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4886,6 +5120,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -4941,6 +5191,10 @@ packages:
   stackblur-canvas@2.7.0:
     resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
     engines: {node: '>=0.1.14'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -5082,6 +5336,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -5168,6 +5426,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typedoc@0.28.18:
     resolution: {integrity: sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==}
     engines: {node: '>= 18', pnpm: '>= 10'}
@@ -5231,6 +5493,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -5496,6 +5762,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -6657,6 +6928,10 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -7100,6 +7375,28 @@ snapshots:
     dependencies:
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/canvas-android-arm64@0.1.100':
     optional: true
@@ -7548,7 +7845,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.19.37
+      '@types/node': 24.12.4
 
   '@types/hast@3.0.4':
     dependencies:
@@ -7584,7 +7881,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 24.12.4
 
   '@types/lodash-es@4.17.12':
     dependencies:
@@ -7981,6 +8278,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -8217,6 +8519,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   boxen@7.0.0:
@@ -8278,6 +8594,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -8426,7 +8747,17 @@ snapshots:
 
   content-disposition@0.5.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   core-js-compat@3.49.0:
     dependencies:
@@ -8434,6 +8765,11 @@ snapshots:
 
   core-js@3.49.0:
     optional: true
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig@6.0.0:
     dependencies:
@@ -8524,6 +8860,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2:
@@ -8585,6 +8923,8 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ee-first@1.1.1: {}
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
@@ -8619,6 +8959,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -8687,6 +9029,8 @@ snapshots:
       '@esbuild/win32-x64': 0.21.5
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
 
@@ -8813,9 +9157,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
 
   eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -8859,6 +9209,44 @@ snapshots:
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -8926,6 +9314,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -8956,6 +9355,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   front-matter@4.0.2:
     dependencies:
@@ -9077,6 +9480,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  hono@4.12.27: {}
+
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -9092,6 +9497,14 @@ snapshots:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
     optional: true
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -9153,6 +9566,10 @@ snapshots:
 
   iobuffer@5.4.0: {}
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
@@ -9192,6 +9609,8 @@ snapshots:
   is-port-reachable@4.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -9609,6 +10028,8 @@ snapshots:
 
   jju@1.4.0: {}
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -9656,6 +10077,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -9834,7 +10257,11 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  media-typer@1.1.0: {}
+
   memoize-one@6.0.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -9860,6 +10287,10 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -9919,6 +10350,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.4: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -10003,6 +10436,14 @@ snapshots:
       '@nx/nx-win32-x64-msvc': 20.0.4
     transitivePeerDependencies:
       - debug
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   on-headers@1.1.0: {}
 
@@ -10101,6 +10542,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -10119,6 +10562,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@3.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -10142,6 +10587,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -10203,6 +10650,11 @@ snapshots:
 
   proc-log@3.0.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@2.1.0: {}
 
   punycode.js@2.3.1: {}
@@ -10210,6 +10662,11 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@7.0.1: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quansync@0.2.11: {}
 
@@ -10223,6 +10680,15 @@ snapshots:
     optional: true
 
   range-parser@1.2.0: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rbush@4.0.1:
     dependencies:
@@ -10375,6 +10841,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.8.0: {}
 
   run-parallel@1.2.0:
@@ -10407,6 +10883,22 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serve-handler@6.1.7:
     dependencies:
       bytes: 3.0.0
@@ -10416,6 +10908,15 @@ snapshots:
       path-is-inside: 1.0.2
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   serve@14.2.6:
     dependencies:
@@ -10433,11 +10934,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   signal-exit@3.0.7: {}
 
@@ -10486,6 +11017,8 @@ snapshots:
 
   stackblur-canvas@2.7.0:
     optional: true
+
+  statuses@2.0.2: {}
 
   string-argv@0.3.2: {}
 
@@ -10626,6 +11159,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -10698,6 +11233,12 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typedoc@0.28.18(typescript@5.9.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
@@ -10749,6 +11290,8 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -11029,5 +11572,9 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}


### PR DESCRIPTION
## Summary

Adds `@mlightcad/cad-mcp-server`, a [Model Context Protocol](https://modelcontextprotocol.io)
server that exposes cad-viewer's drawing tools to Claude Code, Codex, and other MCP clients.

- Reuses the exact tool set and logic already used by the in-app CAD Agent
  (`@mlightcad/cad-agent-plugin`'s `cadActionExecutor`) — no duplicated drawing logic.
  Exports `cadActionExecutor`, `createCadTools`, and `getDrawingContext` from
  `cad-agent-plugin`'s public `index.ts` so the new package (and any future consumer) can
  reuse them.
- Drives a headless Chromium session via Playwright, following the same runner pattern as
  `cad-html-exporter-cli` (a static-served `runner/` page that boots
  `@mlightcad/cad-simple-viewer` in-page). The session is started lazily on the first tool
  call and kept alive for the process lifetime so drawing state persists across calls.
- Tools: `open_drawing`, `get_drawing_context`, `draw_line`, `draw_circle`, `draw_arc`,
  `draw_rectangle`, `draw_polyline`, `draw_text`, `set_current_layer`, `create_layer`,
  `zoom_extents`.
- `bin: cad-mcp-server` — runs as a stdio MCP server (`node dist/cli.js`); see the package
  README for Claude Code/Codex config examples.

## Notes

- A handful of `server.registerTool(...)` calls hit TypeScript's type-instantiation depth
  limit (`TS2589`) under `@modelcontextprotocol/sdk@1.29` + zod 3.25 + TS 5.9, independent
  of schema complexity (confirmed by testing simpler/other overloads and even an
  empty-schema tool tripping it in some configurations). These are suppressed with
  `@ts-expect-error` and a comment explaining the limitation; runtime behavior is
  unaffected. Happy to revisit if there's a cleaner known workaround.
- `tsc` for this package needs a larger heap than Node's default on some machines given
  the size of the workspace's type graph (same characteristic affects `cad-agent-plugin`),
  so the `build` script now invokes `tsc` via `node --max-old-space-size=6144` directly.
- Export tools (DXF/PNG/PDF/HTML) are out of scope for this first version and are a
  natural follow-up.

## Test plan

- [x] `pnpm --filter @mlightcad/cad-mcp-server build` succeeds (tsc + vite runner bundle +
      worker asset copy)
- [x] `eslint` clean
- [x] Full workspace `nx run-many -t build` passes across all 12 projects
- [ ] Manually connect Claude Code to the server and run `draw_line`/`draw_circle`/etc.
      against a fresh session, then `open_drawing` against a real DXF/DWG file