### PR TITLE
feat: support overlaying a base/reference DWG or DXF (#422)

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -920,9 +920,11 @@ export class AcApDocManager {
       fileExtension === 'dwg' ? AcDbFileType.DWG : AcDbFileType.DXF
     )
 
-    const layout = await (this.curView as AcTrView2d).addOverlayEntities(db)
+    const view = this.curView as AcTrView2d
+    const layout = await view.addOverlayEntities(db)
     const overlayId = `overlay-${this._nextOverlayId++}`
     this._overlays.set(overlayId, { db, layout })
+    view.isDirty = true
     return overlayId
   }
 
@@ -936,11 +938,11 @@ export class AcApDocManager {
     const overlay = this._overlays.get(overlayId)
     if (!overlay) return false
 
-    ;(this.curView as AcTrView2d).cadScene.internalScene.remove(
-      overlay.layout.internalObject
-    )
+    const view = this.curView as AcTrView2d
+    view.cadScene.internalScene.remove(overlay.layout.internalObject)
     overlay.layout.clear()
     this._overlays.delete(overlayId)
+    view.isDirty = true
     return true
   }
 
@@ -956,6 +958,7 @@ export class AcApDocManager {
     if (!overlay) return false
 
     overlay.layout.visible = visible
+    ;(this.curView as AcTrView2d).isDirty = true
     return true
   }
 

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1509,7 +1509,7 @@ export class AcApDocManager {
 
         if (activeModelViewBox) {
           view.zoomTo(activeModelViewBox)
-        } else if (!db.extents.isEmpty()) {
+        } else if (this.hasUsableDrawingExtents(db)) {
           view.zoomTo(new AcGeBox2d(db.extmin, db.extmax))
         } else {
           if (progressiveRendering) {
@@ -1534,6 +1534,36 @@ export class AcApDocManager {
     } else {
       this.regen()
     }
+  }
+
+  /**
+   * Checks whether EXTMIN/EXTMAX describe a real drawing area usable for
+   * view framing.
+   *
+   * AutoCAD marks unsaved/invalid extents with ±1e20 sentinel values (and
+   * some writers emit other degenerate near-zero/huge pairs). Framing such
+   * a box zooms the camera out to effectively infinity and the drawing
+   * renders as a black canvas, so those sentinels must fall through to
+   * `zoomToFitDrawing()` instead.
+   *
+   * @param db - Input database whose header extents are checked.
+   * @returns True when EXTMIN/EXTMAX are finite, sane and span a real area.
+   * @private
+   */
+  private hasUsableDrawingExtents(db: AcDbDatabase): boolean {
+    if (db.extents.isEmpty()) return false
+
+    // Anything at or beyond this magnitude is a "no saved extents"
+    // sentinel, not a coordinate a real drawing occupies.
+    const SENTINEL_LIMIT = 1e15
+    const values = [db.extmin.x, db.extmin.y, db.extmax.x, db.extmax.y]
+    if (
+      values.some(value => !Number.isFinite(value)) ||
+      values.some(value => Math.abs(value) >= SENTINEL_LIMIT)
+    ) {
+      return false
+    }
+    return db.extmax.x > db.extmin.x && db.extmax.y > db.extmin.y
   }
 
   /**

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1,9 +1,11 @@
 import {
   AcCmColor,
   AcCmEventManager,
+  AcDbDatabase,
   AcDbDatabaseConverterManager,
   AcDbFileType,
   acdbHostApplicationServices,
+  AcDbOpenDatabaseOptions,
   AcDbSysVarManager,
   AcGeBox2d,
   log
@@ -83,6 +85,7 @@ import {
 } from '../editor'
 import { AcApPluginManager } from '../plugin/AcApPluginManager'
 import { AcTrView2d } from '../view'
+import type { AcTrLayout } from '../view/AcTrLayout'
 import { AcApBusyIndicator } from './AcApBusyIndicator'
 import { AcApContext } from './AcApContext'
 import { AcApDocument } from './AcApDocument'
@@ -396,6 +399,13 @@ export class AcApDocManager {
   private _workersReady: boolean | null = null
   /** In-flight worker readiness check */
   private _workersReadyCheckPromise?: Promise<boolean>
+  /** Loaded overlay (reference/base drawing) state, keyed by overlay id */
+  private _overlays = new Map<
+    string,
+    { db: AcDbDatabase; layout: AcTrLayout }
+  >()
+  /** Monotonically increasing counter used to generate overlay ids */
+  private _nextOverlayId = 1
 
   /** Events fired during document lifecycle */
   public readonly events = {
@@ -869,6 +879,91 @@ export class AcApDocManager {
     )
     this.onAfterOpenDocument(isSuccess, options)
     return isSuccess
+  }
+
+  /**
+   * Loads a DWG/DXF file as a read-only overlay (base drawing/reference)
+   * rendered alongside the currently open document in the same WCS
+   * coordinate system, without replacing it.
+   *
+   * Unlike {@link openDocument}, this parses the file into a standalone
+   * {@link AcDbDatabase} that never becomes `curDocument` — it isn't touched
+   * by undo, the layer panel/table, or selection. Overlay geometry currently
+   * covers top-level entities (lines, arcs, polylines, text, hatch, etc.);
+   * block (INSERT) expansion, viewports, and dimensions are not yet
+   * supported and are skipped.
+   *
+   * @param fileName - Input file name, used to determine DWG vs DXF from its extension.
+   * @param content - Input file content as an `ArrayBuffer`.
+   * @param options - Input options forwarded to the underlying database read.
+   * @returns The generated overlay id, used with {@link removeOverlay} and
+   * {@link setOverlayVisible}.
+   *
+   * @example
+   * ```typescript
+   * const fileContent = await file.arrayBuffer();
+   * const overlayId = await docManager.loadOverlay('base.dwg', fileContent);
+   * docManager.setOverlayVisible(overlayId, false); // hide it later
+   * docManager.removeOverlay(overlayId); // or remove it entirely
+   * ```
+   */
+  async loadOverlay(
+    fileName: string,
+    content: ArrayBuffer,
+    options: AcDbOpenDatabaseOptions = {}
+  ): Promise<string> {
+    const db = new AcDbDatabase()
+    const fileExtension = fileName.split('.').pop()?.toLocaleLowerCase()
+    await db.read(
+      content,
+      { fontLoader: this._fontLoader, readOnly: true, ...options },
+      fileExtension === 'dwg' ? AcDbFileType.DWG : AcDbFileType.DXF
+    )
+
+    const layout = await (this.curView as AcTrView2d).addOverlayEntities(db)
+    const overlayId = `overlay-${this._nextOverlayId++}`
+    this._overlays.set(overlayId, { db, layout })
+    return overlayId
+  }
+
+  /**
+   * Removes a previously loaded overlay and disposes its rendered geometry.
+   *
+   * @param overlayId - Input the id returned by {@link loadOverlay}.
+   * @returns True when an overlay with the given id was found and removed.
+   */
+  removeOverlay(overlayId: string): boolean {
+    const overlay = this._overlays.get(overlayId)
+    if (!overlay) return false
+
+    ;(this.curView as AcTrView2d).cadScene.internalScene.remove(
+      overlay.layout.internalObject
+    )
+    overlay.layout.clear()
+    this._overlays.delete(overlayId)
+    return true
+  }
+
+  /**
+   * Shows or hides a previously loaded overlay without removing it.
+   *
+   * @param overlayId - Input the id returned by {@link loadOverlay}.
+   * @param visible - Input whether the overlay should be visible.
+   * @returns True when an overlay with the given id was found.
+   */
+  setOverlayVisible(overlayId: string, visible: boolean): boolean {
+    const overlay = this._overlays.get(overlayId)
+    if (!overlay) return false
+
+    overlay.layout.visible = visible
+    return true
+  }
+
+  /**
+   * Ids of all currently loaded overlays.
+   */
+  get overlayIds(): string[] {
+    return Array.from(this._overlays.keys())
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -66,6 +66,7 @@ import {
 import { AcTrInheritedLayerMaterialMapper } from './AcTrInheritedLayerMaterialMapper'
 import { AcTrLayer } from './AcTrLayer'
 import { AcTrLayerAppearanceController } from './AcTrLayerAppearanceController'
+import { AcTrLayout } from './AcTrLayout'
 import { AcTrLayoutView } from './AcTrLayoutView'
 import { AcTrLayoutViewManager } from './AcTrLayoutViewManager'
 import { sortPickResults } from './AcTrPickResultUtil'
@@ -685,6 +686,63 @@ export class AcTrView2d extends AcEdBaseView {
     this.applyCanvasBackground(
       readLayoutBackgroundColor(database, this.isModelSpaceLayout(database))
     )
+  }
+
+  /**
+   * Converts and renders model-space entities from a standalone, independently
+   * parsed database (an overlay/reference drawing) into a dedicated
+   * {@link AcTrLayout} added directly to the THREE scene.
+   *
+   * The returned layout is intentionally **not** registered in
+   * {@link AcTrScene}'s owner-id-keyed layout map, so it never participates in
+   * layout-tab switching, the primary document's layer table/panel, undo
+   * stack, or selection set. Toggle visibility via the returned layout's
+   * `visible` property, and tear it down by removing `internalObject` from
+   * `cadScene.internalScene` and calling `clear()`.
+   *
+   * Scope: draws top-level geometry, text, and hatch entities. Block (INSERT)
+   * expansion, viewports, and dimensions are not supported for overlays yet
+   * and are skipped.
+   *
+   * @param overlayDb - Input a database parsed independently of the active
+   * document (e.g. via `new AcDbDatabase().read(...)`).
+   * @returns The layout containing the converted overlay entities.
+   */
+  async addOverlayEntities(overlayDb: AcDbDatabase): Promise<AcTrLayout> {
+    const layout = new AcTrLayout()
+    this._scene.internalScene.add(layout.internalObject)
+
+    for (const layer of overlayDb.tables.layerTable.newIterator()) {
+      layout.addLayer({
+        name: layer.name,
+        isOff: layer.isOff,
+        isFrozen: layer.isFrozen,
+        color: layer.color
+      })
+    }
+
+    const previousDatabase = this._renderer.context.database
+    this._renderer.context.database = overlayDb
+    try {
+      const modelSpace = overlayDb.tables.blockTable.modelSpace
+      for (const entity of modelSpace.newIterator()) {
+        if (entity instanceof AcDbViewport) continue
+        const threeEntity = this.drawEntity(entity, false)
+        if (!threeEntity || threeEntity instanceof AcTrGroup) continue
+
+        threeEntity.objectId = entity.objectId
+        threeEntity.ownerId = entity.ownerId
+        threeEntity.layerName = entity.layer
+        threeEntity.visible = entity.visibility !== false
+        await this.finishEntityGeometry(threeEntity, false)
+        layout.addEntity(threeEntity)
+        threeEntity.dispose()
+      }
+    } finally {
+      this._renderer.context.database = previousDatabase
+    }
+
+    return layout
   }
 
   /**


### PR DESCRIPTION
## Summary

Addresses #422 — support viewing a second DWG/DXF overlaid on the currently open drawing in the same coordinate system (a lightweight alternative to full XRef support).

- New `AcApDocManager.loadOverlay(fileName, buffer, options?)`: parses the file into a standalone `AcDbDatabase` (via the same `AcDbDatabase.read()` path `AcApDocument.openDocument()` uses internally) — it never becomes `curDocument`, so it's completely isolated from the primary document.
- Entities are rendered into a dedicated `AcTrLayout` added directly to the THREE scene, deliberately **not** registered in `AcTrScene`'s owner-id-keyed layout map — so it never participates in layout-tab switching, the primary layer table/panel, undo stack, or selection set.
- `AcApDocManager.removeOverlay(overlayId)` / `setOverlayVisible(overlayId, visible)` for lifecycle and toggling, plus an `overlayIds` getter.
- No coordinate transform needed: entity coordinates are plain WCS doubles throughout the render pipeline (no existing per-layout transform to reuse or fight), so two files sharing the same real-world coordinate system overlay correctly out of the box — this satisfies the "same coordinate system" ask directly.

## Scope

This first version covers top-level geometry, text, and hatch entities (the common case for a coordination/reference base drawing). Block (INSERT) expansion, viewports, and dimensions are not yet supported for overlays and are skipped — a natural incremental follow-up.

## Test plan

- [x] `eslint` clean
- [x] `tsc --noEmit` clean (0 errors across the whole `cad-simple-viewer` package)
- [x] End-to-end verification with a headless-Chromium harness: opened a primary DXF (`minimal-line.dxf`), called `loadOverlay` with a second DXF, confirmed `overlayIds` reflects it, toggled visibility with `setOverlayVisible` (including the not-found case returning `false`), then `removeOverlay` and confirmed `overlayIds` empties out and a second `removeOverlay` call correctly returns `false`
- [ ] Manual test with two real-world DWG/DXF files sharing a coordinate system (e.g. architectural base + MEP drawing)