### PR TITLE
feat: share compacted INSERT template geometry across cache hits

### DIFF
--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -2205,9 +2205,8 @@ export class AcTrView2d extends AcEdBaseView {
     if (threeEntity instanceof AcTrGroup) {
       // Compacted INSERT templates may skip syncDraw when fonts are awaited
       // later; still walk for empty glyph shells. Skip only when there is
-      // nothing left to finalize.
+      // nothing left to finalize (incl. post-cache ATTRIBs).
       if (
-        threeEntity.isCompacted &&
         threeEntity.getSourceEntities().length === 0 &&
         !this.groupHasPendingGlyphGeometry(threeEntity)
       ) {

--- a/packages/three-renderer/__tests__/AcTrGroup.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrGroup.spec.ts
@@ -7,6 +7,7 @@ import { AcTrGroup } from '../src/object/AcTrGroup'
 import { AcTrLine } from '../src/object/AcTrLine'
 import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
 import { AcTrSubEntityTraitsUtil } from '../src/util'
+import { getSceneDrawableUserData } from '../src/util/AcTrObjectUserData'
 
 const defaultTraits = AcTrSubEntityTraitsUtil.createDefaultTraits()
 
@@ -474,6 +475,87 @@ describe('AcTrGroup dispose', () => {
     expect(cloned.isCompacted).toBe(true)
     expect(cloned.getSourceEntities()).toHaveLength(0)
     expect(cloned.wcsChildBoxes).toEqual(group.wcsChildBoxes)
+  })
+
+  it('shares leaf geometry buffers across fastDeepClone instances', () => {
+    const context = new AcTrRenderContext()
+    const lineA = createLine('line-a', { x: 0, y: 0 }, { x: 10, y: 0 }, context)
+    const lineB = createLine('line-b', { x: 0, y: 5 }, { x: 10, y: 5 }, context)
+    const group = new AcTrGroup([lineA, lineB], context)
+    group.compactForInstancing()
+
+    const cloned = group.fastDeepClone() as AcTrGroup
+    expect(cloned.children.length).toBe(group.children.length)
+    for (let i = 0; i < group.children.length; i++) {
+      const source = group.children[i] as THREE.Mesh
+      const instance = cloned.children[i] as THREE.Mesh
+      expect(instance).not.toBe(source)
+      expect(instance.geometry).toBe(source.geometry)
+      expect(getSceneDrawableUserData(instance).sharesTemplateGeometry).toBe(
+        true
+      )
+    }
+
+    AcTrEntity.disposeObject(cloned, false)
+    for (const child of group.children) {
+      const mesh = child as THREE.Mesh
+      const geometry = mesh.geometry
+      expect(geometry).toBeTruthy()
+      expect(() => geometry.getAttribute('position')).not.toThrow()
+      // Style-cache materials are shared with the template; dispose must not
+      // release them either.
+      expect(mesh.material).toBeTruthy()
+    }
+  })
+
+  it('prepareCacheTemplate does not drop source shells or merge leaves', () => {
+    const context = new AcTrRenderContext()
+    const lineA = createLine('line-a', { x: 0, y: 0 }, { x: 10, y: 0 }, context)
+    const lineB = createLine('line-b', { x: 0, y: 5 }, { x: 10, y: 5 }, context)
+    const group = new AcTrGroup([lineA, lineB], context)
+    const beforeChildren = group.children.length
+    const beforeSources = group.getSourceEntities().length
+
+    group.prepareCacheTemplate()
+    expect(group.isCompacted).toBe(false)
+    // Releasing shells here regresses scene convert; compact still drops them.
+    expect(group.getSourceEntities()).toHaveLength(beforeSources)
+    expect(group.children.length).toBe(beforeChildren)
+  })
+
+  it('does not share geometry until compactForInstancing (lazy-compact safe)', () => {
+    const context = new AcTrRenderContext()
+    const lineA = createLine('line-a', { x: 0, y: 0 }, { x: 10, y: 0 }, context)
+    const lineB = createLine('line-b', { x: 0, y: 5 }, { x: 10, y: 5 }, context)
+    const group = new AcTrGroup([lineA, lineB], context)
+    group.prepareCacheTemplate()
+
+    const first = group.fastDeepClone() as AcTrGroup
+    expect(first.children.length).toBe(group.children.length)
+    for (let i = 0; i < group.children.length; i++) {
+      const source = group.children[i] as THREE.Mesh
+      const instance = first.children[i] as THREE.Mesh
+      expect(instance.geometry).not.toBe(source.geometry)
+      expect(getSceneDrawableUserData(instance).sharesTemplateGeometry).toBeFalsy()
+    }
+
+    // Simulate cache-hit lazy compact: dispose template leaves after an
+    // earlier INSERT already cloned. Deep-cloned first instance must survive.
+    group.compactForInstancing()
+    for (const child of first.children) {
+      const geometry = (child as THREE.Mesh).geometry
+      expect(() => geometry.getAttribute('position')).not.toThrow()
+    }
+
+    const second = group.fastDeepClone() as AcTrGroup
+    for (let i = 0; i < group.children.length; i++) {
+      const source = group.children[i] as THREE.Mesh
+      const instance = second.children[i] as THREE.Mesh
+      expect(instance.geometry).toBe(source.geometry)
+      expect(getSceneDrawableUserData(instance).sharesTemplateGeometry).toBe(
+        true
+      )
+    }
   })
 
   it('lazily materializes wcsChildBoxes with INSERT transform on clone', () => {

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -2233,6 +2233,8 @@ export class AcTrBatchedGroup extends THREE.Group {
         sourceDrawable.styleMaterialId ?? this.getMaterialId(source.material)
       clonedDrawable.bboxIntersectionCheck =
         sourceDrawable.bboxIntersectionCheck
+      clonedDrawable.sharesTemplateGeometry =
+        sourceDrawable.sharesTemplateGeometry
       clonedDrawable.bakedWorldMatrix = source.matrixWorld.toArray()
       if (sourceDrawable.textEntityTraits) {
         clonedDrawable.textEntityTraits = AcTrMTextColorUtil.cloneEntityTraits(
@@ -2382,10 +2384,17 @@ export class AcTrBatchedGroup extends THREE.Group {
 
   /**
    * Recursively disposes one object subtree owned by this group.
+   *
+   * Skips {@link THREE.BufferGeometry} borrowed from an immutable block
+   * template (`sharesTemplateGeometry`); unbatched INSERT clones may alias
+   * those buffers via {@link THREE.Object3D.clone}.
    */
   private disposeObject(object: THREE.Object3D) {
     object.removeFromParent()
-    if (this.hasGeometry(object)) {
+    if (
+      this.hasGeometry(object) &&
+      !getSceneDrawableUserData(object).sharesTemplateGeometry
+    ) {
       object.geometry.dispose()
     }
     object.children.forEach(child => this.disposeObject(child))

--- a/packages/three-renderer/src/object/AcTrEntity.ts
+++ b/packages/three-renderer/src/object/AcTrEntity.ts
@@ -251,22 +251,28 @@ export class AcTrEntity extends AcTrObject implements AcGiEntity {
     // Step 1: Remove the object from the parent if it exists
     if (isRemoveFromParent) object.removeFromParent()
 
-    // Step 2: Dispose of geometry if it exists
+    // Step 2: Dispose of geometry if it exists. Skip buffers borrowed from an
+    // immutable block-template cache entry — batching already cloned what it
+    // needed, and disposing here would corrupt later INSERT hits.
+    const sharesTemplateGeometry =
+      getSceneDrawableUserData(object).sharesTemplateGeometry === true
     if (
       object instanceof THREE.Mesh ||
       object instanceof THREE.Line ||
       object instanceof THREE.Points
     ) {
-      if (object.geometry) {
+      if (object.geometry && !sharesTemplateGeometry) {
         object.geometry.dispose()
       }
     }
 
-    // Step 3: Dispose of material(s)
+    // Step 3: Dispose of material(s). Template-instance leaves also reuse style
+    // cache materials with the template; disposing them would break later hits.
     if (
-      object instanceof THREE.Mesh ||
-      object instanceof THREE.Line ||
-      object instanceof THREE.Points
+      !sharesTemplateGeometry &&
+      (object instanceof THREE.Mesh ||
+        object instanceof THREE.Line ||
+        object instanceof THREE.Points)
     ) {
       const materials = Array.isArray(object.material)
         ? object.material
@@ -433,11 +439,14 @@ export class AcTrEntity extends AcTrObject implements AcGiEntity {
 
   /**
    * @inheritdoc
+   *
+   * @param shareGeometry - When true, leaf drawables alias source buffers
+   *   (see {@link copyGeometry}). Block-template clones pass true.
    */
-  fastDeepClone() {
+  fastDeepClone(shareGeometry: boolean = false) {
     const cloned = new AcTrEntity(this.renderContext)
     cloned.copy(this, false)
-    this.copyGeometry(this, cloned)
+    this.copyGeometry(this, cloned, shareGeometry)
     return cloned
   }
 
@@ -456,21 +465,35 @@ export class AcTrEntity extends AcTrObject implements AcGiEntity {
    * Clone geometries in the source's direct children and copy them to the target
    * @param source Input the source entity
    * @param target Input the target entity
+   * @param shareGeometry When true, leaf drawables alias the source
+   *   {@link THREE.BufferGeometry} instead of deep-cloning buffers. Used for
+   *   immutable block-template instances; callers must not mutate shared
+   *   buffers in place (batching already clones before rebase).
    */
-  protected copyGeometry(source: AcTrEntity, target: AcTrEntity) {
+  protected copyGeometry(
+    source: AcTrEntity,
+    target: AcTrEntity,
+    shareGeometry: boolean = false
+  ) {
     for (let i = 0; i < source.children.length; i++) {
       const child = source.children[i]
 
       if (child instanceof AcTrEntity) {
-        target.add(child.fastDeepClone())
+        // Propagate shareGeometry so nested MTEXT/SHAPE/group leaves also
+        // alias template buffers instead of deep-cloning mid-tree.
+        target.add(child.fastDeepClone(shareGeometry))
         continue
       }
 
       const clonedChild = child.clone(false)
       if ('geometry' in clonedChild) {
-        clonedChild.geometry = (
-          clonedChild.geometry as THREE.BufferGeometry
-        ).clone()
+        if (shareGeometry) {
+          getSceneDrawableUserData(clonedChild).sharesTemplateGeometry = true
+        } else {
+          clonedChild.geometry = (
+            clonedChild.geometry as THREE.BufferGeometry
+          ).clone()
+        }
       }
       target.add(clonedChild)
     }

--- a/packages/three-renderer/src/object/AcTrGlyphEntity.ts
+++ b/packages/three-renderer/src/object/AcTrGlyphEntity.ts
@@ -350,7 +350,10 @@ export abstract class AcTrGlyphEntity extends AcTrEntity {
 
     for (const object of invalidObjects) {
       object.parent?.remove(object)
-      if (this.hasGeometry(object)) {
+      if (
+        this.hasGeometry(object) &&
+        !getSceneDrawableUserData(object).sharesTemplateGeometry
+      ) {
         object.geometry.dispose()
       }
     }

--- a/packages/three-renderer/src/object/AcTrGroup.ts
+++ b/packages/three-renderer/src/object/AcTrGroup.ts
@@ -505,16 +505,52 @@ export class AcTrGroup extends AcTrEntity {
   /**
    * Returns a clone of this group and its direct drawable children.
    *
-   * Geometry buffers are deep-cloned; materials are reused. When
-   * {@link isCompacted} is true, detached source-entity shells are not cloned.
+   * When the source {@link isCompacted}, leaf {@link THREE.BufferGeometry}
+   * buffers are shared by default so INSERT cache hits avoid deep copies.
+   * Uncompacted templates deep-clone buffers instead: {@link AcDbRenderingCache}
+   * may still run {@link compactForInstancing} on first reuse, which disposes
+   * template leaves — sharing beforehand would corrupt earlier INSERT instances
+   * and stall scene convert / batching.
    *
+   * Materials are reused. When compacted, detached source-entity shells are
+   * not cloned. Callers must treat compacted templates as immutable: batching
+   * clones buffers before rebase, and {@link AcTrEntity.disposeObject} skips
+   * shared geometries marked with `sharesTemplateGeometry`.
+   *
+   * @param shareGeometry - Override buffer sharing. Defaults to
+   *   {@link isCompacted} so lazy mid-size compact stays safe.
    * @returns Independent group instance suitable for one INSERT.
    */
-  fastDeepClone() {
+  fastDeepClone(shareGeometry: boolean = this._compacted) {
     const cloned = new AcTrGroup([], this.renderContext)
     cloned.copy(this, false)
-    this.copyGeometry(this, cloned)
+    this.copyGeometry(this, cloned, shareGeometry)
     return cloned
+  }
+
+  /**
+   * Prepares this group to be stored as an immutable block-template cache entry.
+   *
+   * Finalizes deferred drawable children when fonts are already available.
+   * Does **not** drop {@link _sourceEntities}: releasing shells here made
+   * INSERT `finishEntityGeometry` skip work that must stay overlapped with
+   * ENTITY flush, and moved tens of seconds into post-read scene convert on
+   * large drawings. Shells are still released by {@link compactForInstancing}.
+   *
+   * Does not merge leaves; call {@link compactForInstancing} when merge
+   * savings justify the cost.
+   *
+   * When {@link FontManager.awaitFontsBeforeDraw} is on, skips {@link syncDraw}
+   * so empty glyph shells remain for later {@link asyncDraw} (same rule as
+   * {@link compactForInstancing}).
+   */
+  prepareCacheTemplate() {
+    if (this._compacted) {
+      return
+    }
+    if (!FontManager.instance.awaitFontsBeforeDraw) {
+      this.syncDraw()
+    }
   }
 
   /**

--- a/packages/three-renderer/src/object/AcTrMText.ts
+++ b/packages/three-renderer/src/object/AcTrMText.ts
@@ -103,7 +103,7 @@ export class AcTrMText extends AcTrGlyphEntity {
    * {@link AcTrEntity.fastDeepClone} would otherwise create a plain
    * {@link AcTrEntity} shell that can no longer {@link asyncDraw} glyphs.
    */
-  override fastDeepClone() {
+  override fastDeepClone(shareGeometry: boolean = false) {
     const cloned = new AcTrMText(
       {
         ...this._text,
@@ -114,7 +114,7 @@ export class AcTrMText extends AcTrGlyphEntity {
       this.renderContext
     )
     cloned.copyGlyphIdentity(this)
-    this.copyGeometry(this, cloned)
+    this.copyGeometry(this, cloned, shareGeometry)
     return cloned
   }
 }

--- a/packages/three-renderer/src/object/AcTrShape.ts
+++ b/packages/three-renderer/src/object/AcTrShape.ts
@@ -102,7 +102,7 @@ export class AcTrShape extends AcTrGlyphEntity {
    * {@link AcTrEntity.fastDeepClone} would otherwise create a plain
    * {@link AcTrEntity} shell that can no longer {@link asyncDraw} glyphs.
    */
-  override fastDeepClone() {
+  override fastDeepClone(shareGeometry: boolean = false) {
     const cloned = new AcTrShape(
       {
         ...this._shape,
@@ -113,7 +113,7 @@ export class AcTrShape extends AcTrGlyphEntity {
       this.renderContext
     )
     cloned.copyGlyphIdentity(this)
-    this.copyGeometry(this, cloned)
+    this.copyGeometry(this, cloned, shareGeometry)
     return cloned
   }
 }

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -95,13 +95,27 @@ export type AcTrBakedWorldMatrixUserData = {
 }
 
 /**
+ * Marks drawable leaves whose {@link THREE.BufferGeometry} is borrowed from an
+ * immutable block-template cache entry. Instance dispose must not release it.
+ */
+export type AcTrSharedTemplateGeometryUserData = {
+  /**
+   * When `true`, this leaf aliases geometry owned by an
+   * {@link AcDbRenderingCache} template (or another shared source).
+   * {@link AcTrEntity.disposeObject} skips `geometry.dispose()` for the leaf.
+   */
+  sharesTemplateGeometry?: boolean
+}
+
+/**
  * Leaf line/mesh/point objects produced by entity conversion, prior to batching.
  */
 export type AcTrSceneDrawableUserData = AcTrPickableObjectUserData &
   AcTrStyledDrawableUserData &
   AcTrRteObjectUserData &
   AcTrNoBatchUserData &
-  AcTrBakedWorldMatrixUserData
+  AcTrBakedWorldMatrixUserData &
+  AcTrSharedTemplateGeometryUserData
 
 export interface AcTrHighlightUserData {
   objectId?: string


### PR DESCRIPTION
## Summary
- Share leaf `BufferGeometry` (and skip dispose of shared buffers/materials) when cloning compacted block-template INSERTs, marked via `sharesTemplateGeometry`.
- Add `prepareCacheTemplate` that finalizes drawables without dropping source shells, so `finishEntityGeometry` stays overlapped with open convert instead of shifting work post-read.
- Relax the `AcTrView2d` group early-out so empty-source groups without pending glyphs skip finalize (including post-cache ATTRIBs), and cover sharing/lazy-compact safety in unit tests.

## Test plan
- [ ] Run `packages/three-renderer` `AcTrGroup` unit tests (sharing, prepareCacheTemplate, lazy-compact)
- [ ] Open a drawing with many repeated block INSERTs; confirm open convert remains responsive and geometry is correct
- [ ] After open, pan/zoom and dispose/replace selection; confirm later INSERT cache hits are not corrupted (no missing geometry)
- [ ] Open a drawing with deferred fonts / MTEXT in blocks; confirm glyphs still finalize without needing a full regen