### PR TITLE
fix: split example bundles for data-model and three caching

### DIFF
--- a/packages/cad-simple-viewer-example/package.json
+++ b/packages/cad-simple-viewer-example/package.json
@@ -24,6 +24,8 @@
     "@mlightcad/cad-svg-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.12.5",
+    "@mlightcad/mtext-renderer": "^0.12.4",
+    "@mlightcad/three-renderer": "workspace:*",
     "lodash-es": "4.17.21",
     "three": "^0.172.0",
     "vue": "^3.4.21"

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -58,6 +58,8 @@
   },
   "peerDependencies": {
     "@mlightcad/data-model": "^1.12.5",
+    "@mlightcad/mtext-renderer": "^0.12.4",
+    "@mlightcad/three-renderer": "workspace:*",
     "lodash-es": "4.17.21",
     "three": "^0.172.0"
   }

--- a/packages/cad-viewer-example/package.json
+++ b/packages/cad-viewer-example/package.json
@@ -39,6 +39,8 @@
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/cad-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.12.5",
+    "@mlightcad/mtext-renderer": "^0.12.4",
+    "@mlightcad/three-renderer": "workspace:*",
     "element-plus": "^2.12.0",
     "lodash-es": "4.17.21",
     "three": "^0.172.0",

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -75,6 +75,7 @@
     "@mlightcad/cad-svg-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.12.5",
+    "@mlightcad/three-renderer": "workspace:*",
     "@vueuse/core": "^11.1.0",
     "element-plus": "^2.12.0",
     "lodash-es": "4.17.21",

--- a/packages/vite-config/pluginRollupOutput.ts
+++ b/packages/vite-config/pluginRollupOutput.ts
@@ -16,6 +16,28 @@ export const VIEWER_PACKAGE_IDS = [
   'three-renderer'
 ] as const
 
+/**
+ * data-model and its tightly coupled packages — keep together to avoid
+ * cross-chunk "extends undefined" for class hierarchies.
+ */
+export const DATA_MODEL_PACKAGE_IDS = [
+  'data-model',
+  'geometry-engine',
+  'graphic-interface',
+  'common'
+] as const
+
+/**
+ * Packages that stay with the three-renderer chunk (text/rendering stack).
+ * three and data-model are split out separately for clearer caching.
+ */
+export const THREE_RENDERER_STACK_IDS = [
+  'three-renderer',
+  'mtext-renderer',
+  'mtext-parser',
+  'shx-parser'
+] as const
+
 function isPluginRegisterModule(id: string, pluginId: string): boolean {
   return (
     id.includes(`${pluginId}/register`) ||
@@ -36,6 +58,22 @@ function matchMonorepoPackage(id: string, packageId: string): boolean {
   )
 }
 
+/** Match the `three` package without catching `three-renderer` / `@types/three`. */
+function matchThreePackage(id: string): boolean {
+  const normalized = id.replace(/\\/g, '/')
+  if (
+    normalized.includes('three-renderer') ||
+    normalized.includes('@types/three')
+  ) {
+    return false
+  }
+  return (
+    normalized.includes('/node_modules/three/') ||
+    normalized.includes('/node_modules/.pnpm/three@') ||
+    /(?:^|\/)three\/(?:build|examples)\//.test(normalized)
+  )
+}
+
 /**
  * Groups monorepo packages into predictable Rollup chunks for example app builds.
  */
@@ -52,7 +90,26 @@ export const exampleManualChunks: ManualChunksOption = (id: string) => {
     return pluginId
   }
 
+  if (matchThreePackage(id)) {
+    return 'three'
+  }
+
+  for (const packageId of DATA_MODEL_PACKAGE_IDS) {
+    if (matchMonorepoPackage(id, packageId)) {
+      return 'data-model'
+    }
+  }
+
+  for (const packageId of THREE_RENDERER_STACK_IDS) {
+    if (matchMonorepoPackage(id, packageId)) {
+      return 'three-renderer'
+    }
+  }
+
   for (const packageId of VIEWER_PACKAGE_IDS) {
+    if (packageId === 'three-renderer') {
+      continue
+    }
     if (matchMonorepoPackage(id, packageId)) {
       return packageId
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,12 @@ importers:
       '@mlightcad/data-model':
         specifier: ^1.12.5
         version: 1.12.5
+      '@mlightcad/mtext-renderer':
+        specifier: ^0.12.4
+        version: 0.12.4(three@0.172.0)
+      '@mlightcad/three-renderer':
+        specifier: workspace:*
+        version: link:../three-renderer
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -433,6 +439,12 @@ importers:
       '@mlightcad/data-model':
         specifier: ^1.12.5
         version: 1.12.5
+      '@mlightcad/mtext-renderer':
+        specifier: ^0.12.4
+        version: 0.12.4(three@0.172.0)
+      '@mlightcad/three-renderer':
+        specifier: workspace:*
+        version: link:../three-renderer
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))


### PR DESCRIPTION
## Summary
- Update example `manualChunks` so `data-model` (+ geometry/graphic/common) stay in one chunk, avoiding cross-chunk `extends undefined` for class hierarchies.
- Split `three` and the three-renderer text stack into dedicated chunks for clearer long-term caching.
- Declare `@mlightcad/three-renderer` / `@mlightcad/mtext-renderer` peers (and example deps) so Rollup can resolve and chunk them predictably.

## Test plan
- [ ] `pnpm --filter @mlightcad/cad-viewer-example build` and confirm assets include separate `data-model-*.js`, `three-*.js`, and `three-renderer-*.js` chunks
- [ ] `pnpm --filter @mlightcad/cad-simple-viewer-example build` and verify the same chunk split
- [ ] Open a DXF/DWG in both example apps and confirm viewer loads without runtime class inheritance errors
- [ ] Spot-check that text (MTEXT) still renders correctly after the chunk split