### PR TITLE
fix: recover view init when openDocument() fails but data already parsed (#384)

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1301,6 +1301,13 @@ export class AcApDocManager {
    * If the document was successfully opened, it dispatches the documentActivated event,
    * sets up layout information, and zooms the view to fit the content.
    *
+   * A large DWG/DXF parse can fail (e.g. a worker timeout) after entities have already
+   * been committed to the database in earlier pipeline stages, leaving `isSuccess` false
+   * while the database already has valid, non-empty extents. Without this check the view
+   * never initializes and the user is left with a blank canvas despite the data being in
+   * memory. When that happens, treat it as a recovered partial open so the view still
+   * activates and frames whatever content did land.
+   *
    * @param isSuccess - Whether the document was successfully opened
    * @protected
    */
@@ -1308,7 +1315,9 @@ export class AcApDocManager {
     isSuccess: boolean,
     options?: AcApOpenDatabaseOptions
   ) {
-    if (isSuccess) {
+    const recoveredPartialContent =
+      !isSuccess && this.hasRecoverablePartialContent()
+    if (isSuccess || recoveredPartialContent) {
       this.context.doc.destroy()
       const doc = this.context.doc
       this.events.documentActivated.dispatch({
@@ -1396,6 +1405,18 @@ export class AcApDocManager {
     } else {
       this.regen()
     }
+  }
+
+  /**
+   * Checks whether the current document's database already has usable content
+   * (non-empty extents) even though the open operation reported failure.
+   *
+   * @returns True when the database has recoverable partial content.
+   * @protected
+   */
+  protected hasRecoverablePartialContent(): boolean {
+    const db = this.context.doc.database
+    return !db.extents.isEmpty()
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #384 — for medium-to-large DWG files (~50-100MB), `AcApDocManager.openDocument()`
can resolve `false` even though the database already has parsed entities and valid
extents, leaving the user with a blank canvas.

## Root cause

`@mlightcad/data-model`'s worker-based DWG parser has a non-scaling timeout ceiling
(capped at 2 minutes regardless of file size). On large files where the actual parse
takes longer, the timeout fires and rejects the in-flight parse **after** earlier
pipeline stages have already committed entities/extents to the (already
view-bound) database. Since `AcApDocManager.onAfterOpenDocument` only dispatched
`documentActivated` and framed the view inside its `if (isSuccess)` branch, a false
`isSuccess` left the view uninitialized despite the data being in memory — the parser
timeout itself lives in the external `data-model` package and isn't something this repo
can patch directly.

## Fix

In `packages/cad-simple-viewer/src/app/AcApDocManager.ts`:
- Added `hasRecoverablePartialContent()` — checks whether the database already has
  non-empty extents.
- `onAfterOpenDocument` now treats a failed open as **recovered** when that check
  passes, so the view still activates, sets up the active layout, and frames whatever
  content did land — instead of leaving a blank canvas.
- `openDocument()`'s return value is unchanged, so callers still get an accurate
  success/failure signal for error handling/toasts; only the view-activation side effect
  is widened to cover this partial-success case.

## Test plan

- [x] `eslint` clean on the changed file
- [x] `tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in this
      package are unchanged before/after this diff)
- [ ] Manually reproduce with a large DWG that hits the worker timeout and confirm the
      view now frames the partially-parsed content instead of staying blank