### PR TITLE
fix: stop hollow-line bbox picks and keep hatch islands selectable

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcTrHierarchicalSpatialIndex.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrHierarchicalSpatialIndex.spec.ts
@@ -53,8 +53,8 @@ jest.mock('rbush', () => {
   }
 })
 
-import { AcTrHierarchicalSpatialIndex } from '../src/spatialIndex/AcTrHierarchicalSpatialIndex'
 import { isEffectiveSpatialQueryHit } from '../src/editor/view/AcEdSpatialQueryResult'
+import { AcTrHierarchicalSpatialIndex } from '../src/spatialIndex/AcTrHierarchicalSpatialIndex'
 
 describe('AcTrHierarchicalSpatialIndex', () => {
   test('does not pollute child index with root item when objectId is reused', () => {
@@ -294,6 +294,53 @@ describe('AcTrHierarchicalSpatialIndex', () => {
     )
     expect(windowAllInside).toHaveLength(1)
     expect(windowAllInside[0].id).toBe(insertId)
+  })
+
+  test('keeps every multi-region hatch island pickable when child boxes share empty ids', () => {
+    const spatialIndex = new AcTrHierarchicalSpatialIndex()
+    const hatchId = 'HATCH-82F'
+
+    // Multi-region hatches store one child AABB per filled island. Fill
+    // polygons usually have no objectId; child indexes must keep every empty-id
+    // box (and leave id empty for osnap gsMark) instead of collapsing to one.
+    spatialIndex.ensureChildIndex(hatchId, [
+      { minX: 0, minY: 40, maxX: 100, maxY: 50, id: '' },
+      { minX: 0, minY: 0, maxX: 100, maxY: 20, id: '' }
+    ])
+
+    const upper = spatialIndex.search({
+      minX: 40,
+      minY: 42,
+      maxX: 45,
+      maxY: 48
+    })
+    expect(upper).toHaveLength(1)
+    expect(upper[0].id).toBe(hatchId)
+    expect(upper[0].children).toHaveLength(1)
+    expect(upper[0].children?.[0]?.id).toBe('')
+    expect(isEffectiveSpatialQueryHit(upper[0])).toBe(true)
+
+    const lower = spatialIndex.search({
+      minX: 40,
+      minY: 5,
+      maxX: 45,
+      maxY: 15
+    })
+    expect(lower).toHaveLength(1)
+    expect(lower[0].id).toBe(hatchId)
+    expect(lower[0].children).toHaveLength(1)
+    expect(lower[0].children?.[0]?.id).toBe('')
+    expect(isEffectiveSpatialQueryHit(lower[0])).toBe(true)
+
+    const gap = spatialIndex.search({
+      minX: 40,
+      minY: 25,
+      maxX: 45,
+      maxY: 35
+    })
+    expect(gap).toHaveLength(1)
+    expect(gap[0].children).toEqual([])
+    expect(isEffectiveSpatialQueryHit(gap[0])).toBe(false)
   })
 
   test('getStats aggregates root and child item counts with estimated bytes', () => {

--- a/packages/cad-simple-viewer/src/editor/view/AcEdSpatialQueryResult.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdSpatialQueryResult.ts
@@ -76,3 +76,30 @@ export function isEffectiveSpatialQueryHit(
 ): boolean {
   return !(item.children !== undefined && item.children.length === 0)
 }
+
+/**
+ * Assigns distinct ids to spatial-query items that share a non-empty id before
+ * they are stored in Map-backed child indexes
+ * ({@link AcTrLinearSpatialIndex}, {@link AcTrRBushSpatialIndex}).
+ *
+ * Empty ids are left unchanged: those indexes store anonymous children under
+ * internal keys so multi-region hatch islands (fill polygons with no
+ * `objectId`) stay pickable without fabricating gsMark values for osnap.
+ */
+export function uniquifySpatialItemIds(
+  items: ReadonlyArray<AcEdSpatialQueryResultItem>
+): AcEdSpatialQueryResultItem[] {
+  const seen = new Map<string, number>()
+  return items.map(item => {
+    const raw = item.id
+    if (typeof raw !== 'string' || raw.length === 0) {
+      return item
+    }
+    const count = seen.get(raw) ?? 0
+    seen.set(raw, count + 1)
+    if (count === 0) {
+      return item
+    }
+    return { ...item, id: `${raw}#${count}` }
+  })
+}

--- a/packages/cad-simple-viewer/src/spatialIndex/AcTrHierarchicalSpatialIndex.ts
+++ b/packages/cad-simple-viewer/src/spatialIndex/AcTrHierarchicalSpatialIndex.ts
@@ -4,7 +4,8 @@ import { AcTrGroup } from '@mlightcad/three-renderer'
 import {
   AcEdSpatialQueryResultItem,
   AcEdSpatialQueryResultItemEx,
-  unionSpatialQueryItems
+  unionSpatialQueryItems,
+  uniquifySpatialItemIds
 } from '../editor/view/AcEdSpatialQueryResult'
 import { isFiniteSpatialBBox } from '../view/AcTrGroupWcsBboxAssert'
 import { AcTrLinearSpatialIndex } from './AcTrLinearSpatialIndex'
@@ -336,7 +337,9 @@ export class AcTrHierarchicalSpatialIndex implements AcTrSpatialIndex {
     id: AcDbObjectId,
     items: readonly AcEdSpatialQueryResultItem[]
   ) {
-    const finiteItems = items.filter(isFiniteSpatialBBox)
+    const finiteItems = uniquifySpatialItemIds(
+      items.filter(isFiniteSpatialBBox)
+    )
     if (finiteItems.length === 0) {
       return undefined
     }

--- a/packages/cad-simple-viewer/src/spatialIndex/AcTrLinearSpatialIndex.ts
+++ b/packages/cad-simple-viewer/src/spatialIndex/AcTrLinearSpatialIndex.ts
@@ -35,25 +35,58 @@ const MAP_ENTRY_BYTES = 40
  * not scale well for large numbers of items.
  */
 export class AcTrLinearSpatialIndex implements AcTrSpatialIndex {
-  /** Items indexed by object id */
-  private items = new Map<AcDbObjectId, AcEdSpatialQueryResultItem>()
+  /**
+   * Items keyed by object id, or by an internal anon key when `item.id` is
+   * empty so multiple hatch fill islands can coexist.
+   */
+  private items = new Map<string, AcEdSpatialQueryResultItem>()
+  private anonKeySeq = 0
+
+  private storageKey(item: AcEdSpatialQueryResultItem): string {
+    if (typeof item.id === 'string' && item.id.length > 0) {
+      return item.id
+    }
+    return `__anon_${this.anonKeySeq++}`
+  }
 
   insert(item: AcEdSpatialQueryResultItem): void {
-    this.items.set(item.id, item)
+    if (typeof item.id === 'string' && item.id.length > 0) {
+      this.items.set(item.id, item)
+      return
+    }
+    this.items.set(this.storageKey(item), item)
   }
 
   load(items: readonly AcEdSpatialQueryResultItem[]): void {
     for (const item of items) {
-      this.items.set(item.id, item)
+      this.insert(item)
     }
   }
 
   remove(item: AcEdSpatialQueryResultItem): void {
-    this.items.delete(item.id)
+    if (typeof item.id === 'string' && item.id.length > 0) {
+      this.items.delete(item.id)
+      return
+    }
+    for (const [key, value] of this.items) {
+      if (
+        value === item ||
+        (value.id === item.id &&
+          value.minX === item.minX &&
+          value.minY === item.minY &&
+          value.maxX === item.maxX &&
+          value.maxY === item.maxY)
+      ) {
+        this.items.delete(key)
+        return
+      }
+    }
   }
 
   removeById(id: AcDbObjectId): void {
-    this.items.delete(id)
+    if (typeof id === 'string' && id.length > 0) {
+      this.items.delete(id)
+    }
   }
 
   clear(): void {

--- a/packages/cad-simple-viewer/src/spatialIndex/AcTrRBushSpatialIndex.ts
+++ b/packages/cad-simple-viewer/src/spatialIndex/AcTrRBushSpatialIndex.ts
@@ -26,25 +26,37 @@ export class AcTrRBushSpatialIndex implements AcTrSpatialIndex {
   }
 
   insert(item: AcEdSpatialQueryResultItem) {
-    const existing = this.idMap.get(item.id)
-    if (existing) {
-      if (
-        existing.minX === item.minX &&
-        existing.minY === item.minY &&
-        existing.maxX === item.maxX &&
-        existing.maxY === item.maxY
-      ) {
-        return
+    const hasId = typeof item.id === 'string' && item.id.length > 0
+    // Empty ids (hatch fill islands) must not share one Map slot — otherwise
+    // later inserts overwrite earlier islands and only the last stays pickable.
+    if (hasId) {
+      const existing = this.idMap.get(item.id)
+      if (existing) {
+        if (
+          existing.minX === item.minX &&
+          existing.minY === item.minY &&
+          existing.maxX === item.maxX &&
+          existing.maxY === item.maxY
+        ) {
+          return
+        }
+        this.remove(existing, (a, b) => a.id === b.id)
+        this.idMap.delete(item.id)
       }
-      this.remove(existing, (a, b) => a.id === b.id)
-      this.idMap.delete(item.id)
     }
     this.tree.insert(item)
-    this.idMap.set(item.id, item)
+    if (hasId) {
+      this.idMap.set(item.id, item)
+    }
   }
 
   load(items: readonly AcEdSpatialQueryResultItem[]) {
     this.tree.load(items)
+    for (const item of items) {
+      if (typeof item.id === 'string' && item.id.length > 0) {
+        this.idMap.set(item.id, item)
+      }
+    }
   }
 
   remove(
@@ -54,11 +66,26 @@ export class AcTrRBushSpatialIndex implements AcTrSpatialIndex {
       b: AcEdSpatialQueryResultItem
     ) => boolean
   ): void {
-    this.tree.remove(item, equals)
-    this.idMap.delete(item.id)
+    this.tree.remove(
+      item,
+      equals ??
+        ((a, b) =>
+          a === b ||
+          (a.id === b.id &&
+            a.minX === b.minX &&
+            a.minY === b.minY &&
+            a.maxX === b.maxX &&
+            a.maxY === b.maxY))
+    )
+    if (typeof item.id === 'string' && item.id.length > 0) {
+      this.idMap.delete(item.id)
+    }
   }
 
   removeById(id: AcDbObjectId): void {
+    if (!(typeof id === 'string' && id.length > 0)) {
+      return
+    }
     // Set minX, minY, maxX, and maxY to 0 in order to pass build
     this.tree.remove(
       {

--- a/packages/three-renderer/__tests__/AcTrBatchedLinePick.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedLinePick.spec.ts
@@ -1,0 +1,96 @@
+import * as THREE from 'three'
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
+import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
+import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
+
+import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
+import { AcTrEntity } from '../src/object/AcTrEntity'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+
+function createEntity(
+  objectId: string,
+  ...drawables: THREE.Object3D[]
+): AcTrEntity {
+  const entity = new AcTrEntity(new AcTrRenderContext())
+  entity.objectId = objectId
+  entity.visible = true
+  for (const drawable of drawables) {
+    entity.add(drawable)
+  }
+  return entity
+}
+
+/** Closed axis-aligned rectangle as discrete line segments (hollow frame). */
+function createRectangleLineSegments(): THREE.LineSegments {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(
+      [
+        // bottom
+        0, 0, 0, 100, 0, 0,
+        // right
+        100, 0, 0, 100, 80, 0,
+        // top
+        100, 80, 0, 0, 80, 0,
+        // left
+        0, 80, 0, 0, 0, 0
+      ],
+      3
+    )
+  )
+  return new THREE.LineSegments(geometry, new THREE.LineBasicMaterial())
+}
+
+function createRectangleLineSegments2(): LineSegments2 {
+  const geometry = new LineSegmentsGeometry()
+  geometry.setPositions([
+    0, 0, 0, 100, 0, 0, 100, 0, 0, 100, 80, 0, 100, 80, 0, 0, 80, 0, 0, 80, 0, 0,
+    0, 0
+  ])
+  const material = new LineMaterial({
+    color: 0xffffff,
+    linewidth: 1,
+    resolution: new THREE.Vector2(800, 600)
+  })
+  return new LineSegments2(geometry, material)
+}
+
+function createOrthoRaycaster(
+  x: number,
+  y: number,
+  threshold = 2
+): THREE.Raycaster {
+  const raycaster = new THREE.Raycaster()
+  const camera = new THREE.OrthographicCamera(-200, 200, 200, -200, 0.1, 1000)
+  camera.position.set(x, y, 100)
+  camera.lookAt(x, y, 0)
+  camera.updateMatrixWorld(true)
+  raycaster.setFromCamera(new THREE.Vector2(0, 0), camera)
+  raycaster.params.Line.threshold = threshold
+  return raycaster
+}
+
+describe('AcTrBatchedLine / AcTrBatchedLine2 pick', () => {
+  it('does not select a hollow LineSegments rectangle via its bounding-box interior', () => {
+    const group = new AcTrBatchedGroup()
+    group.addEntity(createEntity('rect-1', createRectangleLineSegments()))
+
+    const interior = createOrthoRaycaster(50, 40)
+    expect(group.isIntersectWith('rect-1', interior)).toBe(false)
+
+    const onEdge = createOrthoRaycaster(50, 0)
+    expect(group.isIntersectWith('rect-1', onEdge)).toBe(true)
+  })
+
+  it('does not select a hollow LineSegments2 rectangle via its bounding-box interior', () => {
+    const group = new AcTrBatchedGroup()
+    group.addEntity(createEntity('rect-2', createRectangleLineSegments2()))
+
+    const interior = createOrthoRaycaster(50, 40)
+    expect(group.isIntersectWith('rect-2', interior)).toBe(false)
+
+    const onEdge = createOrthoRaycaster(50, 0)
+    expect(group.isIntersectWith('rect-2', onEdge)).toBe(true)
+  })
+})

--- a/packages/three-renderer/src/batch/AcTrBatchedLine.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine.ts
@@ -7,8 +7,7 @@ import {
   AcTrBatchedGeometryInfo,
   AcTrBatchGeometryUserData,
   copyArrayContents,
-  isBatchGeometryActive,
-  isBatchGeometryVisible
+  isBatchGeometryActive
 } from './AcTrBatchedGeometryInfo'
 import {
   applyGeometryAt,
@@ -27,8 +26,6 @@ import { syncBatchDrawVisibilityAfterOptimize } from './drawVisibility'
 const _box = /*@__PURE__*/ new THREE.Box3()
 /** Reusable scratch vector for bounds expansion. */
 const _vector = /*@__PURE__*/ new THREE.Vector3()
-/** Reusable scratch vector for bbox fallback raycast hits. */
-const _vector2 = /*@__PURE__*/ new THREE.Vector3()
 
 /**
  * Mixin base produced by {@link createAcTrBatchedMixin} for indexed line batches.
@@ -52,7 +49,9 @@ const AcTrBatchedLineBase = createAcTrBatchedMixin<AcTrBatchedGeometryInfo>(
  *
  * Multiple line geometries that share compatible attribute layouts and a material
  * are packed into one combined vertex/index buffer to reduce draw calls. Supports
- * point-symbol line regeneration and bbox-expanded raycast fallback for thin lines.
+ * point-symbol line regeneration. Picking uses {@link THREE.LineSegments.raycast}
+ * with `raycaster.params.Line.threshold` (distance to segments), not the geometry
+ * AABB — hollow shapes must not be selectable via their bounding box interior.
  *
  * @see {@link AcTrBatchedMesh} for mesh batching.
  * @see {@link AcTrBatchedLine2} for wide-line (`Line2`) batching.
@@ -723,114 +722,6 @@ export class AcTrBatchedLine extends AcTrBatchedLineBase {
     } else {
       geometry.setDrawRange(0, this._nextVertexStart)
     }
-  }
-
-  /**
-   * Performs ray intersection for one line geometry slot with bbox fallback.
-   *
-   * Overrides the mixin default to improve pick reliability for thin lines:
-   *
-   * 1. When `bboxIntersectionCheck` is set, tests world-space bounding box only.
-   * 2. Otherwise delegates to {@link THREE.LineSegments.raycast} on the sub-range.
-   * 3. If the precise raycast misses, retests against the bounding box expanded by
-   *    `raycaster.params.Line.threshold`.
-   *
-   * @param geometryId - Slot index to test.
-   * @param raycaster - Configured THREE.js raycaster.
-   * @param intersects - Output array populated with intersection records extended
-   *   by `batchId` and `objectId`.
-   */
-  _intersectWith(
-    geometryId: number,
-    raycaster: THREE.Raycaster,
-    intersects: THREE.Intersection[]
-  ) {
-    const geometryInfo = this._geometryInfo[geometryId]
-    if (!isBatchGeometryVisible(geometryInfo.flags)) {
-      return
-    }
-
-    // Fast path: entities flagged for bbox-only intersection check
-    if (geometryInfo.bboxIntersectionCheck) {
-      this.getBoundingBoxAt(geometryId, this._box)
-      this._box.applyMatrix4(this.matrixWorld)
-      if (raycaster.ray.intersectBox(this._box, this._vector)) {
-        const distance = raycaster.ray.origin.distanceTo(this._vector)
-        ;(
-          intersects as Array<
-            THREE.Intersection & { batchId?: number; objectId?: string }
-          >
-        ).push({
-          distance,
-          point: this._vector.clone(),
-          object: this,
-          face: null,
-          faceIndex: undefined,
-          uv: undefined,
-          batchId: geometryId,
-          objectId: geometryInfo.objectId
-        })
-      }
-      return
-    }
-
-    // Standard raycast via THREE.LineSegments
-    const drawRange =
-      this.geometry.index != null
-        ? {
-            start: geometryInfo.indexStart,
-            count: geometryInfo.indexCount
-          }
-        : {
-            start: geometryInfo.vertexStart,
-            count: geometryInfo.vertexCount
-          }
-    this._setRaycastObjectInfo(
-      this._raycastObject,
-      geometryId,
-      drawRange.start,
-      drawRange.count
-    )
-    this._raycastObject.raycast(raycaster, this._batchIntersects)
-
-    // Fallback: when the precise raycast misses, test against the
-    // bounding box expanded by the Line threshold.
-    if (this._batchIntersects.length === 0) {
-      this.getBoundingBoxAt(geometryId, _box)
-      _box.applyMatrix4(this.matrixWorld)
-      const threshold = raycaster.params.Line.threshold
-      if (threshold > 0) {
-        _box.expandByScalar(threshold)
-      }
-      if (raycaster.ray.intersectBox(_box, _vector2)) {
-        const distance = raycaster.ray.origin.distanceTo(_vector2)
-        ;(
-          intersects as Array<
-            THREE.Intersection & { batchId?: number; objectId?: string }
-          >
-        ).push({
-          distance,
-          point: _vector2.clone(),
-          object: this,
-          face: null,
-          faceIndex: undefined,
-          uv: undefined,
-          batchId: geometryId,
-          objectId: geometryInfo.objectId
-        })
-      }
-      return
-    }
-
-    for (let j = 0, l = this._typedBatchIntersects.length; j < l; j++) {
-      const intersect = this._typedBatchIntersects[j]
-      intersect.object = this
-      intersect.batchId = geometryId
-      intersect.objectId = geometryInfo.objectId
-      intersects.push(intersect)
-    }
-
-    this._batchIntersects.length = 0
   }
 
   /**

--- a/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
@@ -29,6 +29,10 @@ type AcTrBatchedLine2GeometryInfo = AcTrVertexBatchGeometryInfo
 const _box = /*@__PURE__*/ new THREE.Box3()
 const _vector = /*@__PURE__*/ new THREE.Vector3()
 const _vector2 = /*@__PURE__*/ new THREE.Vector3()
+const _segmentStart = /*@__PURE__*/ new THREE.Vector3()
+const _segmentEnd = /*@__PURE__*/ new THREE.Vector3()
+const _pointOnRay = /*@__PURE__*/ new THREE.Vector3()
+const _pointOnSegment = /*@__PURE__*/ new THREE.Vector3()
 const _batchIntersects: THREE.Intersection[] = []
 const _raycastObject = /*@__PURE__*/ new LineSegments2(
   new LineSegmentsGeometry()
@@ -576,34 +580,23 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     _raycastObject.updateMatrixWorld(true)
     _raycastObject.raycast(raycaster, _batchIntersects)
 
-    // LineSegments2.raycast() ignores raycaster.params.Line.threshold and
-    // only uses the pixel-based LineMaterial.linewidth for hit detection.
-    // When linewidth is small the pick area can be too narrow, so fall back
-    // to a bounding-box intersection check when the precise raycast misses.
+    // LineSegments2.raycast() uses pixel LineMaterial.linewidth (plus optional
+    // params.Line2.threshold in px), not params.Line.threshold in WCS. When the
+    // screen-space pick misses, test distance to each segment against the WCS
+    // Line threshold. Do not fall back to the geometry AABB — that would make
+    // hollow rectangles / compacted INSERT linework selectable anywhere inside.
     if (_batchIntersects.length === 0) {
-      this.getBoundingBoxAt(geometryId, _box)
-      _box.applyMatrix4(this.matrixWorld)
-      const threshold = raycaster.params.Line.threshold
-      if (threshold > 0) {
-        _box.expandByScalar(threshold)
-      }
-      if (raycaster.ray.intersectBox(_box, _vector2)) {
-        const distance = raycaster.ray.origin.distanceTo(_vector2)
-        ;(
-          intersects as Array<
-            THREE.Intersection & { batchId?: number; objectId?: string }
-          >
-        ).push({
-          distance,
-          point: _vector2.clone(),
-          object: this,
-          face: null,
-          faceIndex: undefined,
-          uv: undefined,
-          batchId: geometryId,
-          objectId: geometryInfo.objectId
-        })
-      }
+      this._intersectSegmentsWithLineThreshold(
+        geometry,
+        // Use the batch world matrix (includes ancestors). `_raycastObject` is
+        // detached and only mirrors local TRS, so its matrixWorld is wrong when
+        // the batch sits under a transformed parent.
+        this.matrixWorld,
+        raycaster,
+        geometryId,
+        geometryInfo.objectId,
+        intersects
+      )
       geometry.dispose()
       return
     }
@@ -627,6 +620,73 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     }
     _batchIntersects.length = 0
     geometry.dispose()
+  }
+
+  /**
+   * Picks against packed segments using `raycaster.params.Line.threshold` (WCS).
+   *
+   * Used when {@link LineSegments2.raycast} misses because it only considers
+   * pixel linewidth. Matches {@link THREE.Line} segment-distance semantics so
+   * clicks inside a hollow shape's bounding box do not count as hits.
+   */
+  private _intersectSegmentsWithLineThreshold(
+    geometry: LineSegmentsGeometry,
+    matrixWorld: THREE.Matrix4,
+    raycaster: THREE.Raycaster,
+    geometryId: number,
+    objectId: string | undefined,
+    intersects: THREE.Intersection[]
+  ) {
+    const threshold = raycaster.params.Line?.threshold ?? 0
+    if (!(threshold > 0)) {
+      return
+    }
+
+    const instanceStart = geometry.getAttribute('instanceStart')
+    const instanceEnd = geometry.getAttribute('instanceEnd')
+    if (!instanceStart || !instanceEnd) {
+      return
+    }
+
+    const thresholdSq = threshold * threshold
+    const typedIntersects = intersects as Array<
+      THREE.Intersection & { batchId?: number; objectId?: string }
+    >
+
+    for (let i = 0, l = instanceStart.count; i < l; i++) {
+      _segmentStart
+        .fromBufferAttribute(instanceStart, i)
+        .applyMatrix4(matrixWorld)
+      _segmentEnd
+        .fromBufferAttribute(instanceEnd, i)
+        .applyMatrix4(matrixWorld)
+
+      const distSq = raycaster.ray.distanceSqToSegment(
+        _segmentStart,
+        _segmentEnd,
+        _pointOnRay,
+        _pointOnSegment
+      )
+      if (distSq > thresholdSq) {
+        continue
+      }
+
+      const distance = raycaster.ray.origin.distanceTo(_pointOnRay)
+      if (distance < raycaster.near || distance > raycaster.far) {
+        continue
+      }
+
+      typedIntersects.push({
+        distance,
+        point: _pointOnSegment.clone(),
+        object: this,
+        face: null,
+        faceIndex: i,
+        uv: undefined,
+        batchId: geometryId,
+        objectId
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Remove batched `LineSegments` / `LineSegments2` AABB raycast fallbacks so hollow rectangles and compacted INSERT linework are not selectable via the bounding-box interior; `Line2` misses fall back to WCS segment-distance using `params.Line.threshold` and the batch `matrixWorld`.
- Keep empty-id child AABBs in linear/RBush child indexes (and uniquify only duplicate non-empty ids) so multi-region hatch islands stay pickable without fabricating osnap `gsMark` values.

## Test plan
- [x] `pnpm test -- --testPathPatterns=AcTrHierarchicalSpatialIndex --testPathPatterns=AcTrBatchedLinePick`
- [ ] Manually pick hollow rectangles / INSERT outlines (interior miss, edge hit)
- [ ] Select multi-region hatch islands that previously shared empty child ids
- [ ] Confirm object snap still works on INSERT sub-entities and hatch boundaries