### PR TITLE
feat(prompt): render AutoCAD-style defaults via options API

### DIFF
--- a/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
+++ b/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
@@ -68,9 +68,8 @@ export class AcApExportHtmlCmd extends AcEdCommand {
 
   private async promptExportInvisibleLayers(): Promise<boolean | undefined> {
     const defaults = resolveAcApHtmlExportOptions()
-    const current = defaults.exportInvisibleLayers ? 'Yes' : 'No'
     const prompt = new AcEdPromptKeywordOptions(
-      `${AcApI18n.t('jig.chtml.exportInvisibleLayers')} <${current}>`
+      AcApI18n.t('jig.chtml.exportInvisibleLayers')
     )
     prompt.allowNone = true
     const yes = prompt.keywords.add(
@@ -108,12 +107,8 @@ export class AcApExportHtmlCmd extends AcEdCommand {
     AcApHtmlExportOptions['initialView'] | undefined
   > {
     const defaults = resolveAcApHtmlExportOptions()
-    const current =
-      defaults.initialView === 'current'
-        ? AcApI18n.t('jig.chtml.keywords.current.global')
-        : AcApI18n.t('jig.chtml.keywords.extents.global')
     const prompt = new AcEdPromptKeywordOptions(
-      `${AcApI18n.t('jig.chtml.initialView')} <${current}>`
+      AcApI18n.t('jig.chtml.initialView')
     )
     prompt.allowNone = true
     const extents = prompt.keywords.add(
@@ -152,12 +147,8 @@ export class AcApExportHtmlCmd extends AcEdCommand {
     AcApHtmlExportOptions['viewerMode'] | undefined
   > {
     const defaults = resolveAcApHtmlExportOptions()
-    const current =
-      defaults.viewerMode === 'view'
-        ? AcApI18n.t('jig.chtml.keywords.view.global')
-        : AcApI18n.t('jig.chtml.keywords.measure.global')
     const prompt = new AcEdPromptKeywordOptions(
-      `${AcApI18n.t('jig.chtml.viewerMode')} <${current}>`
+      AcApI18n.t('jig.chtml.viewerMode')
     )
     prompt.allowNone = true
     const view = prompt.keywords.add(

--- a/packages/cad-simple-viewer/__tests__/AcEdKeywordCollection.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdKeywordCollection.spec.ts
@@ -33,4 +33,13 @@ describe('AcEdKeywordCollection prompt format', () => {
     const format = options.getKeywordPromptFormat()
     expect(format.formattedTail).toBe('[Yes/No] <Yes>:')
   })
+
+  test('valueDefaultDisplayText is preferred after keywords when no keyword default', () => {
+    const options = new AcEdPromptKeywordOptions('Specify distance')
+    options.keywords.add('Through', 'Through', 'Through')
+    options.valueDefaultDisplayText = '10.5'
+
+    expect(options.getKeywordPromptFormat().defaultKeyword).toBeUndefined()
+    expect(options.valueDefaultDisplayText).toBe('10.5')
+  })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdPromptOptionsBehavior.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdPromptOptionsBehavior.spec.ts
@@ -220,3 +220,31 @@ describe('Prompt option classes behavior matrix', () => {
     })
   })
 })
+
+describe('Prompt default display message', () => {
+  test('appends numeric default when useDefaultValue is true', () => {
+    const opt = new AcEdPromptDoubleOptions('Specify scale:')
+    expect(opt.getDisplayMessage()).toBe('Specify scale:')
+    expect(opt.getDefaultValueDisplayText()).toBeUndefined()
+
+    opt.useDefaultValue = true
+    opt.defaultValue = 1
+    expect(opt.getDefaultValueDisplayText()).toBe('1')
+    expect(opt.getDisplayMessage()).toBe('Specify scale <1>')
+  })
+
+  test('appends string default when useDefaultValue is true', () => {
+    const opt = new AcEdPromptStringOptions('Enter name')
+    opt.useDefaultValue = true
+    opt.defaultValue = 'ANSI31'
+    expect(opt.getDisplayMessage()).toBe('Enter name <ANSI31>')
+  })
+
+  test('leaves raw message unchanged so CLI can place default after keywords', () => {
+    const opt = new AcEdPromptDistanceOptions('Specify distance')
+    opt.useDefaultValue = true
+    opt.defaultValue = 10.5
+    expect(opt.message).toBe('Specify distance')
+    expect(opt.getDefaultValueDisplayText()).toBe('10.5')
+  })
+})

--- a/packages/cad-simple-viewer/src/command/AcApSysVarCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApSysVarCmd.ts
@@ -31,9 +31,11 @@ export class AcApSysVarCmd extends AcEdCommand {
       context.doc.database
     )
     const basePrompt = AcApI18n.t('jig.sysvar.prompt').trim()
-    const suffix = currentValue == null ? '' : ` <${String(currentValue)}>`
-    const promptMessage = `${basePrompt}${suffix}`
-    const prompt = new AcEdPromptStringOptions(promptMessage)
+    const prompt = new AcEdPromptStringOptions(basePrompt)
+    if (currentValue != null) {
+      prompt.defaultValue = String(currentValue)
+      prompt.useDefaultValue = true
+    }
     const result = await AcApDocManager.instance.editor.getString(prompt)
     if (result.status !== AcEdPromptStatus.OK || !result.stringResult) return
     const value = result.stringResult

--- a/packages/cad-simple-viewer/src/command/convert/AcApConvertToPngCmd.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApConvertToPngCmd.ts
@@ -69,7 +69,7 @@ export class AcApConvertToPngCmd extends AcEdCommand {
 
     // Prompt for long side value (optional - press Enter for default 1024)
     const longSidePrompt = new AcEdPromptDoubleOptions(
-      `${AcApI18n.t('jig.pngout.longSidePrompt')} <${DEFAULT_LONG_SIDE_PX}>`
+      AcApI18n.t('jig.pngout.longSidePrompt')
     )
     longSidePrompt.allowNone = true
     longSidePrompt.allowNegative = false

--- a/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewCmd.ts
+++ b/packages/cad-simple-viewer/src/command/convert/AcApEntityPreviewCmd.ts
@@ -47,7 +47,7 @@ export class AcApEntityPreviewCmd extends AcEdCommand {
     }
 
     const longSidePrompt = new AcEdPromptDoubleOptions(
-      `${AcApI18n.t('jig.entout.longSidePrompt')} <${DEFAULT_LONG_SIDE_PX}>`
+      AcApI18n.t('jig.entout.longSidePrompt')
     )
     longSidePrompt.allowNone = true
     longSidePrompt.allowNegative = false

--- a/packages/cad-simple-viewer/src/command/draw/AcApHatchCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApHatchCmd.ts
@@ -670,25 +670,25 @@ export class AcApHatchCmd extends AcEdCommand {
   protected async promptStyle() {
     const settings = this.getActiveSettings()
     const current = this.styleToKeyword(settings.style)
-    const options = new AcEdPromptKeywordOptions(
-      `${AcApI18n.t('jig.hatch.style')} <${current}>`
-    )
+    const options = new AcEdPromptKeywordOptions(AcApI18n.t('jig.hatch.style'))
     options.allowNone = true
-    options.keywords.add(
+    const normal = options.keywords.add(
       AcApI18n.t('jig.hatch.keywords.normal.display'),
       AcApI18n.t('jig.hatch.keywords.normal.global'),
       AcApI18n.t('jig.hatch.keywords.normal.local')
     )
-    options.keywords.add(
+    const outer = options.keywords.add(
       AcApI18n.t('jig.hatch.keywords.outer.display'),
       AcApI18n.t('jig.hatch.keywords.outer.global'),
       AcApI18n.t('jig.hatch.keywords.outer.local')
     )
-    options.keywords.add(
+    const ignore = options.keywords.add(
       AcApI18n.t('jig.hatch.keywords.ignore.display'),
       AcApI18n.t('jig.hatch.keywords.ignore.global'),
       AcApI18n.t('jig.hatch.keywords.ignore.local')
     )
+    options.keywords.default =
+      current === 'Outer' ? outer : current === 'Ignore' ? ignore : normal
 
     const result = await AcApDocManager.instance.editor.getKeywords(options)
     if (
@@ -707,21 +707,21 @@ export class AcApHatchCmd extends AcEdCommand {
    */
   protected async promptAssociative() {
     const settings = this.getActiveSettings()
-    const current = settings.associative ? 'Yes' : 'No'
     const options = new AcEdPromptKeywordOptions(
-      `${AcApI18n.t('jig.hatch.associative')} <${current}>`
+      AcApI18n.t('jig.hatch.associative')
     )
     options.allowNone = true
-    options.keywords.add(
+    const yes = options.keywords.add(
       AcApI18n.t('jig.hatch.keywords.yes.display'),
       AcApI18n.t('jig.hatch.keywords.yes.global'),
       AcApI18n.t('jig.hatch.keywords.yes.local')
     )
-    options.keywords.add(
+    const no = options.keywords.add(
       AcApI18n.t('jig.hatch.keywords.no.display'),
       AcApI18n.t('jig.hatch.keywords.no.global'),
       AcApI18n.t('jig.hatch.keywords.no.local')
     )
+    options.keywords.default = settings.associative ? yes : no
     const result = await AcApDocManager.instance.editor.getKeywords(options)
     if (
       result.status === AcEdPromptStatus.OK ||

--- a/packages/cad-simple-viewer/src/command/draw/AcApImageAttachCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApImageAttachCmd.ts
@@ -230,7 +230,7 @@ export class AcApImageAttachCmd extends AcEdCommand {
 
       jig.setMode('scale')
       const scalePrompt = new AcEdPromptDoubleOptions(
-        `${AcApI18n.t('jig.imageattach.scale')} <1>`
+        AcApI18n.t('jig.imageattach.scale')
       )
       scalePrompt.allowNone = true
       scalePrompt.allowNegative = false
@@ -259,7 +259,7 @@ export class AcApImageAttachCmd extends AcEdCommand {
 
       jig.setMode('rotation')
       const rotationPrompt = new AcEdPromptAngleOptions(
-        `${AcApI18n.t('jig.imageattach.rotation')} <0>`
+        AcApI18n.t('jig.imageattach.rotation')
       )
       rotationPrompt.allowNone = true
       rotationPrompt.allowNegative = true

--- a/packages/cad-simple-viewer/src/command/draw/AcApInsertCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApInsertCmd.ts
@@ -217,7 +217,7 @@ export class AcApInsertCmd extends AcEdCommand {
     } else {
       jig.setMode('scale')
       const scalePrompt = new AcEdPromptDoubleOptions(
-        `${AcApI18n.t('jig.insert.scale')} <1>`
+        AcApI18n.t('jig.insert.scale')
       )
       scalePrompt.allowNone = true
       scalePrompt.allowNegative = false
@@ -256,7 +256,7 @@ export class AcApInsertCmd extends AcEdCommand {
     } else {
       jig.setMode('rotation')
       const rotationPrompt = new AcEdPromptAngleOptions(
-        `${AcApI18n.t('jig.insert.rotation')} <0>`
+        AcApI18n.t('jig.insert.rotation')
       )
       rotationPrompt.allowNone = true
       rotationPrompt.allowNegative = true

--- a/packages/cad-simple-viewer/src/command/draw/AcApPolygonCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApPolygonCmd.ts
@@ -319,16 +319,19 @@ export class AcApPolygonCmd extends AcEdCommand {
     while (true) {
       const defaultSides = AcApPolygonCmd._lastSides
       const sidesPrompt = new AcEdPromptStringOptions(
-        `${AcApI18n.t('jig.polygon.numberOfSides')} <${defaultSides}>`
+        AcApI18n.t('jig.polygon.numberOfSides')
       )
       sidesPrompt.allowEmpty = true
       sidesPrompt.allowSpaces = false
+      sidesPrompt.defaultValue = String(defaultSides)
+      sidesPrompt.useDefaultValue = true
       const sidesResult =
         await AcApDocManager.instance.editor.getString(sidesPrompt)
       if (sidesResult.status !== AcEdPromptStatus.OK) return undefined
 
       const rawInput = (sidesResult.stringResult ?? '').trim()
-      const rawValue = rawInput === '' ? defaultSides : Number(rawInput)
+      const rawValue =
+        rawInput === '' ? defaultSides : Number(rawInput)
       if (
         Number.isInteger(rawValue) &&
         rawValue >= MIN_SIDES &&

--- a/packages/cad-simple-viewer/src/command/draw/AcApXAttachCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApXAttachCmd.ts
@@ -273,9 +273,11 @@ export class AcApXAttachCmd extends AcEdCommand {
       // source drawing that shares the host's coordinate system perfectly
       // aligned, so Enter accepts <0,0> instead of forcing an on-screen pick.
       const insertionPrompt = new AcEdPromptPointOptions(
-        `${AcApI18n.t('jig.xattach.insertionPoint')} <0,0>`
+        AcApI18n.t('jig.xattach.insertionPoint')
       )
       insertionPrompt.allowNone = true
+      insertionPrompt.useDefaultValue = true
+      insertionPrompt.defaultValue = new AcGePoint3d(0, 0, 0)
       insertionPrompt.jig = jig
       const insertionResult =
         await AcApDocManager.instance.editor.getPoint(insertionPrompt)
@@ -293,7 +295,7 @@ export class AcApXAttachCmd extends AcEdCommand {
 
       jig.setMode('scale')
       const scalePrompt = new AcEdPromptDoubleOptions(
-        `${AcApI18n.t('jig.xattach.scale')} <1>`
+        AcApI18n.t('jig.xattach.scale')
       )
       scalePrompt.allowNone = true
       scalePrompt.allowNegative = false
@@ -322,7 +324,7 @@ export class AcApXAttachCmd extends AcEdCommand {
 
       jig.setMode('rotation')
       const rotationPrompt = new AcEdPromptAngleOptions(
-        `${AcApI18n.t('jig.xattach.rotation')} <0>`
+        AcApI18n.t('jig.xattach.rotation')
       )
       rotationPrompt.allowNone = true
       rotationPrompt.allowNegative = true

--- a/packages/cad-simple-viewer/src/command/modify/AcApCopyCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApCopyCmd.ts
@@ -162,11 +162,15 @@ export class AcApCopyCmd extends AcEdCommand {
    */
   private async promptCopyMode(currentMode: CopyMode) {
     const prompt = new AcEdPromptKeywordOptions(
-      `${AcApI18n.t('jig.copy.modePrompt')} <${currentMode}>`
+      AcApI18n.t('jig.copy.modePrompt')
     )
     prompt.allowNone = true
     this.addKeyword(prompt, 'single')
     this.addKeyword(prompt, 'multiple')
+    const defaultKeyword = prompt.keywords.findByGlobalName(currentMode)
+    if (defaultKeyword) {
+      prompt.keywords.default = defaultKeyword
+    }
 
     const result = await AcApDocManager.instance.editor.getKeywords(prompt)
     if (result.status === AcEdPromptStatus.None) {

--- a/packages/cad-simple-viewer/src/command/modify/AcApOffsetCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApOffsetCmd.ts
@@ -234,11 +234,9 @@ export class AcApOffsetCmd extends AcEdCommand {
        */
       buildPrompt() {
         const lastDistance = AcApOffsetCmd._lastDistance
-        const message =
-          lastDistance != null
-            ? `${AcApI18n.t('jig.offset.distance')} <${lastDistance}>`
-            : AcApI18n.t('jig.offset.distance')
-        const prompt = new AcEdPromptDistanceOptions(message)
+        const prompt = new AcEdPromptDistanceOptions(
+          AcApI18n.t('jig.offset.distance')
+        )
         prompt.useBasePoint = false
         prompt.useDashedLine = true
         prompt.allowZero = false

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptAngleOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptAngleOptions.ts
@@ -127,6 +127,11 @@ export class AcEdPromptAngleOptions extends AcEdPromptOptions<number> {
     }
   }
 
+  override getDefaultValueDisplayText(): string | undefined {
+    if (!this._useDefaultValue) return undefined
+    return String(this._defaultValue)
+  }
+
   /**
    * Gets or sets whether zero-valued angles are accepted.
    * Corresponds to `PromptAngleOptions.AllowZero`.

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptKeywordOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptKeywordOptions.ts
@@ -7,6 +7,7 @@ import { AcEdPromptOptions } from './AcEdPromptOptions'
 export class AcEdPromptKeywordOptions extends AcEdPromptOptions<string> {
   private _allowNone: boolean = false
   private _allowArbitraryInput: boolean = false
+  private _valueDefaultDisplayText?: string
 
   /**
    * Constructs a new `AcEdPromptKeywordOptions` with a given prompt message.
@@ -14,6 +15,22 @@ export class AcEdPromptKeywordOptions extends AcEdPromptOptions<string> {
    */
   constructor(message: string, globalKeywords?: string) {
     super(message, globalKeywords)
+  }
+
+  /**
+   * Optional numeric/string/point default display text transferred from mixed
+   * prompts (e.g. distance with keywords) so the command line can render
+   * AutoCAD-style `Message [K1/K2] <value>:` tails.
+   *
+   * Keyword defaults via {@link keywords}.default take precedence when both are set.
+   */
+  get valueDefaultDisplayText(): string | undefined {
+    return this._valueDefaultDisplayText
+  }
+  set valueDefaultDisplayText(text: string | undefined) {
+    if (!this.isReadOnly) {
+      this._valueDefaultDisplayText = text
+    }
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptNumericalOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptNumericalOptions.ts
@@ -49,6 +49,11 @@ export class AcEdPromptNumericalOptions extends AcEdPromptOptions<number> {
     }
   }
 
+  override getDefaultValueDisplayText(): string | undefined {
+    if (!this._useDefaultValue) return undefined
+    return String(this._defaultValue)
+  }
+
   /**
    * Gets or sets whether pressing ENTER alone (no input) is accepted.
    * Corresponds to `PromptNumericalOptions.AllowNone` in AutoCAD .NET API.

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptOptions.ts
@@ -50,6 +50,9 @@ export class AcEdPromptOptions<T = number | string | AcGePoint3d> {
   /**
    * Gets or sets the message displayed in the prompt.
    * Corresponds to `PromptOptions.Message` in AutoCAD .NET API.
+   *
+   * This is the raw message without the AutoCAD-style `<default>` suffix.
+   * Use {@link getDisplayMessage} when rendering UI text.
    */
   get message(): string {
     return this._message
@@ -59,6 +62,34 @@ export class AcEdPromptOptions<T = number | string | AcGePoint3d> {
     if (!this._isReadOnly) {
       this._message = msg
     }
+  }
+
+  /**
+   * Returns the text shown inside AutoCAD-style angle brackets for the prompt
+   * default value, e.g. `10.5` in `Specify distance <10.5>:`.
+   *
+   * Subclasses that expose `UseDefaultValue` / `DefaultValue` override this.
+   * Keyword defaults are handled separately via {@link keywords}.default.
+   */
+  getDefaultValueDisplayText(): string | undefined {
+    return undefined
+  }
+
+  /**
+   * Returns the prompt message with an AutoCAD-style `<default>` suffix when a
+   * numeric/string/point default is active.
+   *
+   * Keyword lists and keyword defaults are still rendered by the command line
+   * (`[K1/K2] <Default>:`). Prefer this helper for floating prompts and other
+   * surfaces that show the message without the keyword tail.
+   */
+  getDisplayMessage(): string {
+    const defaultText = this.getDefaultValueDisplayText()
+    if (defaultText == null) {
+      return this._message
+    }
+    const core = this._message.trim().replace(/[：:]\s*$/, '')
+    return `${core} <${defaultText}>`
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptPointOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptPointOptions.ts
@@ -14,6 +14,8 @@ export class AcEdPromptPointOptions extends AcEdPromptOptions<AcGePoint3d> {
   private _useDashedLine: boolean = false
   private _allowNone: boolean = false
   private _disableOSnap: boolean = false
+  private _defaultValue?: AcGePoint3d
+  private _useDefaultValue: boolean = false
 
   /**
    * Constructs a new `AcEdPromptPointOptions` with a given prompt message.
@@ -21,6 +23,47 @@ export class AcEdPromptPointOptions extends AcEdPromptOptions<AcGePoint3d> {
    */
   constructor(message: string, globalKeywords?: string) {
     super(message, globalKeywords)
+  }
+
+  /**
+   * Gets or sets the default point used when the user presses ENTER without
+   * picking or typing a point, if {@link useDefaultValue} is true.
+   *
+   * AutoCAD .NET `PromptPointOptions` does not expose this property; it is
+   * provided here so commands can show and accept defaults such as `<0,0>`.
+   */
+  get defaultValue(): AcGePoint3d | undefined {
+    return this._defaultValue
+  }
+  set defaultValue(point: AcGePoint3d | undefined) {
+    if (!this.isReadOnly) {
+      if (point == null) {
+        this._defaultValue = point
+      } else {
+        this._defaultValue = this._defaultValue
+          ? this._defaultValue.copy(point)
+          : new AcGePoint3d(point)
+      }
+    }
+  }
+
+  /**
+   * Gets or sets whether {@link defaultValue} should be used when the user
+   * presses ENTER without providing other input.
+   */
+  get useDefaultValue(): boolean {
+    return this._useDefaultValue
+  }
+  set useDefaultValue(flag: boolean) {
+    if (!this.isReadOnly) {
+      this._useDefaultValue = flag
+    }
+  }
+
+  override getDefaultValueDisplayText(): string | undefined {
+    if (!this._useDefaultValue || !this._defaultValue) return undefined
+    const { x, y, z } = this._defaultValue
+    return z === 0 ? `${x},${y}` : `${x},${y},${z}`
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptStringOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptStringOptions.ts
@@ -89,4 +89,9 @@ export class AcEdPromptStringOptions extends AcEdPromptOptions<string> {
       this._useDefaultValue = flag
     }
   }
+
+  override getDefaultValueDisplayText(): string | undefined {
+    if (!this._useDefaultValue) return undefined
+    return this._defaultValue
+  }
 }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
@@ -850,10 +850,12 @@ export class AcEdCommandLine {
       })
 
       this.promptEl.append(']')
+    }
 
-      if (promptFormat.defaultKeyword) {
-        this.promptEl.append(` <${promptFormat.defaultKeyword}>`)
-      }
+    const defaultText =
+      promptFormat.defaultKeyword ?? options.valueDefaultDisplayText
+    if (defaultText) {
+      this.promptEl.append(` <${defaultText}>`)
     }
 
     this.promptEl.append(': ')

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -360,6 +360,8 @@ export class AcEdInputManager {
   ): AcEdPromptKeywordOptions {
     const keywordOptions = new AcEdPromptKeywordOptions(options.message)
     keywordOptions.appendKeywordsToMessage = options.appendKeywordsToMessage
+    keywordOptions.valueDefaultDisplayText =
+      options.getDefaultValueDisplayText()
 
     const keywords = options.keywords?.toArray() ?? []
     keywords.forEach(kw => {
@@ -1902,7 +1904,7 @@ export class AcEdInputManager {
     const baseAngle = hasBaseAngle ? (options.baseAngle as number) : undefined
 
     return {
-      message: options.message,
+      message: options.getDisplayMessage(),
       jig: options.jig,
       basePoint,
       useBasePoint,


### PR DESCRIPTION
## Summary
- Centralize AutoCAD-style ` <default> ` prompt rendering through `getDisplayMessage()` / `getDefaultValueDisplayText()` and keyword `valueDefaultDisplayText`, instead of baking suffixes into message strings.
- Migrate command call sites (hatch, insert/xattach/imageattach, offset, copy, sysvar, html export, etc.) to set `useDefaultValue` / `keywords.default` properly.
- Add point `defaultValue` support on `AcEdPromptPointOptions` (e.g. XATTACH `<0,0>`) and cover display behavior with unit tests.

## Test plan
- [ ] Run `pnpm test -- packages/cad-simple-viewer/__tests__/AcEdPromptOptionsBehavior.spec.ts packages/cad-simple-viewer/__tests__/AcEdKeywordCollection.spec.ts`
- [ ] Verify CLI/floating prompts show `Message [K1/K2] <default>:` for keyword prompts (HATCH style/associative, COPY mode, CHTML export)
- [ ] Verify numeric/string defaults render and Enter accepts them (OFFSET last distance, INSERT/XATTACH scale/rotation, POLYGON sides, SYSVAR)
- [ ] Verify XATTACH Enter on insertion point accepts `0,0` without picking
- [ ] Verify mixed keyword+value prompts (OFFSET Through) place the value default after the keyword list