### PR TITLE
fix: register native DXF converter explicitly and update XRef docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,6 @@ These optimizations enable CAD-Viewer to smoothly render complex CAD drawings wi
 
 CAD-Viewer has some known limitations that users should be aware of:
 
-- **Unsupported Entities**: 
-  - **XRefs**: External references (XRefs) are not currently supported. This is mainly because file access in the browser works differently from desktop CAD applications. Support for XRefs is planned for a future release.
 - **DWG File Compatibility**: 
   - Some DWG drawings may fail to open due to bugs in the underlying [LibreDWG](https://github.com/LibreDWG/libredwg) library. This is a known limitation of the current DWG parsing implementation. If you find those issues, please log one issue on [CAD-Viewer issues page](https://github.com/mlightcad/cad-viewer/issues) or [LibreDWG issues page](https://github.com/LibreDWG/libredwg/issues).
   - Drawings that contain third-party custom entities (e.g., Tianzheng drawings in the Chinese architecture and construction industry) may not display correctly unless proxy graphics are saved. When saving such drawings, ensure the system variable `PROXYGRAPHICS` is set to `1`. If proxy graphics are embedded in the file, CAD-Viewer can display them.
@@ -194,6 +192,7 @@ CAD-Viewer has some known limitations that users should be aware of:
   |-------|---------|
   | 0 | Do not save proxy graphics |
   | 1 | Save proxy graphics |
+  
 - **DWG File Size Limits**:
   - Parsing DWG files with LibreDWG is memory-intensive and can easily exceed 2 GB of RAM. `libredwg-web` therefore enforces WASM heap memory limits; very large DWG files may fail to parse.
   - We offer a [**proprietary DWG parser**](./PROPRIETARY-PARSER.md) with significantly lower memory usage, support for larger files, and more accurate parsing. It integrates with the same `@mlightcad/data-model` as the open-source converters and can replace the GPL-based `libredwg-converter` stack for closed-source commercial products. See the [commercial license document](./PROPRIETARY-PARSER.md) for scope, pricing, GPL compliance, and support terms.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,8 +169,6 @@ CAD-Viewer 针对复杂图纸渲染进行了多项优化，可在保持高帧率
 
 ## 已知问题
 
-- **不支持的实体**：
-  - **外部参照（XRef）**：当前暂不支持显示。这主要是因为 Web 端访问文件的方式与桌面端 CAD 应用不一致，后续版本将提供支持。
 - **DWG 兼容性**：
   - 部分 DWG 图纸可能因 [LibreDWG](https://github.com/LibreDWG/libredwg) 的问题无法打开。若遇到此类问题，欢迎在 [CAD-Viewer 问题页](https://github.com/mlightcad/cad-viewer/issues) 或 [LibreDWG 问题页](https://github.com/LibreDWG/libredwg/issues) 反馈。
   - 包含第三方自定义图元的图纸（例如天正软件绘制的图纸）可能无法正确显示。保存此类图纸时，请确保系统变量 `PROXYGRAPHICS` 已开启（设为 `1`）。若图纸中已保存了 proxy graphic，则 CAD-Viewer 也可以正常显示。
@@ -181,6 +179,7 @@ CAD-Viewer 针对复杂图纸渲染进行了多项优化，可在保持高帧率
   |------|------|
   | 0 | 不保存 Proxy Graphics |
   | 1 | 保存 Proxy Graphics |
+  
 - **DWG 文件大小限制**：
   - 使用 LibreDWG 解析 DWG 文件时内存开销较大，很容易占用超过 2 GB 内存。因此 `libredwg-web` 对 WASM 堆内存做了限制，过大的 DWG 文件可能无法解析。
   - 我们提供 [**专有 DWG 解析器**](./PROPRIETARY-PARSER.zh-CN.md)，具有更低的内存开销，支持更大的文件，且解析结果更加准确。它与开源 converter 一样接入 `@mlightcad/data-model`，并可在闭源商业产品中替换基于 GPL 的 `libredwg-converter`。详见 [商业授权说明](./PROPRIETARY-PARSER.zh-CN.md)（支持范围、价格、GPL 合规、支持维护等）。

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -949,8 +949,9 @@ class CadViewerApp {
 
     this.clearMessages()
 
+    let fileContent: ArrayBuffer | null = null
     try {
-      const fileContent = await this.readFile(file)
+      fileContent = await this.readFile(file)
       const options: AcApOpenDatabaseOptions = {
         minimumChunkSize: 1000,
         mode: AcEdOpenMode.Write,
@@ -976,6 +977,7 @@ class CadViewerApp {
       log.error('Error loading file:', error)
       this.showMessage(`Error loading file: ${error}`, 'error')
     } finally {
+      fileContent = null
       this.finishLoadingState()
     }
   }

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -5,6 +5,7 @@ import {
   AcDbDatabaseConverterManager,
   AcDbFileType,
   acdbHostApplicationServices,
+  AcDbNativeDxfConverter,
   AcDbOpenDatabaseOptions,
   AcDbSysVarManager,
   AcGeBox2d,
@@ -1752,15 +1753,28 @@ export class AcApDocManager {
   /**
    * Registers file format converters for CAD file processing.
    *
-   * DXF uses the built-in converter from `@mlightcad/data-model`
-   * (`AcDbNativeDxfConverter`), registered automatically on import.
-   * This method registers the DWG converter (`@mlightcad/libredwg-converter`)
-   * with a worker URL.
+   * DXF uses {@link AcDbNativeDxfConverter} from `@mlightcad/data-model`.
+   * Registration is done explicitly here (not only via the package import
+   * side effect) so the converter is bound to the same
+   * {@link AcDbDatabaseConverterManager} singleton this app imports — import
+   * side effects alone can be dropped by CJS/lib bundling or duplicated
+   * package instances.
+   *
+   * DWG uses `@mlightcad/libredwg-converter` with a worker URL.
    *
    * Registration errors are logged without throwing so the application can
    * continue if registration fails.
    */
   private registerConverters(webworkerFileUrls?: AcApWebworkerFiles) {
+    try {
+      AcDbDatabaseConverterManager.instance.register(
+        AcDbFileType.DXF,
+        new AcDbNativeDxfConverter()
+      )
+    } catch (error) {
+      log.error('Failed to register dxf converter: ', error)
+    }
+
     try {
       const converter = new AcDbLibreDwgConverter({
         convertByEntityType: false,
@@ -1781,8 +1795,8 @@ export class AcApDocManager {
    * Initializes background workers used by the viewer runtime.
    *
    * This function performs two tasks:
-   * - Registers the DWG converter with a worker-based parser. DXF uses the
-   *   built-in `@mlightcad/data-model` converter (no separate worker).
+   * - Registers DXF/DWG converters (native DXF on the main thread; LibreDWG
+   *   DWG parser in a worker).
    * - Initializes the MText renderer by pointing it to its dedicated Web Worker
    *   script for text layout and shaping.
    *

--- a/packages/cad-simple-viewer/src/app/AcApOpenFileDialog.ts
+++ b/packages/cad-simple-viewer/src/app/AcApOpenFileDialog.ts
@@ -116,8 +116,9 @@ const onFileChange = async (event: Event) => {
     return
   }
 
+  let content: ArrayBuffer | null = null
   try {
-    const content = await readFileAsArrayBuffer(file)
+    content = await readFileAsArrayBuffer(file)
     const { AcApDocManager } = await import('./AcApDocManager')
     const options = await resolveOpenDocumentDefaults(
       currentOptions.getOpenDocumentDefaults
@@ -128,6 +129,8 @@ const onFileChange = async (event: Event) => {
     await AcApDocManager.instance.openDocument(file.name, content, options)
   } catch (error) {
     log.error('Failed to open selected file:', error)
+  } finally {
+    content = null
   }
 }
 

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -369,12 +369,13 @@ const openLocalFile = async (file: File) => {
   const options = buildOpenOptions()
   beginDocumentOpening()
   beginPendingOpen(options.mode ?? AcEdOpenMode.Read)
+  let fileContent: ArrayBuffer | null = null
   try {
     const reader = new FileReader()
     reader.readAsArrayBuffer(file)
 
     // Wait for file reading to complete
-    const fileContent = await new Promise<ArrayBuffer>((resolve, reject) => {
+    fileContent = await new Promise<ArrayBuffer>((resolve, reject) => {
       reader.onload = event => {
         const result = event.target?.result
         if (result) {
@@ -403,6 +404,7 @@ const openLocalFile = async (file: File) => {
       showClose: true
     })
   } finally {
+    fileContent = null
     endDocumentOpening()
     endPendingOpen()
   }


### PR DESCRIPTION
## Summary
- Explicitly register `AcDbNativeDxfConverter` on the same `AcDbDatabaseConverterManager` singleton the app uses, so DXF open still works when CJS/lib bundling drops package import side effects or duplicates package instances.
- Null out large `ArrayBuffer` locals after document open in simple-viewer, open-file dialog, and `MlCadViewer` to allow earlier GC of file contents.
- Remove outdated "XRefs unsupported" notes from README / README.zh-CN now that xref overlay support exists.

## Test plan
- [ ] Open a DXF file in cad-simple-viewer-example and confirm it loads
- [ ] Open a DXF via the open-file dialog in cad-viewer
- [ ] Open a DWG to confirm LibreDWG converter registration is unchanged
- [ ] Spot-check README Known Limitations / 已知问题 sections for accurate XRef wording