### PR TITLE
feat(cad-simple-viewer): add newDocument API and improve new drawing workflow

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -105,6 +105,8 @@ import {
 } from './AcDbOpenDatabaseOptions'
 
 const DEFAULT_BASE_URL = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data'
+/** Default ISO drawing template loaded by {@link AcApDocManager.newDocument}. */
+const DEFAULT_NEW_DRAWING_TEMPLATE = 'templates/acadiso.dxf'
 /**
  * Built-in command alias table used when users do not provide explicit alias overrides.
  *
@@ -866,6 +868,38 @@ export class AcApDocManager {
       options
     )
     this.onAfterOpenDocument(isSuccess, options)
+    return isSuccess
+  }
+
+  /**
+   * Creates a new CAD document from the default ISO drawing template.
+   *
+   * This method loads the predefined template (`acadiso.dxf`) from {@link baseUrl}
+   * and replaces the current document in write mode with default open options.
+   *
+   * @param options - Optional database opening options merged with write mode
+   * @returns Promise that resolves to true if the document was successfully created
+   *
+   * @example
+   * ```typescript
+   * const success = await docManager.newDocument();
+   * ```
+   */
+  async newDocument(options?: AcApOpenDatabaseOptions) {
+    const baseUrl = this.baseUrl.endsWith('/')
+      ? this.baseUrl
+      : `${this.baseUrl}/`
+    const templateUrl = `${baseUrl}${DEFAULT_NEW_DRAWING_TEMPLATE}`
+    const openOptions = this.setOptions({
+      mode: AcEdOpenMode.Write,
+      ...options
+    })
+    this.onBeforeOpenDocument(openOptions)
+    const isSuccess = await this.context.doc.openUri(templateUrl, openOptions)
+    if (isSuccess) {
+      this.context.doc.resetNewDocumentIdentity()
+    }
+    this.onAfterOpenDocument(isSuccess, openOptions)
     return isSuccess
   }
 

--- a/packages/cad-simple-viewer/src/app/AcApDocument.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocument.ts
@@ -148,6 +148,18 @@ export class AcApDocument {
   }
 
   /**
+   * Clears file identity after creating a document from a template.
+   *
+   * Template content remains in the database; only URI, file name, and title
+   * are reset so the document presents as a new unsaved drawing.
+   */
+  resetNewDocumentIdentity() {
+    this._uri = undefined
+    this._fileName = ''
+    this.docTitle = 'Untitled'
+  }
+
+  /**
    * Gets the URI of the document if opened from a URI.
    *
    * @returns The document URI, or undefined if not opened from URI

--- a/packages/cad-simple-viewer/src/command/AcApQNewCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApQNewCmd.ts
@@ -1,11 +1,11 @@
 import { AcApContext, AcApDocManager } from '../app'
-import { AcEdCommand, AcEdOpenMode } from '../editor'
+import { AcEdCommand } from '../editor'
 
 /**
  * Command for creating a new CAD document from a template.
  *
- * This command opens a predefined template drawing (acadiso.dxf) from
- * a CDN to create a new document. The template provides:
+ * This command uses {@link AcApDocManager.newDocument} to create a new document
+ * from the default ISO template (`acadiso.dxf`), which provides:
  * - Standard ISO drawing settings
  * - Predefined layers and styles
  * - Default drawing setup
@@ -23,25 +23,15 @@ export class AcApQNewCmd extends AcEdCommand {
   /**
    * Executes the quick new command.
    *
-   * Opens the ISO template from the CDN to create a new document
-   * with standard drawing settings.
+   * Creates a new document from the default ISO template with standard
+   * drawing settings.
    *
    * @param _context - The application context (unused in this command)
    */
   async execute(_context: AcApContext) {
-    const manager = AcApDocManager.instance
-    const baseUrl = manager.baseUrl.endsWith('/')
-      ? manager.baseUrl
-      : `${manager.baseUrl}/`
-    const defaults = await Promise.resolve(
-      manager.resolveOpenDocumentDefaults()
-    )
-    const success = await manager.openUrl(`${baseUrl}templates/acadiso.dxf`, {
-      ...defaults,
-      mode: AcEdOpenMode.Write
-    })
+    const success = await AcApDocManager.instance.newDocument()
     if (!success) {
-      throw new Error('Failed to open new drawing template')
+      throw new Error('Failed to create new drawing')
     }
   }
 }

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -12,14 +12,13 @@
     <div v-else>
       <MlCadViewer
         locale="en"
