### PR TITLE
fix: isolate example chunks and HTML runtime plugin options

### DIFF
--- a/packages/cad-html-plugin/README.md
+++ b/packages/cad-html-plugin/README.md
@@ -65,11 +65,13 @@ import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin/register'
 
 AcApDocManager.createInstance({
-  container: document.getElementById('cad-container')!,
-  htmlViewerRuntimeUrl: './viewer-runtime.iife.js'
+  container: document.getElementById('cad-container')!
 })
 
-registerLazyHtmlPlugin(AcApDocManager.instance.pluginManager)
+// viewerRuntimeUrl is HTML-export only — not required to open DXF/DWG
+registerLazyHtmlPlugin(AcApDocManager.instance.pluginManager, {
+  viewerRuntimeUrl: './viewer-runtime.iife.js'
+})
 ```
 
 Do **not** import `registerLazyHtmlPlugin` from the package root (`@mlightcad/cad-html-plugin`) in application code — that resolves to the full library build and defeats lazy loading.
@@ -136,9 +138,9 @@ For DXF/DWG → HTML without a browser UI, use [`@mlightcad/cad-html-exporter-cl
 
 When embedding HTML export in a web app:
 
-1. Build `@mlightcad/cad-html-plugin` and expose `viewer-runtime.iife.js` at a URL your app can `fetch` (e.g. Vite `public/` copy — see `cad-viewer-example` / `cad-simple-viewer-example` vite configs).
+1. Build `@mlightcad/cad-html-plugin` and expose `viewer-runtime.iife.js` at a URL your app can `fetch` (e.g. Vite `public/` copy — see `cad-viewer-example` / `cad-simple-viewer-example` vite configs). **Skip this step if you do not use HTML export** — opening DXF/DWG does not need this file or this package.
 2. Register via `@mlightcad/cad-html-plugin/register` (or load the plugin eagerly).
-3. Optionally set `htmlViewerRuntimeUrl` on `AcApDocManager.createInstance()` to override the default `./viewer-runtime.iife.js` path.
+3. Pass `viewerRuntimeUrl` to `registerLazyHtmlPlugin` / `createHtmlPlugin` / `AcApHtmlConvertor` (default `./viewer-runtime.iife.js`). Do **not** put this on `AcApDocManager.createInstance()`.
 4. Ensure fonts used by the drawing are reachable during export if you rely on web-font substitution.
 
 The generated HTML itself needs **no backend**; only the export step may fetch the runtime bundle and fonts.

--- a/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
+++ b/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
@@ -12,6 +12,7 @@ import {
   type AcApHtmlExportOptions,
   resolveAcApHtmlExportOptions
 } from './AcApHtmlExportOptions'
