### PR TITLE
fix: 支持导出 HTML 在 macOS 触控板下的三指平移操作

### DIFF
--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -400,9 +400,12 @@ function startViewer(): void {
 
   renderer.domElement.addEventListener('mousedown', event => {
     if (event.button === 1) renderer.domElement.style.cursor = 'grabbing'
+    if (event.button === 0 && !measure?.isActive)
+      renderer.domElement.style.cursor = 'grabbing'
   })
   renderer.domElement.addEventListener('mouseup', event => {
-    if (event.button === 1) renderer.domElement.style.cursor = ''
+    if (event.button === 1 || event.button === 0)
+      renderer.domElement.style.cursor = ''
   })
   renderer.domElement.addEventListener('contextmenu', event => {
     event.preventDefault()
@@ -761,6 +764,7 @@ function createOrbitControls(
   controls.zoomSpeed = 5
   controls.zoomToCursor = true
   controls.mouseButtons = {
+    LEFT: THREE.MOUSE.PAN,
     MIDDLE: THREE.MOUSE.PAN
   }
   controls.touches = {
@@ -797,12 +801,16 @@ function setupMeasurePointerInput(
     if (event.button !== 0) return
     const measure = getMeasure()
     if (measure.isActive) {
+      // Stop the event from reaching OrbitControls so left-click pan
+      // does not conflict with the active measurement tool.
+      event.stopImmediatePropagation()
       if (measure.handlePointerDown(event.clientX, event.clientY)) {
         render()
       }
       return
     }
     if (measure.handleSelectionPointerDown(event.clientX, event.clientY)) {
+      event.stopImmediatePropagation()
       render()
     }
   })


### PR DESCRIPTION
修复了导出的自包含 HTML 查看器在 macOS 触控板下无法平移图纸的问题。

**修改点：**
1. 在 `createOrbitControls` 中将 `LEFT` 键映射为 `THREE.MOUSE.PAN`，以支持左键/三指拖拽平移。
2. 在 `setupMeasurePointerInput` 中，当测量工具激活时调用 `event.stopImmediatePropagation()` 拦截事件，避免左键平移与测量操作冲突。
3. 补充了左键拖拽平移时的 `grabbing` 光标反馈。