### PR TITLE
feat(cad-html-plugin): add Turkish (tr) locale to the offline HTML viewer

### DIFF
--- a/packages/cad-html-plugin/README.md
+++ b/packages/cad-html-plugin/README.md
@@ -17,7 +17,7 @@ The plugin path is designed for **lazy loading** so the export bundle is only do
 - **Display-only snapshot** — layers, layouts, line/mesh batches, extents, and drawing units (no editable DXF/DWG payload)
 - **Self-contained HTML** — gzip/base64 snapshot + inline viewer runtime; opens offline in any modern browser
 - **Offline viewer** — pan/zoom (OrbitControls), layer panel, layout switching, measurement, object snap (OSNAP)
-- **i18n** — embedded English / Chinese / Czech UI; initial language follows the browser (`zh*` → Chinese, `cs*` → Czech, otherwise English); the toolbar language button cycles through the supported locales, and the choice persists in `localStorage`
+- **i18n** — embedded English / Chinese / Czech / Turkish UI; initial language follows the browser (`zh*` → Chinese, `cs*` → Czech, `tr*` → Turkish, otherwise English); the toolbar language button cycles through the supported locales, and the choice persists in `localStorage`
 - **Plugin API** — implements `AcApPlugin`; register once with `registerLazyHtmlPlugin`
 - **Composable API** — build snapshots from your own pipeline or call `packHtml` with a pre-built snapshot
 
@@ -185,7 +185,7 @@ import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.j
 | `src/AcExHtmlShell.ts` | Static HTML/CSS shell markup |
 | `src/AcExOsnap*.ts` | Object snap index and primitives |
 | `src/AcExMeasurement.ts` | Distance/area measurement in the offline viewer |
-| `src/AcExHtmlI18n.ts` | English / Chinese / Czech UI messages |
+| `src/AcExHtmlI18n.ts` | English / Chinese / Czech / Turkish UI messages |
 
 ## Role in MLightCAD
 

