### PR TITLE
feat: make measurements undoable and share ribbon draw style

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
@@ -209,7 +209,8 @@ jest.mock('../src/command', () => {
         jest.fn().mockImplementation(() => ({ trigger: jest.fn() }))
       ])
     ),
-    resetMarkupSession: jest.fn()
+    resetMarkupSession: jest.fn(),
+    resetMeasurementSession: jest.fn()
   }
 })
 

--- a/packages/cad-simple-viewer/__tests__/AcApMarkupHistory.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupHistory.spec.ts
@@ -1,6 +1,7 @@
 import type { AcDbDatabase } from '@mlightcad/data-model'
 
 import {
+  bindOverlayHistory,
   getMarkupHistory,
   getSessionUndo
 } from '../src/command/markup/AcApMarkupHistory'
@@ -25,6 +26,7 @@ describe('AcApSessionUndo fallback', () => {
   beforeEach(() => {
     getMarkupHistory().clear()
     getSessionUndo().clear()
+    bindOverlayHistory(undefined)
     jest.restoreAllMocks()
   })
 
@@ -57,6 +59,32 @@ describe('AcApSessionUndo fallback', () => {
   it('returns db when leftover db undo succeeds', () => {
     expect(getSessionUndo().undo(mockDb({ canUndo: true, undo: true }))).toBe(
       'db'
+    )
+  })
+
+  it('returns overlay when leftover overlay undo succeeds', () => {
+    bindOverlayHistory({
+      canUndo: () => true,
+      canRedo: () => false,
+      undo: () => true,
+      redo: () => false,
+      clearRedo: () => {},
+      clear: () => {}
+    })
+    expect(getSessionUndo().undo(mockDb({}))).toBe('overlay')
+  })
+
+  it('returns false when leftover overlay undo fails', () => {
+    bindOverlayHistory({
+      canUndo: () => true,
+      canRedo: () => false,
+      undo: () => false,
+      redo: () => false,
+      clearRedo: () => {},
+      clear: () => {}
+    })
+    expect(getSessionUndo().undo(mockDb({ canUndo: true, undo: false }))).toBe(
+      false
     )
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcApMarkupStore.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupStore.spec.ts
@@ -34,4 +34,32 @@ describe('AcApMarkupStore', () => {
     expect(store.selectedId).toBeUndefined()
     expect(store.drawingName).toBeUndefined()
   })
+
+  it('updateMeta patches the label and keeps attached callout text in sync', () => {
+    const store = new AcApMarkupStore()
+    store.upsert({
+      ...sampleRecord('cloud-1'),
+      type: 'cloud',
+      text: 'Old',
+      geometry: {
+        type: 'cloud',
+        corner1: { x: 0, y: 0 },
+        corner2: { x: 2, y: 2 },
+        callout: {
+          tip: { x: 0, y: 0 },
+          anchor: { x: 3, y: 3 },
+          text: 'Old'
+        }
+      }
+    })
+
+    const updated = store.updateMeta('cloud-1', { text: 'New label' })
+    expect(updated?.text).toBe('New label')
+    expect(store.get('cloud-1')?.text).toBe('New label')
+    const geom = store.get('cloud-1')?.geometry
+    expect(geom?.type).toBe('cloud')
+    if (geom?.type === 'cloud') {
+      expect(geom.callout?.text).toBe('New label')
+    }
+  })
 })

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementHistory.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementHistory.spec.ts
@@ -1,0 +1,149 @@
+import { AcCmColor, type AcDbDatabase } from '@mlightcad/data-model'
+import type { AcTrHtmlGroup } from '@mlightcad/three-renderer'
+
+import {
+  getMarkupHistory,
+  getSessionUndo
+} from '../src/command/markup/AcApMarkupHistory'
+import {
+  bindMeasurementOverlayHistory,
+  resetMeasurementSession,
+  runMeasurementEdit
+} from '../src/command/measure/AcApMeasurementHistory'
+import {
+  applyMeasurementStyle,
+  commitMeasurementGroup,
+  getMeasurementStyle,
+  MEASUREMENT_LAYER
+} from '../src/command/measure/AcApMeasurementStore'
+import {
+  MEASUREMENT_FONT_SIZE,
+  MEASUREMENT_LINE_WEIGHT
+} from '../src/util/AcApMeasurementUtil'
+import type { AcTrView2d } from '../src/view'
+
+function mockDb(): AcDbDatabase {
+  return {
+    transactionManager: {
+      canUndo: () => false,
+      undo: () => false,
+      canRedo: () => false,
+      redo: () => false
+    }
+  } as unknown as AcDbDatabase
+}
+
+function createView() {
+  const groups = new Map<string, AcTrHtmlGroup>()
+  const manager = {
+    groupsOnLayer(layer: string) {
+      return [...groups.values()].filter(group => group.layer === layer)
+    },
+    add(group: AcTrHtmlGroup) {
+      groups.set(group.id, group)
+    },
+    detach(id: string) {
+      const group = groups.get(id)
+      groups.delete(id)
+      return group
+    },
+    reattach(group: AcTrHtmlGroup) {
+      groups.set(group.id, group)
+    },
+    has(id: string) {
+      return groups.has(id)
+    },
+    getGroup(id: string) {
+      return groups.get(id)
+    }
+  }
+  const view = {
+    htmlTransientManager: manager,
+    isDirty: false,
+    removeTransientEntity: jest.fn(),
+    addTransientEntity: jest.fn(),
+    highlight: jest.fn(),
+    unhighlight: jest.fn(),
+    setTransientEntityVisible: jest.fn()
+  } as unknown as AcTrView2d
+  return { view, manager }
+}
+
+function makeGroup(id: string): AcTrHtmlGroup {
+  return {
+    id,
+    layer: MEASUREMENT_LAYER,
+    children: [],
+    dispose: jest.fn()
+  } as unknown as AcTrHtmlGroup
+}
+
+describe('AcApMeasurementHistory', () => {
+  beforeEach(() => {
+    bindMeasurementOverlayHistory()
+    resetMeasurementSession()
+    getMarkupHistory().clear()
+    getSessionUndo().clear()
+  })
+
+  afterEach(() => {
+    resetMeasurementSession()
+    getSessionUndo().clear()
+  })
+
+  it('undo detaches a created measurement and redo reattaches it', () => {
+    const { view, manager } = createView()
+    const group = makeGroup('m-create')
+    runMeasurementEdit(view, 'Create Measurement', () => {
+      manager.add(group)
+    })
+
+    expect(manager.getGroup('m-create')).toBe(group)
+    expect(getSessionUndo().undo(mockDb())).toBe('overlay')
+    expect(manager.getGroup('m-create')).toBeUndefined()
+    expect(getSessionUndo().redo(mockDb())).toBe('overlay')
+    expect(manager.getGroup('m-create')).toBe(group)
+  })
+
+  it('undo restores a deleted measurement', () => {
+    const { view, manager } = createView()
+    const group = makeGroup('m-del')
+    runMeasurementEdit(view, 'Create Measurement', () => {
+      manager.add(group)
+    })
+
+    runMeasurementEdit(view, 'Delete Measurement', () => {
+      manager.detach(group.id)
+    })
+    expect(manager.getGroup('m-del')).toBeUndefined()
+
+    expect(getSessionUndo().undo(mockDb())).toBe('overlay')
+    expect(manager.getGroup('m-del')).toBe(group)
+  })
+
+  it('undo restores a measurement style-only edit', () => {
+    const { view, manager } = createView()
+    const group = makeGroup('m-style')
+    const color = new AcCmColor()
+    color.setRGB(123, 45, 67)
+    commitMeasurementGroup(view, group, {
+      style: {
+        color,
+        lineWeight: MEASUREMENT_LINE_WEIGHT,
+        fontSize: MEASUREMENT_FONT_SIZE
+      }
+    })
+    expect(manager.getGroup('m-style')).toBe(group)
+    expect(getMeasurementStyle('m-style')?.fontSize).toBe(MEASUREMENT_FONT_SIZE)
+
+    runMeasurementEdit(view, 'Measurement Style', () => {
+      applyMeasurementStyle(view, group, { fontSize: 20 })
+    })
+    expect(getMeasurementStyle('m-style')?.fontSize).toBe(20)
+
+    expect(getSessionUndo().undo(mockDb())).toBe('overlay')
+    expect(getMeasurementStyle('m-style')?.fontSize).toBe(MEASUREMENT_FONT_SIZE)
+    expect(getSessionUndo().redo(mockDb())).toBe('overlay')
+    expect(getMeasurementStyle('m-style')?.fontSize).toBe(20)
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts
@@ -1,0 +1,68 @@
+import { AcCmColor, AcGiLineWeight, type AcDbDatabase } from '@mlightcad/data-model'
+
+import {
+  currentMeasurementStyle,
+  getMeasurementFontSize,
+  getMeasurementLineWeight,
+  MEASUREMENT_FONT_SIZE,
+  MEASUREMENT_LINE_WEIGHT,
+  measurementCanvasLineWidth,
+  measurementColor,
+  resetMeasurementDrawStyle,
+  setMeasurementDrawColor,
+  setMeasurementDrawFontSize,
+  setMeasurementDrawLineWeight
+} from '../src/util/AcApMeasurementUtil'
+
+function mockDb(): AcDbDatabase {
+  return {} as AcDbDatabase
+}
+
+describe('AcApMeasurementUtil', () => {
+  afterEach(() => {
+    resetMeasurementDrawStyle()
+  })
+
+  it('keeps factory line weight and font size until they are changed', () => {
+    expect(getMeasurementLineWeight()).toBe(MEASUREMENT_LINE_WEIGHT)
+    expect(getMeasurementFontSize()).toBe(MEASUREMENT_FONT_SIZE)
+  })
+
+  it('stores session draw color, line weight, and font size for later measurements', () => {
+    const color = new AcCmColor()
+    color.setRGB(10, 20, 30)
+    setMeasurementDrawColor(color)
+    setMeasurementDrawLineWeight(AcGiLineWeight.LineWeight013)
+    setMeasurementDrawFontSize(18)
+
+    const drawn = measurementColor(mockDb())
+    expect(drawn.red).toBe(10)
+    expect(drawn.green).toBe(20)
+    expect(drawn.blue).toBe(30)
+    expect(getMeasurementLineWeight()).toBe(AcGiLineWeight.LineWeight013)
+    expect(getMeasurementFontSize()).toBe(18)
+
+    const style = currentMeasurementStyle(mockDb())
+    expect(style.fontSize).toBe(18)
+    expect(style.lineWeight).toBe(AcGiLineWeight.LineWeight013)
+    expect(style.color.red).toBe(10)
+  })
+
+  it('ignores non-positive font sizes', () => {
+    setMeasurementDrawFontSize(16)
+    setMeasurementDrawFontSize(0)
+    setMeasurementDrawFontSize(-4)
+    expect(getMeasurementFontSize()).toBe(16)
+  })
+
+  it('maps CAD line weight 070 to a 2.5px canvas stroke', () => {
+    expect(measurementCanvasLineWidth(MEASUREMENT_LINE_WEIGHT)).toBeCloseTo(2.5)
+  })
+
+  it('ignores non-positive line weights', () => {
+    setMeasurementDrawLineWeight(AcGiLineWeight.LineWeight211)
+    setMeasurementDrawLineWeight(AcGiLineWeight.ByLayer)
+    setMeasurementDrawLineWeight(AcGiLineWeight.ByBlock)
+    expect(getMeasurementLineWeight()).toBe(AcGiLineWeight.LineWeight211)
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcEdViewKeyHandler.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdViewKeyHandler.spec.ts
@@ -32,7 +32,11 @@ function keyboardEvent(partial: Partial<KeyboardEvent>): KeyboardEvent {
 
 function createMockView(
   isEditorActive = false,
-  htmlSelection: { hasSelection?: boolean; deleted?: boolean } = {}
+  htmlSelection: {
+    hasSelection?: boolean
+    deleted?: boolean
+    groups?: { id: string; layer: string }[]
+  } = {}
 ): AcTrView2d {
   return {
     editor: { isActive: isEditorActive },
@@ -40,7 +44,11 @@ function createMockView(
     htmlTransientManager: {
       hasSelection: jest.fn(() => htmlSelection.hasSelection ?? false),
       deleteSelected: jest.fn(() => htmlSelection.deleted ?? false),
-      deselectAll: jest.fn()
+      deselectAll: jest.fn(),
+      getSelectedGroups: jest.fn(() => htmlSelection.groups ?? []),
+      detach: jest.fn((id: string) => ({ id })),
+      groupsOnLayer: jest.fn(() => []),
+      has: jest.fn(() => false)
     },
     isDirty: false
   } as unknown as AcTrView2d
@@ -95,6 +103,38 @@ describe('AcEdViewKeyHandler', () => {
 
     expect(handled).toBe(false)
     expect(sendCommand).not.toHaveBeenCalled()
+  })
+
+  test('Delete detaches a selected measurement overlay without dispatching erase', () => {
+    const view = createMockView(false, {
+      hasSelection: true,
+      groups: [{ id: 'm1', layer: 'measurement' }]
+    })
+    const handler = new AcEdViewKeyHandler(view)
+    const sendCommand = AcApDocManager.instance.sendStringToExecute as jest.Mock
+    const event = keyboardEvent({ code: 'Delete' })
+
+    expect(handler.handleKeyDown(event)).toBe(true)
+    expect(view.htmlTransientManager.detach).toHaveBeenCalledWith('m1')
+    expect(view.htmlTransientManager.deleteSelected).not.toHaveBeenCalled()
+    expect(sendCommand).not.toHaveBeenCalled()
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  test('Backspace detaches a selected measurement overlay (macOS delete key)', () => {
+    const view = createMockView(false, {
+      hasSelection: true,
+      groups: [{ id: 'm1', layer: 'measurement' }]
+    })
+    const handler = new AcEdViewKeyHandler(view)
+    const sendCommand = AcApDocManager.instance.sendStringToExecute as jest.Mock
+    const event = keyboardEvent({ code: 'Backspace' })
+
+    expect(handler.handleKeyDown(event)).toBe(true)
+    expect(view.htmlTransientManager.detach).toHaveBeenCalledWith('m1')
+    expect(view.htmlTransientManager.deleteSelected).not.toHaveBeenCalled()
+    expect(sendCommand).not.toHaveBeenCalled()
+    expect(event.preventDefault).toHaveBeenCalled()
   })
 
   test('Delete removes a selected HTML overlay without dispatching erase', () => {

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -93,7 +93,8 @@ import {
   AcApXAttachCmd,
   AcApXLineCmd,
   AcApZoomCmd,
-  resetMarkupSession
+  resetMarkupSession,
+  resetMeasurementSession
 } from '../command'
 import {
   AcEdCalculateSizeCallback,
@@ -1609,7 +1610,8 @@ export class AcApDocManager {
     this._openFileProgress.setSeeThroughOverlay(
       options?.progressiveRendering ?? false
     )
-    // Drop markup records / history before view.clear() disposes HTML overlays.
+    // Drop overlay / markup history before view.clear() disposes HTML.
+    resetMeasurementSession()
     resetMarkupSession()
     this.curView.clear()
     // OPENPROF: start stage timings before db.read / entity flush.

--- a/packages/cad-simple-viewer/src/command/AcApRedoCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApRedoCmd.ts
@@ -6,7 +6,7 @@ import { getSessionUndo } from './markup/AcApMarkupHistory'
 import { getMarkupPresenter } from './markup/AcApMarkupPresenter'
 
 /**
- * Redoes the last undone session editing operation (database or markup).
+ * Redoes the last undone session editing operation (database, markup, or measurement).
  */
 export class AcApRedoCmd extends AcEdCommand {
   constructor() {

--- a/packages/cad-simple-viewer/src/command/AcApUndoCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApUndoCmd.ts
@@ -6,7 +6,7 @@ import { getSessionUndo } from './markup/AcApMarkupHistory'
 import { getMarkupPresenter } from './markup/AcApMarkupPresenter'
 
 /**
- * Undoes the last session editing operation (database or Design Review markup).
+ * Undoes the last session editing operation (database, markup, or measurement).
  */
 export class AcApUndoCmd extends AcEdCommand {
   constructor() {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupHistory.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupHistory.ts
@@ -6,16 +6,65 @@ import { acapNotifyUndoStackChanged } from '../../util/AcApDatabaseEdit'
 import { getMarkupStore } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 
-/** One undoable markup store mutation (full-store snapshots). */
+/**
+ * One undoable markup store mutation (full-store snapshots).
+ */
 interface AcApMarkupHistoryEntry {
+  /** Human-readable undo label (e.g. command name). */
   label: string
+  /** Markup records before the mutation. */
   before: AcApMarkupRecord[]
+  /** Markup records after the mutation. */
   after: AcApMarkupRecord[]
+  /** Store dirty flag before the mutation. */
   beforeDirty: boolean
+  /** Store dirty flag after the mutation. */
   afterDirty: boolean
 }
 
-type SessionOpKind = 'db' | 'markup'
+/**
+ * Kind of session-level undoable operation.
+ * - `'db'`: CAD database transaction
+ * - `'markup'`: Design Review markup store snapshot
+ * - `'overlay'`: HTML overlay (e.g. measurement) history
+ */
+type SessionOpKind = 'db' | 'markup' | 'overlay'
+
+/** Undo/redo binding for HTML overlay histories (e.g. measurements). */
+export interface AcApOverlayHistoryBinding {
+  /** Whether the overlay history has an undo step. */
+  canUndo(): boolean
+  /** Whether the overlay history has a redo step. */
+  canRedo(): boolean
+  /**
+   * Undo the last overlay mutation.
+   * @returns true when a step was applied.
+   */
+  undo(): boolean
+  /**
+   * Redo the last undone overlay mutation.
+   * @returns true when a step was applied.
+   */
+  redo(): boolean
+  /** Drop redo entries (e.g. after a new DB or markup edit). */
+  clearRedo(): void
+  /** Drop all overlay history (e.g. document close). */
+  clear(): void
+}
+
+/** Bound HTML overlay history consulted by {@link AcApSessionUndo}. */
+let overlayHistory: AcApOverlayHistoryBinding | undefined
+
+/**
+ * Register the measurement / HTML overlay history with session undo.
+ * Pass `undefined` to unbind.
+ * @param history - Overlay history adapter, or `undefined` to clear the binding.
+ */
+export function bindOverlayHistory(
+  history: AcApOverlayHistoryBinding | undefined
+): void {
+  overlayHistory = history
+}
 
 /**
  * Snapshot-based undo/redo for Design Review markups.
@@ -26,8 +75,14 @@ type SessionOpKind = 'db' | 'markup'
  * Visual republish is the caller's responsibility after {@link undo}/{@link redo}.
  */
 export class AcApMarkupHistory {
+  /** Undo stack of markup store snapshots (oldest first). */
   private readonly undoStack: AcApMarkupHistoryEntry[] = []
+  /** Redo stack of markup store snapshots (oldest first). */
   private readonly redoStack: AcApMarkupHistoryEntry[] = []
+  /**
+   * Nesting depth of {@link run} / {@link apply}. Greater than zero means a
+   * mutation is in progress and nested {@link run} calls are not recorded.
+   */
   private depth = 0
 
   /** True while applying undo/redo or nested inside {@link run}. */
@@ -35,10 +90,12 @@ export class AcApMarkupHistory {
     return this.depth > 0
   }
 
+  /** Whether there is at least one markup undo step. */
   canUndo(): boolean {
     return this.undoStack.length > 0
   }
 
+  /** Whether there is at least one markup redo step. */
   canRedo(): boolean {
     return this.redoStack.length > 0
   }
@@ -57,6 +114,9 @@ export class AcApMarkupHistory {
   /**
    * Run a markup mutation and record one undo step when the store changes.
    * Nested calls do not create extra entries.
+   * @param _view - Active view (unused; kept for API symmetry with overlay history).
+   * @param label - Human-readable undo label.
+   * @param mutate - Mutation to run against the markup store.
    */
   run(_view: AcEdBaseView, label: string, mutate: () => void): void {
     if (this.depth > 0) {
@@ -111,6 +171,11 @@ export class AcApMarkupHistory {
     return true
   }
 
+  /**
+   * Replace the markup store with a snapshot and restore its dirty flag.
+   * @param records - Markup records to restore.
+   * @param dirty - Dirty flag to restore alongside the records.
+   */
   private apply(records: AcApMarkupRecord[], dirty: boolean): void {
     this.depth++
     try {
@@ -122,10 +187,13 @@ export class AcApMarkupHistory {
 }
 
 /**
- * Chronological session undo that interleaves DB edits and markup edits.
+ * Chronological session undo that interleaves DB edits, markup edits,
+ * and HTML overlay (measurement) edits.
  */
 export class AcApSessionUndo {
+  /** Chronological kinds of committed session ops (oldest first). */
   private readonly undoKinds: SessionOpKind[] = []
+  /** Chronological kinds of undone session ops waiting to redo (oldest first). */
   private readonly redoKinds: SessionOpKind[] = []
 
   /** Call when a new outermost DB undo mark is committed. */
@@ -133,42 +201,70 @@ export class AcApSessionUndo {
     this.undoKinds.push('db')
     this.redoKinds.length = 0
     getMarkupHistory().clearRedo()
+    overlayHistory?.clearRedo()
   }
 
   /** Call when a new markup history entry is pushed. */
   recordMarkup(): void {
     this.undoKinds.push('markup')
     this.redoKinds.length = 0
+    overlayHistory?.clearRedo()
   }
 
+  /** Call when a new HTML overlay (measurement) history entry is pushed. */
+  recordOverlay(): void {
+    this.undoKinds.push('overlay')
+    this.redoKinds.length = 0
+    getMarkupHistory().clearRedo()
+  }
+
+  /**
+   * Whether any session op (DB, markup, or overlay) can be undone.
+   * @param db - Database whose transaction manager is consulted for DB undo.
+   */
   canUndo(db: AcDbDatabase): boolean {
     return (
       this.undoKinds.length > 0 ||
       getMarkupHistory().canUndo() ||
+      (overlayHistory?.canUndo() ?? false) ||
       (db.transactionManager?.canUndo() ?? false)
     )
   }
 
+  /**
+   * Whether any session op (DB, markup, or overlay) can be redone.
+   * @param db - Database whose transaction manager is consulted for DB redo.
+   */
   canRedo(db: AcDbDatabase): boolean {
     return (
       this.redoKinds.length > 0 ||
       getMarkupHistory().canRedo() ||
+      (overlayHistory?.canRedo() ?? false) ||
       (db.transactionManager?.canRedo() ?? false)
     )
   }
 
   /**
    * Undo the chronologically last session op.
-   * @returns `'markup'` when visuals must be republished, `'db'` when only DB
+   * @param db - Database used when the last op was a DB transaction.
+   * @returns `'markup'` when markup visuals must be republished, `'overlay'`
+   *   when HTML overlay undo already updated the view, `'db'` when only DB
    *   changed, or `false` when nothing was undone.
    */
-  undo(db: AcDbDatabase): 'markup' | 'db' | false {
+  undo(db: AcDbDatabase): 'markup' | 'overlay' | 'db' | false {
     while (true) {
       const kind = this.undoKinds.pop()
       if (kind === 'markup') {
         if (getMarkupHistory().undo()) {
           this.redoKinds.push('markup')
           return 'markup'
+        }
+        continue
+      }
+      if (kind === 'overlay') {
+        if (overlayHistory?.undo()) {
+          this.redoKinds.push('overlay')
+          return 'overlay'
         }
         continue
       }
@@ -183,6 +279,10 @@ export class AcApSessionUndo {
         this.redoKinds.push('markup')
         return 'markup'
       }
+      if (overlayHistory?.undo()) {
+        this.redoKinds.push('overlay')
+        return 'overlay'
+      }
       if (db.transactionManager?.undo()) {
         this.redoKinds.push('db')
         return 'db'
@@ -193,16 +293,25 @@ export class AcApSessionUndo {
 
   /**
    * Redo the chronologically last undone session op.
-   * @returns `'markup'` when visuals must be republished, `'db'` when only DB
+   * @param db - Database used when the last undone op was a DB transaction.
+   * @returns `'markup'` when markup visuals must be republished, `'overlay'`
+   *   when HTML overlay redo already updated the view, `'db'` when only DB
    *   changed, or `false` when nothing was redone.
    */
-  redo(db: AcDbDatabase): 'markup' | 'db' | false {
+  redo(db: AcDbDatabase): 'markup' | 'overlay' | 'db' | false {
     while (true) {
       const kind = this.redoKinds.pop()
       if (kind === 'markup') {
         if (getMarkupHistory().redo()) {
           this.undoKinds.push('markup')
           return 'markup'
+        }
+        continue
+      }
+      if (kind === 'overlay') {
+        if (overlayHistory?.redo()) {
+          this.undoKinds.push('overlay')
+          return 'overlay'
         }
         continue
       }
@@ -217,6 +326,10 @@ export class AcApSessionUndo {
         this.undoKinds.push('markup')
         return 'markup'
       }
+      if (overlayHistory?.redo()) {
+        this.undoKinds.push('overlay')
+        return 'overlay'
+      }
       if (db.transactionManager?.redo()) {
         this.undoKinds.push('db')
         return 'db'
@@ -225,13 +338,17 @@ export class AcApSessionUndo {
     }
   }
 
+  /** Drop session undo/redo kinds and bound overlay history. */
   clear(): void {
     this.undoKinds.length = 0
     this.redoKinds.length = 0
+    overlayHistory?.clear()
   }
 }
 
+/** Session-wide markup history singleton. */
 let sharedHistory: AcApMarkupHistory | undefined
+/** Session-wide DB / markup / overlay undo coordinator singleton. */
 let sharedSessionUndo: AcApSessionUndo | undefined
 
 /** Shared markup history for the active session. */
@@ -249,6 +366,9 @@ export function getSessionUndo(): AcApSessionUndo {
 /**
  * Record an undoable markup edit.
  * Prefer this over mutating the store directly from UI / commands.
+ * @param view - Active view (unused by history; kept for API symmetry).
+ * @param label - Human-readable undo label.
+ * @param mutate - Mutation to run against the markup store.
  */
 export function runMarkupEdit(
   view: AcEdBaseView,
@@ -263,10 +383,21 @@ eventBus.on('session-db-edit-committed', () => {
   getSessionUndo().recordDb()
 })
 
+/**
+ * Deep-clone markup records so later store mutations cannot alias history.
+ * @param records - Records to snapshot.
+ * @returns Independent copies of `records`.
+ */
 function cloneRecords(records: AcApMarkupRecord[]): AcApMarkupRecord[] {
   return structuredClone(records)
 }
 
+/**
+ * Whether two markup-record snapshots are structurally equal.
+ * @param a - First snapshot.
+ * @param b - Second snapshot.
+ * @returns true when both arrays stringify to the same JSON.
+ */
 function recordsEqual(a: AcApMarkupRecord[], b: AcApMarkupRecord[]): boolean {
   if (a.length !== b.length) return false
   return JSON.stringify(a) === JSON.stringify(b)

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
@@ -36,7 +36,8 @@ import type {
 } from './AcApMarkupTypes'
 import {
   cssToMarkupColor,
-  MARKUP_LINE_WEIGHT
+  MARKUP_LINE_WEIGHT,
+  markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
 const CLOUD_DIAMETER_PIXELS = 8
@@ -184,10 +185,11 @@ function drawLeader(
   tip: { x: number; y: number },
   anchor: { x: number; y: number },
   color: string,
-  withArrow = true
+  withArrow = true,
+  lineWidth = 2
 ): void {
   ctx.strokeStyle = color
-  ctx.lineWidth = 2
+  ctx.lineWidth = lineWidth
   ctx.beginPath()
   ctx.moveTo(tip.x, tip.y)
   ctx.lineTo(anchor.x, anchor.y)
@@ -201,7 +203,8 @@ function drawHighlight(
   ctx: CanvasRenderingContext2D,
   a: { x: number; y: number },
   b: { x: number; y: number },
-  color: string
+  color: string,
+  lineWidth = 1.5
 ): void {
   const x = Math.min(a.x, b.x)
   const y = Math.min(a.y, b.y)
@@ -212,7 +215,7 @@ function drawHighlight(
   ctx.fillRect(x, y, w, h)
   ctx.globalAlpha = 1
   ctx.strokeStyle = color
-  ctx.lineWidth = 1.5
+  ctx.lineWidth = lineWidth
   ctx.strokeRect(x, y, w, h)
 }
 
@@ -253,7 +256,12 @@ function publishAttachedCallout(
       view2d.worldToScreen(live.tip),
       view2d.worldToScreen(live.anchor),
       record.style.color,
-      false
+      false,
+      markupCanvasLineWidth(
+        record.style.lineWeight != null && record.style.lineWeight > 0
+          ? record.style.lineWeight
+          : MARKUP_LINE_WEIGHT
+      )
     )
   }
   redraw()
@@ -344,14 +352,17 @@ export class AcApMarkupPresenter {
    */
   publish(view: AcEdBaseView, record: AcApMarkupRecord): void {
     const view2d = asView2d(view)
+    const restoreSelection = getMarkupStore().selectedId === record.id
     if (this.published.has(record.id)) {
       this.unpublish(view, record.id, { keepInStore: true })
     }
 
     const color = cssToMarkupColor(record.style.color)
     const lineWeight =
-      (record.style.lineWeight as AcGiLineWeight | undefined) ??
-      MARKUP_LINE_WEIGHT
+      record.style.lineWeight != null && record.style.lineWeight > 0
+        ? (record.style.lineWeight as AcGiLineWeight)
+        : MARKUP_LINE_WEIGHT
+    const canvasLineWidth = markupCanvasLineWidth(lineWeight)
     const layer = MARKUP_LAYER
     const layoutId = record.layoutId
     const extras: VisualExtras = { entityIds: [], dispose: () => undefined }
@@ -569,7 +580,8 @@ export class AcApMarkupPresenter {
             ctx,
             view2d.worldToScreen(geom.corner1),
             view2d.worldToScreen(geom.corner2),
-            record.style.color
+            record.style.color,
+            canvasLineWidth
           )
         }
         redraw()
@@ -612,7 +624,9 @@ export class AcApMarkupPresenter {
             ctx,
             view2d.worldToScreen(live.tip),
             view2d.worldToScreen(live.anchor),
-            record.style.color
+            record.style.color,
+            true,
+            canvasLineWidth
           )
         }
         redraw()
@@ -731,8 +745,10 @@ export class AcApMarkupPresenter {
     view2d.isDirty = true
     this.published.add(record.id)
 
-    // Preserve selection across republish (style edits / geometry commits).
-    if (getMarkupStore().selectedId === record.id) {
+    // Preserve selection across republish (style / label / geometry edits).
+    // Removing the previous group clears selection; restore it on the new one.
+    if (restoreSelection) {
+      getMarkupStore().setSelectedId(record.id)
       view2d.htmlTransientManager.selectGroup(record.id)
     }
   }

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupStore.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupStore.ts
@@ -87,6 +87,10 @@ export class AcApMarkupStore {
     const next: AcApMarkupRecord = {
       ...existing,
       ...patch,
+      geometry:
+        patch.text !== undefined
+          ? withAttachedCalloutText(existing.geometry, patch.text)
+          : existing.geometry,
       updatedAt: new Date().toISOString()
     }
     this.records.set(id, next)
@@ -247,6 +251,27 @@ let sharedStore: AcApMarkupStore | undefined
 export function getMarkupStore(): AcApMarkupStore {
   if (!sharedStore) sharedStore = new AcApMarkupStore()
   return sharedStore
+}
+
+/**
+ * Keep shape-attached callout bubble text in sync with the record label.
+ */
+function withAttachedCalloutText(
+  geometry: AcApMarkupRecord['geometry'],
+  text: string | undefined
+): AcApMarkupRecord['geometry'] {
+  if (
+    (geometry.type === 'cloud' ||
+      geometry.type === 'rect' ||
+      geometry.type === 'circle') &&
+    geometry.callout
+  ) {
+    return {
+      ...geometry,
+      callout: { ...geometry.callout, text }
+    }
+  }
+  return geometry
 }
 
 /** Valid status values for UI / validation. */

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
@@ -50,6 +50,7 @@ export function setMarkupDrawColor(color: AcCmColor): void {
 
 /** Update the session markup draw line weight. */
 export function setMarkupDrawLineWeight(weight: AcGiLineWeight): void {
+  if (!(weight > 0)) return
   markupDrawLineWeight = weight
 }
 
@@ -57,6 +58,13 @@ export function setMarkupDrawLineWeight(weight: AcGiLineWeight): void {
 export function setMarkupDrawFontSize(size: number): void {
   if (!Number.isFinite(size) || size <= 0) return
   markupDrawFontSize = size
+}
+
+/** Map a CAD line weight to a canvas stroke width in CSS pixels. */
+export function markupCanvasLineWidth(weight: AcGiLineWeight | number): number {
+  const n = Number(weight)
+  if (!Number.isFinite(n) || n <= 0) return 2
+  return Math.max(1, n / 28)
 }
 
 /** Convert AcCmColor to a CSS color string for sidecar style. */

--- a/packages/cad-simple-viewer/src/command/measure/AcApClearMeasurementsCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApClearMeasurementsCmd.ts
@@ -1,6 +1,7 @@
 import { AcApContext } from '../../app'
 import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { AcTrView2d } from '../../view'
+import { runMeasurementEdit } from './AcApMeasurementHistory'
 import {
   MEASUREMENT_LAYER,
   MEASUREMENT_LIVE_LAYER
@@ -14,13 +15,15 @@ export {
 } from './AcApMeasurementStore'
 
 /**
- * Removes every measurement HTML overlay (committed + live) and clears
- * selection. Group `onDispose` hooks release CAD / canvas resources.
+ * Removes every committed measurement overlay (detached so Undo can restore
+ * them) and disposes live jig overlays.
  */
 export function clearAllMeasurements(view: AcTrView2d): void {
   const ht = view.htmlTransientManager
-  ht.deselectAll()
-  ht.clear(MEASUREMENT_LAYER)
+  runMeasurementEdit(view, 'Clear Measurements', () => {
+    ht.deselectAll()
+    ht.detachLayer(MEASUREMENT_LAYER)
+  })
   ht.clear(MEASUREMENT_LIVE_LAYER)
   view.isDirty = true
 }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
@@ -2,8 +2,7 @@ import {
   AcCmColor,
   AcDbDatabase,
   AcDbLine,
-  AcGePoint3dLike,
-  AcGiLineWeight
+  AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
   AcTrHtmlBadge,
@@ -25,10 +24,18 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
-import { cssColor, measurementColor } from '../../util'
+import {
+  cssColor,
+  currentMeasurementStyle,
+  getMeasurementFontSize,
+  getMeasurementLineWeight,
+  measurementCanvasLineWidth,
+  measurementColor
+} from '../../util'
 import { AcTrView2d } from '../../view'
 import {
   commitMeasurementGroup,
+  getMeasurementStyle,
   MEASUREMENT_LAYER,
   MEASUREMENT_LIVE_LAYER
 } from './AcApMeasurementStore'
@@ -62,7 +69,8 @@ function drawArm1OnCanvas(
   view: AcEdBaseView,
   vertex: AcGePoint3dLike,
   arm1: AcGePoint3dLike,
-  color: AcCmColor
+  color: AcCmColor,
+  lineWidth = 2
 ): void {
   const rect = view.canvas.getBoundingClientRect()
   const dpr = window.devicePixelRatio || 1
@@ -94,7 +102,7 @@ function drawArm1OnCanvas(
   ctx.moveTo(sv.x, sv.y)
   ctx.lineTo(sa.x, sa.y)
   ctx.strokeStyle = cssColor(color)
-  ctx.lineWidth = 2
+  ctx.lineWidth = lineWidth
   ctx.setLineDash([8, 5])
   ctx.stroke()
   ctx.setLineDash([])
@@ -112,7 +120,8 @@ function drawAngleArcOnCanvas(
   vertex: AcGePoint3dLike,
   arm1: AcGePoint3dLike,
   arm2: AcGePoint3dLike,
-  color: AcCmColor
+  color: AcCmColor,
+  lineWidth = 2
 ): void {
   const rect = view.canvas.getBoundingClientRect()
   const dpr = window.devicePixelRatio || 1
@@ -152,7 +161,7 @@ function drawAngleArcOnCanvas(
   ctx.beginPath()
   ctx.arc(sv.x, sv.y, arcR, startAngle, endAngle, antiClockwise)
   ctx.strokeStyle = cssColor(color)
-  ctx.lineWidth = 2
+  ctx.lineWidth = lineWidth
   ctx.stroke()
   ctx.restore()
 }
@@ -168,7 +177,7 @@ class AcApMeasureArm1Jig extends AcEdPreviewJig<AcGePoint3dLike> {
     super(view)
     this._line = new AcDbLine(vertex, vertex)
     this._line.color = color
-    this._line.lineWeight = AcGiLineWeight.LineWeight070
+    this._line.lineWeight = getMeasurementLineWeight()
   }
 
   get entity(): AcDbLine {
@@ -214,7 +223,7 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._db = db
     this._line = new AcDbLine(vertex, vertex)
     this._line.color = color
-    this._line.lineWeight = AcGiLineWeight.LineWeight070
+    this._line.lineWeight = getMeasurementLineWeight()
 
     this._badgeId = `live-angle-badge-${Date.now()}`
     this._htManager = (view as AcTrView2d).htmlTransientManager
@@ -224,6 +233,7 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
       worldPosition: vertex,
       layer: MEASUREMENT_LIVE_LAYER,
       layoutId: (view as AcTrView2d).activeLayoutBtrId,
+      fontSize: getMeasurementFontSize(),
       // Keep the label slightly above the vertex (was -30px screen offset).
       transform: 'translate(-50%, calc(-50% - 30px))'
     })
@@ -244,7 +254,8 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
       this._view,
       this._vertex,
       this._arm1,
-      this._color
+      this._color,
+      measurementCanvasLineWidth(getMeasurementLineWeight())
     )
 
     const deg = calcAngleDeg(this._vertex, this._arm1, p)
@@ -283,6 +294,8 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
     const editor = context.view.editor
     const db = context.doc.database
     const color = measurementColor(db)
+    const style = currentMeasurementStyle(db)
+    const canvasLineWidth = measurementCanvasLineWidth(style.lineWeight)
 
     await context.view.withMode(AcEdViewMode.SELECTION, () =>
       editor.withCursor(AcEdCorsorType.Crosshair, async () => {
@@ -313,7 +326,14 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
         })
         const htLive = (context.view as AcTrView2d).htmlTransientManager
         htLive.add(armOverlay)
-        drawArm1OnCanvas(armOverlay.canvas, context.view, vertex, arm1, color)
+        drawArm1OnCanvas(
+          armOverlay.canvas,
+          context.view,
+          vertex,
+          arm1,
+          color,
+          canvasLineWidth
+        )
 
         const redrawOnViewChange = () =>
           drawArm1OnCanvas(
@@ -321,7 +341,8 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
             context.view,
             vertex,
             arm1,
-            color
+            color,
+            canvasLineWidth
           )
         context.view.events.viewChanged.addEventListener(redrawOnViewChange)
 
@@ -368,13 +389,15 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
         // Persistent CAD transient lines for both arms (zoom/pan aware)
         const line1 = new AcDbLine(vertex, arm1)
         line1.color = color
-        line1.lineWeight = AcGiLineWeight.LineWeight070
+        line1.lineWeight = style.lineWeight
         context.view.addTransientEntity(line1)
 
         const line2 = new AcDbLine(vertex, arm2)
         line2.color = color
-        line2.lineWeight = AcGiLineWeight.LineWeight070
+        line2.lineWeight = style.lineWeight
         context.view.addTransientEntity(line2)
+
+        const id = `angle-${Date.now()}`
 
         // Persistent arc canvas — redrawn on viewChanged, cleaned up by Clear
         const persistOverlay = new AcTrHtmlCanvasOverlay({
@@ -383,28 +406,22 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
           layer: MEASUREMENT_LAYER,
           layoutId: (context.view as AcTrView2d).activeLayoutBtrId
         })
-        drawAngleArcOnCanvas(
-          persistOverlay.canvas,
-          context.view,
-          vertex,
-          arm1,
-          arm2,
-          color
-        )
-
-        const redrawPersist = () =>
+        const paintArc = (paintStyle = style) =>
           drawAngleArcOnCanvas(
             persistOverlay.canvas,
             context.view,
             vertex,
             arm1,
             arm2,
-            color
+            paintStyle.color,
+            measurementCanvasLineWidth(paintStyle.lineWeight)
           )
+        paintArc()
+
+        const redrawPersist = () => paintArc(getMeasurementStyle(id) ?? style)
         context.view.events.viewChanged.addEventListener(redrawPersist)
 
         // Persistent overlays via htmlTransientManager (auto-positioned by CSS2DRenderer)
-        const id = `angle-${Date.now()}`
 
         // Place badge along the angle bisector in world space
         const dx1 = arm1.x - vertex.x
@@ -472,13 +489,17 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
                 applyAngbaseAngdir: false
               }),
               worldPosition: badgeWorld,
-              layer: MEASUREMENT_LAYER
+              layer: MEASUREMENT_LAYER,
+              fontSize: style.fontSize
             })
           )
           .addCanvas(persistOverlay)
 
         commitMeasurementGroup(context.view as AcTrView2d, group, {
           entityIds: [line1.objectId, line2.objectId],
+          entities: [line1, line2],
+          style,
+          redraw: paintArc,
           dispose: () => {
             context.view.removeTransientEntity(line1.objectId)
             context.view.removeTransientEntity(line2.objectId)

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
@@ -28,11 +28,14 @@ import {
 import { AcApI18n } from '../../i18n'
 import {
   cssColor,
+  currentMeasurementStyle,
+  measurementCanvasLineWidth,
   measurementColor
 } from '../../util'
 import { AcTrView2d } from '../../view'
 import {
   commitMeasurementGroup,
+  getMeasurementStyle,
   MEASUREMENT_LAYER,
   MEASUREMENT_LIVE_LAYER
 } from './AcApMeasurementStore'
@@ -96,7 +99,8 @@ function drawArcOnCanvas(
   g: CircleGeom,
   p1: { x: number; y: number },
   p2: { x: number; y: number },
-  color: AcCmColor
+  color: AcCmColor,
+  lineWidth = 4
 ) {
   const rect = view.canvas.getBoundingClientRect()
   const dpr = window.devicePixelRatio || 1
@@ -137,7 +141,7 @@ function drawArcOnCanvas(
   ctx.beginPath()
   ctx.arc(sc.x, sc.y, screenR, sa, ea, antiClockwise)
   ctx.strokeStyle = cssColor(color)
-  ctx.lineWidth = 4
+  ctx.lineWidth = lineWidth
   ctx.stroke()
 
   ctx.restore()
@@ -330,6 +334,8 @@ export class AcApMeasureArcCmd extends AcEdCommand {
     const editor = context.view.editor
     const db = context.doc.database
     const color = measurementColor(db)
+    const style = currentMeasurementStyle(db)
+    const canvasLineWidth = measurementCanvasLineWidth(style.lineWeight)
 
     // Construction-phase canvas — removed before this method returns
     const liveId = `live-arc-${Date.now()}`
@@ -395,7 +401,8 @@ export class AcApMeasureArcCmd extends AcEdCommand {
           color,
           worldPosition: start,
           layer: MEASUREMENT_LIVE_LAYER,
-          layoutId: (context.view as AcTrView2d).activeLayoutBtrId
+          layoutId: (context.view as AcTrView2d).activeLayoutBtrId,
+          fontSize: style.fontSize
         })
         liveBadge.object.visible = false
         htManager.add(liveBadge)
@@ -407,7 +414,8 @@ export class AcApMeasureArcCmd extends AcEdCommand {
             geom,
             start,
             start,
-            color
+            color,
+            canvasLineWidth
           )
         const onViewChangedPreview = () => redrawPreview()
         context.view.events.viewChanged.addEventListener(onViewChangedPreview)
@@ -428,7 +436,8 @@ export class AcApMeasureArcCmd extends AcEdCommand {
             geom,
             start,
             snapped,
-            color
+            color,
+            canvasLineWidth
           )
 
           const len = shortArcLength(start, snapped, geom)
@@ -467,6 +476,8 @@ export class AcApMeasureArcCmd extends AcEdCommand {
         const arcLen = shortArcLength(start, end, geom)
         const mid = shortArcMid(start, end, geom)
 
+        const id = `arc-${Date.now()}`
+
         // Persistent arc canvas — redrawn on viewChanged, cleaned up by Clear
         const persistOverlay = new AcTrHtmlCanvasOverlay({
           id: `arc-canvas-${Date.now()}`,
@@ -474,28 +485,20 @@ export class AcApMeasureArcCmd extends AcEdCommand {
           layer: MEASUREMENT_LAYER,
           layoutId: (context.view as AcTrView2d).activeLayoutBtrId
         })
-        drawArcOnCanvas(
-          persistOverlay.canvas,
-          context.view,
-          geom,
-          start,
-          end,
-          color
-        )
-
-        const redrawPersist = () =>
+        const paintArc = (paintStyle = style) =>
           drawArcOnCanvas(
             persistOverlay.canvas,
             context.view,
             geom,
             start,
             end,
-            color
+            paintStyle.color,
+            measurementCanvasLineWidth(paintStyle.lineWeight)
           )
-        context.view.events.viewChanged.addEventListener(redrawPersist)
+        paintArc()
 
-        // Persistent badge + dots via htmlTransientManager
-        const id = `arc-${Date.now()}`
+        const redrawPersist = () => paintArc(getMeasurementStyle(id) ?? style)
+        context.view.events.viewChanged.addEventListener(redrawPersist)
 
         const group = new AcTrHtmlGroup({
           id,
@@ -524,12 +527,15 @@ export class AcApMeasureArcCmd extends AcEdCommand {
                 showApproximate: true
               }),
               worldPosition: mid,
-              layer: MEASUREMENT_LAYER
+              layer: MEASUREMENT_LAYER,
+              fontSize: style.fontSize
             })
           )
           .addCanvas(persistOverlay)
 
         commitMeasurementGroup(context.view as AcTrView2d, group, {
+          style,
+          redraw: paintArc,
           dispose: () => {
             context.view.events.viewChanged.removeEventListener(redrawPersist)
           }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
@@ -1,8 +1,7 @@
 import {
   AcCmColor,
   AcDbLine,
-  AcGePoint3dLike,
-  AcGiLineWeight
+  AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
   AcTrHtmlBadge,
@@ -26,11 +25,15 @@ import { AcApI18n } from '../../i18n'
 import {
   colorToCssAlpha,
   cssColor,
+  currentMeasurementStyle,
+  getMeasurementLineWeight,
+  measurementCanvasLineWidth,
   measurementColor
 } from '../../util'
 import { AcTrView2d } from '../../view'
 import {
   commitMeasurementGroup,
+  getMeasurementStyle,
   MEASUREMENT_LAYER,
   MEASUREMENT_LIVE_LAYER
 } from './AcApMeasurementStore'
@@ -52,7 +55,7 @@ class AcApMeasureAreaJig extends AcEdPreviewJig<AcGePoint3dLike> {
     super(view)
     this._line = new AcDbLine(from, from)
     this._line.color = color
-    this._line.lineWeight = AcGiLineWeight.LineWeight070
+    this._line.lineWeight = getMeasurementLineWeight()
     this._onMove = onMove
   }
 
@@ -113,7 +116,8 @@ function drawAreaOnCanvas(
   canvas: HTMLCanvasElement,
   view: AcEdBaseView,
   points: AcGePoint3dLike[],
-  color: AcCmColor
+  color: AcCmColor,
+  lineWidth = 2.5
 ): void {
   const rect = view.canvas.getBoundingClientRect()
   const dpr = window.devicePixelRatio || 1
@@ -147,7 +151,7 @@ function drawAreaOnCanvas(
   ctx.fillStyle = colorToCssAlpha(color, 0.2)
   ctx.fill()
   ctx.strokeStyle = cssColor(color)
-  ctx.lineWidth = 2.5
+  ctx.lineWidth = lineWidth
   ctx.stroke()
 
   ctx.restore()
@@ -177,6 +181,8 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
     const editor = context.view.editor
     const db = context.doc.database
     const color = measurementColor(db)
+    const style = currentMeasurementStyle(db)
+    const canvasLineWidth = measurementCanvasLineWidth(style.lineWeight)
 
     const points: AcGePoint3dLike[] = []
 
@@ -198,7 +204,8 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
       color,
       worldPosition: { x: 0, y: 0 },
       layer: MEASUREMENT_LIVE_LAYER,
-      layoutId: (context.view as AcTrView2d).activeLayoutBtrId
+      layoutId: (context.view as AcTrView2d).activeLayoutBtrId,
+      fontSize: style.fontSize
     })
     liveBadge.object.visible = false
     htManagerLive.add(liveBadge)
@@ -248,7 +255,7 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
         for (let i = 1; i < confirmedSpts.length; i++)
           ctx.lineTo(confirmedSpts[i].x, confirmedSpts[i].y)
         ctx.strokeStyle = cssColor(color)
-        ctx.lineWidth = 2.5
+        ctx.lineWidth = canvasLineWidth
         ctx.setLineDash([8, 5])
         ctx.stroke()
         ctx.setLineDash([])
@@ -353,6 +360,9 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
 
     const area = shoelaceArea(points)
 
+    const id = `area-${Date.now()}`
+    const mid = centroid(points)
+
     // Persistent fill canvas — redrawn on viewChanged, cleaned up by Clear
     const persistOverlay = new AcTrHtmlCanvasOverlay({
       id: `area-canvas-${Date.now()}`,
@@ -360,15 +370,18 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
       layer: MEASUREMENT_LAYER,
       layoutId: (context.view as AcTrView2d).activeLayoutBtrId
     })
-    drawAreaOnCanvas(persistOverlay.canvas, context.view, points, color)
+    const paintArea = (paintStyle = style) =>
+      drawAreaOnCanvas(
+        persistOverlay.canvas,
+        context.view,
+        points,
+        paintStyle.color,
+        measurementCanvasLineWidth(paintStyle.lineWeight)
+      )
+    paintArea()
 
-    const redrawPersist = () =>
-      drawAreaOnCanvas(persistOverlay.canvas, context.view, points, color)
+    const redrawPersist = () => paintArea(getMeasurementStyle(id) ?? style)
     context.view.events.viewChanged.addEventListener(redrawPersist)
-
-    // Persistent badge + dots via htmlTransientManager
-    const id = `area-${Date.now()}`
-    const mid = centroid(points)
 
     const group = new AcTrHtmlGroup({
       id,
@@ -385,7 +398,8 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
             showApproximate: true
           })}²`,
           worldPosition: mid,
-          layer: MEASUREMENT_LAYER
+          layer: MEASUREMENT_LAYER,
+          fontSize: style.fontSize
         }),
         ...points.map(
           (p, i) =>
@@ -400,6 +414,8 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
       .addCanvas(persistOverlay)
 
     commitMeasurementGroup(context.view as AcTrView2d, group, {
+      style,
+      redraw: paintArea,
       dispose: () => {
         context.view.events.viewChanged.removeEventListener(redrawPersist)
       }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
@@ -2,8 +2,7 @@ import {
   AcCmColor,
   AcDbDatabase,
   AcDbLine,
-  AcGePoint3dLike,
-  AcGiLineWeight
+  AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
   AcTrHtmlBadge,
@@ -24,7 +23,12 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
-import { measurementColor } from '../../util'
+import {
+  currentMeasurementStyle,
+  getMeasurementFontSize,
+  getMeasurementLineWeight,
+  measurementColor
+} from '../../util'
 import { AcTrView2d } from '../../view'
 import {
   commitMeasurementGroup,
@@ -66,7 +70,7 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._db = db
     this._line = new AcDbLine(p1, p1)
     this._line.color = color
-    this._line.lineWeight = AcGiLineWeight.LineWeight070
+    this._line.lineWeight = getMeasurementLineWeight()
 
     this._badgeId = `live-dist-badge-${Date.now()}`
     this._htManager = (view as AcTrView2d).htmlTransientManager
@@ -75,7 +79,8 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
       color,
       worldPosition: p1,
       layer: MEASUREMENT_LIVE_LAYER,
-      layoutId: (view as AcTrView2d).activeLayoutBtrId
+      layoutId: (view as AcTrView2d).activeLayoutBtrId,
+      fontSize: getMeasurementFontSize()
     })
     this._badge.object.visible = false
     this._htManager.add(this._badge)
@@ -131,6 +136,7 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
     const editor = context.view.editor
     const db = context.doc.database
     const color = measurementColor(db)
+    const style = currentMeasurementStyle(db)
 
     await context.view.withMode(AcEdViewMode.SELECTION, () =>
       editor.withCursor(AcEdCorsorType.Crosshair, async () => {
@@ -155,7 +161,7 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
         // CAD transient line (zoom/pan aware, rendered by the engine)
         const line = new AcDbLine(p1, p2)
         line.color = color
-        line.lineWeight = AcGiLineWeight.LineWeight070
+        line.lineWeight = style.lineWeight
         context.view.addTransientEntity(line)
 
         // Persistent overlays via htmlTransientManager (auto-positioned by CSS2DRenderer)
@@ -188,12 +194,15 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
               showApproximate: true
             }),
             worldPosition: mid,
-            layer: MEASUREMENT_LAYER
+            layer: MEASUREMENT_LAYER,
+            fontSize: style.fontSize
           })
         )
 
         commitMeasurementGroup(context.view as AcTrView2d, group, {
           entityIds: [line.objectId],
+          entities: [line],
+          style,
           dispose: () => {
             context.view.removeTransientEntity(line.objectId)
           }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurePointCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurePointCmd.ts
@@ -15,7 +15,7 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
-import { measurementColor } from '../../util'
+import { currentMeasurementStyle, measurementColor } from '../../util'
 import { AcTrView2d } from '../../view'
 import {
   commitMeasurementGroup,
@@ -50,6 +50,7 @@ export class AcApMeasurePointCmd extends AcEdCommand {
     const editor = context.view.editor
     const db = context.doc.database
     const color = measurementColor(db)
+    const style = currentMeasurementStyle(db)
 
     await context.view.withMode(AcEdViewMode.SELECTION, () =>
       editor.withCursor(AcEdCorsorType.Crosshair, async () => {
@@ -81,12 +82,13 @@ export class AcApMeasurePointCmd extends AcEdCommand {
             text: label,
             worldPosition: point,
             layer: MEASUREMENT_LAYER,
+            fontSize: style.fontSize,
             // Offset the badge above the marker so it does not cover the dot.
             transform: 'translate(-50%, calc(-50% - 16px))'
           })
         )
 
-        commitMeasurementGroup(context.view as AcTrView2d, group)
+        commitMeasurementGroup(context.view as AcTrView2d, group, { style })
       })
     )
   }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementHistory.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementHistory.ts
@@ -1,0 +1,310 @@
+import type { AcTrHtmlGroup } from '@mlightcad/three-renderer'
+
+import type { AcEdBaseView } from '../../editor'
+import { acapNotifyUndoStackChanged } from '../../util/AcApDatabaseEdit'
+import {
+  type AcApMeasurementStyle,
+  cloneMeasurementStyle} from '../../util/AcApMeasurementUtil'
+import type { AcTrView2d } from '../../view'
+import {
+  bindOverlayHistory,
+  getSessionUndo
+} from '../markup/AcApMarkupHistory'
+import {
+  applyMeasurementStyle,
+  getMeasurementStyle,
+  MEASUREMENT_LAYER,
+  resetMeasurementStyleState
+} from './AcApMeasurementStore'
+
+/**
+ * One undoable measurement overlay mutation.
+ *
+ * Groups in {@link AcApMeasurementHistoryEntry.added} /
+ * {@link AcApMeasurementHistoryEntry.removed} are
+ * {@link AcTrHtmlTransientManager.detach}ed (kept alive) so undo can
+ * {@link AcTrHtmlTransientManager.reattach} them.
+ */
+interface AcApMeasurementHistoryEntry {
+  /** Human-readable undo label (e.g. command name). */
+  label: string
+  /** View whose HTML transients this entry belongs to. */
+  view: AcTrView2d
+  /** Groups present after the mutation but not before. */
+  added: AcTrHtmlGroup[]
+  /** Groups present before the mutation but not after. */
+  removed: AcTrHtmlGroup[]
+  /** Per-group style before the mutation. */
+  stylesBefore: Record<string, AcApMeasurementStyle>
+  /** Per-group style after the mutation. */
+  stylesAfter: Record<string, AcApMeasurementStyle>
+}
+
+/**
+ * Snapshot-based undo/redo for measurement HTML overlays.
+ *
+ * Measurements are not DWG objects and have no sidecar. Groups are
+ * {@link AcTrHtmlTransientManager.detach}ed (kept alive) so undo can
+ * {@link AcTrHtmlTransientManager.reattach} them.
+ */
+export class AcApMeasurementHistory {
+  /** Undo stack of measurement overlay mutations (oldest first). */
+  private readonly undoStack: AcApMeasurementHistoryEntry[] = []
+  /** Redo stack of measurement overlay mutations (oldest first). */
+  private readonly redoStack: AcApMeasurementHistoryEntry[] = []
+  /**
+   * Nesting depth of {@link run} / {@link apply}. Greater than zero means a
+   * mutation is in progress and nested {@link run} calls are not recorded.
+   */
+  private depth = 0
+
+  /** True while applying undo/redo or nested inside {@link run}. */
+  get isBusy(): boolean {
+    return this.depth > 0
+  }
+
+  /** Whether there is at least one measurement overlay undo step. */
+  canUndo(): boolean {
+    return this.undoStack.length > 0
+  }
+
+  /** Whether there is at least one measurement overlay redo step. */
+  canRedo(): boolean {
+    return this.redoStack.length > 0
+  }
+
+  /**
+   * Drop redo entries and dispose detached groups they still hold.
+   * Called after a new undoable edit so redo cannot jump over it.
+   */
+  clearRedo(): void {
+    for (const entry of this.redoStack) {
+      disposeDetachedGroups(entry)
+    }
+    this.redoStack.length = 0
+  }
+
+  /**
+   * Drop history. Detached groups still referenced by the stacks are disposed.
+   * Groups that remain on the view are left for {@link AcTrView2d.clear}.
+   */
+  clear(): void {
+    for (const entry of [...this.undoStack, ...this.redoStack]) {
+      disposeDetachedGroups(entry)
+    }
+    this.undoStack.length = 0
+    this.redoStack.length = 0
+  }
+
+  /**
+   * Run a measurement mutation and record one undo step when the committed
+   * measurement groups on the view change. Nested calls do not create extra
+   * entries.
+   * @param view - View whose measurement HTML overlays are snapshotted.
+   * @param label - Human-readable undo label.
+   * @param mutate - Mutation that adds or removes measurement groups.
+   */
+  run(view: AcEdBaseView, label: string, mutate: () => void): void {
+    if (this.depth > 0) {
+      mutate()
+      return
+    }
+
+    const view2d = view as AcTrView2d
+    const before = snapshotMeasurementGroups(view2d)
+    const stylesBefore = snapshotMeasurementStyles(before)
+
+    this.depth++
+    try {
+      mutate()
+    } finally {
+      this.depth--
+    }
+
+    const after = snapshotMeasurementGroups(view2d)
+    const added = after.filter(group => before.indexOf(group) < 0)
+    const removed = before.filter(group => after.indexOf(group) < 0)
+    const stylesAfter = snapshotMeasurementStyles(after)
+    if (
+      added.length === 0 &&
+      removed.length === 0 &&
+      !stylesChanged(stylesBefore, stylesAfter)
+    ) {
+      return
+    }
+
+    this.undoStack.push({
+      label,
+      view: view2d,
+      added,
+      removed,
+      stylesBefore,
+      stylesAfter
+    })
+    this.clearRedo()
+    getSessionUndo().recordOverlay()
+    acapNotifyUndoStackChanged()
+  }
+
+  /**
+   * Undo the last measurement overlay mutation.
+   * @returns true when an entry was applied.
+   */
+  undo(): boolean {
+    const entry = this.undoStack.pop()
+    if (!entry) return false
+    this.apply(entry, 'undo')
+    this.redoStack.push(entry)
+    return true
+  }
+
+  /**
+   * Redo the last undone measurement overlay mutation.
+   * @returns true when an entry was applied.
+   */
+  redo(): boolean {
+    const entry = this.redoStack.pop()
+    if (!entry) return false
+    this.apply(entry, 'redo')
+    this.undoStack.push(entry)
+    return true
+  }
+
+  /**
+   * Apply one history entry by detaching and reattaching HTML groups.
+   * @param entry - Snapshot of groups added and removed by the original edit.
+   * @param direction - `'undo'` restores the pre-edit set; `'redo'` restores
+   *   the post-edit set.
+   */
+  private apply(
+    entry: AcApMeasurementHistoryEntry,
+    direction: 'undo' | 'redo'
+  ): void {
+    this.depth++
+    try {
+      const ht = entry.view.htmlTransientManager
+      const detach = direction === 'undo' ? entry.added : entry.removed
+      const attach = direction === 'undo' ? entry.removed : entry.added
+      for (const group of detach) {
+        ht.detach(group.id)
+      }
+      for (const group of attach) {
+        ht.reattach(group)
+      }
+      const styles = direction === 'undo' ? entry.stylesBefore : entry.stylesAfter
+      for (const group of snapshotMeasurementGroups(entry.view)) {
+        const style = styles[group.id]
+        if (style) applyMeasurementStyle(entry.view, group, style)
+      }
+      entry.view.isDirty = true
+    } finally {
+      this.depth--
+    }
+  }
+}
+
+/**
+ * Capture the committed measurement HTML groups currently on the view.
+ * @param view - View whose measurement layer is snapshotted.
+ * @returns Groups on {@link MEASUREMENT_LAYER}, in manager order.
+ */
+function snapshotMeasurementGroups(view: AcTrView2d): AcTrHtmlGroup[] {
+  return view.htmlTransientManager.groupsOnLayer(MEASUREMENT_LAYER)
+}
+
+function snapshotMeasurementStyles(
+  groups: AcTrHtmlGroup[]
+): Record<string, AcApMeasurementStyle> {
+  const styles: Record<string, AcApMeasurementStyle> = {}
+  for (const group of groups) {
+    const style = getMeasurementStyle(group.id)
+    if (style) styles[group.id] = cloneMeasurementStyle(style)
+  }
+  return styles
+}
+
+function stylesChanged(
+  before: Record<string, AcApMeasurementStyle>,
+  after: Record<string, AcApMeasurementStyle>
+): boolean {
+  const beforeIds = Object.keys(before)
+  const afterIds = Object.keys(after)
+  if (beforeIds.length !== afterIds.length) return true
+  for (const id of beforeIds) {
+    const a = before[id]
+    const b = after[id]
+    if (!b) return true
+    if (
+      a.lineWeight !== b.lineWeight ||
+      a.fontSize !== b.fontSize ||
+      a.color.red !== b.color.red ||
+      a.color.green !== b.color.green ||
+      a.color.blue !== b.color.blue
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Dispose groups in an entry that are no longer attached to the view.
+ * Attached groups are left for the view / manager to own.
+ * @param entry - History entry whose detached groups may be discarded.
+ */
+function disposeDetachedGroups(entry: AcApMeasurementHistoryEntry): void {
+  const ht = entry.view.htmlTransientManager
+  for (const group of [...entry.added, ...entry.removed]) {
+    if (ht.has(group.id)) continue
+    for (const child of group.children) {
+      child.dispose()
+    }
+    group.dispose()
+  }
+}
+
+/** Session-wide measurement overlay history singleton. */
+let sharedHistory: AcApMeasurementHistory | undefined
+
+/** Shared measurement overlay history for the active session. */
+export function getMeasurementHistory(): AcApMeasurementHistory {
+  if (!sharedHistory) sharedHistory = new AcApMeasurementHistory()
+  return sharedHistory
+}
+
+/**
+ * Record an undoable measurement overlay edit.
+ * @param view - View whose measurement HTML overlays are snapshotted.
+ * @param label - Human-readable undo label.
+ * @param mutate - Mutation that adds or removes measurement groups.
+ */
+export function runMeasurementEdit(
+  view: AcEdBaseView,
+  label: string,
+  mutate: () => void
+): void {
+  getMeasurementHistory().run(view, label, mutate)
+}
+
+/**
+ * Drop measurement overlay history (document open / close).
+ * Detached groups are disposed; attached groups stay for view.clear().
+ */
+export function resetMeasurementSession(): void {
+  getMeasurementHistory().clear()
+  resetMeasurementStyleState()
+}
+
+/** Bind this history into session undo (also runs at module load). */
+export function bindMeasurementOverlayHistory(): void {
+  bindOverlayHistory({
+    canUndo: () => getMeasurementHistory().canUndo(),
+    canRedo: () => getMeasurementHistory().canRedo(),
+    undo: () => getMeasurementHistory().undo(),
+    redo: () => getMeasurementHistory().redo(),
+    clearRedo: () => getMeasurementHistory().clearRedo(),
+    clear: () => getMeasurementHistory().clear()
+  })
+}
+
+bindMeasurementOverlayHistory()

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -1,7 +1,13 @@
-import type { AcDbObjectId } from '@mlightcad/data-model'
-import { AcTrHtmlGroup } from '@mlightcad/three-renderer'
+import type { AcCmColor, AcDbEntity, AcDbObjectId } from '@mlightcad/data-model'
+import type { AcTrHtmlGroup } from '@mlightcad/three-renderer'
 
+import {
+  type AcApMeasurementStyle,
+  cloneMeasurementStyle,
+  MEASUREMENT_FONT_SIZE,
+  MEASUREMENT_LINE_WEIGHT} from '../../util/AcApMeasurementUtil'
 import type { AcTrView2d } from '../../view'
+import { runMeasurementEdit } from './AcApMeasurementHistory'
 
 /** HTML transient layer for committed measurement overlays. */
 export const MEASUREMENT_LAYER = 'measurement'
@@ -15,12 +21,136 @@ export const MEASUREMENT_LIVE_LAYER = 'measurement-live'
 export interface AcApMeasurementGroupExtras {
   /** CAD transient entity object ids (lines, etc.). */
   entityIds?: AcDbObjectId[]
+  /** Live CAD entity refs so color / line weight can be updated in place. */
+  entities?: AcDbEntity[]
+  /** Style used when the group was committed (and after later style edits). */
+  style?: AcApMeasurementStyle
+  /** Redraw canvas overlays after a style change (color / line weight). */
+  redraw?: (style: AcApMeasurementStyle) => void
   /**
    * Removes non-HTML resources (CAD transients, viewChanged listeners).
-   * HTML children and group-owned canvas overlays are removed by the html
+   * HTML children and group-owned canvases are removed by the html
    * transient manager / group dispose.
    */
   dispose?: () => void
+}
+
+type MeasurementSelectionListener = () => void
+
+const extrasById = new Map<string, AcApMeasurementGroupExtras>()
+const stylesById = new Map<string, AcApMeasurementStyle>()
+const selectionListeners = new Set<MeasurementSelectionListener>()
+let selectedMeasurementId: string | undefined
+
+/** Style currently stored for a committed measurement group. */
+export function getMeasurementStyle(
+  id: string
+): AcApMeasurementStyle | undefined {
+  const style = stylesById.get(id)
+  return style ? cloneMeasurementStyle(style) : undefined
+}
+
+/** Style of the currently selected measurement, if any. */
+export function getActiveMeasurementStyle(): AcApMeasurementStyle | undefined {
+  return selectedMeasurementId
+    ? getMeasurementStyle(selectedMeasurementId)
+    : undefined
+}
+
+/** Notify when the selected measurement group changes. */
+export function subscribeMeasurementSelection(
+  listener: MeasurementSelectionListener
+): () => void {
+  selectionListeners.add(listener)
+  return () => {
+    selectionListeners.delete(listener)
+  }
+}
+
+function notifyMeasurementSelection(): void {
+  for (const listener of selectionListeners) listener()
+}
+
+function rememberStyle(id: string, style: AcApMeasurementStyle): void {
+  stylesById.set(id, cloneMeasurementStyle(style))
+}
+
+/**
+ * Apply a style patch to one measurement group (HTML, CAD transients, canvases).
+ * Does not record undo; wrap with {@link runMeasurementEdit} from UI.
+ */
+export function applyMeasurementStyle(
+  view: AcTrView2d,
+  group: AcTrHtmlGroup,
+  patch: Partial<AcApMeasurementStyle>
+): void {
+  const prev = stylesById.get(group.id)
+  const color = patch.color?.clone() ?? prev?.color.clone()
+  if (!color) return
+  const next: AcApMeasurementStyle = {
+    color,
+    lineWeight: patch.lineWeight ?? prev?.lineWeight ?? MEASUREMENT_LINE_WEIGHT,
+    fontSize: patch.fontSize ?? prev?.fontSize ?? MEASUREMENT_FONT_SIZE
+  }
+  rememberStyle(group.id, next)
+  const extras = extrasById.get(group.id)
+  if (extras) extras.style = cloneMeasurementStyle(next)
+  paintMeasurementGroup(view, group, next)
+}
+
+/**
+ * Apply a style patch to every selected measurement group (undoable).
+ */
+export function applyMeasurementStyleToSelection(
+  view: AcTrView2d,
+  patch: Partial<AcApMeasurementStyle>
+): void {
+  const groups = view.htmlTransientManager
+    .getSelectedGroups()
+    .filter(group => group.layer === MEASUREMENT_LAYER)
+  if (groups.length === 0) return
+  runMeasurementEdit(view, 'Measurement Style', () => {
+    for (const group of groups) {
+      applyMeasurementStyle(view, group, patch)
+    }
+  })
+}
+
+function paintMeasurementGroup(
+  view: AcTrView2d,
+  group: AcTrHtmlGroup,
+  style: AcApMeasurementStyle
+): void {
+  for (const child of group.children) {
+    const colorful = child as {
+      setColor?: (color: AcCmColor) => void
+      setFontSize?: (size: number) => void
+    }
+    colorful.setColor?.(style.color)
+    colorful.setFontSize?.(style.fontSize)
+  }
+
+  const extras = extrasById.get(group.id)
+  const selected = group.selected
+  for (const entity of extras?.entities ?? []) {
+    entity.color = style.color.clone()
+    entity.lineWeight = style.lineWeight
+    view.removeTransientEntity(entity.objectId)
+    view.addTransientEntity(entity)
+  }
+  if (selected && (extras?.entityIds?.length ?? 0) > 0) {
+    view.highlight(extras!.entityIds!)
+  }
+  extras?.redraw?.(style)
+  view.isDirty = true
+}
+
+/** Drop style / extras maps (document open). Attached groups are left for view.clear(). */
+export function resetMeasurementStyleState(): void {
+  extrasById.clear()
+  stylesById.clear()
+  selectedMeasurementId = undefined
+  notifyMeasurementSelection()
 }
 
 /**
@@ -36,15 +166,24 @@ export function commitMeasurementGroup(
   extras?: AcApMeasurementGroupExtras
 ): void {
   const entityIds = extras?.entityIds ?? []
+  extrasById.set(group.id, extras ?? {})
+  if (extras?.style) {
+    rememberStyle(group.id, extras.style)
+  }
 
   const prevSelectedChanged = group.onSelectedChanged
   group.onSelectedChanged = (selected, g) => {
     prevSelectedChanged?.(selected, g)
-    if (entityIds.length === 0) return
     if (selected) {
-      view.highlight(entityIds)
+      selectedMeasurementId = g.id
+      notifyMeasurementSelection()
+      if (entityIds.length > 0) view.highlight(entityIds)
     } else {
-      view.unhighlight(entityIds)
+      if (selectedMeasurementId === g.id) {
+        selectedMeasurementId = undefined
+        notifyMeasurementSelection()
+      }
+      if (entityIds.length > 0) view.unhighlight(entityIds)
     }
   }
 
@@ -59,7 +198,12 @@ export function commitMeasurementGroup(
   const prevDispose = group.onDispose
   group.onDispose = () => {
     prevDispose?.()
-    // Ensure CAD highlights are cleared even if deletion skipped deselect.
+    extrasById.delete(group.id)
+    stylesById.delete(group.id)
+    if (selectedMeasurementId === group.id) {
+      selectedMeasurementId = undefined
+      notifyMeasurementSelection()
+    }
     if (entityIds.length > 0) {
       view.unhighlight(entityIds)
     }
@@ -70,6 +214,8 @@ export function commitMeasurementGroup(
     }
   }
 
-  view.htmlTransientManager.add(group)
+  runMeasurementEdit(view, 'Create Measurement', () => {
+    view.htmlTransientManager.add(group)
+  })
   view.isDirty = true
 }

--- a/packages/cad-simple-viewer/src/command/measure/index.ts
+++ b/packages/cad-simple-viewer/src/command/measure/index.ts
@@ -1,4 +1,5 @@
 export * from './AcApClearMeasurementsCmd'
+export * from './AcApMeasurementHistory'
 export * from './AcApMeasurementStore'
 export * from './AcApMeasureAngleCmd'
 export * from './AcApMeasureAreaCmd'

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
@@ -2,15 +2,104 @@ import {
   AcCmColor,
   AcDbDatabase,
   AcDbSystemVariables,
-  AcDbSysVarManager
+  AcDbSysVarManager,
+  AcGiLineWeight
 } from '@mlightcad/data-model'
 
-/** Returns the current measurement overlay color from the MEASUREMENTCOLOR system variable. */
+/** Factory default CAD line weight for measurement geometry. */
+export const MEASUREMENT_LINE_WEIGHT = AcGiLineWeight.LineWeight070
+
+/** Factory default screen font size (CSS px) for measurement badges. */
+export const MEASUREMENT_FONT_SIZE = 13
+
+/** Session draw color for newly created measurements (undefined = use sysvar). */
+let measurementDrawColor: AcCmColor | undefined
+
+/** Session draw line weight for newly created measurements. */
+let measurementDrawLineWeight: AcGiLineWeight = MEASUREMENT_LINE_WEIGHT
+
+/** Session draw font size for newly created measurement badges. */
+let measurementDrawFontSize = MEASUREMENT_FONT_SIZE
+
+/** Visual style stored on a committed measurement group. */
+export interface AcApMeasurementStyle {
+  color: AcCmColor
+  lineWeight: AcGiLineWeight
+  fontSize: number
+}
+
+/** Returns the current measurement overlay color (session override or MEASUREMENTCOLOR). */
 export function measurementColor(db: AcDbDatabase): AcCmColor {
+  if (measurementDrawColor) return measurementDrawColor.clone()
   return AcDbSysVarManager.instance().getVar(
     AcDbSystemVariables.MEASUREMENTCOLOR,
     db
   ) as AcCmColor
+}
+
+/** Current line weight used when drawing measurements. */
+export function getMeasurementLineWeight(): AcGiLineWeight {
+  return measurementDrawLineWeight
+}
+
+/** Current font size (CSS px) used when drawing measurement badges. */
+export function getMeasurementFontSize(): number {
+  return measurementDrawFontSize
+}
+
+/** Update the session measurement draw color (affects current/future measurements). */
+export function setMeasurementDrawColor(color: AcCmColor): void {
+  measurementDrawColor = color.clone()
+}
+
+/** Update the session measurement draw line weight. */
+export function setMeasurementDrawLineWeight(weight: AcGiLineWeight): void {
+  if (!(weight > 0)) return
+  measurementDrawLineWeight = weight
+}
+
+/** Update the session measurement draw font size (CSS px). */
+export function setMeasurementDrawFontSize(size: number): void {
+  if (!Number.isFinite(size) || size <= 0) return
+  measurementDrawFontSize = size
+}
+
+/** Restore factory session measurement draw style (tests / document reset). */
+export function resetMeasurementDrawStyle(): void {
+  measurementDrawColor = undefined
+  measurementDrawLineWeight = MEASUREMENT_LINE_WEIGHT
+  measurementDrawFontSize = MEASUREMENT_FONT_SIZE
+}
+
+/** Build a style object from the current measurement draw color / line weight / font size. */
+export function currentMeasurementStyle(db: AcDbDatabase): AcApMeasurementStyle {
+  return {
+    color: measurementColor(db),
+    lineWeight: getMeasurementLineWeight(),
+    fontSize: getMeasurementFontSize()
+  }
+}
+
+/** Clone a measurement style (color is cloned). */
+export function cloneMeasurementStyle(
+  style: AcApMeasurementStyle
+): AcApMeasurementStyle {
+  return {
+    color: style.color.clone(),
+    lineWeight: style.lineWeight,
+    fontSize: style.fontSize
+  }
+}
+
+/**
+ * Map a CAD line weight to a canvas stroke width in CSS pixels.
+ * {@link AcGiLineWeight.LineWeight070} (70) ≈ 2.5px, matching the previous
+ * area-measurement default.
+ */
+export function measurementCanvasLineWidth(weight: AcGiLineWeight): number {
+  const n = Number(weight)
+  if (!Number.isFinite(n) || n <= 0) return 2
+  return Math.max(1, n / 28)
 }
 
 /** Converts an AcCmColor to a CSS rgba() string. */

--- a/packages/cad-simple-viewer/src/view/AcEdViewKeyHandler.ts
+++ b/packages/cad-simple-viewer/src/view/AcEdViewKeyHandler.ts
@@ -1,5 +1,7 @@
 import { AcApDocManager } from '../app'
 import { runMarkupEdit } from '../command/markup/AcApMarkupHistory'
+import { runMeasurementEdit } from '../command/measure/AcApMeasurementHistory'
+import { MEASUREMENT_LAYER } from '../command/measure/AcApMeasurementStore'
 import { AcEdMTextEditor } from '../editor/input/ui/AcEdMTextEditor'
 import type { AcTrView2d } from './AcTrView2d'
 
@@ -67,10 +69,27 @@ export class AcEdViewKeyHandler {
         // sendStringToExecute clears scripted inputs unconditionally.
         if (!this.view.editor.isActive) {
           let removed = false
-          if (this.view.htmlTransientManager.hasSelection()) {
-            runMarkupEdit(this.view, 'Delete Markup', () => {
-              removed = this.view.htmlTransientManager.deleteSelected()
-            })
+          const ht = this.view.htmlTransientManager
+          if (ht.hasSelection()) {
+            const selected = ht.getSelectedGroups()
+            const measurements = selected.filter(
+              group => group.layer === MEASUREMENT_LAYER
+            )
+            if (measurements.length > 0) {
+              runMeasurementEdit(this.view, 'Delete Measurement', () => {
+                for (const group of measurements) {
+                  if (ht.detach(group.id)) removed = true
+                }
+              })
+            }
+            const hasMarkupSelection =
+              selected.some(group => group.layer !== MEASUREMENT_LAYER) ||
+              (selected.length === 0 && ht.hasSelection())
+            if (hasMarkupSelection) {
+              runMarkupEdit(this.view, 'Delete Markup', () => {
+                removed = ht.deleteSelected() || removed
+              })
+            }
           }
           if (removed) {
             this.view.isDirty = true

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -1479,27 +1479,35 @@ export class AcTrView2d extends AcEdBaseView {
   addTransientEntity(entity: AcDbEntity | AcDbEntity[]) {
     const entities = Array.isArray(entity) ? entity : [entity]
     const epoch = this._convertEpoch
-    for (let i = 0; i < entities.length; ++i) {
-      const entity = entities[i]
-      const threeEntity: AcTrEntity | null = this.drawEntity(entity, true)
-      if (threeEntity) {
-        threeEntity.objectId = entity.objectId
-        void threeEntity
-          .asyncDraw()
-          .then(() => {
-            // Drop stale transients started before clear()/regen invalidated the view.
-            if (epoch !== this._convertEpoch) {
+    // Overlay transients (markup / measurement / jigs) must honor entity
+    // lineweight even when LWDISPLAY is off; otherwise ribbon style is a no-op.
+    const previousForce = this._renderer.forceShowLineWeight
+    this._renderer.forceShowLineWeight = true
+    try {
+      for (let i = 0; i < entities.length; ++i) {
+        const entity = entities[i]
+        const threeEntity: AcTrEntity | null = this.drawEntity(entity, true)
+        if (threeEntity) {
+          threeEntity.objectId = entity.objectId
+          void threeEntity
+            .asyncDraw()
+            .then(() => {
+              // Drop stale transients started before clear()/regen invalidated the view.
+              if (epoch !== this._convertEpoch) {
+                threeEntity.dispose()
+                return
+              }
+              this._scene.addTransientEntity(threeEntity)
+              this._isDirty = true
+            })
+            .catch(error => {
+              log.error('[AcTrView2d] Transient entity geometry failed:', error)
               threeEntity.dispose()
-              return
-            }
-            this._scene.addTransientEntity(threeEntity)
-            this._isDirty = true
-          })
-          .catch(error => {
-            log.error('[AcTrView2d] Transient entity geometry failed:', error)
-            threeEntity.dispose()
-          })
+            })
+        }
       }
+    } finally {
+      this._renderer.forceShowLineWeight = previousForce
     }
   }
 

--- a/packages/cad-viewer/src/component/common/MlLineWeightSelect.vue
+++ b/packages/cad-viewer/src/component/common/MlLineWeightSelect.vue
@@ -80,6 +80,8 @@ interface LineWeightSelectProps {
   disabled?: boolean
   /** Placeholder shown when no line weight can be resolved. */
   placeholder?: string
+  /** When true, hide ByLayer / ByBlock / Default (overlay style pickers). */
+  numericOnly?: boolean
 }
 
 const props = defineProps<LineWeightSelectProps>()
@@ -151,7 +153,9 @@ const lineWeightItems = computed<LineWeightItem[]>(() =>
     new Set(
       Object.values(AcGiLineWeight).filter(
         (v): v is AcGiLineWeight =>
-          typeof v === 'number' && v !== AcGiLineWeight.ByDIPs
+          typeof v === 'number' &&
+          v !== AcGiLineWeight.ByDIPs &&
+          (!props.numericOnly || v > 0)
       )
     )
   )

--- a/packages/cad-viewer/src/component/palette/MlDesignReviewPalette.vue
+++ b/packages/cad-viewer/src/component/palette/MlDesignReviewPalette.vue
@@ -55,11 +55,24 @@
       </el-table-column>
     </el-table>
 
-    <div v-if="selected" class="ml-design-review-detail">
-      <div class="ml-design-review-detail-title">
-        {{ t('main.toolPalette.designReview.details') }}
+    <div v-if="selected && detailsOpen" class="ml-design-review-detail">
+      <div class="ml-design-review-detail-header">
+        <div class="ml-design-review-detail-title">
+          {{ t('main.toolPalette.designReview.details') }}
+        </div>
+        <el-button
+          text
+          circle
+          size="small"
+          class="ml-design-review-detail-close"
+          :title="t('main.toolPalette.designReview.closeDetails')"
+          :aria-label="t('main.toolPalette.designReview.closeDetails')"
+          @click="closeDetails"
+        >
+          <el-icon><Close /></el-icon>
+        </el-button>
       </div>
-      <el-form label-position="top" size="small">
+      <el-form label-position="top" size="small" class="ml-design-review-detail-form">
         <el-form-item :label="t('main.toolPalette.designReview.status')">
           <el-select
             :model-value="selected.status"
@@ -78,16 +91,17 @@
         </el-form-item>
         <el-form-item :label="t('main.toolPalette.designReview.label')">
           <el-input
-            :model-value="selected.text ?? ''"
-            @change="(v: string) => updateMeta(selected!.id, { text: v })"
+            v-model="draftText"
+            @blur="commitText"
+            @keydown.enter="onLabelEnter"
           />
         </el-form-item>
         <el-form-item :label="t('main.toolPalette.designReview.comment')">
           <el-input
+            v-model="draftComment"
             type="textarea"
-            :rows="3"
-            :model-value="selected.comment"
-            @change="(v: string) => updateMeta(selected!.id, { comment: v })"
+            :rows="2"
+            @blur="commitComment"
           />
         </el-form-item>
         <div class="ml-design-review-detail-actions">
@@ -104,24 +118,29 @@
 </template>
 
 <script setup lang="ts">
+import { Close } from '@element-plus/icons-vue'
 import type { AcApMarkupStatus } from '@mlightcad/cad-simple-viewer'
 import {
   ElButton,
   ElForm,
   ElFormItem,
+  ElIcon,
   ElInput,
   ElOption,
   ElSelect,
   ElTable,
   ElTableColumn
 } from 'element-plus'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useMarkup } from '../../composable/useMarkup'
 
 const { t } = useI18n()
 const search = ref('')
+const draftText = ref('')
+const draftComment = ref('')
+const detailsOpen = ref(true)
 const {
   markups,
   selectedId,
@@ -146,8 +165,64 @@ const selected = computed(
   () => markups.value.find(m => m.id === selectedId.value) ?? null
 )
 
+watch(
+  selectedId,
+  (id, prevId) => {
+    if (prevId && prevId !== id) {
+      const prevRow = markups.value.find(m => m.id === prevId)
+      if (prevRow) {
+        if (draftText.value !== (prevRow.text ?? '')) {
+          updateMeta(prevId, { text: draftText.value })
+        }
+        if (draftComment.value !== (prevRow.comment ?? '')) {
+          updateMeta(prevId, { comment: draftComment.value })
+        }
+      }
+    }
+    const row = markups.value.find(m => m.id === id)
+    draftText.value = row?.text ?? ''
+    draftComment.value = row?.comment ?? ''
+    if (id) detailsOpen.value = true
+  },
+  { immediate: true }
+)
+
 const handleRowClick = (row: { id: string }) => {
+  detailsOpen.value = true
   select(row.id)
+}
+
+const closeDetails = () => {
+  commitText()
+  commitComment()
+  detailsOpen.value = false
+}
+
+const commitText = () => {
+  const id = selectedId.value
+  if (!id) return
+  const current = markups.value.find(m => m.id === id)
+  const next = draftText.value
+  const prev = current?.text ?? ''
+  if (next === prev) return
+  updateMeta(id, { text: next })
+}
+
+const commitComment = () => {
+  const id = selectedId.value
+  if (!id) return
+  const current = markups.value.find(m => m.id === id)
+  const next = draftComment.value
+  const prev = current?.comment ?? ''
+  if (next === prev) return
+  updateMeta(id, { comment: next })
+}
+
+const onLabelEnter = (event: KeyboardEvent) => {
+  if (event.isComposing || event.keyCode === 229) return
+  event.preventDefault()
+  commitText()
+  ;(event.target as HTMLInputElement | null)?.blur()
 }
 
 const patchStatus = (value: string) => {
@@ -197,18 +272,50 @@ const statusLabel = (status: AcApMarkupStatus) => {
 
 .ml-design-review-detail {
   border-top: 1px solid var(--el-border-color-lighter);
-  padding-top: 8px;
+  padding-top: 6px;
   max-height: 46%;
   overflow: auto;
 }
 
+.ml-design-review-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
 .ml-design-review-detail-title {
   font-weight: 600;
-  margin-bottom: 6px;
+}
+
+.ml-design-review-detail-close {
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.ml-design-review-detail-form {
+  --el-form-item-margin-bottom: 4px;
+}
+
+.ml-design-review-detail-form :deep(.el-form-item) {
+  margin-bottom: 4px;
+}
+
+.ml-design-review-detail-form :deep(.el-form-item .el-form-item__label) {
+  margin-bottom: 2px;
+  line-height: 1.2;
+  height: auto;
+}
+
+.ml-design-review-detail-form :deep(.el-select),
+.ml-design-review-detail-form :deep(.el-input) {
+  width: 100%;
 }
 
 .ml-design-review-detail-actions {
   display: flex;
   gap: 8px;
+  margin-top: 4px;
 }
 </style>

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -17,26 +17,35 @@ import {
   View
 } from '@element-plus/icons-vue'
 import {
-  AcApAnnotation,
   AcApConvertToDxfCmd,
   AcApDocManager,
   AcApOpenCmd,
   AcApQNewCmd,
   acapRunDatabaseEdit,
   AcEdOpenMode,
+  type AcTrView2d,
+  applyMeasurementStyleToSelection,
+  cssColor,
   cssToMarkupColor,
   defaultMarkupColor,
+  getActiveMeasurementStyle,
   getMarkupFontSize,
   getMarkupLineWeight,
   getMarkupPresenter,
   getMarkupStore,
+  getMeasurementFontSize,
+  getMeasurementLineWeight,
   isMarkupVisible,
   markupColorToCss,
+  measurementColor,
   runMarkupEdit,
   setMarkupDrawColor,
   setMarkupDrawFontSize,
-  setMarkupDrawLineWeight
-} from '@mlightcad/cad-simple-viewer'
+  setMarkupDrawLineWeight,
+  setMeasurementDrawColor,
+  setMeasurementDrawFontSize,
+  setMeasurementDrawLineWeight,
+  subscribeMeasurementSelection} from '@mlightcad/cad-simple-viewer'
 import {
   AcCmColor,
   AcDbDatabase,
@@ -125,7 +134,6 @@ import {
   rect,
   revCircle,
   revCloud,
-  revFreeDraw,
   revRect,
   setting,
   splineFitPoints,
@@ -166,12 +174,15 @@ const ribbonContainerRef = ref<HTMLElement>()
 const { isDocumentOpening, openMode: docOpenMode } = useDocument()
 const { canUndo, canRedo } = useUndoRedo()
 const { t, locale } = useI18n()
-const isAnnotationVisible = ref(true)
 const isMarkupOverlayVisible = ref(true)
 const markupDrawColor = shallowRef(defaultMarkupColor())
 const markupDrawColorDisplay = ref(markupColorToCss(markupDrawColor.value))
 const markupDrawLineWeight = ref<AcGiLineWeight>(getMarkupLineWeight())
 const markupDrawFontSize = ref(getMarkupFontSize())
+const measurementDrawColor = shallowRef(new AcCmColor())
+const measurementDrawColorDisplay = ref('#7b8794')
+const measurementDrawLineWeight = ref<AcGiLineWeight>(getMeasurementLineWeight())
+const measurementDrawFontSize = ref(getMeasurementFontSize())
 const isRibbonDisabled = computed(() => isDocumentOpening.value)
 const ribbonColor = ref<AcCmColor | undefined>(new AcCmColor())
 const ribbonColorDisplay = ref('#7b8794')
@@ -355,30 +366,11 @@ const syncRibbonProperties = (db = getCurrentDatabase()) => {
       : resolveRibbonColorDisplay(db.cecolor, db, db.clayer)
 }
 
-const syncAnnotationVisibility = () => {
-  const db = AcApDocManager.instance?.curDocument?.database
-  if (!db) {
-    isAnnotationVisible.value = true
-    return
-  }
-
-  const annotation = new AcApAnnotation(db)
-  for (const layer of db.tables.layerTable.newIterator()) {
-    if (annotation.hasAnnotationXData(layer)) {
-      isAnnotationVisible.value = !layer.isOff
-      return
-    }
-  }
-
-  isAnnotationVisible.value = true
-}
-
 const syncMarkupVisibility = () => {
   isMarkupOverlayVisible.value = isMarkupVisible()
 }
 
 const handleAnnotationLayerChange = () => {
-  syncAnnotationVisibility()
   syncRibbonProperties(observedDatabase)
 }
 
@@ -498,8 +490,9 @@ const handleDocumentActivated = () => {
   bindAnnotationVisibilityEvents(AcApDocManager.instance?.curDocument?.database)
   ribbonLayerIsolationSnapshot.value = null
   ribbonLayerPreviousSnapshot.value = null
-  syncAnnotationVisibility()
   syncMarkupVisibility()
+  syncMarkupStyleControls()
+  syncMeasurementStyleControls()
   syncRibbonProperties(AcApDocManager.instance?.curDocument?.database)
   syncHatchSelectionContext(AcApDocManager.instance?.curDocument?.database)
 }
@@ -522,6 +515,7 @@ const applyToSelectedEntities = (mutator: (entity: AcDbEntity) => void) => {
 }
 
 let unsubscribeMarkupStore: (() => void) | undefined
+let unsubscribeMeasurementSelection: (() => void) | undefined
 
 onMounted(() => {
   AcDbSysVarManager.instance().events.sysVarChanged.addEventListener(
@@ -547,12 +541,18 @@ onMounted(() => {
   )
   unsubscribeMarkupStore = getMarkupStore().subscribe(syncMarkupStyleControls)
   syncMarkupStyleControls()
+  unsubscribeMeasurementSelection = subscribeMeasurementSelection(
+    syncMeasurementStyleControls
+  )
+  syncMeasurementStyleControls()
   handleDocumentActivated()
 })
 
 onUnmounted(() => {
   unsubscribeMarkupStore?.()
   unsubscribeMarkupStore = undefined
+  unsubscribeMeasurementSelection?.()
+  unsubscribeMeasurementSelection = undefined
   AcDbSysVarManager.instance().events.sysVarChanged.removeEventListener(
     handleSysVarChange
   )
@@ -691,6 +691,50 @@ const handleMarkupDrawFontSizeChange = (value: number) => {
   applyMarkupStyleToSelection({ fontSize: getMarkupFontSize() })
 }
 
+const syncMeasurementStyleControls = () => {
+  const selected = getActiveMeasurementStyle()
+  if (selected) {
+    measurementDrawColor.value = selected.color.clone()
+    measurementDrawColorDisplay.value = cssColor(selected.color)
+    measurementDrawLineWeight.value = selected.lineWeight
+    measurementDrawFontSize.value = selected.fontSize
+    return
+  }
+  const db = getCurrentDatabase()
+  if (db) {
+    const color = measurementColor(db)
+    measurementDrawColor.value = color.clone()
+    measurementDrawColorDisplay.value = cssColor(color)
+  }
+  measurementDrawLineWeight.value = getMeasurementLineWeight()
+  measurementDrawFontSize.value = getMeasurementFontSize()
+}
+
+const handleMeasurementDrawColorChange = (value?: AcCmColor) => {
+  if (!value) return
+  setMeasurementDrawColor(value)
+  measurementDrawColor.value = value.clone()
+  measurementDrawColorDisplay.value = cssColor(value)
+  const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
+  if (view) applyMeasurementStyleToSelection(view, { color: value })
+}
+
+const handleMeasurementDrawLineWeightChange = (value: AcGiLineWeight) => {
+  setMeasurementDrawLineWeight(value)
+  measurementDrawLineWeight.value = value
+  const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
+  if (view) applyMeasurementStyleToSelection(view, { lineWeight: value })
+}
+
+const handleMeasurementDrawFontSizeChange = (value: number) => {
+  setMeasurementDrawFontSize(value)
+  measurementDrawFontSize.value = getMeasurementFontSize()
+  const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
+  if (view) {
+    applyMeasurementStyleToSelection(view, { fontSize: getMeasurementFontSize() })
+  }
+}
+
 /**
  * Applies a newly selected ribbon line type to the active database defaults.
  *
@@ -772,7 +816,6 @@ const handleRibbonLayerStateToggle = (payload: {
 
 const buildBaseTabs = (
   openMode: AcEdOpenMode,
-  annotationVisible: boolean,
   markupVisible: boolean,
   undoRedoState: { canUndo: boolean; canRedo: boolean },
   agentPluginEnabled: boolean
@@ -847,12 +890,6 @@ const buildBaseTabs = (
     restore: t('main.ribbon.tooltip.layerAction.restore')
   }
   const verticalToolbarDescriptions = {
-    revFreehand: t('main.verticalToolbar.revFreehand.description'),
-    revRect: t('main.verticalToolbar.revRect.description'),
-    revCloud: t('main.verticalToolbar.revCloud.description'),
-    revCircle: t('main.verticalToolbar.revCircle.description'),
-    showAnnotation: t('main.verticalToolbar.showAnnotation.description'),
-    hideAnnotation: t('main.verticalToolbar.hideAnnotation.description'),
     measureDistance: t('main.verticalToolbar.measureDistance.description'),
     measureAngle: t('main.verticalToolbar.measureAngle.description'),
     measureArea: t('main.verticalToolbar.measureArea.description'),
@@ -1011,6 +1048,7 @@ const buildBaseTabs = (
         componentProps: {
           modelValue: markupDrawLineWeight.value,
           placeholder: t('main.ribbon.property.lineWeight'),
+          numericOnly: true,
           'onUpdate:modelValue': handleMarkupDrawLineWeightChange
         }
       }
@@ -1029,59 +1067,6 @@ const buildBaseTabs = (
           controlWidth: '108px',
           'onUpdate:modelValue': handleMarkupDrawFontSizeChange
         }
-      }
-    }
-  ]
-
-  const annotationItems: RibbonItemModel[] = [
-    {
-      id: 'cmd-tool-rev-freehand',
-      type: 'button',
-      label: t('main.verticalToolbar.revFreehand.text'),
-      tooltip: verticalToolbarDescriptions.revFreehand,
-      size: 'large',
-      props: { icon: revFreeDraw }
-    },
-    {
-      id: 'cmd-tool-rev-rect',
-      type: 'button',
-      label: t('main.verticalToolbar.revRect.text'),
-      tooltip: verticalToolbarDescriptions.revRect,
-      size: 'large',
-      props: { icon: revRect }
-    },
-    {
-      id: 'cmd-tool-rev-cloud',
-      type: 'button',
-      label: t('main.verticalToolbar.revCloud.text'),
-      tooltip: verticalToolbarDescriptions.revCloud,
-      size: 'large',
-      props: { icon: revCloud }
-    },
-    {
-      id: 'cmd-tool-rev-circle',
-      type: 'button',
-      label: t('main.verticalToolbar.revCircle.text'),
-      tooltip: verticalToolbarDescriptions.revCircle,
-      size: 'large',
-      props: { icon: revCircle }
-    },
-    {
-      id: 'cmd-tool-rev-vis',
-      type: 'toggle',
-      label: t('main.verticalToolbar.showAnnotation.text'),
-      tooltip: annotationVisible
-        ? verticalToolbarDescriptions.hideAnnotation
-        : verticalToolbarDescriptions.showAnnotation,
-      size: 'large',
-      props: {
-        modelValue: annotationVisible,
-        activeIcon: View,
-        inactiveIcon: Hide,
-        activeLabel: t('main.verticalToolbar.showAnnotation.text'),
-        inactiveLabel: t('main.verticalToolbar.hideAnnotation.text'),
-        activeValue: 'cmd-tool-rev-vis',
-        inactiveValue: 'cmd-tool-rev-vis'
       }
     }
   ]
@@ -1137,73 +1122,130 @@ const buildBaseTabs = (
     }
   ]
 
-  const toolGroups: RibbonGroupModel[] = []
-
-  if (openMode >= AcEdOpenMode.Review) {
-    toolGroups.push({
-      id: 'tools-review',
+  const reviewGroups: RibbonGroupModel[] = [
+    {
+      id: 'review-review',
       title: t('main.ribbon.group.review'),
       orientation: 'row',
       collections: [
         {
-          id: 'tools-review-primary',
+          id: 'review-primary',
           layout: 'row',
           items: reviewPrimaryItems
         },
         {
-          id: 'tools-review-shapes',
+          id: 'review-shapes',
           layout: 'column',
           rows: 3,
           items: reviewShapeItems
         },
         {
-          id: 'tools-review-more',
+          id: 'review-more',
           layout: 'column',
           rows: 3,
           items: reviewMoreItems
         },
         {
-          id: 'tools-review-manage',
+          id: 'review-manage',
           layout: 'column',
           rows: 3,
           items: reviewManageItems
-        },
+        }
+      ]
+    },
+    {
+      id: 'review-style',
+      title: t('main.ribbon.group.style'),
+      orientation: 'row',
+      collections: [
         {
-          id: 'tools-review-style',
+          id: 'review-style-main',
           layout: 'column',
           rows: 3,
           items: reviewStyleItems
         }
       ]
-    })
-    toolGroups.push({
-      id: 'tools-annotation',
-      title: t('main.ribbon.group.annotation'),
+    }
+  ]
+
+  const measurementStyleItems: RibbonItemModel[] = [
+    {
+      id: 'measurement-draw-color',
+      type: 'custom',
+      size: 'small',
+      tooltip: t('main.verticalToolbar.measurementColor.description'),
+      props: {
+        component: MlRibbonPropertyColorDropdown,
+        componentProps: {
+          modelValue: measurementDrawColor.value,
+          displayColor: measurementDrawColorDisplay.value,
+          placeholder: t('main.ribbon.property.color'),
+          'onUpdate:modelValue': handleMeasurementDrawColorChange
+        }
+      }
+    },
+    {
+      id: 'measurement-draw-line-weight',
+      type: 'custom',
+      size: 'small',
+      tooltip: t('main.verticalToolbar.measurementLineWeight.description'),
+      props: {
+        component: MlRibbonPropertyLineWeightSelect,
+        componentProps: {
+          modelValue: measurementDrawLineWeight.value,
+          placeholder: t('main.ribbon.property.lineWeight'),
+          numericOnly: true,
+          'onUpdate:modelValue': handleMeasurementDrawLineWeightChange
+        }
+      }
+    },
+    {
+      id: 'measurement-draw-font-size',
+      type: 'custom',
+      size: 'small',
+      tooltip: t('main.verticalToolbar.measurementFontSize.description'),
+      props: {
+        component: MlRibbonMarkupFontSizeSelect,
+        componentProps: {
+          modelValue: measurementDrawFontSize.value,
+          options: [10, 12, 13, 14, 16, 18, 20, 24, 28, 32],
+          placeholder: t('main.verticalToolbar.measurementFontSize.text'),
+          controlWidth: '108px',
+          'onUpdate:modelValue': handleMeasurementDrawFontSizeChange
+        }
+      }
+    }
+  ]
+
+  const measurementGroups: RibbonGroupModel[] = [
+    {
+      id: 'measurement-measure',
+      title: t('main.ribbon.group.measurement'),
       orientation: 'row',
       collections: [
         {
-          id: 'tools-annotation-main',
+          id: 'measurement-main',
           layout: 'row',
-          items: annotationItems
+          items: measureItems
         }
       ]
-    })
-  }
+    },
+    {
+      id: 'measurement-style',
+      title: t('main.ribbon.group.style'),
+      orientation: 'row',
+      collections: [
+        {
+          id: 'measurement-style-main',
+          layout: 'column',
+          rows: 3,
+          items: measurementStyleItems
+        }
+      ]
+    }
+  ]
 
-  toolGroups.push({
-    id: 'tools-measure',
-    title: t('main.ribbon.group.measurement'),
-    orientation: 'row',
-    collections: [
-      {
-        id: 'tools-measure-main',
-        layout: 'row',
-        items: measureItems
-      }
-    ]
-  })
-
-  return markComponentConfigRaw([
+  const tabs: RibbonTabModel[] = [
     {
       id: 'home',
       title: t('main.ribbon.tab.home'),
@@ -1943,26 +1985,41 @@ const buildBaseTabs = (
           ]
         }
       ]
-    },
-    {
-      id: 'tools',
-      title: t('main.ribbon.tab.tools'),
-      groups: toolGroups
     }
-  ])
+  ]
+
+  if (openMode >= AcEdOpenMode.Review) {
+    tabs.push({
+      id: 'review',
+      title: t('main.ribbon.tab.review'),
+      groups: reviewGroups
+    })
+  }
+
+  tabs.push({
+    id: 'measurement',
+    title: t('main.ribbon.tab.measurement'),
+    groups: measurementGroups
+  })
+
+  return markComponentConfigRaw(tabs)
 }
 
 const ribbonData = computed(() => {
   locale.value
   store.features.agentPlugin
   const openMode = docOpenMode.value
-  const annotationVisible = isAnnotationVisible.value
   const markupVisible = isMarkupOverlayVisible.value
   // Track markup draw style so Review ribbon color / lineweight controls refresh.
   markupDrawColor.value
   markupDrawColorDisplay.value
   markupDrawLineWeight.value
   markupDrawFontSize.value
+  // Track measurement draw style so Measurement ribbon controls refresh.
+  measurementDrawColor.value
+  measurementDrawColorDisplay.value
+  measurementDrawLineWeight.value
+  measurementDrawFontSize.value
   const commandByItemId = new Map<string, string>()
   commandByItemId.set('cmd-line', 'line')
   commandByItemId.set('cmd-polyline', 'pline')
@@ -2034,11 +2091,6 @@ const ribbonData = computed(() => {
   commandByItemId.set('cmd-tool-markup-export', 'markupexport')
   commandByItemId.set('cmd-tool-markup-vis', 'markupvis')
   commandByItemId.set('cmd-tool-markup-clear', 'clearmarkups')
-  commandByItemId.set('cmd-tool-rev-freehand', 'sketch')
-  commandByItemId.set('cmd-tool-rev-rect', 'revrect')
-  commandByItemId.set('cmd-tool-rev-cloud', 'revcloud')
-  commandByItemId.set('cmd-tool-rev-circle', 'revcircle')
-  commandByItemId.set('cmd-tool-rev-vis', 'revvis')
   commandByItemId.set('cmd-tool-measure-distance', 'measuredistance')
   commandByItemId.set('cmd-tool-measure-angle', 'measureangle')
   commandByItemId.set('cmd-tool-measure-area', 'measurearea')
@@ -2058,7 +2110,6 @@ const ribbonData = computed(() => {
 
   const tabs: RibbonTabModel[] = buildBaseTabs(
     openMode,
-    annotationVisible,
     markupVisible,
     {
       canUndo: canUndo.value,

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonPropertyLineWeightSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonPropertyLineWeightSelect.vue
@@ -8,6 +8,7 @@
       :model-value="modelValue"
       :disabled="disabled"
       :placeholder="placeholder"
+      :numeric-only="numericOnly"
       @update:modelValue="emit('update:modelValue', $event)"
     />
   </ml-ribbon-property-field>
@@ -30,6 +31,8 @@ interface RibbonPropertyLineWeightSelectProps {
   disabled?: boolean
   /** Placeholder shown when no line weight can be resolved. */
   placeholder?: string
+  /** When true, hide ByLayer / ByBlock / Default (overlay style pickers). */
+  numericOnly?: boolean
 }
 
 defineProps<RibbonPropertyLineWeightSelectProps>()

--- a/packages/cad-viewer/src/composable/useMarkup.ts
+++ b/packages/cad-viewer/src/composable/useMarkup.ts
@@ -5,7 +5,8 @@ import {
   getMarkupPresenter,
   getMarkupStore,
   MARKUP_STATUSES,
-  runMarkupEdit} from '@mlightcad/cad-simple-viewer'
+  runMarkupEdit
+} from '@mlightcad/cad-simple-viewer'
 import { onMounted, onUnmounted, ref } from 'vue'
 
 /**
@@ -52,7 +53,7 @@ export function useMarkup() {
     runMarkupEdit(view, 'Edit Markup', () => {
       const updated = getMarkupStore().updateMeta(id, patch)
       if (!updated) return
-      if (patch.text != null) {
+      if (patch.text !== undefined || patch.comment !== undefined) {
         getMarkupPresenter().publish(view, updated)
       }
     })

--- a/packages/cad-viewer/src/composable/useUndoRedo.ts
+++ b/packages/cad-viewer/src/composable/useUndoRedo.ts
@@ -3,7 +3,7 @@ import { type DeepReadonly, readonly, type Ref, ref } from 'vue'
 
 /**
  * Reactive undo/redo availability for the active document session
- * (database edits + Design Review markups).
+ * (database edits, Design Review markups, and measurements).
  */
 export interface UseUndoRedoReturn {
   /** Whether the active session has undoable operations. */

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -15,7 +15,8 @@ export default {
     tab: {
       home: 'Domů',
       insert: 'Vložit',
-      tools: 'Nástroje',
+      review: 'Kontrola',
+      measurement: 'Měření',
       hatchContext: 'Šrafování',
       mtextEditorContext: 'Editor textu'
     },
@@ -215,6 +216,7 @@ export default {
       annotation: 'Poznámky',
       review: 'Kontrola',
       measurement: 'Měření',
+      style: 'Styl',
       reference: 'Reference',
       block: 'Blok'
     },
@@ -527,6 +529,21 @@ export default {
       text: 'Font size',
       description: 'Set the font size for text and callout markups'
     },
+    measurementColor: {
+      text: 'Color',
+      description:
+        'Set the color for the selected measurement, or for measurements you add next'
+    },
+    measurementLineWeight: {
+      text: 'Lineweight',
+      description:
+        'Set the lineweight for the selected measurement, or for measurements you add next'
+    },
+    measurementFontSize: {
+      text: 'Font size',
+      description:
+        'Set the font size for the selected measurement, or for measurements you add next'
+    },
     showMarkup: {
       text: 'Show',
       description: 'Shows Design Review markups'
@@ -717,6 +734,7 @@ export default {
       author: 'Author',
       summary: 'Summary',
       details: 'Details',
+      closeDetails: 'Close details',
       label: 'Label',
       comment: 'Comment',
       zoomTo: 'Zoom to',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -15,7 +15,8 @@ export default {
     tab: {
       home: 'Home',
       insert: 'Insert',
-      tools: 'Tools',
+      review: 'Review',
+      measurement: 'Measurement',
       hatchContext: 'Hatch',
       mtextEditorContext: 'Text Editor'
     },
@@ -215,6 +216,7 @@ export default {
       annotation: 'Annotation',
       review: 'Review',
       measurement: 'Measurement',
+      style: 'Style',
       reference: 'Reference',
       block: 'Block'
     },
@@ -536,6 +538,21 @@ export default {
       text: 'Font size',
       description: 'Set the font size for text and callout markups'
     },
+    measurementColor: {
+      text: 'Color',
+      description:
+        'Set the color for the selected measurement, or for measurements you add next'
+    },
+    measurementLineWeight: {
+      text: 'Lineweight',
+      description:
+        'Set the lineweight for the selected measurement, or for measurements you add next'
+    },
+    measurementFontSize: {
+      text: 'Font size',
+      description:
+        'Set the font size for the selected measurement, or for measurements you add next'
+    },
     showMarkup: {
       text: 'Show',
       description: 'Shows Design Review markups'
@@ -727,6 +744,7 @@ export default {
       author: 'Author',
       summary: 'Summary',
       details: 'Details',
+      closeDetails: 'Close details',
       label: 'Label',
       comment: 'Comment',
       zoomTo: 'Zoom to',

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -15,7 +15,8 @@ export default {
     tab: {
       home: 'Ana Sayfa',
       insert: 'Ekle',
-      tools: 'Araçlar',
+      review: 'İnceleme',
+      measurement: 'Ölçüm',
       hatchContext: 'Tarama',
       mtextEditorContext: 'Metin Düzenleyici'
     },
@@ -216,6 +217,7 @@ export default {
       annotation: 'Açıklama',
       review: 'İnceleme',
       measurement: 'Ölçüm',
+      style: 'Stil',
       reference: 'Referans',
       block: 'Blok'
     },
@@ -539,6 +541,21 @@ export default {
       text: 'Font size',
       description: 'Set the font size for text and callout markups'
     },
+    measurementColor: {
+      text: 'Color',
+      description:
+        'Set the color for the selected measurement, or for measurements you add next'
+    },
+    measurementLineWeight: {
+      text: 'Lineweight',
+      description:
+        'Set the lineweight for the selected measurement, or for measurements you add next'
+    },
+    measurementFontSize: {
+      text: 'Font size',
+      description:
+        'Set the font size for the selected measurement, or for measurements you add next'
+    },
     showMarkup: {
       text: 'Show',
       description: 'Shows Design Review markups'
@@ -732,6 +749,7 @@ export default {
       author: 'Author',
       summary: 'Summary',
       details: 'Details',
+      closeDetails: 'Close details',
       label: 'Label',
       comment: 'Comment',
       zoomTo: 'Zoom to',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -15,7 +15,8 @@ export default {
     tab: {
       home: '常用',
       insert: '插入',
-      tools: '工具',
+      review: '审阅',
+      measurement: '测量',
       hatchContext: '填充',
       mtextEditorContext: '文字编辑器'
     },
@@ -212,6 +213,7 @@ export default {
       annotation: '批注',
       review: '审阅',
       measurement: '测量',
+      style: '样式',
       reference: '参照',
       block: '块'
     },
@@ -494,6 +496,18 @@ export default {
       text: '字号',
       description: '设置文字与标注文本框的字号'
     },
+    measurementColor: {
+      text: '颜色',
+      description: '有选中测量标注时修改其颜色；未选中时用于后续添加的测量标注'
+    },
+    measurementLineWeight: {
+      text: '线宽',
+      description: '有选中测量标注时修改其线宽；未选中时用于后续添加的测量标注'
+    },
+    measurementFontSize: {
+      text: '字号',
+      description: '有选中测量标注时修改其字号；未选中时用于后续添加的测量标注'
+    },
     showMarkup: {
       text: '显示批注',
       description: '显示 Design Review 批注'
@@ -684,6 +698,7 @@ export default {
       author: '作者',
       summary: '摘要',
       details: '详情',
+      closeDetails: '关闭详情',
       label: '标签',
       comment: '评论',
       zoomTo: '缩放到',

--- a/packages/three-renderer/__tests__/AcTrHtmlTransientManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrHtmlTransientManager.spec.ts
@@ -315,4 +315,61 @@ describe('AcTrHtmlTransientManager', () => {
 
     manager.dispose()
   })
+
+  it('detaches a group without disposing children and reattaches it', () => {
+    const scene = new THREE.Scene()
+    const manager = new AcTrHtmlTransientManager(scene)
+    let disposed = false
+
+    const child = new AcTrHtmlElement(document.createElement('div'), {
+      id: 'g-detach-child',
+      worldPosition: { x: 0, y: 0 },
+      layer: 'measurement'
+    })
+    const dispose = child.dispose.bind(child)
+    child.dispose = () => {
+      disposed = true
+      dispose()
+    }
+
+    const group = new AcTrHtmlGroup({
+      id: 'g-detach',
+      layer: 'measurement',
+      selectable: true
+    }).add(child)
+
+    manager.add(group)
+    expect(manager.detach('g-detach')).toBe(group)
+    expect(manager.getGroup('g-detach')).toBeUndefined()
+    expect(manager.get('g-detach-child')).toBeUndefined()
+    expect(disposed).toBe(false)
+    expect(group.visible).toBe(false)
+
+    manager.reattach(group)
+    expect(manager.getGroup('g-detach')).toBe(group)
+    expect(manager.get('g-detach-child')).toBe(child)
+    expect(group.visible).toBe(true)
+    expect(disposed).toBe(false)
+
+    manager.dispose()
+  })
+
+  it('groupsOnLayer lists currently published groups', () => {
+    const scene = new THREE.Scene()
+    const manager = new AcTrHtmlTransientManager(scene)
+    const group = new AcTrHtmlGroup({
+      id: 'g-layer',
+      layer: 'measurement'
+    }).add(
+      new AcTrHtmlElement(document.createElement('div'), {
+        id: 'g-layer-child',
+        worldPosition: { x: 0, y: 0 },
+        layer: 'measurement'
+      })
+    )
+    manager.add(group)
+    expect(manager.groupsOnLayer('measurement')).toEqual([group])
+    expect(manager.groupsOnLayer('markup')).toEqual([])
+    manager.dispose()
+  })
 })

--- a/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrStyleManager.spec.ts
@@ -1,5 +1,6 @@
 import { AcCmColor, AcGiLineWeight } from '@mlightcad/data-model'
 import * as THREE from 'three'
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 
 import {
   getMaterialMetadata,
@@ -568,5 +569,19 @@ describe('AcTrStyleManager', () => {
     const metadata = getMaterialMetadata(material)
     expect(metadata.drawOrder).toBe(-1)
     expect(metadata.isBackgroundFill).toBe(false)
+  })
+
+  it('uses fat line materials when forceShowLineWeight is on even if LWDISPLAY is off', () => {
+    const styleManager = new AcTrStyleManager()
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.lineWeight = AcGiLineWeight.LineWeight211
+
+    const hairline = styleManager.getLineMaterial(traits)
+    expect(hairline).toBeInstanceOf(THREE.LineBasicMaterial)
+
+    styleManager.forceShowLineWeight = true
+    const fat = styleManager.getLineMaterial(traits)
+    expect(fat).toBeInstanceOf(LineMaterial)
+    expect((fat as LineMaterial).linewidth).toBeCloseTo(211 / 40)
   })
 })

--- a/packages/three-renderer/src/html/AcTrHtmlBadge.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlBadge.ts
@@ -47,6 +47,11 @@ export class AcTrHtmlBadge extends AcTrHtmlElement {
     this.element.style.fontSize = `${fontSize}px`
   }
 
+  /** Update the badge text color. */
+  setColor(color: AcCmColor): void {
+    this.element.style.color = acTrHtmlCssColor(color)
+  }
+
   private static createElement(
     color: AcCmColor,
     text: string,

--- a/packages/three-renderer/src/html/AcTrHtmlDot.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlDot.ts
@@ -19,6 +19,11 @@ export class AcTrHtmlDot extends AcTrHtmlElement {
     super(AcTrHtmlDot.createElement(options.color), options)
   }
 
+  /** Update the marker fill color. */
+  setColor(color: AcCmColor): void {
+    this.element.style.background = acTrHtmlCssColor(color)
+  }
+
   private static createElement(color: AcCmColor): HTMLDivElement {
     const el = document.createElement('div')
     el.className = 'ml-html-dot'

--- a/packages/three-renderer/src/html/AcTrHtmlTransientManager.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlTransientManager.ts
@@ -7,12 +7,21 @@ import {
 import { AC_TR_HTML_SELECTED_CLASS, AcTrHtmlElement } from './AcTrHtmlElement'
 import { AcTrHtmlGroup } from './AcTrHtmlGroup'
 
+/** Scratch vector reused when decomposing CSS2D object matrices. */
 const _position = /*@__PURE__*/ new THREE.Vector3()
+/** Scratch quaternion reused when decomposing CSS2D object matrices. */
 const _quaternion = /*@__PURE__*/ new THREE.Quaternion()
+/** Scratch scale vector reused when decomposing CSS2D object matrices. */
 const _scale = /*@__PURE__*/ new THREE.Vector3()
 
+/** Whether the shared HTML-selection stylesheet has been injected into `document.head`. */
 let selectionStylesInstalled = false
 
+/**
+ * Injects the CSS used to highlight selected HTML overlays.
+ *
+ * No-op after the first call, and when `document` is unavailable (SSR / workers).
+ */
 function ensureSelectionStyles(): void {
   if (selectionStylesInstalled || typeof document === 'undefined') return
   selectionStylesInstalled = true
@@ -58,25 +67,33 @@ function ensureSelectionStyles(): void {
  * categories of overlays (e.g. measurements, annotations).
  */
 export class AcTrHtmlTransientManager {
+  /** Scene that owns the HTML overlay container. */
   private readonly scene: THREE.Scene
+  /** Scene-graph group that holds every published CSS2D overlay. */
   private readonly htmlGroup: THREE.Group
 
-  /** Mapping from leaf element ID → element */
+  /** Mapping from leaf element ID to element. */
   private readonly entries: Map<string, AcTrHtmlElement>
-  /** Mapping from group ID → group */
+  /** Mapping from group ID to group. */
   private readonly groups: Map<string, AcTrHtmlGroup>
-  /** Mapping from standalone canvas overlay ID → overlay */
+  /** Mapping from standalone canvas overlay ID to overlay. */
   private readonly canvases: Map<string, AcTrHtmlCanvasOverlay>
   /** Leaf ids that belong to a group (visibility driven by the group). */
   private readonly groupChildIds = new Set<string>()
-  /** Currently selected group ids */
+  /** Currently selected group ids. */
   private readonly selectedGroupIds = new Set<string>()
   /** Active layout BTR id used to filter layout-scoped overlays. */
   private _activeLayoutId?: string
   /** World matrix captured when each leaf transient was published. */
   private readonly _baselineMatrices = new Map<string, THREE.Matrix4>()
+  /** Scratch matrix used to compose world transforms in {@link applyTransforms}. */
   private readonly _composedMatrix = new THREE.Matrix4()
 
+  /**
+   * Creates the HTML overlay group and attaches it to the scene.
+   *
+   * @param scene - Scene that owns the HTML overlay container
+   */
   constructor(scene: THREE.Scene) {
     this.scene = scene
 
@@ -100,6 +117,8 @@ export class AcTrHtmlTransientManager {
    * Overlays / groups with a matching {@link AcTrHtmlElement.layoutId} (or
    * no `layoutId`) stay visible; others are hidden. Selection on groups that
    * become hidden is cleared.
+   *
+   * @param layoutId - Layout block-table-record id to filter overlays against
    */
   setActiveLayoutId(layoutId: string): void {
     if (this._activeLayoutId === layoutId) return
@@ -111,6 +130,8 @@ export class AcTrHtmlTransientManager {
    * Add a leaf HTML overlay, a group, or a standalone canvas overlay.
    *
    * If an item with the same id already exists, it is replaced.
+   *
+   * @param item - Overlay, group, or canvas to publish
    */
   add(item: AcTrHtmlElement | AcTrHtmlGroup | AcTrHtmlCanvasOverlay): void {
     if (item instanceof AcTrHtmlGroup) {
@@ -124,6 +145,9 @@ export class AcTrHtmlTransientManager {
 
   /**
    * Update the world position of an existing leaf element.
+   *
+   * @param id - Leaf element id
+   * @param worldPosition - New world-space anchor; `z` defaults to `0`
    */
   updatePosition(
     id: string,
@@ -138,6 +162,9 @@ export class AcTrHtmlTransientManager {
 
   /**
    * Enable or disable view-synced scaling for an existing leaf element.
+   *
+   * @param id - Leaf element id
+   * @param scaleWithView - When `true`, the DOM node scales with orthographic zoom
    */
   setScaleWithView(id: string, scaleWithView: boolean): void {
     const entry = this.entries.get(id)
@@ -149,6 +176,9 @@ export class AcTrHtmlTransientManager {
   /**
    * Applies world transforms to existing leaf HTML transients without
    * recreating DOM.
+   *
+   * @param transforms - Per-leaf world matrices composed onto each published baseline
+   * @returns `true` when at least one overlay matrix changed
    */
   applyTransforms(
     transforms: ReadonlyArray<{ id: string; matrix: THREE.Matrix4 }>
@@ -176,7 +206,12 @@ export class AcTrHtmlTransientManager {
   }
 
   /**
-   * Remove a leaf element, canvas overlay, or an entire group by ID.
+   * Remove a leaf HTML overlay, a group, or a standalone canvas overlay.
+   *
+   * Groups are disposed. Use {@link detach} to take a group off the scene
+   * without destroying it (undo / redo).
+   *
+   * @param id - Leaf, group, or canvas id
    */
   remove(id: string): void {
     const group = this.groups.get(id)
@@ -192,11 +227,88 @@ export class AcTrHtmlTransientManager {
   }
 
   /**
+   * Take a group off the scene without disposing it or its children.
+   * CAD / canvas extras stay on the group and are hidden via `setVisible(false)`.
+   *
+   * @param id - Group id
+   * @returns The detached group, or `undefined` when `id` is not a group
+   */
+  detach(id: string): AcTrHtmlGroup | undefined {
+    const group = this.groups.get(id)
+    if (!group) return undefined
+    this.detachGroup(group)
+    return group
+  }
+
+  /**
+   * Detach every group on `layer` without disposing them.
+   * Loose leaf elements / canvases on that layer are not touched.
+   *
+   * @param layer - Layer name whose groups should be unpublished
+   * @returns Groups that were detached
+   */
+  detachLayer(layer: string): AcTrHtmlGroup[] {
+    const detached: AcTrHtmlGroup[] = []
+    for (const group of [...this.groups.values()]) {
+      if (group.layer !== layer) continue
+      this.detachGroup(group)
+      detached.push(group)
+    }
+    return detached
+  }
+
+  /**
+   * Publish a previously {@link detach}ed group back onto the scene.
+   *
+   * @param group - Group previously returned by {@link detach} or {@link detachLayer}
+   */
+  reattach(group: AcTrHtmlGroup): void {
+    this.add(group)
+    if (!group.visible) {
+      const visible =
+        group.layoutId == null ||
+        this._activeLayoutId == null ||
+        group.layoutId === this._activeLayoutId
+      group.setVisible(visible)
+    }
+  }
+
+  /**
+   * Groups currently marked selected.
+   *
+   * @returns Selected groups that are still published
+   */
+  getSelectedGroups(): AcTrHtmlGroup[] {
+    const groups: AcTrHtmlGroup[] = []
+    for (const id of this.selectedGroupIds) {
+      const group = this.groups.get(id)
+      if (group) groups.push(group)
+    }
+    return groups
+  }
+
+  /**
+   * Groups currently published on `layer`.
+   *
+   * @param layer - Layer name to match
+   * @returns Published groups whose {@link AcTrHtmlGroup.layer} equals `layer`
+   */
+  groupsOnLayer(layer: string): AcTrHtmlGroup[] {
+    const groups: AcTrHtmlGroup[] = []
+    for (const group of this.groups.values()) {
+      if (group.layer === layer) groups.push(group)
+    }
+    return groups
+  }
+
+  /**
    * Clear all items, or only items on a specific layer.
    *
    * Groups on the layer are removed first (with their children / canvases);
    * remaining loose leaf elements and standalone canvases are removed
    * afterwards.
+   *
+   * @param layer - When set, only items on this layer are removed
    */
   clear(layer?: string): void {
     for (const [id, group] of [...this.groups]) {
@@ -225,35 +337,66 @@ export class AcTrHtmlTransientManager {
     }
   }
 
-  /** Check whether a leaf element, canvas overlay, or group exists. */
+  /**
+   * Check whether a leaf element, canvas overlay, or group exists.
+   *
+   * @param id - Leaf, group, or canvas id
+   * @returns `true` when the id is currently published
+   */
   has(id: string): boolean {
     return (
       this.entries.has(id) || this.groups.has(id) || this.canvases.has(id)
     )
   }
 
-  /** Retrieve a leaf element by ID. */
+  /**
+   * Retrieve a leaf element by ID.
+   *
+   * @param id - Leaf element id
+   * @returns The published leaf, or `undefined` if it is not registered
+   */
   get(id: string): AcTrHtmlElement | undefined {
     return this.entries.get(id)
   }
 
-  /** Retrieve a group by ID. */
+  /**
+   * Retrieve a group by ID.
+   *
+   * @param id - Group id
+   * @returns The published group, or `undefined` if it is not registered
+   */
   getGroup(id: string): AcTrHtmlGroup | undefined {
     return this.groups.get(id)
   }
 
-  /** Retrieve a standalone canvas overlay by ID. */
+  /**
+   * Retrieve a standalone canvas overlay by ID.
+   *
+   * @param id - Canvas overlay id
+   * @returns The published canvas, or `undefined` if it is not registered
+   */
   getCanvas(id: string): AcTrHtmlCanvasOverlay | undefined {
     return this.canvases.get(id)
   }
 
-  /** Retrieve the DOM node for a leaf element. */
+  /**
+   * Retrieve the DOM node for a leaf element.
+   *
+   * @param id - Leaf element id
+   * @returns The wrapped HTML element, or `undefined` if the leaf is not registered
+   */
   getElement(id: string): HTMLElement | undefined {
     return this.entries.get(id)?.element
   }
 
   /**
    * Show or hide all items, or only items on a specific layer.
+   *
+   * Group children are skipped when iterating leaves; their visibility is
+   * driven by the owning group.
+   *
+   * @param visible - Target visibility
+   * @param layer - When set, only items on this layer are updated
    */
   setVisible(visible: boolean, layer?: string): void {
     if (layer == null) {
@@ -291,8 +434,11 @@ export class AcTrHtmlTransientManager {
 
   /**
    * Select a group by id.
-   * @param exclusive When `true` (default), clears any prior selection first.
+   *
+   * @param id - Group id
+   * @param exclusive - When `true` (default), clears any prior selection first.
    *   Pass `false` for additive multi-select.
+   * @returns `true` when the group was newly selected
    */
   selectGroup(id: string, exclusive = true): boolean {
     const group = this.groups.get(id)
@@ -323,18 +469,23 @@ export class AcTrHtmlTransientManager {
     this.selectedGroupIds.clear()
   }
 
-  /** Whether any group is currently selected. */
+  /**
+   * Whether any group is currently selected.
+   *
+   * @returns `true` when {@link selectedGroupIds} is non-empty
+   */
   hasSelection(): boolean {
     return this.selectedGroupIds.size > 0
   }
 
   /**
    * Remove every currently selected group.
-   * @returns `true` when at least one group was removed.
    *
    * Selection is cleared via {@link removeGroup} (which calls
    * `setSelected(false)`) so `onSelectedChanged` still runs for domain
    * cleanup such as CAD entity unhighlight.
+   *
+   * @returns `true` when at least one group was removed
    */
   deleteSelected(): boolean {
     if (this.selectedGroupIds.size === 0) return false
@@ -357,6 +508,11 @@ export class AcTrHtmlTransientManager {
     this.scene.remove(this.htmlGroup)
   }
 
+  /**
+   * Publish a group and its CSS2D children, replacing any item with the same id.
+   *
+   * @param group - Group to register
+   */
   private addGroup(group: AcTrHtmlGroup): void {
     this.remove(group.id)
     this.groups.set(group.id, group)
@@ -373,6 +529,11 @@ export class AcTrHtmlTransientManager {
     this.applyItemLayoutVisibility(group)
   }
 
+  /**
+   * Unpublish a group, dispose it, and remove its CSS2D children.
+   *
+   * @param group - Group currently registered in {@link groups}
+   */
   private removeGroup(group: AcTrHtmlGroup): void {
     if (this.selectedGroupIds.has(group.id)) {
       group.setSelected(false)
@@ -386,6 +547,30 @@ export class AcTrHtmlTransientManager {
     group.dispose()
   }
 
+  /**
+   * Unpublish a group without disposing HTML children, canvases, or `onDispose`.
+   *
+   * @param group - Group currently registered in {@link groups}
+   */
+  private detachGroup(group: AcTrHtmlGroup): void {
+    if (this.selectedGroupIds.has(group.id)) {
+      group.setSelected(false)
+      this.selectedGroupIds.delete(group.id)
+    }
+    this.groups.delete(group.id)
+    group.unbindSelection()
+    group.setVisible(false)
+    for (const child of [...group.children]) {
+      this.groupChildIds.delete(child.id)
+      this.unpublishElement(child.id)
+    }
+  }
+
+  /**
+   * Publish a leaf CSS2D overlay, replacing any leaf with the same id.
+   *
+   * @param element - Leaf overlay to attach to {@link htmlGroup}
+   */
   private addElement(element: AcTrHtmlElement): void {
     this.removeElement(element.id)
 
@@ -400,6 +585,11 @@ export class AcTrHtmlTransientManager {
     }
   }
 
+  /**
+   * Remove a leaf overlay from the scene and dispose its DOM node.
+   *
+   * @param id - Leaf element id
+   */
   private removeElement(id: string): void {
     const entry = this.entries.get(id)
     if (!entry) return
@@ -410,12 +600,35 @@ export class AcTrHtmlTransientManager {
     this._baselineMatrices.delete(id)
   }
 
+  /**
+   * Remove a leaf from the CSS2D scene without disposing the DOM node.
+   *
+   * @param id - Leaf element id
+   */
+  private unpublishElement(id: string): void {
+    const entry = this.entries.get(id)
+    if (!entry) return
+    this.htmlGroup.remove(entry.object)
+    this.entries.delete(id)
+    this._baselineMatrices.delete(id)
+  }
+
+  /**
+   * Register a standalone canvas overlay, replacing any item with the same id.
+   *
+   * @param canvas - Canvas overlay to register
+   */
   private addCanvas(canvas: AcTrHtmlCanvasOverlay): void {
     this.remove(canvas.id)
     this.canvases.set(canvas.id, canvas)
     this.applyItemLayoutVisibility(canvas)
   }
 
+  /**
+   * Unregister and dispose a standalone canvas overlay.
+   *
+   * @param id - Canvas overlay id
+   */
   private removeCanvas(id: string): void {
     const canvas = this.canvases.get(id)
     if (!canvas) return
@@ -423,6 +636,11 @@ export class AcTrHtmlTransientManager {
     canvas.dispose()
   }
 
+  /**
+   * Recompute visibility of every published overlay against {@link _activeLayoutId}.
+   *
+   * Groups whose layout no longer matches are also deselected.
+   */
   private applyLayoutVisibility(): void {
     for (const id of [...this.selectedGroupIds]) {
       const group = this.groups.get(id)
@@ -448,6 +666,13 @@ export class AcTrHtmlTransientManager {
     }
   }
 
+  /**
+   * Show or hide one overlay based on whether its `layoutId` matches the active layout.
+   *
+   * Items without a `layoutId`, or when no active layout is set, are left unchanged.
+   *
+   * @param item - Leaf, group, or canvas whose visibility should be updated
+   */
   private applyItemLayoutVisibility(
     item: AcTrHtmlElement | AcTrHtmlGroup | AcTrHtmlCanvasOverlay
   ): void {
@@ -468,6 +693,8 @@ export class AcTrHtmlTransientManager {
    * After CSS2DRenderer writes its translation-only transform, append scale
    * from {@link applyTransforms} and, when {@link AcTrHtmlElement.scaleWithView}
    * is set, from orthographic camera zoom relative to first paint.
+   *
+   * @param entry - Leaf overlay whose `onAfterRender` hook should be installed
    */
   private bindViewSyncedTransform(entry: AcTrHtmlElement): void {
     const object = entry.object

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -430,6 +430,18 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
     this._context.styleManager.showLineWeight = value
   }
 
+  /**
+   * Whether the next line conversion should honor entity lineweights even
+   * when {@link showLineWeight} (LWDISPLAY) is off.
+   */
+  get forceShowLineWeight() {
+    return this._context.styleManager.forceShowLineWeight
+  }
+
+  set forceShowLineWeight(value: boolean) {
+    this._context.styleManager.forceShowLineWeight = value
+  }
+
   updateLayerMaterial(
     layerName: string,
     newTraits: Partial<AcGiSubEntityTraits>

--- a/packages/three-renderer/src/style/AcTrStyleManager.ts
+++ b/packages/three-renderer/src/style/AcTrStyleManager.ts
@@ -50,6 +50,12 @@ export class AcTrStyleManager {
   private pointMgr: AcTrPointMaterialManager
   private lineMgr: AcTrLineMaterialManager
   private fillMgr: AcTrFillMaterialManager
+  /**
+   * When true, fat-line materials are used even if {@link showLineWeight}
+   * (LWDISPLAY) is off. Overlay transients (markup / measurement) set this
+   * for the duration of conversion so ribbon lineweight is visible.
+   */
+  private _forceShowLineWeight = false
 
   constructor() {
     this.pointMgr = new AcTrPointMaterialManager(this.options)
@@ -85,7 +91,9 @@ export class AcTrStyleManager {
     const hasLinePattern = !!(
       traits.lineType.pattern && traits.lineType.pattern.length > 0
     )
-    const forceBasicMaterial = !this.options.showLineWeight && !hasLinePattern
+    const showLineWeight =
+      this.options.showLineWeight || this._forceShowLineWeight
+    const forceBasicMaterial = !showLineWeight && !hasLinePattern
     return this.lineMgr.getMaterial(traits, {
       basicMaterialOnly: basicMaterialOnly || forceBasicMaterial
     })!
@@ -103,6 +111,18 @@ export class AcTrStyleManager {
    */
   set showLineWeight(value: boolean) {
     this.options.showLineWeight = value
+  }
+
+  /**
+   * Whether overlay conversion should honor entity lineweights even when
+   * {@link showLineWeight} is false.
+   */
+  get forceShowLineWeight(): boolean {
+    return this._forceShowLineWeight
+  }
+
+  set forceShowLineWeight(value: boolean) {
+    this._forceShowLineWeight = value
   }
 
   /**


### PR DESCRIPTION
## Summary
- Put measurements on the same session undo/redo stack as DWG and Design Review markups (detach/reattach), including Delete and Clear Measurements.
- Drive measurement color, line weight, and font size from the ribbon; changing those controls updates the selection and later draws.
- Honor overlay lineweight even when LWDISPLAY is off, so markup and measurement strokes actually change thickness.
- Keep cloud/rect/circle callout bubble text in sync with the markup label, and make the Design Review details pane closable with blur-commit editing.

## Test plan
- [ ] Create distance/angle/area/arc/point measurements, change color/weight/font from the ribbon, press Delete, then Undo/Redo and Clear Measurements + Undo.
- [ ] Mix markup and measurement edits and confirm Ctrl+Z/Y walks them in chronological order.
- [ ] Change overlay lineweight (e.g. 0.70 mm to 2.11 mm) with LWDISPLAY off and confirm both new and selected markup/measurement strokes update.
- [ ] Open a new drawing and confirm previous overlay history and HTML transients are gone.