### PR TITLE
fix(three-renderer): restore ACI 7 solid hatch foreground inversion

### DIFF
--- a/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
@@ -272,16 +272,7 @@ describe('AcTrStyleManager', () => {
     expect(getMaterialMetadata(inherited).isForeground).toBe(false)
   })
 
-  it('solid foreground hatches fuse with the canvas bg (AutoCAD-aligned)', () => {
-    // AutoCAD reference: a solid ACI 7 hatch is rendered as if painted with
-    // the paper colour, so it fuses into both light and dark canvases and
-    // only the overlaid wireframe remains visible. See
-    // images-ex/hatch-bg-bug-refact-lee/autocad/tower-{light,dark}.png and
-    // the "drawing" pair in the same folder for the reference visuals.
-    //
-    // Linework-tier fills (drawOrder >= 0 — wide polylines, MText glyphs)
-    // are NOT hatches: they represent linework rasterized as a mesh and
-    // must invert with the theme so ACI 7 stays legible.
+  it('solid foreground hatches invert with the theme like linework', () => {
     const styleManager = new AcTrStyleManager()
     styleManager.currentBackgroundColor = 0xffffff
 
@@ -302,25 +293,23 @@ describe('AcTrStyleManager', () => {
       lineworkFillTraits
     ) as THREE.MeshBasicMaterial
 
-    // Solid hatch and linework-tier fill must NOT share a cache slot —
-    // otherwise the bg-tracked hatch material would be repainted by
-    // `changeForeground` and vice-versa.
     expect(hatchMaterial).not.toBe(lineworkFillMaterial)
 
     const hatchMetadata = getMaterialMetadata(hatchMaterial)
     expect(hatchMetadata.drawOrder).toBe(-1)
-    expect(hatchMetadata.isBackgroundFill).toBe(true)
-    expect(hatchMetadata.isForeground).toBe(false)
-    // Material is BORN with the current bg colour, not its trait RGB —
-    // so a DWG opened in dark theme does not flash a white silhouette
-    // before the first changeBackground call.
-    expect(hatchMaterial.color.getHex()).toBe(0xffffff)
+    expect(hatchMetadata.isBackgroundFill).toBe(false)
+    expect(hatchMetadata.isForeground).toBe(true)
+    expect(hatchMaterial.color.getHex()).toBe(0x000000)
 
     const lineworkFillMetadata = getMaterialMetadata(lineworkFillMaterial)
     expect(lineworkFillMetadata.drawOrder).toBe(0)
     expect(lineworkFillMetadata.isForeground).toBe(true)
     expect(lineworkFillMetadata.isBackgroundFill).toBe(false)
     expect(lineworkFillMaterial.color.getHex()).toBe(0x000000)
+
+    styleManager.currentBackgroundColor = 0x000000
+    expect(hatchMaterial.color.getHex()).toBe(0xffffff)
+    expect(lineworkFillMaterial.color.getHex()).toBe(0xffffff)
   })
 
   it('keeps patterned foreground hatches as visible shader linework', () => {
@@ -365,8 +354,7 @@ describe('AcTrStyleManager', () => {
     // A DWG author who picked an explicit RGB via the truecolor picker
     // (e.g. 255,255,255 from the colour palette) gets a literal hatch.
     // `traits.color.isForeground` is only true for the ACI 7 / foreground
-    // pseudo-colour, so an explicit truecolor falls outside the bg-fuse
-    // rule even when the picked RGB happens to match the canvas paper.
+    // pseudo-colour, so an explicit truecolor is not repainted by theme flips.
     const styleManager = new AcTrStyleManager()
     styleManager.currentBackgroundColor = 0xffffff
 
@@ -388,31 +376,6 @@ describe('AcTrStyleManager', () => {
     // Theme flip must not mutate the literal truecolor.
     styleManager.currentBackgroundColor = 0x000000
     expect(material.color.getHex()).toBe(0x808080)
-  })
-
-  it('repaints solid foreground hatches on theme flip', () => {
-    // Lock the `_bgfill` cache partition + `isBackgroundFill` metadata
-    // contract: changeBackground must walk these materials and repaint
-    // them so the fuse-with-bg behaviour persists across theme flips.
-    const styleManager = new AcTrStyleManager()
-    styleManager.currentBackgroundColor = 0xffffff
-
-    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
-    traits.layer = 'A-WALL'
-    traits.color = new AcCmColor().setForeground()
-    traits.drawOrder = -1
-
-    const material = styleManager.getFillMaterial(
-      traits
-    ) as THREE.MeshBasicMaterial
-
-    expect(material.color.getHex()).toBe(0xffffff)
-
-    styleManager.currentBackgroundColor = 0x000000
-    expect(material.color.getHex()).toBe(0x000000)
-
-    styleManager.currentBackgroundColor = 0xffffff
-    expect(material.color.getHex()).toBe(0xffffff)
   })
 
   it('creates a new patterned hatch material when pattern offset changes', () => {

--- a/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrFillMaterialManager.ts
@@ -73,51 +73,23 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
    * MText glyphs and wide polylines — meshes that are rasterized as
    * fill but represent linework.
    *
-   * Patterned hatches at the hatch tier (`drawOrder < 0` with non-empty
-   * `definitionLines`) also invert: their visible component is the
-   * pattern lines themselves, which must stay legible against both
-   * light and dark canvases.
-   *
-   * Solid foreground hatches are deliberately excluded from this
-   * branch — they go through `shouldTrackBackground` instead so they
-   * fuse with the canvas bg (matching AutoCAD's reference rendering;
-   * see `images-ex/hatch-bg-bug-refact-lee/autocad/tower-*.png`).
+   * Hatch-tier fills (`drawOrder < 0`, including solid and patterned
+   * hatches) also invert with the theme so ACI 7 stays visible against
+   * both light and dark canvases, matching AutoCAD model-space behaviour.
    */
   protected shouldTrackForeground(
     traits: AcGiSubEntityTraits,
     _options: AcTrFillMaterialOptions
   ): boolean {
-    if (!traits.color.isForeground) return false
-    const drawOrder = traits.drawOrder ?? 0
-    if (drawOrder >= 0) return true
     const style = traits.fillType
-    const isPatterned = !style.gradient && !!style.definitionLines?.length
-    return isPatterned
-  }
-
-  /**
-   * Solid foreground hatch fills (ACI 7, `drawOrder < 0`, no pattern,
-   * no gradient) follow the canvas background colour rather than carry
-   * an absolute RGB. AutoCAD renders them as if they were painted with
-   * the paper colour, so they fuse into both light and dark canvases
-   * and only the overlaid wireframe remains visible.
-   *
-   * Hatches with an explicit RGB (including a literal truecolor white
-   * 0xFFFFFF) fall outside this rule — `traits.color.isForeground` is
-   * only true for the ACI 7 / foreground pseudo-colour, so a DWG
-   * author who picked `255,255,255` via the truecolor picker still
-   * gets a literal white hatch.
-   */
-  protected shouldTrackBackground(
-    traits: AcGiSubEntityTraits,
-    _options: AcTrFillMaterialOptions
-  ): boolean {
-    if (!traits.color.isForeground) return false
-    if ((traits.drawOrder ?? 0) >= 0) return false
-    const style = traits.fillType
-    if (style.gradient) return false
-    const isSolid = !style.definitionLines || style.definitionLines.length === 0
-    return isSolid
+    const isVisibleHatch =
+      (traits.drawOrder ?? 0) < 0 &&
+      !style.gradient &&
+      (style.solidFill || !!style.definitionLines?.length)
+    return (
+      traits.color.isForeground &&
+      ((traits.drawOrder ?? 0) >= 0 || isVisibleHatch)
+    )
   }
 
   /**
@@ -131,9 +103,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const style = traits.fillType
     const side = options.side ?? 'front'
     const threeSide = side === 'back' ? THREE.BackSide : THREE.FrontSide
-    const rgb = this.shouldTrackBackground(traits, options)
-      ? this.options.currentBackgroundColor
-      : this.resolveMaterialRgb(traits, layerColorRgb)
+    const rgb = this.resolveMaterialRgb(traits, layerColorRgb)
 
     let material: THREE.Material
     if (style.gradient) {
@@ -309,11 +279,6 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
    *   line-like fill meshes (wide polylines, text glyphs) because the
    *   batcher groups by material id and applies one `renderOrder` tier
    *   per batch.
-   * - `_bgfill`: background-tracked fills (solid foreground hatches)
-   *   get their own partition so `changeBackground` can mutate them
-   *   in place without affecting any literal-RGB hatch that happens
-   *   to share layer + colour (e.g. a truecolor 0xFFFFFF hatch on the
-   *   same layer as an ACI 7 hatch).
    *
    * All suffixes are appended only when they differ from the default,
    * keeping existing keys stable and avoiding unnecessary cache
@@ -326,12 +291,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
     const style = traits.fillType
     const sideSuffix = options.side === 'back' ? '_back' : ''
     const drawOrderSuffix = this.buildDrawOrderSuffix(traits)
-    const bgSuffix = this.shouldTrackBackground(traits, options)
-      ? '_bgfill'
-      : ''
-    const colorKey = this.shouldTrackBackground(traits, options)
-      ? String(this.options.currentBackgroundColor)
-      : this.buildKeyColorSegment(traits)
+    const colorKey = this.buildKeyColorSegment(traits)
     // Use colour semantics + layer + rebaseOffset + pattern info for key
     if (style.gradient) {
       const gradient = style.gradient
@@ -358,7 +318,7 @@ export class AcTrFillMaterialManager extends AcTrMaterialManager<AcTrFillMateria
 
     const isSolid = !style.definitionLines || style.definitionLines.length === 0
     if (isSolid) {
-      return `solid_${traits.layer}_${colorKey}${sideSuffix}${drawOrderSuffix}${bgSuffix}`
+      return `solid_${traits.layer}_${colorKey}${sideSuffix}${drawOrderSuffix}`
     }
 
     const patternHash = style.definitionLines


### PR DESCRIPTION
## Summary
- Reverts the solid-hatch background-fusion behaviour introduced by #259.
- ACI 7 solid hatches at the hatch tier (`drawOrder < 0`) now follow foreground inversion again, matching AutoCAD model-space rendering and keeping fills visible on dark canvases.
- Fixes invisible digitised title-block signatures (SOLID HATCH on layer colour 7) that only appeared on hover/selection.

## Context
PR #259 assumed ACI 7 solid hatches should fuse with the canvas background. In practice this hides hatch fills on dark themes and conflicts with AutoCAD model-space behaviour (also noted in follow-up discussion on #259).

## Test plan
- [x] `pnpm test -- packages/three-renderer/__tests__/AcTrStyleManager.spec.ts`
- [ ] Verify ACI 7 solid hatches remain legible when switching between light/dark canvas themes