--- a/packages/cad-html-plugin/__tests__/AcExHtmlI18n.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlI18n.spec.ts
@@ -1,6 +1,6 @@
 import {
-  AcExHtmlI18n,
   ACEX_HTML_LOCALE_STORAGE_KEY,
+  AcExHtmlI18n,
   detectAcExHtmlLocale,
   detectBrowserAcExHtmlLocale,
   formatAcExHtmlMessage,
@@ -53,6 +53,7 @@ describe('AcExHtmlI18n', () => {
     expect(resolveAcExHtmlLocale('zh-CN')).toBe('zh')
     expect(resolveAcExHtmlLocale('en-US')).toBe('en')
     expect(resolveAcExHtmlLocale('cs-CZ')).toBe('cs')
+    expect(resolveAcExHtmlLocale('tr-TR')).toBe('tr')
     expect(resolveAcExHtmlLocale('fr')).toBeNull()
   })
 
@@ -84,7 +85,7 @@ describe('AcExHtmlI18n', () => {
     expect(formatAcExHtmlMessage('Zoom: {name}', { name: '0' })).toBe('Zoom: 0')
   })
 
-  it('cycles the locale through en -> zh -> cs -> en', () => {
+  it('cycles the locale through en -> zh -> cs -> tr -> en', () => {
     const i18n = new AcExHtmlI18n('en')
     expect(i18n.t('layers.title')).toBe('Layers')
     expect(i18n.localeBadge).toBe('EN')
@@ -97,7 +98,19 @@ describe('AcExHtmlI18n', () => {
     expect(i18n.t('layers.title')).toBe('Hladiny')
     expect(i18n.localeBadge).toBe('CS')
 
+    expect(i18n.toggleLocale()).toBe('tr')
+    expect(i18n.t('layers.title')).toBe('Katmanlar')
+    expect(i18n.localeBadge).toBe('TR')
+
     expect(i18n.toggleLocale()).toBe('en')
     expect(i18n.locale).toBe('en')
+  })
+
+  it('translates Turkish messages with parameters', () => {
+    const i18n = new AcExHtmlI18n('tr')
+    expect(i18n.t('status.distance', { value: '12.5' })).toBe('Mesafe: 12.5')
+    expect(i18n.t('layers.zoomTo', { name: 'Duvarlar' })).toBe(
+      'Duvarlar katmanına yakınlaştır'
+    )
   })
 })

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -1,18 +1,19 @@
 /** Supported locales in the offline HTML viewer. */
-export type AcExHtmlLocale = 'en' | 'zh' | 'cs'
+export type AcExHtmlLocale = 'en' | 'zh' | 'cs' | 'tr'
 
 /**
  * All locales accepted by the offline viewer, in display order.
  * The language button cycles through this list; add a locale here plus a
  * {@link LOCALE_BADGES} entry and a `MESSAGES` tree to support it.
  */
-export const ACEX_HTML_LOCALES: AcExHtmlLocale[] = ['en', 'zh', 'cs']
+export const ACEX_HTML_LOCALES: AcExHtmlLocale[] = ['en', 'zh', 'cs', 'tr']
 
 /** Short button badge per locale (shown on the language toolbar button). */
 const LOCALE_BADGES: Record<AcExHtmlLocale, string> = {
   en: 'EN',
   zh: '中',
-  cs: 'CS'
+  cs: 'CS',
+  tr: 'TR'
 }
 
 /**
@@ -234,6 +235,61 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       zoomLayer: 'Zoom: {name}',
       loadFailed: 'Nepodařilo se načíst výkres: {error}',
       noLayout: 'Snímek neobsahuje data rozvržení.'
+    }
+  },
+  tr: {
+    toolbar: {
+      viewerTools: 'Görüntüleyici araçları',
+      zoomExtents: 'Sınırlara yakınlaştır',
+      measureDistance: 'Mesafe ölç',
+      measureAngle: 'Açı ölç',
+      measureArc: 'Yay uzunluğu ölç',
+      measureArea: 'Alan ölç',
+      measureCoordinate: 'Koordinat ölç',
+      clearMeasurements: 'Ölçümleri temizle',
+      settings: 'Ölçüm ayarları',
+      layers: 'Katmanlar',
+      language: 'Dil',
+      languageSwitch: 'Dili değiştir',
+      collapse: 'Araç çubuğunu daralt',
+      expand: 'Araç çubuğunu genişlet'
+    },
+    settings: {
+      toolbar: 'Ölçüm ayarları',
+      measureColor: 'Ölçüm rengi',
+      ortho: 'Dik modu aç/kapat',
+      polar: 'Kutupsal izleme açıları',
+      polarAngles: 'Kutupsal izleme açıları'
+    },
+    layers: {
+      title: 'Katmanlar',
+      close: 'Katmanları kapat',
+      showAll: 'Tümünü göster',
+      hideAll: 'Tümünü gizle',
+      zoomTo: '{name} katmanına yakınlaştır'
+    },
+    status: {
+      ready: 'Hazır',
+      measureDistanceHint:
+        'Mesafe ölçmek için iki nokta tıklayın (nesne yakalama etkin).',
+      measureAngleHint:
+        'Önce köşe noktasını, sonra her koldan birer nokta tıklayın (nesne yakalama etkin).',
+      measureArcHint:
+        'Yay başlangıcını, yay üzerinde bir noktayı ve yay sonunu tıklayın (nesne yakalama etkin).',
+      measureAreaHint:
+        'Çokgen köşelerini tıklayın; bitirmek için ilk noktanın yakınına tıklayın veya Enter’a basın.',
+      measureCoordinateHint:
+        'X/Y koordinatlarını okumak için bir nokta tıklayın (nesne yakalama etkin).',
+      distance: 'Mesafe: {value}',
+      coordinates: 'X: {x}  Y: {y}',
+      angle: 'Açı: {value}',
+      arcLength: 'Yay uzunluğu: {value}',
+      area: 'Alan: {value}',
+      lengthTotal: 'Toplam uzunluk: {value}',
+      areaTotal: 'Toplam alan: {value}',
+      zoomLayer: 'Yakınlaştır: {name}',
+      loadFailed: 'Çizim yüklenemedi: {error}',
+      noLayout: 'Anlık görüntüde yerleşim verisi yok.'
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #452, as discussed in #440 — adds Turkish to the offline HTML exporter's N-locale `AcExHtmlI18n`.

- `AcExHtmlLocale` += `'tr'`; `ACEX_HTML_LOCALES` cycle is now `en → zh → cs → tr`; `TR` badge
- Full `tr` `MESSAGES` tree (~40 keys), using the terminology already established by the viewer's Turkish locale (`Katmanlar`, `Nesne Yakalama`, `Ölçüm`)
- README i18n mentions updated
- Tests: full locale cycle including `tr`, `tr-TR` resolution, and parameterized Turkish messages

## Test plan

- [x] `AcExHtmlI18n` suite: 7/7 passing
- [x] `eslint` clean
- [x] Single commit rebased onto current `main` (post-#452)