### PR TITLE
docs: align proprietary DWG converter with @mlight-cad scope

### DIFF
--- a/PROPRIETARY-PARSER.md
+++ b/PROPRIETARY-PARSER.md
@@ -128,12 +128,13 @@ Typical integration (conceptual):
 
 ```typescript
 import { AcDbDatabaseConverterManager, AcDbFileType } from '@mlightcad/data-model'
-// Import the proprietary converter from the licensed package
-import { AcDbProprietaryConverter } from '@mlightcad/proprietary-converter' // package name provided on purchase
+import { AcDbDwgConverter } from '@mlight-cad/dwg-converter'
 
-const converter = new AcDbProprietaryConverter({ /* options */ })
+const converter = new AcDbDwgConverter({ /* options */ })
 AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, converter)
 ```
+
+For a complete working sample (authentication, worker assets, registration, and database browsing), see [realdwg-web-example](https://github.com/mlightcad/realdwg-web-example).
 
 Do **not** register the GPL-based `libredwg-converter` if you rely on the proprietary parser for compliance.
 
@@ -196,6 +197,25 @@ Email [mlight.lee@outlook.com](mailto:mlight.lee@outlook.com) with a brief descr
 ### How do we apply for a trial license?
 
 See the [Trial License](#trial-license) section above. Send an application email with your company details, intended use, and a **GitHub username**. If approved, you will be invited to the **mlight-cad** GitHub organization to access **`@mlight-cad/dwg-converter`**.
+
+### Does the proprietary parser support 3D entities in DWG?
+
+**Partially.** The parser can extract **3DSOLID** entities from DWG files and decode a portion of the embedded **ACIS SAB** payload. Full B-rep tessellation is not yet available; when SAB/SAT data is present, the data model exposes a best-effort wireframe (or a bounding-box fallback).
+
+For details, see:
+
+- [`AcDb3dSolid` API documentation](https://mlightcad.github.io/realdwg-web/classes/_mlightcad_data-model.AcDb3dSolid.html)
+- ACIS-related source under [`packages/data-model/src/acis`](https://github.com/mlightcad/realdwg-web/tree/main/packages/data-model/src/acis) in the [realdwg-web](https://github.com/mlightcad/realdwg-web) repository
+
+### Can we evaluate the proprietary parser without a trial license?
+
+**Yes.** You can explore the proprietary DWG parser’s capabilities through the public demo project [realdwg-web-example](https://github.com/mlightcad/realdwg-web-example), which demonstrates installation, worker asset deployment, converter registration, and browsing the resulting database after parse.
+
+For longer evaluation or production pilots, apply for a formal [trial license](#trial-license).
+
+### How do we use the proprietary DWG parser?
+
+The proprietary parser does **not** expose a standalone “parse DWG” API. Like the open-source [`libredwg-converter`](https://github.com/mlightcad/realdwg-web/tree/main/packages/libredwg-converter), it implements the **`AcDbDatabaseConverter`** interface and registers with **`AcDbDatabaseConverterManager`**. After conversion, you work with the resulting drawing through the MIT-licensed **`@mlightcad/data-model`** (`AcDbDatabase`, entities, symbol tables, and so on)—the same integration path described in [Integration with the Existing Data Model](#integration-with-the-existing-data-model).
 
 ---
 

--- a/PROPRIETARY-PARSER.zh-CN.md
+++ b/PROPRIETARY-PARSER.zh-CN.md
@@ -128,12 +128,13 @@
 
 ```typescript
 import { AcDbDatabaseConverterManager, AcDbFileType } from '@mlightcad/data-model'
-// 从授权包中导入专有 converter（购买后提供具体包名）
-import { AcDbProprietaryConverter } from '@mlightcad/proprietary-converter'
+import { AcDbDwgConverter } from '@mlight-cad/dwg-converter'
 
-const converter = new AcDbProprietaryConverter({ /* options */ })
+const converter = new AcDbDwgConverter({ /* options */ })
 AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, converter)
 ```
+
+完整可运行示例（认证、Worker 资源、注册与数据库浏览）见 [realdwg-web-example](https://github.com/mlightcad/realdwg-web-example)。
 
 若使用专有解析器以满足合规要求，请**不要**再注册基于 GPL 的 `libredwg-converter`。
 
@@ -196,6 +197,25 @@ cad-viewer 目前为**个人开源项目**（非公司运营），作者**全职
 ### 如何申请试用授权？
 
 请参阅上文 [试用授权（Trial License）](#试用授权trial-license) 一节。发送申请邮件时需提供公司信息、预期用途及 **GitHub 用户名**。审批通过后，您将被邀请加入 **mlight-cad** GitHub 组织，以访问 **`@mlight-cad/dwg-converter`** 包。
+
+### 是否支持 DWG 中的三维实体（3D Entity）？
+
+**部分支持。** 专有解析器可从 DWG 中提取 **3DSOLID** 实体，并部分解码其中的 **ACIS SAB** 数据。完整 B-rep 细分（tessellation）尚不支持；在存在 SAB/SAT 数据时，数据模型会尽量生成线框预览，否则回退为基于包围盒的线框。
+
+详情请参阅：
+
+- [`AcDb3dSolid` API 文档](https://mlightcad.github.io/realdwg-web/classes/_mlightcad_data-model.AcDb3dSolid.html)
+- [realdwg-web](https://github.com/mlightcad/realdwg-web) 仓库中的 ACIS 相关实现：[`packages/data-model/src/acis`](https://github.com/mlightcad/realdwg-web/tree/main/packages/data-model/src/acis)
+
+### 在未获得试用授权的情况下，能否体验专有 DWG 解析器？
+
+**可以。** 公开示例项目 [realdwg-web-example](https://github.com/mlightcad/realdwg-web-example) 展示了专有 DWG 解析器的能力，包括安装认证、Worker 资源部署、converter 注册，以及解析后浏览数据库内容。
+
+如需更长时间评估或生产试点，请申请正式 [试用授权](#试用授权trial-license)。
+
+### 如何使用专有 DWG 解析器？
+
+专有解析器**不提供独立的“直接解析 DWG”API**。其接入方式与开源的 [`libredwg-converter`](https://github.com/mlightcad/realdwg-web/tree/main/packages/libredwg-converter) 相同：实现 **`AcDbDatabaseConverter`** 接口，并通过 **`AcDbDatabaseConverterManager`** 注册。解析完成后，您通过 MIT 授权的 **`@mlightcad/data-model`**（`AcDbDatabase`、各类实体、符号表等）访问 DWG 内容——与上文 [与现有数据模型的集成](#与现有数据模型的集成) 描述的路径一致。
 
 ---
 

--- a/packages/cad-simple-viewer/src/app/AcApWorkerAssets.ts
+++ b/packages/cad-simple-viewer/src/app/AcApWorkerAssets.ts
@@ -12,7 +12,7 @@ export const LIBREDWG_PARSER_WORKER_FILE = 'libredwg-parser-worker.js'
 export const MTEXT_RENDERER_WORKER_FILE = 'mtext-renderer-worker.js'
 
 /**
- * Proprietary DWG parser worker from private package `@mlightcad/dwg-converter`.
+ * Proprietary DWG parser worker from private package `@mlight-cad/dwg-converter`.
  * Not registered by default; used when the host app opts into that converter.
  */
 export const DWG_PARSER_WORKER_FILE = 'dwg-parser-worker.js'
@@ -24,4 +24,4 @@ export const LIBREDWG_CONVERTER_PACKAGE = '@mlightcad/libredwg-converter'
 export const MTEXT_RENDERER_PACKAGE = '@mlightcad/mtext-renderer'
 
 /** Private npm package that ships {@link DWG_PARSER_WORKER_FILE}. */
-export const DWG_CONVERTER_PACKAGE = '@mlightcad/dwg-converter'
+export const DWG_CONVERTER_PACKAGE = '@mlight-cad/dwg-converter'

--- a/tools/use-dwg-converter.mjs
+++ b/tools/use-dwg-converter.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Switch cad-simple-viewer from @mlightcad/libredwg-converter (GPL)
- * to the proprietary @mlightcad/dwg-converter (local realdwg-web path).
+ * to the proprietary @mlight-cad/dwg-converter (local realdwg-web path).
  * Also repoints the @mlightcad/data-model pnpm override to the local
  * realdwg-web checkout.
  *
@@ -48,16 +48,16 @@ const targets = [
     label: 'package.json',
     transform(content) {
       if (
-        content.includes('"@mlightcad/dwg-converter"') &&
+        content.includes('"@mlight-cad/dwg-converter"') &&
         !content.includes('"@mlightcad/libredwg-converter"')
       ) {
-        console.log('  already using @mlightcad/dwg-converter')
+        console.log('  already using @mlight-cad/dwg-converter')
         return null
       }
 
       const next = content.replace(
         /"@mlightcad\/libredwg-converter"\s*:\s*"[^"]*"/,
-        `"@mlightcad/dwg-converter": "${DWG_CONVERTER_VERSION}"`
+        `"@mlight-cad/dwg-converter": "${DWG_CONVERTER_VERSION}"`
       )
 
       if (next === content) {
@@ -113,12 +113,12 @@ const targets = [
       let next = content
       next = next.replaceAll(
         "from '@mlightcad/libredwg-converter'",
-        "from '@mlightcad/dwg-converter'"
+        "from '@mlight-cad/dwg-converter'"
       )
       next = next.replaceAll('AcDbLibreDwgConverter', 'AcDbDwgConverter')
       next = next.replaceAll(
         '`@mlightcad/libredwg-converter`',
-        '`@mlightcad/dwg-converter`'
+        '`@mlight-cad/dwg-converter`'
       )
 
       if (next === content) {
@@ -175,7 +175,7 @@ const targets = [
 ]
 
 function main() {
-  console.log('Switching cad-simple-viewer to @mlightcad/dwg-converter…')
+  console.log('Switching cad-simple-viewer to @mlight-cad/dwg-converter…')
 
   let changed = 0
   for (const target of targets) {

--- a/tools/worker-assets.mjs
+++ b/tools/worker-assets.mjs
@@ -13,7 +13,7 @@ export const LIBREDWG_PARSER_WORKER_FILE = 'libredwg-parser-worker.js'
 export const MTEXT_RENDERER_WORKER_FILE = 'mtext-renderer-worker.js'
 
 /**
- * Proprietary DWG parser worker from private package `@mlightcad/dwg-converter`.
+ * Proprietary DWG parser worker from private package `@mlight-cad/dwg-converter`.
  * Optional — copied only when that package is resolvable (e.g. via local
  * pnpm-workspace override).
  */
@@ -21,4 +21,4 @@ export const DWG_PARSER_WORKER_FILE = 'dwg-parser-worker.js'
 
 export const LIBREDWG_CONVERTER_PACKAGE = '@mlightcad/libredwg-converter'
 export const MTEXT_RENDERER_PACKAGE = '@mlightcad/mtext-renderer'
-export const DWG_CONVERTER_PACKAGE = '@mlightcad/dwg-converter'
+export const DWG_CONVERTER_PACKAGE = '@mlight-cad/dwg-converter'


### PR DESCRIPTION
## Summary
- Rename proprietary package references from `@mlightcad/dwg-converter` to the published `@mlight-cad/dwg-converter` scope in docs, worker asset constants, and `use-dwg-converter` tooling.
- Update integration samples to use `AcDbDwgConverter` and link the public `realdwg-web-example` demo.
- Add FAQs covering partial 3D/ACIS support, evaluation without a trial license, and the converter registration integration path.

## Test plan
- [ ] Confirm package name `@mlight-cad/dwg-converter` matches GitHub Packages / org access docs.
- [ ] Skim EN and ZH proprietary parser docs for consistent API names and FAQ answers.
- [ ] Spot-check that `tools/use-dwg-converter.mjs` still swaps libredwg → proprietary converter correctly after the rename.