-        :url="newDrawingUrl"
         :local-file="store.selectedFile ?? undefined"
         :mode="selectedMode"
         :use-main-thread-draw="useMainThreadDraw"
         :draw-no-plot-layers="drawNoPlotLayers"
         :progressive-rendering="progressiveRendering"
         :open-view-mode="openViewMode"
-        @create="initialize"
+        @create="onViewerCreate"
         :base-url="BASE_URL"
       />
     </div>
@@ -35,6 +34,7 @@ import {
   AcEdOpenMode
 } from '@mlightcad/cad-simple-viewer'
 import { MlCadViewer } from '@mlightcad/cad-viewer'
+import { log } from '@mlightcad/data-model'
 import { computed, ref } from 'vue'
 
 import { AcApQuitCmd } from './commands'
@@ -72,16 +72,9 @@ const initialize = () => {
 // AcApSettingManager.instance.isShowCoordinate = false
 
 const BASE_URL = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/'
-const NEW_DRAWING_TEMPLATE_URL = `${BASE_URL}templates/acadiso.dxf`
 
 const showViewer = computed(
   () => store.selectedFile != null || store.isNewDrawing
-)
-
-const newDrawingUrl = computed(() =>
-  store.isNewDrawing && store.selectedFile == null
-    ? NEW_DRAWING_TEMPLATE_URL
-    : undefined
 )
 
 const selectedMode = ref<AcEdOpenMode>(AcEdOpenMode.Write)
@@ -89,6 +82,27 @@ const useMainThreadDraw = ref(false)
 const drawNoPlotLayers = ref(false)
 const progressiveRendering = ref(false)
 const openViewMode = ref<AcApOpenViewMode | undefined>(undefined)
+
+const createNewDrawing = async () => {
+  const success = await AcApDocManager.instance.newDocument({
+    mode: selectedMode.value,
+    drawNoPlotLayers: drawNoPlotLayers.value,
+    progressiveRendering: progressiveRendering.value,
+    ...(openViewMode.value != null
+      ? { openViewMode: openViewMode.value }
+      : {})
+  })
+  if (!success) {
+    log.error('Failed to create new drawing')
+  }
+}
+
+const onViewerCreate = () => {
+  initialize()
+  if (store.isNewDrawing) {
+    void createNewDrawing()
+  }
+}
 
 const applyOpenOptions = (
   mode: AcEdOpenMode,

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -35,7 +35,7 @@ import {
 } from '@mlightcad/cad-simple-viewer'
 import { MlCadViewer } from '@mlightcad/cad-viewer'
 import { log } from '@mlightcad/data-model'
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 
 import { AcApQuitCmd } from './commands'
 import FileUpload from './components/FileUpload.vue'
@@ -97,10 +97,11 @@ const createNewDrawing = async () => {
   }
 }
 
-const onViewerCreate = () => {
+const onViewerCreate = async () => {
   initialize()
   if (store.isNewDrawing) {
-    void createNewDrawing()
+    await nextTick()
+    await createNewDrawing()
   }
 }
 

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -331,6 +331,7 @@ const isValidFile = (file: File): boolean => {
 .upload-panel {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-rows: auto;
   width: 100%;
   border-radius: 14px;
   background: #ffffff;
@@ -591,14 +592,16 @@ const isValidFile = (file: File): boolean => {
   color: #4f5fd0;
 }
 
-@media (max-width: 680px) {
+/* Narrow viewports: stack upload + settings as two vertical rows */
+@media (max-width: 768px) {
   .file-upload-container {
-    max-width: 420px;
+    max-width: 100%;
     padding: 12px;
   }
 
   .upload-panel {
     grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
   }
 
   .settings-section {

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -452,9 +452,10 @@ watch(
 
 // Component lifecycle: Initialize and load initial file if URL or localFile is provided
 onMounted(async () => {
+  beginPendingOpen(props.mode)
+
   if (props.url || props.localFile) {
     beginDocumentOpening()
-    beginPendingOpen(props.mode)
   }
 
   // Initialize the CAD viewer with the internal canvas

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -1688,10 +1688,7 @@ const handleFileMenuSelect = async (command: string) => {
         />
       </template>
     </ml-ribbon>
-    <ml-ribbon-file-name
-      v-if="features.isShowFileName"
-      :container-el="ribbonContainerRef"
-    />
+    <ml-ribbon-file-name v-if="features.isShowFileName" />
     <ml-character-map-dialog
       v-model="mtextCharacterMapVisible"
       :font-options="mtextCharacterMapFontOptions"

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -1688,7 +1688,10 @@ const handleFileMenuSelect = async (command: string) => {
         />
       </template>
     </ml-ribbon>
-    <ml-ribbon-file-name v-if="features.isShowFileName" />
+    <ml-ribbon-file-name
+      v-if="features.isShowFileName"
+      :container-el="ribbonContainerRef"
+    />
     <ml-character-map-dialog
       v-model="mtextCharacterMapVisible"
       :font-options="mtextCharacterMapFontOptions"

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonFileName.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonFileName.vue
@@ -22,11 +22,17 @@ const { displayName } = useDocument()
 const headerEl = ref<HTMLElement>()
 const overlayStyle = ref<CSSProperties>()
 
+let resizeObserver: ResizeObserver | undefined
+let rafId = 0
+let layoutRetryCount = 0
+const MAX_LAYOUT_RETRIES = 30
+
 const updatePosition = () => {
   const container = props.containerEl
   if (!container) {
     headerEl.value = undefined
     overlayStyle.value = undefined
+    layoutRetryCount = 0
     return
   }
 
@@ -40,9 +46,15 @@ const updatePosition = () => {
   ) {
     headerEl.value = undefined
     overlayStyle.value = undefined
+    if (displayName.value && layoutRetryCount < MAX_LAYOUT_RETRIES) {
+      layoutRetryCount += 1
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(updatePosition)
+    }
     return
   }
 
+  layoutRetryCount = 0
   headerEl.value = header
 
   const headerRect = header.getBoundingClientRect()
@@ -58,11 +70,9 @@ const updatePosition = () => {
   }
 }
 
-let resizeObserver: ResizeObserver | undefined
-let rafId = 0
-
 const scheduleUpdate = () => {
   cancelAnimationFrame(rafId)
+  layoutRetryCount = 0
   rafId = requestAnimationFrame(updatePosition)
 }
 

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonFileName.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonFileName.vue
@@ -1,131 +1,27 @@
 <template>
-  <Teleport v-if="headerEl && displayName" :to="headerEl">
-    <div class="ml-ribbon-file-name" :style="overlayStyle">
-      {{ displayName }}
-    </div>
-  </Teleport>
+  <div v-if="displayName" class="ml-ribbon-file-name">
+    {{ displayName }}
+  </div>
 </template>
 
 <script setup lang="ts">
-import { type CSSProperties, onUnmounted, ref, watchEffect } from 'vue'
-
 import { useDocument } from '../../composable'
 
-interface Props {
-  containerEl?: HTMLElement | null
-}
-
-const props = defineProps<Props>()
-
 const { displayName } = useDocument()
-
-const headerEl = ref<HTMLElement>()
-const overlayStyle = ref<CSSProperties>()
-
-let resizeObserver: ResizeObserver | undefined
-let rafId = 0
-let layoutRetryCount = 0
-const MAX_LAYOUT_RETRIES = 30
-
-const updatePosition = () => {
-  const container = props.containerEl
-  if (!container) {
-    headerEl.value = undefined
-    overlayStyle.value = undefined
-    layoutRetryCount = 0
-    return
-  }
-
-  const header = container.querySelector('.ml-ribbon__header')
-  const headLeft = container.querySelector('.ml-ribbon__head-left')
-  const headRight = container.querySelector('.ml-ribbon__head-right')
-  if (
-    !(header instanceof HTMLElement) ||
-    !(headLeft instanceof HTMLElement) ||
-    !(headRight instanceof HTMLElement)
-  ) {
-    headerEl.value = undefined
-    overlayStyle.value = undefined
-    if (displayName.value && layoutRetryCount < MAX_LAYOUT_RETRIES) {
-      layoutRetryCount += 1
-      cancelAnimationFrame(rafId)
-      rafId = requestAnimationFrame(updatePosition)
-    }
-    return
-  }
-
-  layoutRetryCount = 0
-  headerEl.value = header
-
-  const headerRect = header.getBoundingClientRect()
-  const leftRect = headLeft.getBoundingClientRect()
-  const rightRect = headRight.getBoundingClientRect()
-  const gapLeft = leftRect.right - headerRect.left
-  const gapWidth = Math.max(0, rightRect.left - leftRect.right)
-
-  overlayStyle.value = {
-    left: `${gapLeft}px`,
-    width: `${gapWidth}px`,
-    height: `${headerRect.height}px`
-  }
-}
-
-const scheduleUpdate = () => {
-  cancelAnimationFrame(rafId)
-  layoutRetryCount = 0
-  rafId = requestAnimationFrame(updatePosition)
-}
-
-watchEffect(onCleanup => {
-  const container = props.containerEl
-  if (!container) {
-    headerEl.value = undefined
-    overlayStyle.value = undefined
-    return
-  }
-
-  scheduleUpdate()
-
-  if (typeof ResizeObserver !== 'undefined') {
-    resizeObserver = new ResizeObserver(scheduleUpdate)
-    resizeObserver.observe(container)
-    for (const selector of [
-      '.ml-ribbon__header',
-      '.ml-ribbon__head-left',
-      '.ml-ribbon__head-right'
-    ]) {
-      const element = container.querySelector(selector)
-      if (element) resizeObserver.observe(element)
-    }
-  }
-
-  onCleanup(() => {
-    cancelAnimationFrame(rafId)
-    resizeObserver?.disconnect()
-    resizeObserver = undefined
-  })
-})
-
-watchEffect(() => {
-  displayName.value
-  scheduleUpdate()
-})
-
-onUnmounted(() => {
-  cancelAnimationFrame(rafId)
-  resizeObserver?.disconnect()
-})
 </script>
 
 <style scoped>
 .ml-ribbon-file-name {
   position: absolute;
   top: 0;
+  left: 50%;
   z-index: 11;
   display: flex;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
+  max-width: min(40%, 320px);
+  height: 40px;
   padding: 0 8px;
   color: var(--el-text-color-regular);
   font-size: var(--el-font-size-small);
@@ -135,5 +31,6 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transform: translateX(-50%);
 }
 </style>

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonFileName.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonFileName.vue
@@ -1,27 +1,129 @@
 <template>
-  <div v-if="displayName" class="ml-ribbon-file-name">
+  <div
+    v-if="displayName && overlayStyle"
+    class="ml-ribbon-file-name"
+    :style="overlayStyle"
+  >
     {{ displayName }}
   </div>
 </template>
 
 <script setup lang="ts">
+import { type CSSProperties, onUnmounted, ref, watchEffect } from 'vue'
+
 import { useDocument } from '../../composable'
 
+interface Props {
+  containerEl?: HTMLElement | null
+}
+
+const props = defineProps<Props>()
+
 const { displayName } = useDocument()
+
+const overlayStyle = ref<CSSProperties>()
+
+let resizeObserver: ResizeObserver | undefined
+let rafId = 0
+let layoutRetryCount = 0
+const MAX_LAYOUT_RETRIES = 30
+
+const updatePosition = () => {
+  const container = props.containerEl
+  if (!container) {
+    overlayStyle.value = undefined
+    layoutRetryCount = 0
+    return
+  }
+
+  const header = container.querySelector('.ml-ribbon__header')
+  const headLeft = container.querySelector('.ml-ribbon__head-left')
+  const headRight = container.querySelector('.ml-ribbon__head-right')
+  if (
+    !(header instanceof HTMLElement) ||
+    !(headLeft instanceof HTMLElement) ||
+    !(headRight instanceof HTMLElement)
+  ) {
+    overlayStyle.value = undefined
+    if (displayName.value && layoutRetryCount < MAX_LAYOUT_RETRIES) {
+      layoutRetryCount += 1
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(updatePosition)
+    }
+    return
+  }
+
+  layoutRetryCount = 0
+
+  const containerRect = container.getBoundingClientRect()
+  const headerRect = header.getBoundingClientRect()
+  const leftRect = headLeft.getBoundingClientRect()
+  const rightRect = headRight.getBoundingClientRect()
+  const gapLeft = leftRect.right - containerRect.left
+  const gapWidth = Math.max(0, rightRect.left - leftRect.right)
+
+  overlayStyle.value = {
+    top: `${headerRect.top - containerRect.top}px`,
+    left: `${gapLeft}px`,
+    width: `${gapWidth}px`,
+    height: `${headerRect.height}px`
+  }
+}
+
+const scheduleUpdate = () => {
+  cancelAnimationFrame(rafId)
+  layoutRetryCount = 0
+  rafId = requestAnimationFrame(updatePosition)
+}
+
+watchEffect(onCleanup => {
+  const container = props.containerEl
+  if (!container) {
+    overlayStyle.value = undefined
+    return
+  }
+
+  scheduleUpdate()
+
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(scheduleUpdate)
+    resizeObserver.observe(container)
+    for (const selector of [
+      '.ml-ribbon__header',
+      '.ml-ribbon__head-left',
+      '.ml-ribbon__head-right'
+    ]) {
+      const element = container.querySelector(selector)
+      if (element) resizeObserver.observe(element)
+    }
+  }
+
+  onCleanup(() => {
+    cancelAnimationFrame(rafId)
+    resizeObserver?.disconnect()
+    resizeObserver = undefined
+  })
+})
+
+watchEffect(() => {
+  displayName.value
+  scheduleUpdate()
+})
+
+onUnmounted(() => {
+  cancelAnimationFrame(rafId)
+  resizeObserver?.disconnect()
+})
 </script>
 
 <style scoped>
 .ml-ribbon-file-name {
   position: absolute;
-  top: 0;
-  left: 50%;
   z-index: 11;
   display: flex;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  max-width: min(40%, 320px);
-  height: 40px;
   padding: 0 8px;
   color: var(--el-text-color-regular);
   font-size: var(--el-font-size-small);
@@ -31,6 +133,5 @@ const { displayName } = useDocument()
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  transform: translateX(-50%);
 }
 </style>

--- a/packages/cad-viewer/src/composable/useDocument.ts
+++ b/packages/cad-viewer/src/composable/useDocument.ts
@@ -102,6 +102,9 @@ const displayName = computed(() => docTitle.value || fileName.value)
 /** Whether lifecycle listeners have already been attached to the doc manager. */
 let isBound = false
 
+/** Manager instance that {@link isBound} listeners are attached to. */
+let boundManager: AcApDocManager | null = null
+
 /** Polling timer used while waiting for {@link AcApDocManager.instance}. */
 let retryTimer: ReturnType<typeof setInterval> | undefined
 
@@ -203,14 +206,22 @@ function stopRetryTimer() {
  * @returns `true` when binding succeeded; otherwise `false`
  */
 function tryBind() {
+  const manager = getExistingDocManager()
+
+  if (isBound && (!manager || boundManager !== manager)) {
+    isBound = false
+    boundManager = null
+  }
+
+  if (!manager) return false
   if (isBound) return true
 
   try {
-    const manager = AcApDocManager.instance
     syncFromDocument(manager.curDocument)
     manager.events.documentToBeOpened.addEventListener(onDocumentToBeOpened)
     manager.events.documentActivated.addEventListener(onDocumentActivated)
     eventBus.on('failed-to-open-file', onFailedToOpenFile)
+    boundManager = manager
     isBound = true
     stopRetryTimer()
     return true

--- a/packages/cad-viewer/src/composable/useDocument.ts
+++ b/packages/cad-viewer/src/composable/useDocument.ts
@@ -214,7 +214,10 @@ function tryBind() {
   }
 
   if (!manager) return false
-  if (isBound) return true
+  if (isBound) {
+    syncFromDocument(manager.curDocument)
+    return true
+  }
 
   try {
     syncFromDocument(manager.curDocument)


### PR DESCRIPTION
## Summary

- Add `AcApDocManager.newDocument()` to load the default ISO template from `baseUrl` and present it as a new unsaved drawing via `resetNewDocumentIdentity()`.
- Refactor `AcApQNewCmd` to delegate to the shared API instead of duplicating template URL logic.
- Update `cad-viewer-example` to create new drawings programmatically after viewer init (preserving upload-screen open options) instead of passing a template URL prop.
- Improve `FileUpload` responsive layout for narrow viewports (768px breakpoint).

## Test plan

- [ ] Run `pnpm --filter @mlightcad/cad-simple-viewer exec tsc --noEmit`
- [ ] In cad-viewer-example, click **New Drawing** and verify the ISO template loads with selected access/view options
- [ ] Verify document title shows as **Untitled** (not the template filename)
- [ ] Run **QNew** from ribbon and confirm it still creates a new drawing
- [ ] Resize upload screen below 768px and confirm upload/settings stack vertically