### PR TITLE
feat: localize untitled document title in UI display

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApDocument.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocument.ts
@@ -26,6 +26,9 @@ import { LAYER_LOCKED_FLAG } from '../service/types'
 import type { AcApLayerPreviousSnapshot } from './AcApLayerSessionState'
 import { AcApOpenDatabaseOptions } from './AcDbOpenDatabaseOptions'
 
+/** Sentinel stored in {@link AcApDocument.docTitle} for unsaved documents. */
+export const ACAP_UNTITLED_DOC_TITLE = 'Untitled'
+
 /**
  * Represents a CAD document that manages a drawing database and associated metadata.
  *
@@ -62,11 +65,11 @@ export class AcApDocument {
   /**
    * Creates a new document instance with an empty database.
    *
-   * The document is initialized with an "Untitled" title and write mode enabled.
+   * The document is initialized with {@link ACAP_UNTITLED_DOC_TITLE} and write mode enabled.
    */
   constructor() {
     this._database = new AcDbDatabase()
-    this.docTitle = 'Untitled'
+    this.docTitle = ACAP_UNTITLED_DOC_TITLE
     this._openMode = AcEdOpenMode.Write
   }
 
@@ -159,7 +162,7 @@ export class AcApDocument {
   resetNewDocumentIdentity() {
     this._uri = undefined
     this._fileName = ''
-    this.docTitle = 'Untitled'
+    this.docTitle = ACAP_UNTITLED_DOC_TITLE
   }
 
   /**

--- a/packages/cad-simple-viewer/src/i18n/en/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/main.ts
@@ -1,4 +1,7 @@
 export default {
+  document: {
+    untitled: 'Untitled'
+  },
   commandLine: {
     noLast: '(no last command)',
     unknownCommand: 'Unknown command',

--- a/packages/cad-simple-viewer/src/i18n/tr/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/tr/main.ts
@@ -1,4 +1,7 @@
 export default {
+  document: {
+    untitled: 'Adsız'
+  },
   commandLine: {
     noLast: '(önceki komut yok)',
     unknownCommand: 'Bilinmeyen komut',

--- a/packages/cad-simple-viewer/src/i18n/zh/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/main.ts
@@ -1,4 +1,7 @@
 export default {
+  document: {
+    untitled: '未命名'
+  },
   commandLine: {
     noLast: '(无上一次命令)',
     unknownCommand: '未知命令',

--- a/packages/cad-viewer/src/composable/useDocument.ts
+++ b/packages/cad-viewer/src/composable/useDocument.ts
@@ -1,4 +1,5 @@
 import {
+  ACAP_UNTITLED_DOC_TITLE,
   AcApDocManager,
   AcApDocument,
   AcDbDocumentEventArgs,
@@ -16,6 +17,8 @@ import {
   type Ref,
   ref
 } from 'vue'
+
+import { i18n } from '../locale'
 
 /**
  * Reactive view of the active CAD document and its open lifecycle.
@@ -55,7 +58,7 @@ export interface UseDocumentReturn {
    * Display title of the active document.
    *
    * Mirrors {@link AcApDocument.docTitle}. For a new document this is
-   * typically `"Untitled"` until a file is opened.
+   * {@link ACAP_UNTITLED_DOC_TITLE} until a file is opened.
    */
   docTitle: DeepReadonly<Ref<string>>
 
@@ -63,7 +66,8 @@ export interface UseDocumentReturn {
    * User-facing document label for UI display.
    *
    * Resolves to {@link docTitle} when present, otherwise falls back to
-   * {@link fileName}.
+   * {@link fileName}. When the document is unsaved, localizes
+   * {@link ACAP_UNTITLED_DOC_TITLE} via `main.document.untitled`.
    */
   displayName: ComputedRef<string>
 
@@ -104,8 +108,24 @@ const fileName = ref('')
 /** Shared active document title sourced from {@link AcApDocument.docTitle}. */
 const docTitle = ref('')
 
+/**
+ * Resolves the user-facing document label from raw title and file name.
+ *
+ * @param title - {@link AcApDocument.docTitle}
+ * @param name - {@link AcApDocument.fileName}
+ */
+function resolveDisplayName(title: string, name: string): string {
+  if (title === ACAP_UNTITLED_DOC_TITLE && !name) {
+    return i18n.global.t('main.document.untitled')
+  }
+  return title || name
+}
+
 /** Shared computed label for UI surfaces that show the current document name. */
-const displayName = computed(() => docTitle.value || fileName.value)
+const displayName = computed(() => {
+  void i18n.global.locale.value
+  return resolveDisplayName(docTitle.value, fileName.value)
+})
 
 /** Structured error code from the latest failed open attempt. */
 const lastOpenErrorCode = ref<AcDbOpenDatabaseErrorCode>()


### PR DESCRIPTION
## Summary
- Add `ACAP_UNTITLED_DOC_TITLE` sentinel in `AcApDocument` so unsaved documents keep a stable internal title.
- Add `main.document.untitled` i18n keys for en/zh/tr.
- Localize `useDocument.displayName` at the presentation layer so ribbon and viewer title follow the active locale without changing export filenames.

## Test plan
- [ ] Create a new drawing and confirm the ribbon title shows `Untitled` / `未命名` / `Adsız` based on locale.
- [ ] Switch language while an unsaved document is open and confirm the title updates immediately.
- [ ] Open a saved drawing and confirm the file name is shown unchanged.
- [ ] Export an unsaved drawing and confirm the default filename still uses `Untitled`.