### PR TITLE
feat: layout tab overflow and paper-space viewport detection

### DIFF
--- a/packages/cad-viewer/src/component/statusBar/MlLayoutTabs.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlLayoutTabs.vue
@@ -1,0 +1,366 @@
+<template>
+  <div ref="rootRef" class="ml-layout-tabs">
+    <el-button-group class="ml-layout-tabs-list" role="tablist">
+      <el-button
+        v-for="layout in layouts"
+        :key="layout.blockTableRecordId"
+        :ref="
+          (el: Element | ComponentPublicInstance | null) =>
+            setButtonRef(layout.blockTableRecordId, el)
+        "
+        class="ml-layout-tabs-button"
+        size="small"
+        role="tab"
+        :hidden="overflowIds.includes(layout.blockTableRecordId)"
+        :type="layout.isActive ? 'primary' : ''"
+        :aria-selected="layout.isActive"
+        @click="handleSelectLayout(layout)"
+      >
+        {{ layout.name }}
+      </el-button>
+      <el-dropdown
+        v-show="overflowLayouts.length > 0"
+        trigger="click"
+        placement="top-start"
+        @command="handleSelectById"
+      >
+        <el-button
+          ref="overflowButtonRef"
+          class="ml-layout-tabs-overflow-button"
+          size="small"
+          :class="{ 'is-active': overflowContainsActive }"
+          :type="overflowContainsActive ? 'primary' : ''"
+          :title="t('main.statusBar.moreLayouts')"
+          :aria-label="t('main.statusBar.moreLayouts')"
+        >
+          {{ overflowButtonLabel }}
+        </el-button>
+        <template #dropdown>
+          <el-dropdown-menu class="ml-layout-tabs-overflow-menu">
+            <el-dropdown-item
+              v-for="layout in overflowLayouts"
+              :key="layout.blockTableRecordId"
+              :command="layout.blockTableRecordId"
+              :class="{ 'is-selected': layout.isActive }"
+            >
+              {{ layout.name }}
+            </el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
+    </el-button-group>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import {
+  acdbHostApplicationServices,
+  AcDbObjectId
+} from '@mlightcad/data-model'
+import {
+  ElButton,
+  ElButtonGroup,
+  ElDropdown,
+  ElDropdownItem,
+  ElDropdownMenu
+} from 'element-plus'
+import {
+  type ComponentPublicInstance,
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch
+} from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { type LayoutInfo, useLayouts } from '../../composable'
+
+const OVERFLOW_BTN_WIDTH = 28
+const overflowButtonLabel = '...'
+
+const props = defineProps<{
+  disabled?: boolean
+  /** Extra width (px) reserved for status-bar content such as coordinates. */
+  reservedWidth?: number
+}>()
+
+const { t } = useI18n()
+const layouts = useLayouts(AcApDocManager.instance)
+
+const rootRef = ref<HTMLElement | null>(null)
+const overflowButtonRef = ref<ComponentPublicInstance | null>(null)
+const overflowIds = ref<AcDbObjectId[]>([])
+const buttonRefs = new Map<AcDbObjectId, HTMLElement>()
+let overflowFrame: number | undefined
+let resizeObserver: ResizeObserver | undefined
+
+const resolvedReservedWidth = computed(() => props.reservedWidth ?? 0)
+
+const overflowLayouts = computed(() =>
+  layouts.filter(layout => overflowIds.value.includes(layout.blockTableRecordId))
+)
+
+const activeLayoutId = computed(
+  () => layouts.find(layout => layout.isActive)?.blockTableRecordId
+)
+
+const overflowContainsActive = computed(() => {
+  const activeId = activeLayoutId.value
+  return activeId != null && overflowIds.value.includes(activeId)
+})
+
+const setButtonRef = (id: AcDbObjectId, el: unknown) => {
+  const element =
+    el instanceof HTMLElement
+      ? el
+      : el && typeof el === 'object' && '$el' in el
+        ? (el as ComponentPublicInstance).$el
+        : null
+
+  if (element instanceof HTMLElement) {
+    buttonRefs.set(id, element)
+  } else {
+    buttonRefs.delete(id)
+  }
+}
+
+const handleSelectLayout = (layout: LayoutInfo) => {
+  if (props.disabled) return
+  acdbHostApplicationServices().layoutManager.setCurrentLayoutBtrId(
+    layout.blockTableRecordId
+  )
+}
+
+const handleSelectById = (id: AcDbObjectId) => {
+  if (props.disabled) return
+  const layout = layouts.find(item => item.blockTableRecordId === id)
+  if (layout) {
+    handleSelectLayout(layout)
+  }
+}
+
+const scheduleUpdateOverflow = () => {
+  if (overflowFrame !== undefined) return
+  overflowFrame = requestAnimationFrame(() => {
+    overflowFrame = undefined
+    void updateOverflow()
+  })
+}
+
+/**
+ * Extra pixels still needed so coordinates can grow up to {@link resolvedReservedWidth}
+ * without covering layout tabs. Returns 0 when the coordinate button already holds
+ * that width (e.g. via CSS min-width).
+ */
+const getCoordinateReserveExtra = (root: HTMLElement): number => {
+  const reserved = resolvedReservedWidth.value
+  if (reserved <= 0) return 0
+
+  const statusBar = root.closest('.ml-status-bar')
+  const coord = statusBar?.querySelector(
+    '.ml-status-bar-current-pos'
+  ) as HTMLElement | null
+
+  if (!coord) {
+    // Coordinates will appear later — keep the full reservation.
+    return reserved
+  }
+
+  return Math.max(0, reserved - coord.offsetWidth)
+}
+
+const updateOverflow = async () => {
+  const root = rootRef.value
+  if (!root || layouts.length === 0) {
+    overflowIds.value = []
+    return
+  }
+
+  // Measure with all buttons visible.
+  overflowIds.value = []
+  await nextTick()
+
+  const rootWidth = root.clientWidth
+  if (rootWidth <= 0) return
+
+  const widths = new Map(
+    layouts.map(layout => [
+      layout.blockTableRecordId,
+      buttonRefs.get(layout.blockTableRecordId)?.offsetWidth ?? 0
+    ])
+  )
+  const totalWidth = layouts.reduce(
+    (sum, layout) => sum + (widths.get(layout.blockTableRecordId) ?? 0),
+    0
+  )
+
+  // Overflow control is v-show'd off while measuring, so offsetWidth is 0 —
+  // always fall back to the reserved constant in that case.
+  const measuredOverflowBtnWidth =
+    overflowButtonRef.value?.$el instanceof HTMLElement
+      ? overflowButtonRef.value.$el.offsetWidth
+      : 0
+  const overflowButtonWidth = measuredOverflowBtnWidth || OVERFLOW_BTN_WIDTH
+  const coordinateReserveExtra = getCoordinateReserveExtra(root)
+  // Keep coordinate slack free even when all tabs would otherwise fit.
+  const widthForTabs = rootWidth - coordinateReserveExtra
+
+  if (totalWidth <= widthForTabs) {
+    overflowIds.value = []
+    return
+  }
+
+  // Overflow control is only needed when tabs do not all fit.
+  const availableWidth = widthForTabs - overflowButtonWidth
+  const activeId = activeLayoutId.value ?? layouts[0].blockTableRecordId
+  const visible = new Set(layouts.map(layout => layout.blockTableRecordId))
+  const hidden = new Set<AcDbObjectId>()
+
+  const sumVisibleWidth = () =>
+    layouts
+      .filter(layout => visible.has(layout.blockTableRecordId))
+      .reduce(
+        (sum, layout) => sum + (widths.get(layout.blockTableRecordId) ?? 0),
+        0
+      )
+
+  while (visible.size > 1 && sumVisibleWidth() > availableWidth) {
+    let hideId: AcDbObjectId | undefined
+    for (let index = layouts.length - 1; index >= 0; index -= 1) {
+      const id = layouts[index].blockTableRecordId
+      if (id === activeId || !visible.has(id)) continue
+      hideId = id
+      break
+    }
+    if (!hideId) break
+    visible.delete(hideId)
+    hidden.add(hideId)
+  }
+
+  if (!visible.has(activeId)) {
+    hidden.delete(activeId)
+    visible.add(activeId)
+    while (visible.size > 1 && sumVisibleWidth() > availableWidth) {
+      let hideId: AcDbObjectId | undefined
+      for (let index = layouts.length - 1; index >= 0; index -= 1) {
+        const id = layouts[index].blockTableRecordId
+        if (id === activeId || !visible.has(id)) continue
+        hideId = id
+        break
+      }
+      if (!hideId) break
+      visible.delete(hideId)
+      hidden.add(hideId)
+    }
+  }
+
+  overflowIds.value = layouts
+    .filter(layout => hidden.has(layout.blockTableRecordId))
+    .map(layout => layout.blockTableRecordId)
+}
+
+watch(
+  () =>
+    layouts.map(layout => [
+      layout.blockTableRecordId,
+      layout.name,
+      layout.isActive
+    ]),
+  () => {
+    scheduleUpdateOverflow()
+  },
+  { deep: true }
+)
+
+watch(resolvedReservedWidth, () => {
+  scheduleUpdateOverflow()
+})
+
+onMounted(() => {
+  if (!rootRef.value) return
+  resizeObserver = new ResizeObserver(() => {
+    scheduleUpdateOverflow()
+  })
+  resizeObserver.observe(rootRef.value)
+
+  const statusBar = rootRef.value.closest('.ml-status-bar')
+  const right = statusBar?.querySelector('.ml-status-bar-right')
+  if (right instanceof HTMLElement) {
+    // Recalculate when coordinates / other right-side controls change width.
+    resizeObserver.observe(right)
+  }
+
+  scheduleUpdateOverflow()
+})
+
+onBeforeUnmount(() => {
+  if (overflowFrame !== undefined) {
+    cancelAnimationFrame(overflowFrame)
+    overflowFrame = undefined
+  }
+  resizeObserver?.disconnect()
+  resizeObserver = undefined
+})
+</script>
+
+<style scoped>
+.ml-layout-tabs {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  min-width: 0;
+  height: var(--ml-status-bar-height);
+  overflow: hidden;
+  box-sizing: border-box;
+  gap: 0;
+}
+
+.ml-layout-tabs-list {
+  display: inline-flex;
+  align-items: stretch;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  border: none;
+}
+
+.ml-layout-tabs-list :deep(.el-dropdown) {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-self: stretch;
+}
+
+.ml-layout-tabs-list :deep(.el-button) {
+  margin: 0;
+}
+
+.ml-layout-tabs-button {
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  height: 100%;
+  padding: 0 4px;
+  margin: 0;
+}
+
+.ml-layout-tabs-button[hidden] {
+  display: none !important;
+}
+
+.ml-layout-tabs-overflow-button {
+  box-sizing: border-box;
+  height: 100%;
+  min-width: 24px;
+  padding: 0 2px;
+  margin: 0;
+  letter-spacing: 0;
+}
+</style>
+
+<style>
+.ml-layout-tabs-overflow-menu .el-dropdown-menu__item.is-selected {
+  color: var(--el-color-primary, #409eff);
+}
+</style>

--- a/packages/cad-viewer/src/component/statusBar/MlStatusBar.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlStatusBar.vue
@@ -6,17 +6,10 @@
   >
     <!-- Left Slot Content -->
     <template #left>
-      <el-button-group class="ml-status-bar-left-button-group">
-        <el-button
-          v-for="layout in layouts"
-          class="ml-status-bar-layout-button"
-          :key="layout.name"
-          :type="layout.isActive ? 'primary' : ''"
-          @click="handleSelectLayout(layout)"
-        >
-          {{ layout.name }}
-        </el-button>
-      </el-button-group>
+      <ml-layout-tabs
+        :disabled="isStatusBarDisabled"
+        :reserved-width="layoutTabsReservedWidth"
+      />
     </template>
 
     <!-- Right Slot Content -->
@@ -74,26 +67,17 @@
 
 <script setup lang="ts">
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
-import {
-  acdbHostApplicationServices,
-  AcDbSystemVariables
-} from '@mlightcad/data-model'
+import { AcDbSystemVariables } from '@mlightcad/data-model'
 import { MlStatusBar } from '@mlightcad/ui-components'
 import { ElButton, ElButtonGroup } from 'element-plus'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import {
-  LayoutInfo,
-  useCurrentPos,
-  useDocument,
-  useIsMobile,
-  useLayouts,
-  useSettings
-} from '../../composable'
+import { useCurrentPos, useDocument, useIsMobile, useSettings } from '../../composable'
 import { dynamicInput, lineWidth, orthoMode } from '../../svg'
 import { MlSysVarToggleButton } from '../common'
 import MlFullScreenButton from './MlFullScreenButton.vue'
+import MlLayoutTabs from './MlLayoutTabs.vue'
 import MlNotificationButton from './MlNotificationButton.vue'
 import MlOsnapButton from './MlOsnapButton.vue'
 import MlPointStyleButton from './MlPointStyleButton.vue'
@@ -103,25 +87,24 @@ import MlSettingButton from './MlSettingButton.vue'
 import MlThemeButton from './MlThemeButton.vue'
 import MlWarningButton from './MlWarningButton.vue'
 
+/** Room kept free for longer coordinates while the mouse moves. */
+const COORDINATE_RESERVED_WIDTH = 220
+
 const props = defineProps<{
   isDark: boolean
   toggleDark: () => void
 }>()
 
 const { text: posText } = useCurrentPos(AcApDocManager.instance.curView)
-const layouts = useLayouts(AcApDocManager.instance)
 const features = useSettings()
 const { isDocumentOpening } = useDocument()
 const { isMobile } = useIsMobile()
 const { t } = useI18n()
 const isStatusBarDisabled = computed(() => isDocumentOpening.value)
 
-const handleSelectLayout = (layout: LayoutInfo) => {
-  if (isStatusBarDisabled.value) return
-  acdbHostApplicationServices().layoutManager.setCurrentLayoutBtrId(
-    layout.blockTableRecordId
-  )
-}
+const layoutTabsReservedWidth = computed(() =>
+  features.isShowCoordinate && !isMobile.value ? COORDINATE_RESERVED_WIDTH : 0
+)
 
 const emit = defineEmits<{
   toggleNotificationCenter: []
@@ -144,14 +127,14 @@ const toggleNotificationCenter = () => {
   user-select: none;
 }
 
-.ml-status-bar-left-button-group {
-  border: none;
-  box-sizing: border-box;
-  height: var(--ml-status-bar-height);
+.ml-status-bar :deep(.ml-status-bar-left) {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
 }
 
-.ml-status-bar-layout-button {
-  box-sizing: border-box;
+.ml-status-bar :deep(.ml-status-bar-right) {
+  flex: 0 0 auto;
 }
 
 .ml-status-bar-right-button-group {
@@ -163,5 +146,13 @@ const toggleNotificationCenter = () => {
 .ml-status-bar-current-pos {
   border: none;
   height: 100%;
+  /*
+   * Hold a baseline slot for coordinates. Layout tabs reserve up to 220px;
+   * min-width covers the common short-value case so that slot is not released.
+   */
+  min-width: 180px;
+  box-sizing: border-box;
+  font-variant-numeric: tabular-nums;
+  justify-content: flex-start;
 }
 </style>

--- a/packages/cad-viewer/src/component/statusBar/index.ts
+++ b/packages/cad-viewer/src/component/statusBar/index.ts
@@ -1,1 +1,2 @@
+export { default as MlLayoutTabs } from './MlLayoutTabs.vue'
 export { default as MlStatusBar } from './MlStatusBar.vue'

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -547,7 +547,8 @@ export default {
     },
     export: {
       tooltip: 'Exportovat obrázek jako PNG'
-    }
+    },
+    moreLayouts: 'Další rozvržení'
   },
   toolPalette: {
     moreTabs: 'Další karty',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -556,7 +556,8 @@ export default {
     },
     export: {
       tooltip: 'Export image as PNG'
-    }
+    },
+    moreLayouts: 'More layouts'
   },
   toolPalette: {
     moreTabs: 'More tabs',

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -561,7 +561,8 @@ export default {
     },
     export: {
       tooltip: 'Görüntüyü PNG olarak dışa aktar'
-    }
+    },
+    moreLayouts: 'Diğer düzenler'
   },
   toolPalette: {
     moreTabs: 'Diğer sekmeler',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -514,7 +514,8 @@ export default {
     },
     export: {
       tooltip: '导出图片为 PNG'
-    }
+    },
+    moreLayouts: '更多布局'
   },
   toolPalette: {
     moreTabs: '更多标签页',

--- a/packages/three-renderer/__tests__/AcTrViewportView.isDefaultPaperSpaceViewport.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrViewportView.isDefaultPaperSpaceViewport.spec.ts
@@ -1,0 +1,66 @@
+import { AcTrViewportView } from '../src/viewport/AcTrViewportView'
+
+describe('AcTrViewportView.isDefaultPaperSpaceViewport', () => {
+  it('detects the classic looks-at-itself default', () => {
+    expect(
+      AcTrViewportView.isDefaultPaperSpaceViewport({
+        number: 2,
+        centerPoint: { x: 6, y: 4.5 },
+        viewCenter: { x: 6, y: 4.5 }
+      })
+    ).toBe(true)
+  })
+
+  it('detects LibreDWG defaults with collapsed paper center at origin', () => {
+    // Reproduced from layout-bugs.dwg 製品図(5) / 製品図(11):
+    // paper center parsed as (0,0), but viewHeight == height and target is 0.
+    expect(
+      AcTrViewportView.isDefaultPaperSpaceViewport({
+        number: 37,
+        centerPoint: { x: 0, y: 0 },
+        viewCenter: { x: 725.1528110291506, y: -87.18816194503466 },
+        height: 388.39780069959994,
+        viewHeight: 388.39780069959994,
+        viewTarget: { x: 0, y: 0 }
+      })
+    ).toBe(true)
+  })
+
+  it('treats missing viewTarget as zero for origin-centered 1:1 defaults', () => {
+    expect(
+      AcTrViewportView.isDefaultPaperSpaceViewport({
+        number: 49,
+        centerPoint: { x: 0, y: 0 },
+        viewCenter: { x: 3345.564071149263, y: -200.5486403191827 },
+        height: 473.2194251814754,
+        viewHeight: 473.2194251814754
+      })
+    ).toBe(true)
+  })
+
+  it('does not flag a real viewport that happens to have a paper center near origin', () => {
+    expect(
+      AcTrViewportView.isDefaultPaperSpaceViewport({
+        number: 38,
+        centerPoint: { x: 0, y: 0 },
+        viewCenter: { x: -1106528.2173647524, y: -337785.3063487748 },
+        height: 296.64684898929556,
+        viewHeight: 11865.87395957182,
+        viewTarget: { x: 1111867.66380098, y: 300645.9460363481 }
+      })
+    ).toBe(false)
+  })
+
+  it('does not flag a real viewport with nonzero paper center', () => {
+    expect(
+      AcTrViewportView.isDefaultPaperSpaceViewport({
+        number: 30,
+        centerPoint: { x: 287.48355637404165, y: 404.4357034532701 },
+        viewCenter: { x: -1108628.2173647524, y: -318503.2611644705 },
+        height: 296.64684898929727,
+        viewHeight: 8899.405469678917,
+        viewTarget: { x: 1111867.66380098, y: 300645.9460363481 }
+      })
+    ).toBe(false)
+  })
+})

--- a/packages/three-renderer/src/viewport/AcTrViewportView.ts
+++ b/packages/three-renderer/src/viewport/AcTrViewportView.ts
@@ -54,13 +54,22 @@ export class AcTrViewportView extends AcTrBaseView {
    *   viewport's model content (e.g. a large site-plan viewport whose paper
    *   box spans most of the sheet).
    *
-   * Because `number` misfires both ways, we rely **solely** on the
-   * structural fingerprint: the default viewport "looks at itself" in
-   * paper space, so its `centerPoint` (paper WCS) coincides with its
-   * `viewCenter` (model DCS). The genuine template default is the
-   * `(0,0)-(12,9)` viewport with `centerPoint == viewCenter == (6,4.5)`,
-   * while every real viewport pans the model view to a `viewCenter`
-   * tens-to-hundreds of units away from its paper `centerPoint`.
+   * Because `number` misfires both ways, we rely on structural fingerprints:
+   *
+   * 1. The default viewport "looks at itself" in paper space, so its
+   *    `centerPoint` (paper WCS) coincides with its `viewCenter` (model DCS).
+   *    The genuine template default is the `(0,0)-(12,9)` viewport with
+   *    `centerPoint == viewCenter == (6,4.5)`.
+   * 2. Some LibreDWG parses leave the default's paper `centerPoint` at the
+   *    origin `(0,0)` while still storing a sheet-local `viewCenter` and a
+   *    1:1 `viewHeight == height` with a zero `viewTarget`. That broken
+   *    default must also be filtered: otherwise it draws a large empty
+   *    rectangle near the origin and stretches first-visit zoom far away
+   *    from the real sheet content.
+   *
+   * Real user viewports pan/zoom the model (`viewCenter`/`viewTarget` away
+   * from the paper rectangle, `viewHeight` unrelated to paper `height`), so
+   * they do not match either fingerprint.
    *
    * @param viewport the viewport read from `AcDbViewport.toGiViewport()`
    *                 (or the database entity, which exposes the same
@@ -70,16 +79,45 @@ export class AcTrViewportView extends AcTrBaseView {
     number: number
     centerPoint: { x: number; y: number }
     viewCenter: { x: number; y: number }
+    height?: number
+    viewHeight?: number
+    viewTarget?: { x: number; y: number }
   }): boolean {
     // Tolerance ~1µ in drawing units — generous enough to absorb
     // floating-point round-tripping through the parser, tight enough
     // that no real user viewport (even one panned to (0,0) of model
     // space) collides with the paper rectangle's center by accident.
     const eps = 1e-6
-    return (
+    const looksAtItself =
       Math.abs(viewport.centerPoint.x - viewport.viewCenter.x) < eps &&
       Math.abs(viewport.centerPoint.y - viewport.viewCenter.y) < eps
-    )
+    if (looksAtItself) return true
+
+    // Broken LibreDWG default: paper center collapsed to origin, but the
+    // viewport still "looks at paper" (1:1 height, zero view target).
+    const centerAtOrigin =
+      Math.abs(viewport.centerPoint.x) < eps &&
+      Math.abs(viewport.centerPoint.y) < eps
+    if (!centerAtOrigin) return false
+
+    const height = viewport.height
+    const viewHeight = viewport.viewHeight
+    if (
+      height == null ||
+      viewHeight == null ||
+      !Number.isFinite(height) ||
+      !Number.isFinite(viewHeight) ||
+      Math.abs(viewHeight - height) >= eps
+    ) {
+      return false
+    }
+
+    // Missing viewTarget is treated as (0,0): older converters did not
+    // surface DXF group 17, but these broken defaults still have a zero
+    // target in the DWG.
+    const target = viewport.viewTarget
+    if (!target) return true
+    return Math.abs(target.x) < eps && Math.abs(target.y) < eps
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.11.2
-  '@mlightcad/dxf-json-converter': ^1.11.2
-  '@mlightcad/libredwg-converter': ^3.11.2
+  '@mlightcad/data-model': ^1.11.3
+  '@mlightcad/dxf-json-converter': ^1.11.3
+  '@mlightcad/libredwg-converter': ^3.11.3
   '@mlightcad/mtext-input-box': ^0.2.21
   '@mlightcad/mtext-renderer': ^0.11.10
   '@mlightcad/ribbon': ^0.1.10
@@ -133,8 +133,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(vite@6.4.3(@types/node@24.12.4)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
@@ -154,14 +154,14 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       '@mlightcad/dxf-json-converter':
-        specifier: ^1.11.2
-        version: 1.11.2(@mlightcad/data-model@1.11.2)
+        specifier: ^1.11.3
+        version: 1.11.3(@mlightcad/data-model@1.11.3)
       '@mlightcad/libredwg-converter':
-        specifier: ^3.11.2
-        version: 3.11.2(@mlightcad/data-model@1.11.2)
+        specifier: ^3.11.3
+        version: 3.11.3(@mlightcad/data-model@1.11.3)
       '@mlightcad/mtext-renderer':
         specifier: ^0.11.10
         version: 0.11.10(three@0.172.0)
@@ -191,8 +191,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -224,8 +224,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1
@@ -242,20 +242,20 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
 
   packages/cad-simple-viewer:
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       '@mlightcad/dxf-json-converter':
-        specifier: ^1.11.2
-        version: 1.11.2(@mlightcad/data-model@1.11.2)
+        specifier: ^1.11.3
+        version: 1.11.3(@mlightcad/data-model@1.11.3)
       '@mlightcad/libredwg-converter':
-        specifier: ^3.11.2
-        version: 3.11.2(@mlightcad/data-model@1.11.2)
+        specifier: ^3.11.3
+        version: 3.11.3(@mlightcad/data-model@1.11.3)
       '@mlightcad/mtext-input-box':
         specifier: ^0.2.21
         version: 0.2.21(@mlightcad/mtext-renderer@0.11.10(three@0.172.0))(three@0.172.0)
@@ -311,8 +311,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -333,8 +333,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       '@mlightcad/mtext-parser':
         specifier: ^1.4.1
         version: 1.4.1
@@ -363,8 +363,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       '@mlightcad/ribbon':
         specifier: ^0.1.10
         version: 0.1.10(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
@@ -438,8 +438,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -503,8 +503,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       '@mlightcad/mtext-renderer':
         specifier: ^0.11.10
         version: 0.11.10(three@0.172.0)
@@ -1762,38 +1762,38 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.11.2':
-    resolution: {integrity: sha512-6vsuiAvjo+wN1zOGUkWS2olz/z99f03i8daLZniY1BD+BoXuRFK18fS5zRho4NnBFfDlaqRQ9lI3Epf4YoMpBQ==}
+  '@mlightcad/common@1.11.3':
+    resolution: {integrity: sha512-iwLo5Ui0oNbvT1E+HUjizOgeX3jz8YkqNYCP93DMRRR/2TfbWoYm/l8sssIN9JAnuGLcWj7oAbMxuKp3hN+A8A==}
 
-  '@mlightcad/data-model@1.11.2':
-    resolution: {integrity: sha512-0L60Nzq0D7ZKjGnahX5qwSQLaEGUvAfeqmxizKfU9S2JHFXp+RmV9dtJ3pCyVq+B4Q4k+Zk4mVJFjOFekhFo4A==}
+  '@mlightcad/data-model@1.11.3':
+    resolution: {integrity: sha512-FxskJuqMw0Jq3fb7gRIkrrxM/2MRL/vM/ToH9ax1yg2vjEaWsDPj5Ks3LRSQLyQIYnAnl/uxuXeTlcyATenEag==}
 
-  '@mlightcad/dxf-json-converter@1.11.2':
-    resolution: {integrity: sha512-BM6+Yu89eUwVX8obxWcZJj63N4JImZdRkLLs7qivrtOOX8mJ5zPJ2rlQDQ2ZlHgkxM60H0uicyF8HO46yV4isQ==}
+  '@mlightcad/dxf-json-converter@1.11.3':
+    resolution: {integrity: sha512-LEKqlAcAOwPBbEaeUOxz8E4/kDyBCtN/7a50rwLTww2pPE3DJ38ZQz08yNqkuRwB+XtPsaC15bxSgj+9AKNqtQ==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.11.2
+      '@mlightcad/data-model': ^1.11.3
 
   '@mlightcad/dxf-json@1.2.8':
     resolution: {integrity: sha512-pn4kY2+cYLq9xVVeUJUwzBPyYGGIuO6uKc+bKAzWfSaZAWTgrbK7WrY+VHR4od9wrWdDwNWknIqVq4KBZPD7SA==}
 
-  '@mlightcad/geometry-engine@3.11.2':
-    resolution: {integrity: sha512-WK943vgWSCveaL2FreNhsvW64avT/GAKQqu7jBoZ/s4CrZSWIfbfRtkC0YT5L73kJwGu/W6n84E4zuGmD53QUA==}
+  '@mlightcad/geometry-engine@3.11.3':
+    resolution: {integrity: sha512-BR4OzXbTfviv7/mIEZaZS2k0+9XjfDRbRLhwr0baOWtvIetr/8wHdlEBg9EamO0opWr8IdXcGhwdvtMLQG1IFA==}
     peerDependencies:
-      '@mlightcad/common': 1.11.2
+      '@mlightcad/common': 1.11.3
 
-  '@mlightcad/graphic-interface@3.11.2':
-    resolution: {integrity: sha512-lEncB971vfE15K2ooHFO7qOEFVaIiPtqOEQR2vejAPKmdVTWGDY8LR27kTBdJGxMSuusbfG4jMT+Uf8faen+aQ==}
+  '@mlightcad/graphic-interface@3.11.3':
+    resolution: {integrity: sha512-26KUXsBddFSzag+ndHDlQVMdF1L4D6+Q3DhtcRUhARMbfXyF2rs0blwmI67rWDv6JIdnQJjE4C76K38pgv1Ynw==}
     peerDependencies:
-      '@mlightcad/common': 1.11.2
-      '@mlightcad/geometry-engine': 3.11.2
+      '@mlightcad/common': 1.11.3
+      '@mlightcad/geometry-engine': 3.11.3
 
-  '@mlightcad/libredwg-converter@3.11.2':
-    resolution: {integrity: sha512-5MpoeoJHNmK/by8FBBMrV75NkLje0B4RKBju0MzvVPH54B7kG731OrT40Qa++aGkrjF+OID5ngd4w3IZogQ/Mg==}
+  '@mlightcad/libredwg-converter@3.11.3':
+    resolution: {integrity: sha512-a1e+Zgityvl6qaL9BdtSTm2F+CxcfrSY1OmmiSLsdYl6QC2EUlIv7Vfw5r7n0ZzXJddKFeDdW+qxwnErM4g3GA==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.11.2
+      '@mlightcad/data-model': ^1.11.3
 
-  '@mlightcad/libredwg-web@0.7.8':
-    resolution: {integrity: sha512-3ol9nxsCr5YJarcUs8Pv5WM8MvF45H3Gi8M3/GA4o8sahwG0Ehfz8Nh3OnxuX+pxQCt+pm9n8DFCeOf7kaU81A==}
+  '@mlightcad/libredwg-web@0.7.9':
+    resolution: {integrity: sha512-tqjx0eCiR0CNI3TyO3LVYzl4ptuzSFm7asGn/C1YiJaEk7Vneto+lRrVUco85qw+PZDihaFLwWqdYIEse1swbA==}
     engines: {node: '>=20'}
 
   '@mlightcad/mtext-input-box@0.2.21':
@@ -7204,42 +7204,42 @@ snapshots:
   '@microsoft/tsdoc@0.16.0':
     optional: true
 
-  '@mlightcad/common@1.11.2':
+  '@mlightcad/common@1.11.3':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.11.2':
+  '@mlightcad/data-model@1.11.3':
     dependencies:
-      '@mlightcad/common': 1.11.2
-      '@mlightcad/geometry-engine': 3.11.2(@mlightcad/common@1.11.2)
-      '@mlightcad/graphic-interface': 3.11.2(@mlightcad/common@1.11.2)(@mlightcad/geometry-engine@3.11.2(@mlightcad/common@1.11.2))
+      '@mlightcad/common': 1.11.3
+      '@mlightcad/geometry-engine': 3.11.3(@mlightcad/common@1.11.3)
+      '@mlightcad/graphic-interface': 3.11.3(@mlightcad/common@1.11.3)(@mlightcad/geometry-engine@3.11.3(@mlightcad/common@1.11.3))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
-  '@mlightcad/dxf-json-converter@1.11.2(@mlightcad/data-model@1.11.2)':
+  '@mlightcad/dxf-json-converter@1.11.3(@mlightcad/data-model@1.11.3)':
     dependencies:
-      '@mlightcad/data-model': 1.11.2
+      '@mlightcad/data-model': 1.11.3
       '@mlightcad/dxf-json': 1.2.8
 
   '@mlightcad/dxf-json@1.2.8':
     dependencies:
       '@fxts/core': 1.26.0
 
-  '@mlightcad/geometry-engine@3.11.2(@mlightcad/common@1.11.2)':
+  '@mlightcad/geometry-engine@3.11.3(@mlightcad/common@1.11.3)':
     dependencies:
-      '@mlightcad/common': 1.11.2
+      '@mlightcad/common': 1.11.3
 
-  '@mlightcad/graphic-interface@3.11.2(@mlightcad/common@1.11.2)(@mlightcad/geometry-engine@3.11.2(@mlightcad/common@1.11.2))':
+  '@mlightcad/graphic-interface@3.11.3(@mlightcad/common@1.11.3)(@mlightcad/geometry-engine@3.11.3(@mlightcad/common@1.11.3))':
     dependencies:
-      '@mlightcad/common': 1.11.2
-      '@mlightcad/geometry-engine': 3.11.2(@mlightcad/common@1.11.2)
+      '@mlightcad/common': 1.11.3
+      '@mlightcad/geometry-engine': 3.11.3(@mlightcad/common@1.11.3)
 
-  '@mlightcad/libredwg-converter@3.11.2(@mlightcad/data-model@1.11.2)':
+  '@mlightcad/libredwg-converter@3.11.3(@mlightcad/data-model@1.11.3)':
     dependencies:
-      '@mlightcad/data-model': 1.11.2
-      '@mlightcad/libredwg-web': 0.7.8
+      '@mlightcad/data-model': 1.11.3
+      '@mlightcad/libredwg-web': 0.7.9
 
-  '@mlightcad/libredwg-web@0.7.8': {}
+  '@mlightcad/libredwg-web@0.7.9': {}
 
   '@mlightcad/mtext-input-box@0.2.21(@mlightcad/mtext-renderer@0.11.10(three@0.172.0))(three@0.172.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,9 +8,9 @@ allowBuilds:
   unrs-resolver: true
   vue-demi: true
 overrides:
-  '@mlightcad/data-model': '^1.11.2'
-  '@mlightcad/dxf-json-converter': '^1.11.2'
-  '@mlightcad/libredwg-converter': '^3.11.2'
+  '@mlightcad/data-model': '^1.11.3'
+  '@mlightcad/dxf-json-converter': '^1.11.3'
+  '@mlightcad/libredwg-converter': '^3.11.3'
   '@mlightcad/mtext-input-box': '^0.2.21'
   '@mlightcad/mtext-renderer': '^0.11.10'
   '@mlightcad/ribbon': '^0.1.10'


### PR DESCRIPTION
## Summary
- Add status-bar layout tabs with overflow (`...`) so many layouts do not collide with coordinate display
- Harden `isDefaultPaperSpaceViewport` for LibreDWG-parsed defaults that break sheet zoom/fit, with unit tests
- Bump `@mlightcad/data-model` / converter packages to `1.11.3` / `3.11.3`

## Test plan
- [ ] Open a drawing with many layouts; resize the window and confirm tabs overflow into `...` without covering coordinates
- [ ] Switch layouts from visible tabs and from the overflow menu
- [ ] Open paper-space layouts that previously zoomed incorrectly (LibreDWG default viewport) and confirm zoom-to-fit focuses on real sheet content
- [ ] Confirm real user viewports still render model content
- [ ] Run `packages/three-renderer` unit tests for `isDefaultPaperSpaceViewport`