### PR TITLE
fix: check model-space entity count instead of header extents in hasRecoverablePartialContent

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1443,13 +1443,21 @@ export class AcApDocManager {
 
   /**
    * Checks whether the current document's database already has usable content
-   * (non-empty extents) even though the open operation reported failure.
+   * even though the open operation reported failure.
    *
    * @returns True when the database has recoverable partial content.
    * @protected
    */
   protected hasRecoverablePartialContent(): boolean {
     const db = this.context.doc.database
+    // `db.extents` comes from the DWG/DXF header, and some DXF files omit it
+    // entirely, leaving it empty even when entities parsed successfully. Check
+    // for actual entities in model space first, and only fall back to the
+    // (unreliable) header extents when model space itself is unavailable.
+    const modelSpace = db.tables.blockTable.modelSpace
+    if (modelSpace) {
+      return modelSpace.newIterator().count > 0
+    }
     return !db.extents.isEmpty()
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #418 addressing [review feedback](https://github.com/mlightcad/cad-viewer/pull/418#pullrequestreview) noting that `db.extents` isn't a safe signal — it comes from the DWG/DXF header, and some DXF files omit it entirely even when entities parsed successfully (extents would read as empty in that case).

`hasRecoverablePartialContent()` now checks the actual model-space entity count via `modelSpace.newIterator().count > 0` first, and only falls back to the header extents check if model space itself is unavailable.

## Test plan

- [x] `eslint` clean
- [x] `tsc --noEmit` clean on the changed file