### PR TITLE
fix: support trackpad three-finger pan in exported HTML viewer

### DIFF
--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -400,9 +400,12 @@ function startViewer(): void {
 
   renderer.domElement.addEventListener('mousedown', event => {
     if (event.button === 1) renderer.domElement.style.cursor = 'grabbing'
+    if (event.button === 0 && !measure?.isActive)
+      renderer.domElement.style.cursor = 'grabbing'
   })
   renderer.domElement.addEventListener('mouseup', event => {
-    if (event.button === 1) renderer.domElement.style.cursor = ''
+    if (event.button === 1 || event.button === 0)
+      renderer.domElement.style.cursor = ''
   })
   renderer.domElement.addEventListener('contextmenu', event => {
     event.preventDefault()
@@ -761,6 +764,7 @@ function createOrbitControls(
   controls.zoomSpeed = 5
   controls.zoomToCursor = true
   controls.mouseButtons = {
+    LEFT: THREE.MOUSE.PAN,
     MIDDLE: THREE.MOUSE.PAN
   }
   controls.touches = {
@@ -797,12 +801,16 @@ function setupMeasurePointerInput(
     if (event.button !== 0) return
     const measure = getMeasure()
     if (measure.isActive) {
+      // Stop the event from reaching OrbitControls so left-click pan
+      // does not conflict with the active measurement tool.
+      event.stopImmediatePropagation()
       if (measure.handlePointerDown(event.clientX, event.clientY)) {
         render()
       }
       return
     }
     if (measure.handleSelectionPointerDown(event.clientX, event.clientY)) {
+      event.stopImmediatePropagation()
       render()
     }
   })

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -331,6 +331,9 @@ function startViewer(): void {
       },
       getTrackingOptions: () =>
         measureSettingsRef.current?.getTrackingOptions() ?? null,
+      onActiveChange: active => {
+        setOrbitLeftButtonPan(controls, !active)
+      },
       view: {
         screenToWcs,
         wcsToScreen,
@@ -398,15 +401,8 @@ function startViewer(): void {
     setupMeasurePointerInput(renderer.domElement, () => measure!, render)
   }
 
-  renderer.domElement.addEventListener('mousedown', event => {
-    if (event.button === 1) renderer.domElement.style.cursor = 'grabbing'
-    if (event.button === 0 && !measure?.isActive)
-      renderer.domElement.style.cursor = 'grabbing'
-  })
-  renderer.domElement.addEventListener('mouseup', event => {
-    if (event.button === 1 || event.button === 0)
-      renderer.domElement.style.cursor = ''
-  })
+  setupPanCursorFeedback(renderer.domElement, () => measure?.isActive === true)
+
   renderer.domElement.addEventListener('contextmenu', event => {
     event.preventDefault()
   })
@@ -752,7 +748,8 @@ function createLineObject(
   return object
 }
 
-/** Same defaults as {@link AcTrBaseView#createCameraControls}. */
+/** Same defaults as {@link AcTrBaseView#createCameraControls}, plus left-button pan
+ * for mouse and macOS trackpad three-finger drag. */
 function createOrbitControls(
   camera: THREE.OrthographicCamera,
   domElement: HTMLElement
@@ -763,10 +760,7 @@ function createOrbitControls(
   controls.enableRotate = false
   controls.zoomSpeed = 5
   controls.zoomToCursor = true
-  controls.mouseButtons = {
-    LEFT: THREE.MOUSE.PAN,
-    MIDDLE: THREE.MOUSE.PAN
-  }
+  setOrbitLeftButtonPan(controls, true)
   controls.touches = {
     ONE: THREE.TOUCH.PAN,
     TWO: THREE.TOUCH.DOLLY_PAN
@@ -776,7 +770,51 @@ function createOrbitControls(
 }
 
 /**
- * Left-button picking while a measure tool is active; pan/zoom stay on OrbitControls.
+ * Idle: left + middle pan (trackpad / mouse). Measuring: middle only so left-click
+ * picking does not fight OrbitControls — matches {@link AcTrLayoutView} mode switch.
+ */
+function setOrbitLeftButtonPan(
+  controls: OrbitControls,
+  enableLeftPan: boolean
+): void {
+  controls.mouseButtons = enableLeftPan
+    ? {
+        LEFT: THREE.MOUSE.PAN,
+        MIDDLE: THREE.MOUSE.PAN
+      }
+    : {
+        MIDDLE: THREE.MOUSE.PAN
+      }
+}
+
+/** Grabbing cursor while middle-button or idle left-button pan is held. */
+function setupPanCursorFeedback(
+  domElement: HTMLElement,
+  isMeasureActive: () => boolean
+): void {
+  let panPointerId: number | null = null
+
+  const clearPanCursor = (event: PointerEvent) => {
+    if (panPointerId === null || event.pointerId !== panPointerId) return
+    panPointerId = null
+    domElement.style.cursor = ''
+  }
+
+  domElement.addEventListener('pointerdown', event => {
+    const isMiddlePan = event.button === 1
+    const isLeftPan = event.button === 0 && !isMeasureActive()
+    if (!isMiddlePan && !isLeftPan) return
+    panPointerId = event.pointerId
+    domElement.style.cursor = 'grabbing'
+  })
+  // Capture release even when the pointer leaves the canvas.
+  window.addEventListener('pointerup', clearPanCursor)
+  window.addEventListener('pointercancel', clearPanCursor)
+}
+
+/**
+ * Left-button measure picking / selection on capture so selection can block
+ * OrbitControls pan; while a tool is active left pan is already toggled off.
  */
 function setupMeasurePointerInput(
   domElement: HTMLElement,
@@ -797,23 +835,25 @@ function setupMeasurePointerInput(
     render()
   }
 
-  domElement.addEventListener('pointerdown', event => {
-    if (event.button !== 0) return
-    const measure = getMeasure()
-    if (measure.isActive) {
-      // Stop the event from reaching OrbitControls so left-click pan
-      // does not conflict with the active measurement tool.
-      event.stopImmediatePropagation()
-      if (measure.handlePointerDown(event.clientX, event.clientY)) {
+  domElement.addEventListener(
+    'pointerdown',
+    event => {
+      if (event.button !== 0) return
+      const measure = getMeasure()
+      if (measure.isActive) {
+        if (measure.handlePointerDown(event.clientX, event.clientY)) {
+          render()
+        }
+        return
+      }
+      // Capture phase: stop before OrbitControls starts left-button pan.
+      if (measure.handleSelectionPointerDown(event.clientX, event.clientY)) {
+        event.stopImmediatePropagation()
         render()
       }
-      return
-    }
-    if (measure.handleSelectionPointerDown(event.clientX, event.clientY)) {
-      event.stopImmediatePropagation()
-      render()
-    }
-  })
+    },
+    true
+  )
   domElement.addEventListener('pointermove', event => {
     const measure = getMeasure()
     if (!measure.isActive) return

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -157,6 +157,11 @@ export interface AcExMeasureControllerOptions {
   ) => void
   /** Returns ortho/polar tracking options while measuring; omit to disable tracking. */
   getTrackingOptions?: () => AcExTrackingOptions | null
+  /**
+   * Called when a measurement tool becomes active or returns to idle
+   * (for example to toggle left-button pan on OrbitControls).
+   */
+  onActiveChange?: (active: boolean) => void
 }
 
 /** Teardown callback registered when a measurement overlay is created. @internal */
@@ -664,6 +669,10 @@ export class AcExMeasureController {
   private readonly _getTrackingOptions:
     | (() => AcExTrackingOptions | null)
     | null
+  /** Notifies the viewer when measure-tool activity starts or stops. */
+  private readonly _onActiveChange:
+    | ((active: boolean) => void)
+    | null
   /** Accent color for lines, labels, and canvas overlays. */
   private _measureColor = ACEX_MEASURE_COLOR
   /** Parent group for committed THREE line geometry. */
@@ -721,6 +730,7 @@ export class AcExMeasureController {
     this._getReadyStatus = options.getReadyStatus
     this._onOsnapMarker = options.onOsnapMarker
     this._getTrackingOptions = options.getTrackingOptions ?? null
+    this._onActiveChange = options.onActiveChange ?? null
 
     this._measureGroup = new THREE.Group()
     this._measureGroup.name = 'measurements'
@@ -818,6 +828,7 @@ export class AcExMeasureController {
     this._points = []
     this._updateToolbarActive()
     this._statusEl.textContent = this._hintForMode(mode)
+    this._onActiveChange?.(true)
   }
 
   /**
@@ -825,6 +836,7 @@ export class AcExMeasureController {
    * Does not remove committed measurement graphics (use {@link clearAll}).
    */
   cancelMode(): void {
+    const wasActive = this._mode !== null
     this._mode = null
     this._points = []
     this._lastPointer = null
@@ -834,6 +846,7 @@ export class AcExMeasureController {
     this._updateToolbarActive()
     this._updateIdleStatus()
     this._view.render()
+    if (wasActive) this._onActiveChange?.(false)
   }
 
   /**


### PR DESCRIPTION
## Summary
- Enable left-button / trackpad pan in the exported HTML viewer (`LEFT: THREE.MOUSE.PAN`).
- Fix measure conflict properly: toggle OrbitControls left pan via `onActiveChange` (same idea as `AcTrLayoutView`), instead of ineffective bubble-phase `stopImmediatePropagation`.
- Selection of committed measurements uses capture-phase `stopImmediatePropagation` so left pan does not start.
- Pan `grabbing` cursor clears on `window` `pointerup` / `pointercancel` when the pointer is released outside the canvas.

Supersedes #431 (could not push to the fork; `maintainerCanModify` is on but fork write permission is unavailable).

## Test plan
- [ ] Export HTML viewer: three-finger / left-drag pans the drawing
- [ ] Middle-button pan still works
- [ ] Activate a measure tool: left click places points / does not pan; Escape restores left pan
- [ ] Idle: click a committed measurement selects it without starting a pan
- [ ] Pan cursor returns to default after releasing outside the canvas
