### PR TITLE
feat: switch DXF to built-in data-model converter and bump to 1.12

### DIFF
--- a/PROPRIETARY-PARSER.md
+++ b/PROPRIETARY-PARSER.md
@@ -1,8 +1,8 @@
-# Proprietary DWG/DXF Parser — Commercial License
+# Proprietary DWG Parser — Commercial License
 
 [简体中文](./PROPRIETARY-PARSER.zh-CN.md)
 
-This document describes the **proprietary DWG/DXF parser** offered as a commercial alternative to the open-source `dxf-json` / `dxf-json-converter` and `libredwg-web` / `libredwg-converter` stack shipped with [cad-viewer](https://github.com/mlightcad/cad-viewer).
+This document describes the **proprietary DWG parser** offered as a commercial alternative to the open-source `libredwg-web` / `libredwg-converter` stack shipped with [cad-viewer](https://github.com/mlightcad/cad-viewer).
 
 If you are building a **closed-source commercial product**, a **white-labeled deployment**, or a **SaaS / on-premise CAD viewer** and cannot distribute GPL-3.0 code to your customers, this parser is designed for your use case.
 
@@ -15,9 +15,8 @@ For purchase inquiries, email [mlight.lee@outlook.com](mailto:mlight.lee@outlook
 | Format | Supported |
 |--------|-----------|
 | **DWG** | Yes |
-| **DXF** | Yes |
 
-The proprietary parser covers **both DWG and DXF**. It is intended as a drop-in replacement for the default open-source converters, with:
+The proprietary parser covers **DWG**. It is intended as a drop-in replacement for the default open-source DWG converter, with:
 
 - **Lower memory usage** than the LibreDWG-based stack
 - **Support for larger DWG files** (not constrained by the WASM heap limits of `libredwg-web`)
@@ -44,7 +43,7 @@ You may:
 
 You may **not**:
 
-- **Redistribute or resell the parser as a standalone DWG/DXF parsing library or SDK.** The license is for use inside your own application or service, not for offering a competing parser product. This restriction avoids a direct commercial conflict with the parser itself.
+- **Redistribute or resell the parser as a standalone DWG parsing library or SDK.** The license is for use inside your own application or service, not for offering a competing parser product. This restriction avoids a direct commercial conflict with the parser itself.
 
 If your use case does not fit the above (for example, you plan to ship a parser SDK to third parties), contact us to discuss terms.
 
@@ -71,7 +70,7 @@ There are **no royalties**, **no per-seat fees**, and **no usage caps**.
 The proprietary parser is delivered as a **registerable converter** that plugs into the same pipeline as the open-source stack.
 
 - Output conforms to the MIT-licensed **`@mlightcad/data-model`**: `AcDbDatabase`, `AcDb*` entities, layer tables, blocks, and related structures.
-- You register it via **`AcDbDatabaseConverterManager`**, the same mechanism used by `AcDbDxfConverter` and `AcDbLibreDwgConverter` today.
+- You register it via **`AcDbDatabaseConverterManager`**, the same mechanism used by `AcDbLibreDwgConverter` today.
 - After parsing, your existing **MIT rendering, layer, selection, and interaction pipeline** (`cad-simple-viewer`, `cad-viewer`, plugins, etc.) works unchanged.
 
 Typical integration (conceptual):
@@ -83,25 +82,25 @@ import { AcDbProprietaryConverter } from '@mlightcad/proprietary-converter' // p
 
 const converter = new AcDbProprietaryConverter({ /* options */ })
 AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, converter)
-AcDbDatabaseConverterManager.instance.register(AcDbFileType.DXF, converter)
 ```
 
-Do **not** register the GPL-based `dxf-json-converter` or `libredwg-converter` if you rely on the proprietary parser for compliance.
+Do **not** register the GPL-based `libredwg-converter` if you rely on the proprietary parser for compliance.
 
 ---
 
 ## GPL Compliance
 
-The default cad-viewer file-loading path uses GPL-3.0 packages:
+The default cad-viewer DWG loading path uses GPL-3.0 packages:
 
 | Package | License | Role |
 |---------|---------|------|
-| `dxf-json` / `@mlightcad/dxf-json-converter` | GPL-3.0 | DXF parsing |
 | `libredwg-web` / `@mlightcad/libredwg-converter` | GPL-3.0 | DWG parsing |
 
-If you **replace both converters** with the proprietary parser and **remove those GPL dependencies** from your build, your application can rely on the **MIT-licensed** cad-viewer stack only (`data-model`, `cad-simple-viewer`, renderers, plugins, etc.).
+DXF loading uses the built-in MIT parser in `@mlightcad/data-model` and does not require the proprietary parser.
 
-**You can fully remove GPL packages from your dependency graph** — including `dxf-json`, `dxf-json-converter`, and LibreDWG-related packages — so that **no GPL code is distributed** to your customers, provided you use the proprietary parser for all DWG/DXF ingestion.
+If you **replace the LibreDWG converter** with the proprietary parser and **remove those GPL dependencies** from your build, your application can rely on the **MIT-licensed** cad-viewer stack only (`data-model`, `cad-simple-viewer`, renderers, plugins, etc.).
+
+**You can fully remove GPL packages from your dependency graph** — including LibreDWG-related packages — so that **no GPL code is distributed** to your customers, provided you use the proprietary parser for all DWG ingestion.
 
 ---
 
@@ -113,7 +112,7 @@ cad-viewer is currently maintained as a **personal open-source project** (not op
 |------|----------|
 | **Bug fixes** | Yes — reported issues are addressed as quickly as possible |
 | **Parser updates / upgrade packages** | First year included; thereafter with annual donation |
-| **New DWG/DXF version compatibility** | Delivered via upgrade packages |
+| **New DWG version compatibility** | Delivered via upgrade packages |
 | **Technical integration support** | Reasonable email support for integrating the converter |
 | **Response time** | Typically **within one business day** for reported bugs |
 

--- a/PROPRIETARY-PARSER.zh-CN.md
+++ b/PROPRIETARY-PARSER.zh-CN.md
@@ -1,8 +1,8 @@
-# 专有 DWG/DXF 解析器 — 商业授权说明
+# 专有 DWG 解析器 — 商业授权说明
 
 [English](./PROPRIETARY-PARSER.md)
 
-本文档介绍 [cad-viewer](https://github.com/mlightcad/cad-viewer) 提供的**专有 DWG/DXF 解析器**。它是开源方案 `dxf-json` / `dxf-json-converter` 与 `libredwg-web` / `libredwg-converter` 的商业替代选项。
+本文档介绍 [cad-viewer](https://github.com/mlightcad/cad-viewer) 提供的**专有 DWG 解析器**。它是开源方案 `libredwg-web` / `libredwg-converter` 的商业替代选项。
 
 若您正在构建**闭源商业产品**、**白标部署**，或 **SaaS / 本地部署 CAD 查看器**，且无法向客户分发 GPL-3.0 代码，本解析器适用于您的场景。
 
@@ -15,9 +15,8 @@
 | 格式 | 是否支持 |
 |------|----------|
 | **DWG** | 是 |
-| **DXF** | 是 |
 
-专有解析器**同时支持 DWG 与 DXF**，可作为默认开源解析器的直接替换，并提供：
+专有解析器支持 **DWG**，可作为默认开源 DWG 解析器的直接替换，并提供：
 
 - 相比基于 LibreDWG 的方案，**内存占用更低**
 - **支持更大的 DWG 文件**（不受 `libredwg-web` WASM 堆内存限制）
@@ -44,7 +43,7 @@
 
 您**不得**：
 
-- **将解析器作为独立的 DWG/DXF 解析库或 SDK 二次分发或单独售卖。** 授权范围是在您自己的应用或服务中使用，而非对外提供 competing 的解析器产品。此限制用于避免与解析器本身的商业冲突。
+- **将解析器作为独立的 DWG 解析库或 SDK 二次分发或单独售卖。** 授权范围是在您自己的应用或服务中使用，而非对外提供 competing 的解析器产品。此限制用于避免与解析器本身的商业冲突。
 
 若您的场景不符合上述说明（例如计划向第三方提供解析器 SDK），请联系我们单独协商。
 
@@ -71,7 +70,7 @@
 专有解析器以**可注册的 converter** 形式提供，与开源解析器接入同一套流程。
 
 - 输出符合 MIT 授权的 **`@mlightcad/data-model`**：`AcDbDatabase`、`AcDb*` 实体、图层表、块等结构。
-- 通过 **`AcDbDatabaseConverterManager`** 注册，与当前的 `AcDbDxfConverter`、`AcDbLibreDwgConverter` 机制相同。
+- 通过 **`AcDbDatabaseConverterManager`** 注册，与当前的 `AcDbLibreDwgConverter` 机制相同。
 - 解析完成后，现有 **MIT 渲染、图层、选择与交互管线**（`cad-simple-viewer`、`cad-viewer`、各插件等）**无需改动**。
 
 典型集成方式（示意）：
@@ -83,25 +82,25 @@ import { AcDbProprietaryConverter } from '@mlightcad/proprietary-converter'
 
 const converter = new AcDbProprietaryConverter({ /* options */ })
 AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, converter)
-AcDbDatabaseConverterManager.instance.register(AcDbFileType.DXF, converter)
 ```
 
-若使用专有解析器以满足合规要求，请**不要**再注册基于 GPL 的 `dxf-json-converter` 或 `libredwg-converter`。
+若使用专有解析器以满足合规要求，请**不要**再注册基于 GPL 的 `libredwg-converter`。
 
 ---
 
 ## GPL 合规
 
-cad-viewer 默认文件加载路径使用 GPL-3.0 包：
+cad-viewer 默认 DWG 加载路径使用 GPL-3.0 包：
 
 | 包 | 许可证 | 作用 |
 |----|--------|------|
-| `dxf-json` / `@mlightcad/dxf-json-converter` | GPL-3.0 | DXF 解析 |
 | `libredwg-web` / `@mlightcad/libredwg-converter` | GPL-3.0 | DWG 解析 |
 
-若您**用专有解析器替换上述 converter**，并从构建中**移除 GPL 依赖**，应用可仅依赖 **MIT 授权**的 cad-viewer 技术栈（`data-model`、`cad-simple-viewer`、渲染器、插件等）。
+DXF 加载使用 `@mlightcad/data-model` 中内置的 MIT 解析器，无需专有解析器。
 
-**您可以从依赖图中完全移除 GPL 包** — 包括 `dxf-json`、`dxf-json-converter` 及 LibreDWG 相关包 — 从而**不向客户分发任何 GPL 代码**，前提是所有 DWG/DXF 摄入均通过专有解析器完成。
+若您**用专有解析器替换 LibreDWG converter**，并从构建中**移除 GPL 依赖**，应用可仅依赖 **MIT 授权**的 cad-viewer 技术栈（`data-model`、`cad-simple-viewer`、渲染器、插件等）。
+
+**您可以从依赖图中完全移除 GPL 包** — 包括 LibreDWG 相关包 — 从而**不向客户分发任何 GPL 代码**，前提是所有 DWG 摄入均通过专有解析器完成。
 
 ---
 
@@ -113,7 +112,7 @@ cad-viewer 目前为**个人开源项目**（非公司运营），作者**全职
 |------|------|
 | **缺陷修复** | 包含 — 报告的问题会尽快处理 |
 | **解析器更新 / 升级包** | 首年包含；之后需年度捐赠 |
-| **新 DWG/DXF 版本兼容** | 通过升级包提供 |
+| **新 DWG 版本兼容** | 通过升级包提供 |
 | **集成技术支持** | 合理的邮件支持，协助接入 converter |
 | **响应时间** | 一般**一个工作日内**响应已报告的缺陷 |
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ CAD-Viewer has some known limitations that users should be aware of:
   | 1 | Save proxy graphics |
 - **DWG File Size Limits**:
   - Parsing DWG files with LibreDWG is memory-intensive and can easily exceed 2 GB of RAM. `libredwg-web` therefore enforces WASM heap memory limits; very large DWG files may fail to parse.
-  - We offer a [**proprietary DWG/DXF parser**](./PROPRIETARY-PARSER.md) with significantly lower memory usage, support for larger files, and more accurate parsing. It integrates with the same `@mlightcad/data-model` as the open-source converters and can replace the GPL-based `dxf-json-converter` and `libredwg-converter` stack for closed-source commercial products. See the [commercial license document](./PROPRIETARY-PARSER.md) for scope, pricing, GPL compliance, and support terms.
+  - We offer a [**proprietary DWG parser**](./PROPRIETARY-PARSER.md) with significantly lower memory usage, support for larger files, and more accurate parsing. It integrates with the same `@mlightcad/data-model` as the open-source converters and can replace the GPL-based `libredwg-converter` stack for closed-source commercial products. See the [commercial license document](./PROPRIETARY-PARSER.md) for scope, pricing, GPL compliance, and support terms.
 
 ## Roadmap
 
@@ -418,6 +418,6 @@ Contributions are welcome! Please open issues or pull requests for bug fixes, ne
 
 The cad-viewer monorepo is primarily [MIT](LICENSE) licensed.
 
-The **default DXF/DWG loading path** in `@mlightcad/cad-simple-viewer` depends on GPL-3.0 packages (`dxf-json` / `@mlightcad/dxf-json-converter` for DXF, `libredwg-web` / `@mlightcad/libredwg-converter` for DWG). If you ship a closed-source product and cannot distribute GPL code to your customers, use the [**proprietary DWG/DXF parser**](./PROPRIETARY-PARSER.md) instead — it replaces those converters and lets the rest of the stack remain MIT-only.
+DXF loading uses the built-in MIT parser in `@mlightcad/data-model`. The **default DWG loading path** in `@mlightcad/cad-simple-viewer` depends on GPL-3.0 packages (`libredwg-web` / `@mlightcad/libredwg-converter`). If you ship a closed-source product and cannot distribute GPL code to your customers, use the [**proprietary DWG parser**](./PROPRIETARY-PARSER.md) instead — it replaces that converter and lets the rest of the stack remain MIT-only.
 
 → **Commercial parser:** [PROPRIETARY-PARSER.md](./PROPRIETARY-PARSER.md) (scope, licensing, pricing, integration, GPL compliance, support)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,7 +183,7 @@ CAD-Viewer 针对复杂图纸渲染进行了多项优化，可在保持高帧率
   | 1 | 保存 Proxy Graphics |
 - **DWG 文件大小限制**：
   - 使用 LibreDWG 解析 DWG 文件时内存开销较大，很容易占用超过 2 GB 内存。因此 `libredwg-web` 对 WASM 堆内存做了限制，过大的 DWG 文件可能无法解析。
-  - 我们提供 [**专有 DWG/DXF 解析器**](./PROPRIETARY-PARSER.zh-CN.md)，具有更低的内存开销，支持更大的文件，且解析结果更加准确。它与开源 converter 一样接入 `@mlightcad/data-model`，并可在闭源商业产品中替换基于 GPL 的 `dxf-json-converter` 与 `libredwg-converter`。详见 [商业授权说明](./PROPRIETARY-PARSER.zh-CN.md)（支持范围、价格、GPL 合规、支持维护等）。
+  - 我们提供 [**专有 DWG 解析器**](./PROPRIETARY-PARSER.zh-CN.md)，具有更低的内存开销，支持更大的文件，且解析结果更加准确。它与开源 converter 一样接入 `@mlightcad/data-model`，并可在闭源商业产品中替换基于 GPL 的 `libredwg-converter`。详见 [商业授权说明](./PROPRIETARY-PARSER.zh-CN.md)（支持范围、价格、GPL 合规、支持维护等）。
 
 ## 路线图（Roadmap）
 
@@ -406,7 +406,7 @@ CAD-Viewer 针对复杂图纸渲染进行了多项优化，可在保持高帧率
 
 cad-viewer monorepo 主体采用 [MIT](LICENSE) 授权。
 
-`@mlightcad/cad-simple-viewer` 的**默认 DXF/DWG 加载路径**依赖 GPL-3.0 包（DXF：`dxf-json` / `@mlightcad/dxf-json-converter`；DWG：`libredwg-web` / `@mlightcad/libredwg-converter`）。若您交付闭源产品且无法向客户分发 GPL 代码，可使用 [**专有 DWG/DXF 解析器**](./PROPRIETARY-PARSER.zh-CN.md) 替换上述 converter，其余技术栈可保持纯 MIT。
+DXF 加载使用 `@mlightcad/data-model` 中内置的 MIT 解析器。`@mlightcad/cad-simple-viewer` 的**默认 DWG 加载路径**依赖 GPL-3.0 包（`libredwg-web` / `@mlightcad/libredwg-converter`）。若您交付闭源产品且无法向客户分发 GPL 代码，可使用 [**专有 DWG 解析器**](./PROPRIETARY-PARSER.zh-CN.md) 替换该 converter，其余技术栈可保持纯 MIT。
 
 → **专有解析器说明：** [PROPRIETARY-PARSER.zh-CN.md](./PROPRIETARY-PARSER.zh-CN.md)（支持范围、授权条款、价格、集成方式、GPL 合规、支持维护）
 

--- a/packages/cad-html-exporter-cli/package.json
+++ b/packages/cad-html-exporter-cli/package.json
@@ -22,7 +22,6 @@
     "@mlightcad/cad-html-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.11.1",
-    "@mlightcad/dxf-json-converter": "^1.11.1",
     "@mlightcad/libredwg-converter": "^3.11.1",
     "@mlightcad/mtext-renderer": "^0.11.10",
     "commander": "^12.1.0",

--- a/packages/cad-html-exporter-cli/runner/main.ts
+++ b/packages/cad-html-exporter-cli/runner/main.ts
@@ -38,7 +38,6 @@ async function ensureViewer(): Promise<void> {
     baseUrl: 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/',
     useMainThreadDraw: true,
     webworkerFileUrls: {
-      dxfParser: './workers/dxf-parser-worker.js',
       dwgParser: './workers/libredwg-parser-worker.js',
       mtextRender: './workers/mtext-renderer-worker.js'
     }

--- a/packages/cad-html-exporter-cli/scripts/copy-runner-assets.mjs
+++ b/packages/cad-html-exporter-cli/scripts/copy-runner-assets.mjs
@@ -40,14 +40,6 @@ mkdirSync(workersDir, { recursive: true })
 
 copy(
   join(
-    pkgRoot('@mlightcad/dxf-json-converter'),
-    'dist',
-    'dxf-parser-worker.js'
-  ),
-  join(workersDir, 'dxf-parser-worker.js')
-)
-copy(
-  join(
     pkgRoot('@mlightcad/libredwg-converter'),
     'dist',
     'libredwg-parser-worker.js'

--- a/packages/cad-simple-viewer-example/README.md
+++ b/packages/cad-simple-viewer-example/README.md
@@ -78,7 +78,7 @@ Toast messages at the top report success or errors. The window title updates whe
 
 | Format | Notes |
 |--------|--------|
-| **DXF** | Parsed in a Web Worker (`dxf-parser-worker.js`) |
+| **DXF** | Built-in parser in `@mlightcad/data-model` |
 | **DWG** | LibreDWG WebAssembly via `libredwg-parser-worker.js` |
 
 ## What this example demonstrates

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -759,7 +759,6 @@ class CadViewerApp {
         },
         webworkerFileUrls: {
           mtextRender: './workers/mtext-renderer-worker.js',
-          dxfParser: './workers/dxf-parser-worker.js',
           dwgParser: './workers/libredwg-parser-worker.js'
         },
         htmlViewerRuntimeUrl: './viewer-runtime.iife.js'

--- a/packages/cad-simple-viewer/README.md
+++ b/packages/cad-simple-viewer/README.md
@@ -72,13 +72,15 @@ The `LockAndFade` isolation keyword matches AutoCAD naming but the viewer **lock
 
 ## Web Worker deployment
 
-The viewer loads three worker scripts for DXF parsing, DWG parsing, and MTEXT rendering. Host applications must deploy these files and point to them via `webworkerFileUrls` in `AcApDocManager.createInstance()`.
+The viewer loads worker scripts for DWG parsing and MTEXT rendering. DXF is
+parsed by the built-in converter in `@mlightcad/data-model` (no separate worker).
+Host applications must deploy the DWG/MTEXT worker files and point to them via
+`webworkerFileUrls` in `AcApDocManager.createInstance()`.
 
 Before calling `openDocument()`, verify that the workers are reachable. Use the built-in readiness API rather than downloading worker bodies with a plain GET request (the LibreDWG worker alone is ~12 MB):
 
 ```typescript
 const workerUrls = {
-  dxfParser: './workers/dxf-parser-worker.js',
   dwgParser: './workers/libredwg-parser-worker.js',
   mtextRender: './workers/mtext-renderer-worker.js'
 }

--- a/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
@@ -221,10 +221,6 @@ jest.mock('@mlightcad/data-model', () => ({
   }
 }))
 
-jest.mock('@mlightcad/dxf-json-converter', () => ({
-  AcDbDxfConverter: jest.fn()
-}))
-
 jest.mock('@mlightcad/libredwg-converter', () => ({
   AcDbLibreDwgConverter: jest.fn()
 }))

--- a/packages/cad-simple-viewer/__tests__/AcApOpenFileProgressController.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApOpenFileProgressController.spec.ts
@@ -31,6 +31,11 @@ jest.mock('../src/i18n', () => ({
   }
 }))
 
+jest.mock('../src/util/yieldToMain', () => ({
+  yieldToMain: jest.fn(() => Promise.resolve())
+}))
+
+import { yieldToMain } from '../src/util/yieldToMain'
 import { AcApOpenFileProgressController } from '../src/app/AcApOpenFileProgressController'
 
 describe('AcApOpenFileProgressController', () => {
@@ -44,6 +49,7 @@ describe('AcApOpenFileProgressController', () => {
   beforeEach(() => {
     mockProgressInstances.length = 0
     mockEventBusEmit.mockClear()
+    ;(yieldToMain as jest.Mock).mockClear()
     controller = new AcApOpenFileProgressController({} as HTMLElement)
     progress = mockProgressInstances[0]
     progress.hide.mockClear()
@@ -81,20 +87,19 @@ describe('AcApOpenFileProgressController', () => {
 
     controller.handle({
       database,
-      percentage: 80,
+      percentage: 100,
       stage: 'FETCH_FILE',
-      subStageStatus: 'IN-PROGRESS'
+      subStageStatus: 'END'
     })
-
-    const conversion = controller.handle({
+    const next = controller.handle({
       database,
-      percentage: 10,
+      percentage: 5,
       stage: 'CONVERSION',
-      subStage: 'ENTITY',
-      subStageStatus: 'IN-PROGRESS'
+      subStage: 'PARSE',
+      subStageStatus: 'START'
     })
 
-    expect(conversion.percentage).toBe(10)
+    expect(next.percentage).toBe(5)
   })
 
   it('hides the overlay when open-file progress completes', () => {
@@ -128,6 +133,22 @@ describe('AcApOpenFileProgressController', () => {
     })
 
     expect(next.percentage).toBe(20)
+  })
+
+  it('beginOpen shows the overlay and yields for paint', async () => {
+    await controller.beginOpen({})
+
+    expect(progress.show).toHaveBeenCalled()
+    expect(yieldToMain).toHaveBeenCalled()
+    expect(mockEventBusEmit).toHaveBeenCalledWith(
+      'open-file-progress',
+      expect.objectContaining({
+        percentage: 0,
+        stage: 'CONVERSION',
+        subStage: 'START',
+        subStageStatus: 'START'
+      })
+    )
   })
 
   it('emits fonts-not-loaded when font loading fails but parsing continues', () => {

--- a/packages/cad-simple-viewer/__tests__/AcApWebworkerReadiness.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApWebworkerReadiness.spec.ts
@@ -26,16 +26,16 @@ describe('checkWebworkerReadiness', () => {
     )
 
     const ready = await checkWebworkerReadiness({
-      dxfParser: '/workers/dxf-parser-worker.js',
       dwgParser: '/workers/libredwg-parser-worker.js',
       mtextRender: '/workers/mtext-renderer-worker.js'
     })
 
     expect(ready).toBe(true)
-    expect(global.fetch).toHaveBeenCalledTimes(3)
-    expect(global.fetch).toHaveBeenCalledWith('/workers/dxf-parser-worker.js', {
-      method: 'HEAD'
-    })
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/workers/libredwg-parser-worker.js',
+      { method: 'HEAD' }
+    )
   })
 
   it('does not cache failures so a later retry can succeed', async () => {
@@ -47,14 +47,13 @@ describe('checkWebworkerReadiness', () => {
     )
 
     const urls = {
-      dxfParser: '/workers/dxf-parser-worker.js',
       dwgParser: '/workers/libredwg-parser-worker.js',
       mtextRender: '/workers/mtext-renderer-worker.js'
     }
 
     expect(await checkWebworkerReadiness(urls)).toBe(false)
     expect(await checkWebworkerReadiness(urls)).toBe(true)
-    expect(global.fetch).toHaveBeenCalledTimes(6)
+    expect(global.fetch).toHaveBeenCalledTimes(4)
   })
 
   it('caches a successful result for the current page lifecycle', async () => {
@@ -63,14 +62,13 @@ describe('checkWebworkerReadiness', () => {
     )
 
     const urls = {
-      dxfParser: '/workers/dxf-parser-worker.js',
       dwgParser: '/workers/libredwg-parser-worker.js',
       mtextRender: '/workers/mtext-renderer-worker.js'
     }
 
     expect(await checkWebworkerReadiness(urls)).toBe(true)
     expect(await checkWebworkerReadiness(urls)).toBe(true)
-    expect(global.fetch).toHaveBeenCalledTimes(3)
+    expect(global.fetch).toHaveBeenCalledTimes(2)
   })
 
   it('falls back to a ranged GET when HEAD returns 405', async () => {
@@ -82,15 +80,17 @@ describe('checkWebworkerReadiness', () => {
       .mockResolvedValueOnce({ ok: true, status: 206 } as Response)
 
     const ready = await checkWebworkerReadiness({
-      dxfParser: '/workers/dxf-parser-worker.js'
+      dwgParser: '/workers/libredwg-parser-worker.js'
     })
 
     expect(ready).toBe(true)
-    expect(global.fetch).toHaveBeenCalledWith('/workers/dxf-parser-worker.js', {
-      method: 'HEAD'
-    })
-    expect(global.fetch).toHaveBeenCalledWith('/workers/dxf-parser-worker.js', {
-      headers: { Range: 'bytes=0-0' }
-    })
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/workers/libredwg-parser-worker.js',
+      { method: 'HEAD' }
+    )
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/workers/libredwg-parser-worker.js',
+      { headers: { Range: 'bytes=0-0' } }
+    )
   })
 })

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@mlightcad/data-model": "^1.11.1",
-    "@mlightcad/dxf-json-converter": "^1.11.1",
     "@mlightcad/libredwg-converter": "^3.11.1",
     "@mlightcad/mtext-input-box": "^0.2.21",
     "@mlightcad/mtext-renderer": "^0.11.10",
@@ -58,7 +57,6 @@
   },
   "peerDependencies": {
     "@mlightcad/data-model": "^1.11.1",
-    "@mlightcad/dxf-json-converter": "^1.11.1",
     "lodash-es": "4.17.21",
     "three": "^0.172.0"
   }

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -10,7 +10,6 @@ import {
   AcGeBox2d,
   log
 } from '@mlightcad/data-model'
-import { AcDbDxfConverter } from '@mlightcad/dxf-json-converter'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
 import { FontManager } from '@mlightcad/mtext-renderer'
 import { AcTrMTextRenderer } from '@mlightcad/three-renderer'
@@ -185,14 +184,6 @@ export interface AcDbDocumentEventArgs {
  * off-main-thread processing such as file parsing or text rendering.
  */
 export interface AcApWebworkerFiles {
-  /**
-   * URL of the Web Worker bundle responsible for parsing DXF files.
-   *
-   * This worker performs DXF decoding and entity extraction in a
-   * background thread to avoid blocking the UI.
-   */
-  dxfParser?: string | URL
-
   /**
    * URL of the Web Worker bundle responsible for parsing DWG files.
    *
@@ -858,6 +849,7 @@ export class AcApDocManager {
   async openUrl(url: string, options?: AcApOpenDatabaseOptions) {
     options = this.setOptions(options)
     this.onBeforeOpenDocument(options)
+    await this._openFileProgress.beginOpen(this.context.doc.database)
     // TODO: The correct way is to create one new context instead of using old context and document
     const isSuccess = await this.context.doc.openUri(url, options)
     this.onAfterOpenDocument(isSuccess, options)
@@ -889,6 +881,7 @@ export class AcApDocManager {
   ) {
     options = this.setOptions(options)
     this.onBeforeOpenDocument(options)
+    await this._openFileProgress.beginOpen(this.context.doc.database)
     // TODO: The correct way is to create one new context instead of using old context and document
     const isSuccess = await this.context.doc.openDocument(
       fileName,
@@ -1041,6 +1034,7 @@ export class AcApDocManager {
       mode: AcEdOpenMode.Write
     })
     this.onBeforeOpenDocument(openOptions)
+    await this._openFileProgress.beginOpen(this.context.doc.database)
     const isSuccess = await this.context.doc.openUri(templateUrl, openOptions)
     if (isSuccess) {
       this.context.doc.resetNewDocumentIdentity()
@@ -1758,32 +1752,15 @@ export class AcApDocManager {
   /**
    * Registers file format converters for CAD file processing.
    *
-   * This function initializes and registers both DXF and DWG converters with the
-   * global database converter manager. Each converter is configured to use web workers
-   * for improved performance during file parsing operations.
+   * DXF uses the built-in converter from `@mlightcad/data-model`
+   * (`AcDbNativeDxfConverter`), registered automatically on import.
+   * This method registers the DWG converter (`@mlightcad/libredwg-converter`)
+   * with a worker URL.
    *
-   * The function handles registration errors gracefully by logging them to the console
-   * without throwing exceptions, ensuring that the application can continue to function
-   * even if one or more converters fail to register.
+   * Registration errors are logged without throwing so the application can
+   * continue if registration fails.
    */
   private registerConverters(webworkerFileUrls?: AcApWebworkerFiles) {
-    // Register DXF converter
-    try {
-      const converter = new AcDbDxfConverter({
-        convertByEntityType: false,
-        useWorker: true,
-        parserWorkerUrl:
-          webworkerFileUrls?.dxfParser ?? DEFAULT_WEBWORKER_FILE_URLS.dxfParser
-      })
-      AcDbDatabaseConverterManager.instance.register(
-        AcDbFileType.DXF,
-        converter
-      )
-    } catch (error) {
-      log.error('Failed to register dxf converter: ', error)
-    }
-
-    // Register DWG converter
     try {
       const converter = new AcDbLibreDwgConverter({
         convertByEntityType: false,
@@ -1804,8 +1781,8 @@ export class AcApDocManager {
    * Initializes background workers used by the viewer runtime.
    *
    * This function performs two tasks:
-   * - Ensures DXF/DWG converters are registered with worker-based parsers for
-   *   off-main-thread file processing.
+   * - Registers the DWG converter with a worker-based parser. DXF uses the
+   *   built-in `@mlightcad/data-model` converter (no separate worker).
    * - Initializes the MText renderer by pointing it to its dedicated Web Worker
    *   script for text layout and shaping.
    *

--- a/packages/cad-simple-viewer/src/app/AcApOpenFileProgressController.ts
+++ b/packages/cad-simple-viewer/src/app/AcApOpenFileProgressController.ts
@@ -2,6 +2,7 @@ import { AcDbProgressdEventArgs } from '@mlightcad/data-model'
 
 import { AcEdFontNotLoadedInfo, eventBus } from '../editor'
 import { AcApI18n } from '../i18n'
+import { yieldToMain } from '../util/yieldToMain'
 import { AcApProgress } from './AcApProgress'
 import { isOpenFileProgressComplete } from './openFileProgress'
 
@@ -31,6 +32,21 @@ export class AcApOpenFileProgressController {
   reset(): void {
     this._peak = 0
     this._stage = undefined
+  }
+
+  /**
+   * Shows the open-file overlay immediately and yields so it can paint before
+   * main-thread DXF parse work blocks the UI (native converter path).
+   */
+  async beginOpen(database: AcDbProgressdEventArgs['database']): Promise<void> {
+    this.handle({
+      database,
+      percentage: 0,
+      stage: 'CONVERSION',
+      subStage: 'START',
+      subStageStatus: 'START'
+    })
+    await yieldToMain()
   }
 
   /**

--- a/packages/cad-simple-viewer/src/app/AcApWebworkerReadiness.ts
+++ b/packages/cad-simple-viewer/src/app/AcApWebworkerReadiness.ts
@@ -2,7 +2,6 @@ import type { AcApWebworkerFiles } from './AcApDocManager'
 
 /** Default worker script URLs used when `webworkerFileUrls` is omitted. */
 export const DEFAULT_WEBWORKER_FILE_URLS: Required<AcApWebworkerFiles> = {
-  dxfParser: './assets/dxf-parser-worker.js',
   dwgParser: './assets/libredwg-parser-worker.js',
   mtextRender: './assets/mtext-renderer-worker.js'
 }
@@ -14,7 +13,6 @@ export function resolveWebworkerFileUrls(
   webworkerFileUrls?: AcApWebworkerFiles
 ): string[] {
   return [
-    webworkerFileUrls?.dxfParser ?? DEFAULT_WEBWORKER_FILE_URLS.dxfParser,
     webworkerFileUrls?.dwgParser ?? DEFAULT_WEBWORKER_FILE_URLS.dwgParser,
     webworkerFileUrls?.mtextRender ?? DEFAULT_WEBWORKER_FILE_URLS.mtextRender
   ].map(url => String(url))

--- a/packages/cad-simple-viewer/src/command/convert/AcApDxfConvertor.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApDxfConvertor.ts
@@ -14,8 +14,13 @@ export class AcApDxfConvertor {
     this.createFileAndDownloadIt(dxfContent, `${baseName}.dxf`)
   }
 
-  private createFileAndDownloadIt(dxfContent: string, fileName: string) {
-    const dxfBlob = new Blob([dxfContent], {
+  private createFileAndDownloadIt(
+    dxfContent: string | Uint8Array,
+    fileName: string
+  ) {
+    const blobPart: BlobPart =
+      typeof dxfContent === 'string' ? dxfContent : new Uint8Array(dxfContent)
+    const dxfBlob = new Blob([blobPart], {
       type: 'application/dxf;charset=utf-8'
     })
     const url = URL.createObjectURL(dxfBlob)

--- a/packages/cad-simple-viewer/vite.config.ts
+++ b/packages/cad-simple-viewer/vite.config.ts
@@ -26,13 +26,6 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: './node_modules/@mlightcad/dxf-json-converter/dist/dxf-parser-worker.js',
-          dest: '',
-          // v4 preserves source dir structure; flatten so consumers find
-          // `dist/*-worker.js` (see cad-*-viewer-example static-copy globs).
-          rename: { stripBase: true }
-        },
-        {
           src: './node_modules/@mlightcad/libredwg-converter/dist/libredwg-parser-worker.js',
           dest: '',
           rename: { stripBase: true }

--- a/packages/cad-svg-plugin/__tests__/AcSvgMText.spec.ts
+++ b/packages/cad-svg-plugin/__tests__/AcSvgMText.spec.ts
@@ -134,7 +134,8 @@ describe('buildSvgMText', () => {
     )
     expect(dyValues.filter(value => value > 0).length).toBeGreaterThan(0)
     expect(localSvg).toMatch(/<tspan[^>]*x="0"[^>]*dy="0"/)
-    expect(localSvg).toMatch(/<tspan[^>]*x="0"[^>]*dy="14\.1/)
+    // Default line advance is height * (5/3) with lineSpaceFactor 1.0.
+    expect(localSvg).toMatch(/<tspan[^>]*x="0"[^>]*dy="16\.6/)
   })
 
   it('wraps continuous latin text without spaces', () => {

--- a/packages/cad-svg-plugin/src/AcSvgMTextUtil.ts
+++ b/packages/cad-svg-plugin/src/AcSvgMTextUtil.ts
@@ -25,8 +25,8 @@ import {
 } from './AcSvgFontMap'
 import { AcSvgStyleContext, AcSvgStyleUtil } from './AcSvgStyleUtil'
 
-const DEFAULT_LINE_SPACE_FACTOR = 0.25
-const LINE_SPACING_SCALE_FACTOR = 1.666666
+const DEFAULT_LINE_SPACE_FACTOR = 1.0
+const LINE_SPACING_SCALE_FACTOR = 5 / 3
 const STACK_VERTICAL_SHIFT_FACTOR = 0.3
 const LATIN_CHAR_WIDTH_FACTOR = 0.6
 const WIDE_CHAR_WIDTH_FACTOR = 1
@@ -101,7 +101,7 @@ function resolveLineAdvance(baseHeight: number, mtext: AcGiMTextData): number {
     typeof mtext.lineSpaceFactor === 'number'
       ? mtext.lineSpaceFactor
       : DEFAULT_LINE_SPACE_FACTOR
-  return baseHeight * (1 + factor * LINE_SPACING_SCALE_FACTOR)
+  return baseHeight * Math.max(factor, 0) * LINE_SPACING_SCALE_FACTOR
 }
 
 function resolveWrapWidth(mtext: AcGiMTextData): number | null {

--- a/packages/cad-viewer-example/README.md
+++ b/packages/cad-viewer-example/README.md
@@ -74,7 +74,7 @@ The build runs `vue-tsc`, then copies parser workers and `viewer-runtime.iife.js
 
 | Format | Notes |
 |--------|--------|
-| **DXF** | Parsed in a Web Worker (`dxf-parser-worker.js`) |
+| **DXF** | Built-in parser in `@mlightcad/data-model` |
 | **DWG** | LibreDWG WebAssembly via `libredwg-parser-worker.js` |
 
 ## What this example demonstrates

--- a/packages/three-renderer/__tests__/AcTrMTextColorUtil.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrMTextColorUtil.spec.ts
@@ -76,11 +76,14 @@ describe('AcTrMTextColorUtil', () => {
       layer: 'Viewport'
     })
 
+    // Start from a ByLayer-bound CAD material that lost foreground tracking.
+    const byLayerTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    byLayerTraits.color.setByLayer()
+    byLayerTraits.layer = 'Viewport'
+    const byLayerMaterial = styleManager.getMTextFillMaterial(byLayerTraits)
+
     const root = new THREE.Group()
-    const mesh = new THREE.Mesh(
-      new THREE.PlaneGeometry(1, 1),
-      new THREE.MeshBasicMaterial({ color: 0xffffff })
-    )
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), byLayerMaterial)
     root.add(mesh)
 
     AcTrMTextColorUtil.rematerializeTextHierarchy(root, traits, styleManager)
@@ -88,6 +91,29 @@ describe('AcTrMTextColorUtil', () => {
     const material = mesh.material as THREE.MeshBasicMaterial
     expect(material.color.getHex()).toBe(ACGI_LIGHT_THEME_FOREGROUND)
     expect(material.userData.isForeground).toBe(true)
+  })
+
+  it('does not rematerialize bare mtext-renderer meshes when entity is ACI 7', () => {
+    const styleManager = new AcTrStyleManager()
+    styleManager.currentBackgroundColor = ACGI_PAPER_SPACE_BACKGROUND
+
+    const color = new AcCmColor()
+    color.setForeground()
+    const traits = AcTrMTextColorUtil.snapshotEntityTraits({
+      ...AcTrSubEntityTraitsUtil.createDefaultTraits(),
+      color,
+      layer: 'Viewport'
+    })
+
+    const root = new THREE.Group()
+    const inlineMaterial = new THREE.MeshBasicMaterial({ color: 0x00ff00 })
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), inlineMaterial)
+    root.add(mesh)
+
+    AcTrMTextColorUtil.rematerializeTextHierarchy(root, traits, styleManager)
+
+    expect(mesh.material).toBe(inlineMaterial)
+    expect(inlineMaterial.color.getHex()).toBe(0x00ff00)
   })
 
   it('preserves inline ACI materials that differ from entity base traits', () => {

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -740,7 +740,7 @@ export class AcTrBatchedGroup extends THREE.Group {
   ) {
     for (const root of this._unbatchedObjects.children) {
       const storedTraits = getSceneDrawableUserData(root).textEntityTraits
-      if (storedTraits == null) {
+      if (storedTraits == null || storedTraits.layer !== layerName) {
         continue
       }
 

--- a/packages/three-renderer/src/util/AcTrMTextColorUtil.ts
+++ b/packages/three-renderer/src/util/AcTrMTextColorUtil.ts
@@ -189,7 +189,24 @@ export class AcTrMTextColorUtil {
     const metadata = getMaterialMetadata(material)
 
     if (entityTraits.color.isForeground) {
-      return metadata.isForeground !== true
+      // Keep materials that already track ACI-7 foreground.
+      if (metadata.isForeground === true) {
+        return false
+      }
+      // Rematerialize ByLayer-bound materials that should follow entity ACI 7.
+      if (metadata.isByLayerColor === true) {
+        return true
+      }
+      // mtext-renderer inline `\C` segments usually have no CAD metadata.
+      // Do not paint them with the entity colour (that used to wipe \C90/\C255).
+      if (
+        metadata.isByLayerColor == null &&
+        metadata.isForeground == null &&
+        metadata.materialKey == null
+      ) {
+        return false
+      }
+      return true
     }
 
     if (
@@ -307,6 +324,13 @@ export class AcTrMTextColorUtil {
 
     if (color.isByBlock) {
       resolved.aci = 0
+      return resolved
+    }
+
+    // ACI 7 must stay an explicit index so the renderer can treat it as
+    // canvas foreground — do not fall through to RGB / ByLayer.
+    if (color.isForeground) {
+      resolved.aci = 7
       return resolved
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mlightcad/data-model': ^1.11.3
-  '@mlightcad/dxf-json-converter': ^1.11.3
-  '@mlightcad/libredwg-converter': ^3.11.3
+  '@mlightcad/data-model': ^1.12.0
+  '@mlightcad/libredwg-converter': ^3.12.0
   '@mlightcad/mtext-input-box': ^0.2.21
-  '@mlightcad/mtext-renderer': ^0.11.10
+  '@mlightcad/mtext-renderer': ^0.12.0
   '@mlightcad/ribbon': ^0.1.11
   '@mlightcad/ui-components': ^0.1.7
   element-plus: ^2.12.0
@@ -133,8 +132,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(vite@6.4.3(@types/node@24.12.4)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
@@ -154,17 +153,14 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
-      '@mlightcad/dxf-json-converter':
-        specifier: ^1.11.3
-        version: 1.11.3(@mlightcad/data-model@1.11.3)
+        specifier: ^1.12.0
+        version: 1.12.0
       '@mlightcad/libredwg-converter':
-        specifier: ^3.11.3
-        version: 3.11.3(@mlightcad/data-model@1.11.3)
+        specifier: ^3.12.0
+        version: 3.12.0(@mlightcad/data-model@1.12.0)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.11.10
-        version: 0.11.10(three@0.172.0)
+        specifier: ^0.12.0
+        version: 0.12.0(three@0.172.0)
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -191,8 +187,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -224,8 +220,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1
@@ -242,26 +238,23 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
 
   packages/cad-simple-viewer:
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
-      '@mlightcad/dxf-json-converter':
-        specifier: ^1.11.3
-        version: 1.11.3(@mlightcad/data-model@1.11.3)
+        specifier: ^1.12.0
+        version: 1.12.0
       '@mlightcad/libredwg-converter':
-        specifier: ^3.11.3
-        version: 3.11.3(@mlightcad/data-model@1.11.3)
+        specifier: ^3.12.0
+        version: 3.12.0(@mlightcad/data-model@1.12.0)
       '@mlightcad/mtext-input-box':
         specifier: ^0.2.21
-        version: 0.2.21(@mlightcad/mtext-renderer@0.11.10(three@0.172.0))(three@0.172.0)
+        version: 0.2.21(@mlightcad/mtext-renderer@0.12.0(three@0.172.0))(three@0.172.0)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.11.10
-        version: 0.11.10(three@0.172.0)
+        specifier: ^0.12.0
+        version: 0.12.0(three@0.172.0)
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -311,8 +304,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -333,14 +326,14 @@ importers:
         specifier: workspace:*
         version: link:../cad-simple-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
       '@mlightcad/mtext-parser':
         specifier: ^1.4.1
         version: 1.4.1
       '@mlightcad/mtext-renderer':
-        specifier: ^0.11.10
-        version: 0.11.10(three@0.172.0)
+        specifier: ^0.12.0
+        version: 0.12.0(three@0.172.0)
 
   packages/cad-viewer:
     devDependencies:
@@ -363,8 +356,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-svg-plugin
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
       '@mlightcad/ribbon':
         specifier: ^0.1.11
         version: 0.1.11(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
@@ -438,8 +431,8 @@ importers:
         specifier: workspace:*
         version: link:../cad-viewer
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
@@ -503,11 +496,11 @@ importers:
         version: 1.1.1
     devDependencies:
       '@mlightcad/data-model':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.12.0
+        version: 1.12.0
       '@mlightcad/mtext-renderer':
-        specifier: ^0.11.10
-        version: 0.11.10(three@0.172.0)
+        specifier: ^0.12.0
+        version: 0.12.0(three@0.172.0)
       '@types/three':
         specifier: ^0.172.0
         version: 0.172.0
@@ -1543,9 +1536,6 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fxts/core@1.26.0':
-    resolution: {integrity: sha512-ONaza1CGr8dLKmJ0HQgi0h4XuyDJMr0P70M7o/My/YeeRxuYoSANHjE2nSY7xO4WHgxUD5ojd5dpxlFOzAEJsA==}
-
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
@@ -1762,35 +1752,27 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@mlightcad/common@1.11.3':
-    resolution: {integrity: sha512-iwLo5Ui0oNbvT1E+HUjizOgeX3jz8YkqNYCP93DMRRR/2TfbWoYm/l8sssIN9JAnuGLcWj7oAbMxuKp3hN+A8A==}
+  '@mlightcad/common@1.12.0':
+    resolution: {integrity: sha512-nQhgWoZQ9V14+gdD9/imgjbOhxAWNuexfZsa5Lcz0ZVGv1agthD3VWTDsDB5/j7N9t6saMrVZbX26PzOhpYQGw==}
 
-  '@mlightcad/data-model@1.11.3':
-    resolution: {integrity: sha512-FxskJuqMw0Jq3fb7gRIkrrxM/2MRL/vM/ToH9ax1yg2vjEaWsDPj5Ks3LRSQLyQIYnAnl/uxuXeTlcyATenEag==}
+  '@mlightcad/data-model@1.12.0':
+    resolution: {integrity: sha512-vwJ4jtVB1ugsPQGHklBFZyNtrdC05mS/8R0wPlHgUz3yqTeiFHK7xAR0giiXUqoyvxOpMNEznM1tdCKGPSFoJA==}
 
-  '@mlightcad/dxf-json-converter@1.11.3':
-    resolution: {integrity: sha512-LEKqlAcAOwPBbEaeUOxz8E4/kDyBCtN/7a50rwLTww2pPE3DJ38ZQz08yNqkuRwB+XtPsaC15bxSgj+9AKNqtQ==}
+  '@mlightcad/geometry-engine@3.12.0':
+    resolution: {integrity: sha512-RoLpyCkfxwe5Vm2W+yASF3QpRadUW2LvFU3dwLeKLpzpfTGwAgsZIUk+zdsFqNYVDhUx+2gLRc8U9E+0pN6rmg==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.11.3
+      '@mlightcad/common': 1.12.0
 
-  '@mlightcad/dxf-json@1.2.8':
-    resolution: {integrity: sha512-pn4kY2+cYLq9xVVeUJUwzBPyYGGIuO6uKc+bKAzWfSaZAWTgrbK7WrY+VHR4od9wrWdDwNWknIqVq4KBZPD7SA==}
-
-  '@mlightcad/geometry-engine@3.11.3':
-    resolution: {integrity: sha512-BR4OzXbTfviv7/mIEZaZS2k0+9XjfDRbRLhwr0baOWtvIetr/8wHdlEBg9EamO0opWr8IdXcGhwdvtMLQG1IFA==}
+  '@mlightcad/graphic-interface@3.12.0':
+    resolution: {integrity: sha512-VoRxsIv2v/8oZhraFmUJ8xCCpNGO+fa787Yc9FwcUMPKN1RgNu69GvFjc/0Aa+yVtwkshLY0ZNmFu1mLn7hnaA==}
     peerDependencies:
-      '@mlightcad/common': 1.11.3
+      '@mlightcad/common': 1.12.0
+      '@mlightcad/geometry-engine': 3.12.0
 
-  '@mlightcad/graphic-interface@3.11.3':
-    resolution: {integrity: sha512-26KUXsBddFSzag+ndHDlQVMdF1L4D6+Q3DhtcRUhARMbfXyF2rs0blwmI67rWDv6JIdnQJjE4C76K38pgv1Ynw==}
+  '@mlightcad/libredwg-converter@3.12.0':
+    resolution: {integrity: sha512-+tprl1Y8YpuslfEnbEo8YSAGk0xCU5x/d1bPktbP/4q/QcVLwkjiWiUZxCpk9WR7dLbsM6RWF4CRuqcaUzIt/g==}
     peerDependencies:
-      '@mlightcad/common': 1.11.3
-      '@mlightcad/geometry-engine': 3.11.3
-
-  '@mlightcad/libredwg-converter@3.11.3':
-    resolution: {integrity: sha512-a1e+Zgityvl6qaL9BdtSTm2F+CxcfrSY1OmmiSLsdYl6QC2EUlIv7Vfw5r7n0ZzXJddKFeDdW+qxwnErM4g3GA==}
-    peerDependencies:
-      '@mlightcad/data-model': ^1.11.3
+      '@mlightcad/data-model': ^1.12.0
 
   '@mlightcad/libredwg-web@0.7.9':
     resolution: {integrity: sha512-tqjx0eCiR0CNI3TyO3LVYzl4ptuzSFm7asGn/C1YiJaEk7Vneto+lRrVUco85qw+PZDihaFLwWqdYIEse1swbA==}
@@ -1799,7 +1781,7 @@ packages:
   '@mlightcad/mtext-input-box@0.2.21':
     resolution: {integrity: sha512-m5pRlqkwve7N6Ry/73Uz9mUs3gmhauuw0G4V3LRHOyze0Sd7f+e3+Fmu1qis8jjvLTX+IHPkZ7Vh0oiMAJ81+g==}
     peerDependencies:
-      '@mlightcad/mtext-renderer': ^0.11.10
+      '@mlightcad/mtext-renderer': ^0.12.0
       three: ^0.172.0
 
   '@mlightcad/mtext-parser@1.4.1':
@@ -1808,8 +1790,8 @@ packages:
   '@mlightcad/mtext-parser@1.5.0':
     resolution: {integrity: sha512-Yl/IQmSIGV1UUl/TyUptoOpNBunywcEE7yh4k9SFDXljHDTTI92VmqkVFxf4eYzhoWF4MNXIl4qgQV1P1Rbn6g==}
 
-  '@mlightcad/mtext-renderer@0.11.10':
-    resolution: {integrity: sha512-TDKUFAi4iMTevQCLiyOQN1CW16jET4mQFbDQ/KiyUrqsKxkzqHl/EMlR9Ae6z5BchKs2FosnWxKljAK1fT6zQA==}
+  '@mlightcad/mtext-renderer@0.12.0':
+    resolution: {integrity: sha512-lo/j+5/quYFEnkB4iJ5ozqNzi0qMgpJlXu350ayQiuVYFt7vqXkJfjKzdtmdKHdIX6r8yqGqQ8Zj8Cp633DhYQ==}
     peerDependencies:
       three: ^0.172.0
 
@@ -6821,10 +6803,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fxts/core@1.26.0':
-    dependencies:
-      tslib: 2.8.1
-
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
       '@shikijs/engine-oniguruma': 3.23.0
@@ -7204,46 +7182,37 @@ snapshots:
   '@microsoft/tsdoc@0.16.0':
     optional: true
 
-  '@mlightcad/common@1.11.3':
+  '@mlightcad/common@1.12.0':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.11.3':
+  '@mlightcad/data-model@1.12.0':
     dependencies:
-      '@mlightcad/common': 1.11.3
-      '@mlightcad/geometry-engine': 3.11.3(@mlightcad/common@1.11.3)
-      '@mlightcad/graphic-interface': 3.11.3(@mlightcad/common@1.11.3)(@mlightcad/geometry-engine@3.11.3(@mlightcad/common@1.11.3))
+      '@mlightcad/common': 1.12.0
+      '@mlightcad/geometry-engine': 3.12.0(@mlightcad/common@1.12.0)
+      '@mlightcad/graphic-interface': 3.12.0(@mlightcad/common@1.12.0)(@mlightcad/geometry-engine@3.12.0(@mlightcad/common@1.12.0))
       iconv-lite: 0.7.2
       uid: 2.0.2
 
-  '@mlightcad/dxf-json-converter@1.11.3(@mlightcad/data-model@1.11.3)':
+  '@mlightcad/geometry-engine@3.12.0(@mlightcad/common@1.12.0)':
     dependencies:
-      '@mlightcad/data-model': 1.11.3
-      '@mlightcad/dxf-json': 1.2.8
+      '@mlightcad/common': 1.12.0
 
-  '@mlightcad/dxf-json@1.2.8':
+  '@mlightcad/graphic-interface@3.12.0(@mlightcad/common@1.12.0)(@mlightcad/geometry-engine@3.12.0(@mlightcad/common@1.12.0))':
     dependencies:
-      '@fxts/core': 1.26.0
+      '@mlightcad/common': 1.12.0
+      '@mlightcad/geometry-engine': 3.12.0(@mlightcad/common@1.12.0)
 
-  '@mlightcad/geometry-engine@3.11.3(@mlightcad/common@1.11.3)':
+  '@mlightcad/libredwg-converter@3.12.0(@mlightcad/data-model@1.12.0)':
     dependencies:
-      '@mlightcad/common': 1.11.3
-
-  '@mlightcad/graphic-interface@3.11.3(@mlightcad/common@1.11.3)(@mlightcad/geometry-engine@3.11.3(@mlightcad/common@1.11.3))':
-    dependencies:
-      '@mlightcad/common': 1.11.3
-      '@mlightcad/geometry-engine': 3.11.3(@mlightcad/common@1.11.3)
-
-  '@mlightcad/libredwg-converter@3.11.3(@mlightcad/data-model@1.11.3)':
-    dependencies:
-      '@mlightcad/data-model': 1.11.3
+      '@mlightcad/data-model': 1.12.0
       '@mlightcad/libredwg-web': 0.7.9
 
   '@mlightcad/libredwg-web@0.7.9': {}
 
-  '@mlightcad/mtext-input-box@0.2.21(@mlightcad/mtext-renderer@0.11.10(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/mtext-input-box@0.2.21(@mlightcad/mtext-renderer@0.12.0(three@0.172.0))(three@0.172.0)':
     dependencies:
-      '@mlightcad/mtext-renderer': 0.11.10(three@0.172.0)
+      '@mlightcad/mtext-renderer': 0.12.0(three@0.172.0)
       '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
       three: 0.172.0
 
@@ -7251,7 +7220,7 @@ snapshots:
 
   '@mlightcad/mtext-parser@1.5.0': {}
 
-  '@mlightcad/mtext-renderer@0.11.10(three@0.172.0)':
+  '@mlightcad/mtext-renderer@0.12.0(three@0.172.0)':
     dependencies:
       '@mlightcad/mtext-parser': 1.5.0
       '@mlightcad/shx-parser': 1.4.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,11 +8,10 @@ allowBuilds:
   unrs-resolver: true
   vue-demi: true
 overrides:
-  '@mlightcad/data-model': '^1.11.3'
-  '@mlightcad/dxf-json-converter': '^1.11.3'
-  '@mlightcad/libredwg-converter': '^3.11.3'
+  '@mlightcad/data-model': '^1.12.0'
+  '@mlightcad/libredwg-converter': '^3.12.0'
   '@mlightcad/mtext-input-box': '^0.2.21'
-  '@mlightcad/mtext-renderer': '^0.11.10'
+  '@mlightcad/mtext-renderer': '^0.12.0'
   '@mlightcad/ribbon': '^0.1.11'
   '@mlightcad/ui-components': '^0.1.7'
   element-plus: '^2.12.0'


### PR DESCRIPTION
## Summary
- Replace GPL `@mlightcad/dxf-json-converter` / DXF parser worker with the built-in MIT DXF converter from `@mlightcad/data-model` 1.12, and bump `libredwg-converter` / `mtext-renderer` accordingly.
- Show open-file progress before main-thread DXF parse (`beginOpen` + `yieldToMain`) so the overlay can paint.
- Fix MText ACI-7 / foreground rematerialization (preserve inline `\C` colors), batched text layer filtering, SVG MText line-spacing defaults, and related docs/tests.

## Test plan
- [ ] Open a DXF file in `cad-simple-viewer-example` / `cad-viewer-example` and confirm parse works without `dxf-parser-worker.js`
- [ ] Open a DWG file and confirm LibreDWG worker path still works
- [ ] Confirm open-file progress overlay appears immediately when opening a large DXF
- [ ] Check MText with ACI 7 and inline `\C` color codes still render correctly
- [ ] Change a text entity layer visibility/color and confirm only that layer updates
- [ ] Run package tests for `cad-simple-viewer` and `three-renderer` MText/progress specs
- [ ] HTML exporter CLI still converts without the removed DXF worker asset