### PR TITLE
feat(xattach): default insertion point to origin like AutoCAD

### DIFF
--- a/packages/cad-simple-viewer/src/command/draw/AcApXAttachCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApXAttachCmd.ts
@@ -269,19 +269,26 @@ export class AcApXAttachCmd extends AcEdCommand {
 
     try {
       jig.setMode('point')
+      // Match AutoCAD's XATTACH defaults: attaching at the origin keeps a
+      // source drawing that shares the host's coordinate system perfectly
+      // aligned, so Enter accepts <0,0> instead of forcing an on-screen pick.
       const insertionPrompt = new AcEdPromptPointOptions(
-        AcApI18n.t('jig.xattach.insertionPoint')
+        `${AcApI18n.t('jig.xattach.insertionPoint')} <0,0>`
       )
+      insertionPrompt.allowNone = true
       insertionPrompt.jig = jig
       const insertionResult =
         await AcApDocManager.instance.editor.getPoint(insertionPrompt)
       if (
-        insertionResult.status !== AcEdPromptStatus.OK ||
-        !insertionResult.value
+        insertionResult.status !== AcEdPromptStatus.OK &&
+        insertionResult.status !== AcEdPromptStatus.None
       ) {
         return
       }
-      const insertionPoint = new AcGePoint3d(insertionResult.value)
+      const insertionPoint =
+        insertionResult.status === AcEdPromptStatus.OK && insertionResult.value
+          ? new AcGePoint3d(insertionResult.value)
+          : new AcGePoint3d(0, 0, 0)
       jig.setPosition(insertionPoint)
 
       jig.setMode('scale')


### PR DESCRIPTION
First of two follow-ups for #457 ("coordinate alignment is somewhat complicated").

`AcApXAttachCmd` forced an on-screen pick for the insertion point, then asked for scale and rotation (which already default to `<1>` / `<0>`). AutoCAD's XATTACH defaults the insertion point to `0,0` too — and that default is exactly what makes attaching a drawing that shares the host's WCS a three-Enter operation with perfect alignment.

## Change
- Insertion prompt shows `<0,0>`, sets `allowNone`, and treats Enter (`PromptStatus.None`) as origin.
- Picking a point on screen still works exactly as before.

## Test plan
- [x] `tsc --noEmit` and `eslint` clean
- [x] Manual: XATTACH → Enter, Enter, Enter attaches the #457 fire-protection DWG aligned on its base drawing (same WCS)
- [x] Manual: picking a point still positions the overlay at the picked location