+import type { AcApHtmlPluginOptions } from './AcApHtmlPluginOptions'
 
 /**
  * Editor command that exports the active drawing as a self-contained HTML file
@@ -22,6 +23,13 @@ import {
  * bundles the offline viewer runtime, and triggers a browser download.
  */
 export class AcApExportHtmlCmd extends AcEdCommand {
+  /**
+   * @param pluginOptions - HTML plugin options (e.g. `viewerRuntimeUrl`)
+   */
+  constructor(private readonly pluginOptions: AcApHtmlPluginOptions = {}) {
+    super()
+  }
+
   /**
    * Runs the HTML export workflow for the drawing in `context`.
    *
@@ -35,7 +43,7 @@ export class AcApExportHtmlCmd extends AcEdCommand {
       return
     }
 
-    const converter = new AcApHtmlConvertor()
+    const converter = new AcApHtmlConvertor(this.pluginOptions)
     await converter.convert(
       context.doc.fileName || context.doc.docTitle,
       options,

--- a/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
@@ -12,15 +12,13 @@ import {
   captureAcApHtmlViewState,
   resolveAcApHtmlExportOptions
 } from './AcApHtmlExportOptions'
+import {
+  type AcApHtmlPluginOptions,
+  resolveViewerRuntimeUrl
+} from './AcApHtmlPluginOptions'
 import { AcApHtmlSnapshotBuilder } from './AcApHtmlSnapshotBuilder'
 import { packHtml } from './AcExHtmlPackager'
 import type { AcExSnapshot } from './AcExSnapshotTypes'
-
-/**
- * Relative URL of the bundled offline viewer script when no override is
- * configured on {@link AcApDocManager.htmlViewerRuntimeUrl}.
- */
-const DEFAULT_RUNTIME_URL = './viewer-runtime.iife.js'
 
 /**
  * Orchestrates export of the active drawing to a downloadable HTML file.
@@ -32,10 +30,18 @@ const DEFAULT_RUNTIME_URL = './viewer-runtime.iife.js'
  *
  * A busy indicator is shown for the duration of the operation. The UI thread
  * is yielded between heavy steps so the browser can repaint.
+ *
+ * The runtime URL is configured on this plugin (`viewerRuntimeUrl`), not on
+ * `AcApDocManager` — see {@link AcApHtmlPluginOptions}.
  */
 export class AcApHtmlConvertor {
   /** Collects geometry and metadata from the live Three.js scene. */
   private readonly _snapshotBuilder = new AcApHtmlSnapshotBuilder()
+
+  /**
+   * @param options - Plugin options; `viewerRuntimeUrl` overrides module defaults
+   */
+  constructor(private readonly options: AcApHtmlPluginOptions = {}) {}
 
   /**
    * Prepares the active 2D view for HTML snapshot export.
@@ -112,9 +118,7 @@ export class AcApHtmlConvertor {
 
       await accmYieldForPaint()
 
-      const viewerRuntime = await this.loadViewerRuntime(
-        docManager.htmlViewerRuntimeUrl
-      )
+      const viewerRuntime = await this.loadViewerRuntime()
 
       await accmYieldForPaint()
 
@@ -145,9 +149,7 @@ export class AcApHtmlConvertor {
 
     await docManager.withBusyIndicator(async () => {
       await accmYieldForPaint()
-      const viewerRuntime = await this.loadViewerRuntime(
-        docManager.htmlViewerRuntimeUrl
-      )
+      const viewerRuntime = await this.loadViewerRuntime()
       await accmYieldForPaint()
       const html = packHtml(snapshot, {
         title: snapshot.meta.title,
@@ -161,18 +163,17 @@ export class AcApHtmlConvertor {
   /**
    * Fetches the offline viewer runtime as source text for inlining.
    *
-   * @param url - Absolute or relative URL of `viewer-runtime.iife.js`. When
-   *   omitted, {@link DEFAULT_RUNTIME_URL} is used.
    * @returns The runtime script body as a string.
    * @throws If the HTTP response is not OK (missing build artifact, CORS, etc.).
    */
-  private async loadViewerRuntime(url?: string | URL): Promise<string> {
-    const runtimeUrl = url != null ? String(url) : DEFAULT_RUNTIME_URL
+  private async loadViewerRuntime(): Promise<string> {
+    const runtimeUrl = resolveViewerRuntimeUrl(this.options.viewerRuntimeUrl)
     const response = await fetch(runtimeUrl)
     if (!response.ok) {
       throw new Error(
         `Failed to load HTML viewer runtime from "${runtimeUrl}" (${response.status}). ` +
-          'Build @mlightcad/cad-html-plugin and copy viewer-runtime.iife.js to your app assets.'
+          'Install @mlightcad/cad-html-plugin, copy viewer-runtime.iife.js to your app assets, ' +
+          'and set viewerRuntimeUrl on registerLazyHtmlPlugin / createHtmlPlugin / AcApHtmlConvertor.'
       )
     }
     return response.text()

--- a/packages/cad-html-plugin/src/AcApHtmlPlugin.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlPlugin.ts
@@ -6,6 +6,7 @@ import {
 
 import packageJson from '../package.json'
 import { AcApExportHtmlCmd } from './AcApExportHtmlCmd'
+import type { AcApHtmlPluginOptions } from './AcApHtmlPluginOptions'
 
 /**
  * HTML export plugin for cad-simple-viewer.
@@ -25,6 +26,11 @@ export class AcApHtmlPlugin implements AcApPlugin {
   private registeredCommands: Array<{ group: string; name: string }> = []
 
   /**
+   * @param options - HTML export options (e.g. where to fetch `viewer-runtime.iife.js`)
+   */
+  constructor(private readonly options: AcApHtmlPluginOptions = {}) {}
+
+  /**
    * Registers the `-chtml` system command (command-line, no dialog).
    *
    * @param _context - Application context (unused)
@@ -32,7 +38,7 @@ export class AcApHtmlPlugin implements AcApPlugin {
    */
   onLoad(_context: AcApContext, commandManager: AcEdCommandStack): void {
     const group = AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME
-    const exportCmd = new AcApExportHtmlCmd()
+    const exportCmd = new AcApExportHtmlCmd(this.options)
 
     commandManager.addCommand(group, '-chtml', '-chtml', exportCmd)
     this.registeredCommands.push({ group, name: '-chtml' })

--- a/packages/cad-html-plugin/src/AcApHtmlPluginOptions.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlPluginOptions.ts
@@ -1,0 +1,52 @@
+/**
+ * Options for the HTML export plugin and convertor.
+ *
+ * These settings belong to `@mlightcad/cad-html-plugin`, not to
+ * `AcApDocManager`. Opening DXF/DWG never requires them.
+ */
+export interface AcApHtmlPluginOptions {
+  /**
+   * URL of `viewer-runtime.iife.js` fetched and inlined when exporting HTML
+   * (`chtml` / `-chtml`). Hosts must serve this file only if they use HTML export.
+   *
+   * @default './viewer-runtime.iife.js'
+   */
+  viewerRuntimeUrl?: string | URL
+}
+
+/** Relative URL used when no override is configured. */
+export const DEFAULT_HTML_VIEWER_RUNTIME_URL = './viewer-runtime.iife.js'
+
+let htmlPluginDefaults: AcApHtmlPluginOptions = {}
+
+/**
+ * Merges default options used by {@link createHtmlPlugin},
+ * {@link registerLazyHtmlPlugin}, and {@link AcApHtmlConvertor}.
+ *
+ * Call from the host when registering the plugin, e.g.:
+ * `registerLazyHtmlPlugin(pm, { viewerRuntimeUrl: './assets/viewer-runtime.iife.js' })`.
+ */
+export function configureHtmlPlugin(options: AcApHtmlPluginOptions): void {
+  htmlPluginDefaults = { ...htmlPluginDefaults, ...options }
+}
+
+/** Returns the current HTML plugin defaults (shallow copy). */
+export function getHtmlPluginOptions(): AcApHtmlPluginOptions {
+  return { ...htmlPluginDefaults }
+}
+
+/**
+ * Resolves the runtime script URL for HTML export.
+ *
+ * Precedence: explicit override → {@link configureHtmlPlugin} defaults →
+ * {@link DEFAULT_HTML_VIEWER_RUNTIME_URL}.
+ */
+export function resolveViewerRuntimeUrl(override?: string | URL): string {
+  if (override != null) {
+    return String(override)
+  }
+  if (htmlPluginDefaults.viewerRuntimeUrl != null) {
+    return String(htmlPluginDefaults.viewerRuntimeUrl)
+  }
+  return DEFAULT_HTML_VIEWER_RUNTIME_URL
+}

--- a/packages/cad-html-plugin/src/createHtmlPlugin.ts
+++ b/packages/cad-html-plugin/src/createHtmlPlugin.ts
@@ -1,10 +1,19 @@
 import { AcApHtmlPlugin } from './AcApHtmlPlugin'
+import {
+  type AcApHtmlPluginOptions,
+  configureHtmlPlugin,
+  getHtmlPluginOptions
+} from './AcApHtmlPluginOptions'
 
 /**
  * Creates an HTML export plugin instance.
  *
+ * @param options - Plugin options such as `viewerRuntimeUrl` (HTML export only)
  * @returns A loaded {@link AcApHtmlPlugin} instance
  */
-export async function createHtmlPlugin() {
-  return new AcApHtmlPlugin()
+export async function createHtmlPlugin(options: AcApHtmlPluginOptions = {}) {
+  if (options.viewerRuntimeUrl != null) {
+    configureHtmlPlugin(options)
+  }
+  return new AcApHtmlPlugin(getHtmlPluginOptions())
 }

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -61,6 +61,13 @@ export {
   resolveAcApHtmlExportOptions
 } from './AcApHtmlExportOptions'
 export {
+  type AcApHtmlPluginOptions,
+  configureHtmlPlugin,
+  DEFAULT_HTML_VIEWER_RUNTIME_URL,
+  getHtmlPluginOptions,
+  resolveViewerRuntimeUrl
+} from './AcApHtmlPluginOptions'
+export {
   AcApHtmlSnapshotBuilder,
   type AcApHtmlSnapshotBuilderOptions
 } from './AcApHtmlSnapshotBuilder'

--- a/packages/cad-html-plugin/src/register.ts
+++ b/packages/cad-html-plugin/src/register.ts
@@ -1,5 +1,7 @@
 import type { AcApPluginManager } from '@mlightcad/cad-simple-viewer'
 
+import type { AcApHtmlPluginOptions } from './AcApHtmlPluginOptions'
+
 /** Lazy plugin name for HTML export. */
 export const HTML_PLUGIN_NAME = 'HtmlPlugin'
 
@@ -12,20 +14,40 @@ export const HTML_PLUGIN_NAME = 'HtmlPlugin'
 export const HTML_PLUGIN_TRIGGERS = ['-chtml', 'chtml'] as const
 
 /**
+ * Options captured at registration time and passed into {@link createHtmlPlugin}
+ * when the lazy loader runs. Kept in this module so the `/register` entry does
+ * not statically import the main plugin bundle.
+ */
+let registeredOptions: AcApHtmlPluginOptions = {}
+
+/**
  * Registers the HTML export plugin for lazy loading.
  *
  * Import from `@mlightcad/cad-html-plugin/register` so the main plugin bundle
  * is not pulled into the application entry chunk.
  *
  * @param pluginManager - Plugin manager that receives the lazy registration
+ * @param options - Plugin options (e.g. `viewerRuntimeUrl` for HTML export).
+ *   Opening DXF/DWG does not require this package or these options.
  */
-export function registerLazyHtmlPlugin(pluginManager: AcApPluginManager): void {
+export function registerLazyHtmlPlugin(
+  pluginManager: AcApPluginManager,
+  options?: AcApHtmlPluginOptions
+): void {
+  if (options) {
+    registeredOptions = { ...registeredOptions, ...options }
+  }
+
+  const optionsForLoader = { ...registeredOptions }
+
   pluginManager.registerLazyPlugin({
     name: HTML_PLUGIN_NAME,
     triggers: [...HTML_PLUGIN_TRIGGERS],
     loader: async () => {
       const { createHtmlPlugin } = await import('@mlightcad/cad-html-plugin')
-      return createHtmlPlugin()
+      return createHtmlPlugin(optionsForLoader)
     }
   })
 }
+
+export type { AcApHtmlPluginOptions } from './AcApHtmlPluginOptions'

--- a/packages/cad-simple-viewer-example/README.md
+++ b/packages/cad-simple-viewer-example/README.md
@@ -94,7 +94,7 @@ Integration patterns useful when building your own host app (not a full CAD UI l
 | System variables | `AcDbSysVarManager` + `sendStringToExecute` (e.g. `PICKBOX`) |
 | Plugins | Lazy registration via `@mlightcad/*/register` in `src/register.ts` (only needed plugins) |
 | Command aliases | Demo overrides (`LINE` → `LX`, etc.) via `commandAliases` |
-| Workers & assets | `webworkerFileUrls`, `htmlViewerRuntimeUrl`, static copy in Vite |
+| Workers & assets | `webworkerFileUrls`, static copy in Vite; HTML runtime via plugin options |
 
 Lazy initialization: `AcApDocManager` is created on first file open, not at page load.
 

--- a/packages/cad-simple-viewer-example/package.json
+++ b/packages/cad-simple-viewer-example/package.json
@@ -24,6 +24,8 @@
     "@mlightcad/cad-svg-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.12.5",
+    "@mlightcad/mtext-renderer": "^0.12.4",
+    "@mlightcad/three-renderer": "workspace:*",
     "lodash-es": "4.17.21",
     "three": "^0.172.0",
     "vue": "^3.4.21"

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -816,8 +816,7 @@ class CadViewerApp {
         webworkerFileUrls: {
           mtextRender: `./workers/${MTEXT_RENDERER_WORKER_FILE}`,
           dwgParser: `./workers/${LIBREDWG_PARSER_WORKER_FILE}`
-        },
-        htmlViewerRuntimeUrl: './viewer-runtime.iife.js'
+        }
       })
       if (openProf) {
         const w = window as Window & { __OPEN_MODE__?: string }

--- a/packages/cad-simple-viewer-example/src/register.ts
+++ b/packages/cad-simple-viewer-example/src/register.ts
@@ -19,7 +19,9 @@ export const registerLazyPlugins = () => {
   }
 
   const pluginManager = AcApDocManager.instance.pluginManager
-  registerLazyHtmlPlugin(pluginManager)
+  registerLazyHtmlPlugin(pluginManager, {
+    viewerRuntimeUrl: './viewer-runtime.iife.js'
+  })
   registerLazyPdfPlugin(pluginManager)
   registerLazySvgPlugin(pluginManager)
   registerLazyAgentPlugin(pluginManager)

--- a/packages/cad-simple-viewer-example/vite.config.ts
+++ b/packages/cad-simple-viewer-example/vite.config.ts
@@ -11,18 +11,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 /** Relative to this package root; works with vite-plugin-static-copy on Windows. */
 const VIEWER_RUNTIME_SRC = '../cad-html-plugin/dist/viewer-runtime.iife.js'
 
-function assertViewerRuntimeExists(): void {
+export default defineConfig(() => {
   const runtimePath = resolve(__dirname, VIEWER_RUNTIME_SRC)
-  if (!existsSync(runtimePath)) {
-    throw new Error(
-      'viewer-runtime.iife.js was not found. Build @mlightcad/cad-html-plugin first ' +
-        '(pnpm --filter @mlightcad/cad-html-plugin build, or nx run-many -t build).'
+  const hasViewerRuntime = existsSync(runtimePath)
+  if (!hasViewerRuntime) {
+    console.warn(
+      '[cad-simple-viewer-example] viewer-runtime.iife.js not found — HTML export (chtml) will be unavailable. ' +
+        'Build @mlightcad/cad-html-plugin to enable it. Opening DXF/DWG does not require this file.'
     )
   }
-}
-
-export default defineConfig(() => {
-  assertViewerRuntimeExists()
 
   const realdwgRoot = resolve(__dirname, '../../../realdwg-web')
 
@@ -57,11 +54,15 @@ export default defineConfig(() => {
             dest: 'workers',
             rename: { stripBase: true }
           },
-          {
-            src: VIEWER_RUNTIME_SRC,
-            dest: '',
-            rename: { stripBase: true }
-          }
+          ...(hasViewerRuntime
+            ? [
+                {
+                  src: VIEWER_RUNTIME_SRC,
+                  dest: '',
+                  rename: { stripBase: true }
+                }
+              ]
+            : [])
         ]
       })
     ]

--- a/packages/cad-simple-viewer/package.json
+++ b/packages/cad-simple-viewer/package.json
@@ -58,6 +58,8 @@
   },
   "peerDependencies": {
     "@mlightcad/data-model": "^1.12.5",
+    "@mlightcad/mtext-renderer": "^0.12.4",
+    "@mlightcad/three-renderer": "workspace:*",
     "lodash-es": "4.17.21",
     "three": "^0.172.0"
   }

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -257,12 +257,6 @@ export interface AcApDocManagerOptions {
   checkWorkersOnInit?: boolean
 
   /**
-   * URL of the offline HTML viewer runtime bundle (`viewer-runtime.iife.js`).
-   * Used by the HTML export plugin when packaging standalone HTML files.
-   */
-  htmlViewerRuntimeUrl?: string | URL
-
-  /**
    * Host element for the busy overlay (e.g. HTML export spinner).
    * Set to the viewer shell so the mask covers ribbon, toolbars, and status bar.
    * Defaults to the canvas container when omitted.
@@ -371,8 +365,6 @@ export class AcApDocManager {
   private _fontLoader: AcApFontLoader
   /** Base URL to get fonts, templates, and example files */
   private _baseUrl: string
-  /** URL of the HTML viewer runtime bundle for export */
-  private _htmlViewerRuntimeUrl?: string | URL
   /** Busy overlay for long-running command operations */
   private _busyIndicator: AcApBusyIndicator
   /** Open-file progress overlay and event normalization */
@@ -435,7 +427,6 @@ export class AcApDocManager {
    */
   private constructor(options: AcApDocManagerOptions = {}) {
     this._baseUrl = options.baseUrl ?? DEFAULT_BASE_URL
-    this._htmlViewerRuntimeUrl = options.htmlViewerRuntimeUrl
     this._commandAliasOverrides = this.normalizeCommandAliasConfig(
       options.commandAliases
     )
@@ -719,13 +710,6 @@ export class AcApDocManager {
    */
   get baseUrl() {
     return this._baseUrl
-  }
-
-  /**
-   * URL of the offline HTML viewer runtime bundle used for HTML export.
-   */
-  get htmlViewerRuntimeUrl() {
-    return this._htmlViewerRuntimeUrl
   }
 
   /**

--- a/packages/cad-viewer-example/package.json
+++ b/packages/cad-viewer-example/package.json
@@ -39,6 +39,8 @@
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/cad-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.12.5",
+    "@mlightcad/mtext-renderer": "^0.12.4",
+    "@mlightcad/three-renderer": "workspace:*",
     "element-plus": "^2.12.0",
     "lodash-es": "4.17.21",
     "three": "^0.172.0",

--- a/packages/cad-viewer-example/vite.config.ts
+++ b/packages/cad-viewer-example/vite.config.ts
@@ -25,9 +25,11 @@ function useLocalDataModel(mode: string): boolean {
 }
 
 export default defineConfig(({ command, mode }) => {
-  if (!existsSync(resolve(__dirname, VIEWER_RUNTIME_SRC))) {
-    throw new Error(
-      'viewer-runtime.iife.js not found. Build @mlightcad/cad-html-plugin before cad-viewer-example.'
+  const hasViewerRuntime = existsSync(resolve(__dirname, VIEWER_RUNTIME_SRC))
+  if (!hasViewerRuntime) {
+    console.warn(
+      '[cad-viewer-example] viewer-runtime.iife.js not found — HTML export will be unavailable. ' +
+        'Build @mlightcad/cad-html-plugin to enable it. Opening DXF/DWG does not require this file.'
     )
   }
   const aliases: Alias[] = []
@@ -69,11 +71,15 @@ export default defineConfig(({ command, mode }) => {
           dest: 'assets',
           rename: { stripBase: true }
         },
-        {
-          src: VIEWER_RUNTIME_SRC,
-          dest: 'assets',
-          rename: { stripBase: true }
-        }
+        ...(hasViewerRuntime
+          ? [
+              {
+                src: VIEWER_RUNTIME_SRC,
+                dest: 'assets',
+                rename: { stripBase: true }
+              }
+            ]
+          : [])
       ]
     })
   ]

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -75,6 +75,7 @@
     "@mlightcad/cad-svg-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.12.5",
+    "@mlightcad/three-renderer": "workspace:*",
     "@vueuse/core": "^11.1.0",
     "element-plus": "^2.12.0",
     "lodash-es": "4.17.21",

--- a/packages/cad-viewer/src/app/app.ts
+++ b/packages/cad-viewer/src/app/app.ts
@@ -11,13 +11,33 @@ import {
   registerCmds,
   registerDialogs,
   registerLazyPlugins,
-  registerMTextColorPicker
-} from './register'
+  type RegisterLazyPluginsOptions,
+  registerMTextColorPicker} from './register'
 
-export const initializeCadViewer = (options: AcApDocManagerOptions = {}) => {
-  AcApDocManager.createInstance(options)
+/** Options for {@link initializeCadViewer}. */
+export type InitializeCadViewerOptions = AcApDocManagerOptions & {
+  /**
+   * URL of `viewer-runtime.iife.js` for HTML export (`chtml`).
+   * Forwarded to `@mlightcad/cad-html-plugin` — not required to open DXF/DWG.
+   * @default './assets/viewer-runtime.iife.js'
+   */
+  htmlViewerRuntimeUrl?: string | URL
+}
+
+export const initializeCadViewer = (
+  options: InitializeCadViewerOptions = {}
+) => {
+  const { htmlViewerRuntimeUrl, ...docOptions } = options
+  AcApDocManager.createInstance(docOptions)
   registerCmds()
   registerDialogs()
   registerMTextColorPicker()
-  registerLazyPlugins()
+
+  const lazyPluginOptions: RegisterLazyPluginsOptions = {
+    htmlPlugin: {
+      viewerRuntimeUrl:
+        htmlViewerRuntimeUrl ?? './assets/viewer-runtime.iife.js'
+    }
+  }
+  registerLazyPlugins(lazyPluginOptions)
 }

--- a/packages/cad-viewer/src/app/register.ts
+++ b/packages/cad-viewer/src/app/register.ts
@@ -1,4 +1,7 @@
-import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin/register'
+import {
+  type AcApHtmlPluginOptions,
+  registerLazyHtmlPlugin
+} from '@mlightcad/cad-html-plugin/register'
 import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin/register'
 import {
   AcApDocManager,
@@ -237,21 +240,33 @@ const registerAgentIntegration = async (pluginManager: AcApPluginManager) => {
 }
 
 /**
+ * Options for {@link registerLazyPlugins}.
+ */
+export interface RegisterLazyPluginsOptions {
+  /** Options passed to {@link registerLazyHtmlPlugin} (HTML export only). */
+  htmlPlugin?: AcApHtmlPluginOptions
+}
+
+/**
  * Registers lazy plugins that load on first use of their trigger commands.
  *
  * Currently registers the PDF plugin (`cpdf`, `ipdf`), the HTML export
  * plugin (`-chtml`), the SVG export plugin (`csvg`), and optionally the CAD
  * Agent plugin (`agent`) when `@mlightcad/cad-agent-plugin` is installed.
  * Safe to call multiple times; registration runs once per application lifetime.
+ *
+ * @param options - Optional HTML plugin settings such as `viewerRuntimeUrl`
  */
-export const registerLazyPlugins = () => {
+export const registerLazyPlugins = (
+  options: RegisterLazyPluginsOptions = {}
+) => {
   if (isLazyPluginRegistered) {
     return
   }
 
   const pluginManager = AcApDocManager.instance.pluginManager
   registerLazyPdfPlugin(pluginManager)
-  registerLazyHtmlPlugin(pluginManager)
+  registerLazyHtmlPlugin(pluginManager, options.htmlPlugin)
   registerLazySvgPlugin(pluginManager)
 
   if (!isAgentIntegrationStarted) {

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -152,8 +152,9 @@ interface Props {
   baseUrl?: string
   /**
    * URL of the offline HTML viewer runtime (`viewer-runtime.iife.js`).
-   * Required for File menu “Export to HTML”; copy the file from
-   * `@mlightcad/cad-html-plugin` build output into your app assets.
+   * Used only for File menu “Export to HTML”. Copy the file from
+   * `@mlightcad/cad-html-plugin` into your app assets when you need HTML export.
+   * Not required to open or view DXF/DWG.
    */
   htmlViewerRuntimeUrl?: string | URL
   /**

--- a/packages/cad-viewer/src/component/dialog/MlExportHtmlDlg.vue
+++ b/packages/cad-viewer/src/component/dialog/MlExportHtmlDlg.vue
@@ -234,9 +234,9 @@ async function handleOk() {
       )
     }
 
-    const { AcApHtmlConvertor, resolveAcApHtmlExportOptions } =
+    const { AcApHtmlConvertor, getHtmlPluginOptions, resolveAcApHtmlExportOptions } =
       await import('@mlightcad/cad-html-plugin')
-    const converter = new AcApHtmlConvertor()
+    const converter = new AcApHtmlConvertor(getHtmlPluginOptions())
     await converter.convert(
       document.fileName || document.docTitle,
       resolveAcApHtmlExportOptions(options),

--- a/packages/vite-config/pluginRollupOutput.ts
+++ b/packages/vite-config/pluginRollupOutput.ts
@@ -16,6 +16,28 @@ export const VIEWER_PACKAGE_IDS = [
   'three-renderer'
 ] as const
 
+/**
+ * data-model and its tightly coupled packages — keep together to avoid
+ * cross-chunk "extends undefined" for class hierarchies.
+ */
+export const DATA_MODEL_PACKAGE_IDS = [
+  'data-model',
+  'geometry-engine',
+  'graphic-interface',
+  'common'
+] as const
+
+/**
+ * Packages that stay with the three-renderer chunk (text/rendering stack).
+ * three and data-model are split out separately for clearer caching.
+ */
+export const THREE_RENDERER_STACK_IDS = [
+  'three-renderer',
+  'mtext-renderer',
+  'mtext-parser',
+  'shx-parser'
+] as const
+
 function isPluginRegisterModule(id: string, pluginId: string): boolean {
   return (
     id.includes(`${pluginId}/register`) ||
@@ -36,6 +58,22 @@ function matchMonorepoPackage(id: string, packageId: string): boolean {
   )
 }
 
+/** Match the `three` package without catching `three-renderer` / `@types/three`. */
+function matchThreePackage(id: string): boolean {
+  const normalized = id.replace(/\\/g, '/')
+  if (
+    normalized.includes('three-renderer') ||
+    normalized.includes('@types/three')
+  ) {
+    return false
+  }
+  return (
+    normalized.includes('/node_modules/three/') ||
+    normalized.includes('/node_modules/.pnpm/three@') ||
+    /(?:^|\/)three\/(?:build|examples)\//.test(normalized)
+  )
+}
+
 /**
  * Groups monorepo packages into predictable Rollup chunks for example app builds.
  */
@@ -52,7 +90,26 @@ export const exampleManualChunks: ManualChunksOption = (id: string) => {
     return pluginId
   }
 
+  if (matchThreePackage(id)) {
+    return 'three'
+  }
+
+  for (const packageId of DATA_MODEL_PACKAGE_IDS) {
+    if (matchMonorepoPackage(id, packageId)) {
+      return 'data-model'
+    }
+  }
+
+  for (const packageId of THREE_RENDERER_STACK_IDS) {
+    if (matchMonorepoPackage(id, packageId)) {
+      return 'three-renderer'
+    }
+  }
+
   for (const packageId of VIEWER_PACKAGE_IDS) {
+    if (packageId === 'three-renderer') {
+      continue
+    }
     if (matchMonorepoPackage(id, packageId)) {
       return packageId
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,12 @@ importers:
       '@mlightcad/data-model':
         specifier: ^1.12.5
         version: 1.12.5
+      '@mlightcad/mtext-renderer':
+        specifier: ^0.12.4
+        version: 0.12.4(three@0.172.0)
+      '@mlightcad/three-renderer':
+        specifier: workspace:*
+        version: link:../three-renderer
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -433,6 +439,12 @@ importers:
       '@mlightcad/data-model':
         specifier: ^1.12.5
         version: 1.12.5
+      '@mlightcad/mtext-renderer':
+        specifier: ^0.12.4
+        version: 0.12.4(three@0.172.0)
+      '@mlightcad/three-renderer':
+        specifier: workspace:*
+        version: link:../three-renderer
       element-plus:
         specifier: ^2.12.0
         version: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))


### PR DESCRIPTION
## Summary
- Split example Rollup chunks so `data-model`, `three`, and `three-renderer` stay separately cacheable (avoids cross-chunk class hierarchy breakage).
- Move `htmlViewerRuntimeUrl` off `AcApDocManager` onto `@mlightcad/cad-html-plugin` options (`viewerRuntimeUrl` via `registerLazyHtmlPlugin` / `createHtmlPlugin` / `AcApHtmlConvertor`).
- Soften example Vite configs so missing `viewer-runtime.iife.js` only warns — opening DXF/DWG no longer requires the HTML export asset.

## Test plan
- [ ] Build examples without building `cad-html-plugin` first; confirm DXF/DWG open still works and Vite only warns about missing runtime
- [ ] Build `cad-html-plugin`, restart example, run `chtml` / Export to HTML and confirm runtime is fetched from the configured URL
- [ ] In `cad-viewer`, verify `MlCadViewer` `htmlViewerRuntimeUrl` prop still reaches the plugin via `initializeCadViewer`
- [ ] Confirm example bundle output has separate `data-model` / `three` / `three-renderer` chunks and no runtime "extends undefined" errors on open
