### PR TITLE
feat: add AutoCAD-style REVCLOUD/SKETCH and measurement overlay visibility

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
@@ -173,6 +173,7 @@ jest.mock('../src/command', () => {
     'AcApMeasureDistanceCmd',
     'AcApMeasurementExportCmd',
     'AcApMeasurementImportCmd',
+    'AcApMeasurementVisibilityCmd',
     'AcApMeasurePointCmd',
     'AcApMLineCmd',
     'AcApMoveCmd',

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementVisibility.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementVisibility.spec.ts
@@ -1,0 +1,78 @@
+import type { AcTrHtmlGroup } from '@mlightcad/three-renderer'
+
+import {
+  isMeasurementVisible,
+  MEASUREMENT_LAYER,
+  MEASUREMENT_LIVE_LAYER,
+  resetMeasurementVisibility,
+  setMeasurementVisible
+} from '../src/command/measure/AcApMeasurementStore'
+import type { AcTrView2d } from '../src/view'
+
+function makeGroup(
+  id: string,
+  layoutId: string | undefined
+): AcTrHtmlGroup {
+  return {
+    id,
+    layer: MEASUREMENT_LAYER,
+    layoutId,
+    visible: true,
+    setVisible: jest.fn(function (this: { visible: boolean }, visible: boolean) {
+      this.visible = visible
+    })
+  } as unknown as AcTrHtmlGroup
+}
+
+function createView(groups: AcTrHtmlGroup[], layoutId: string) {
+  const setVisible = jest.fn()
+  const view = {
+    activeLayoutBtrId: layoutId,
+    isDirty: false,
+    htmlTransientManager: {
+      groupsOnLayer(layer: string) {
+        return groups.filter(group => group.layer === layer)
+      },
+      setVisible
+    }
+  } as unknown as AcTrView2d
+  return { view, setVisible }
+}
+
+describe('AcApMeasurementVisibility', () => {
+  afterEach(() => {
+    resetMeasurementVisibility()
+  })
+
+  it('hides only measurements on the active layout', () => {
+    const current = makeGroup('current', 'layout-a')
+    const other = makeGroup('other', 'layout-b')
+    const unscoped = makeGroup('unscoped', undefined)
+    const { view, setVisible } = createView(
+      [current, other, unscoped],
+      'layout-a'
+    )
+
+    setMeasurementVisible(view, false)
+
+    expect(isMeasurementVisible()).toBe(false)
+    expect(current.setVisible).toHaveBeenCalledWith(false)
+    expect(unscoped.setVisible).toHaveBeenCalledWith(false)
+    expect(other.setVisible).not.toHaveBeenCalled()
+    expect(setVisible).toHaveBeenCalledWith(false, MEASUREMENT_LIVE_LAYER)
+    expect(view.isDirty).toBe(true)
+  })
+
+  it('shows measurements on the active layout without revealing other layouts', () => {
+    const current = makeGroup('current', 'layout-a')
+    const other = makeGroup('other', 'layout-b')
+    const { view } = createView([current, other], 'layout-a')
+
+    setMeasurementVisible(view, false)
+    setMeasurementVisible(view, true)
+
+    expect(isMeasurementVisible()).toBe(true)
+    expect(current.setVisible).toHaveBeenLastCalledWith(true)
+    expect(other.setVisible).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcApRevCloudSketch.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApRevCloudSketch.spec.ts
@@ -1,0 +1,175 @@
+jest.mock('../src/app', () => ({
+  AcApDocManager: {
+    instance: {
+      editor: {}
+    }
+  }
+}))
+
+jest.mock('../src/editor', () => {
+  class AcEdCommand {
+    mode: unknown
+  }
+
+  class AcEdPreviewJig {
+    constructor(_view: unknown) {}
+  }
+
+  class MockKeywordCollection {
+    add(display: string, global: string, local: string) {
+      return { display, global, local }
+    }
+  }
+
+  class AcEdPromptPointOptions {
+    keywords = new MockKeywordCollection()
+    constructor(readonly message: string) {}
+  }
+
+  class AcEdPromptDistanceOptions {
+    constructor(readonly message: string) {}
+  }
+
+  class AcEdPromptKeywordOptions {
+    keywords = new MockKeywordCollection()
+    constructor(readonly message: string) {}
+  }
+
+  return {
+    AcEdCommand,
+    AcEdOpenMode: { Write: 8 },
+    AcEdPreviewJig,
+    AcEdPromptDistanceOptions,
+    AcEdPromptKeywordOptions,
+    AcEdPromptPointOptions,
+    AcEdPromptStatus: {
+      OK: 'OK',
+      Keyword: 'Keyword',
+      Cancel: 'Cancel',
+      None: 'None'
+    }
+  }
+})
+
+jest.mock('../src/i18n', () => ({
+  AcApI18n: {
+    t: (key: string) => key
+  }
+}))
+
+import { AcDbPolyline, AcGePoint2d } from '@mlightcad/data-model'
+
+import {
+  buildRevCloud,
+  defaultRevCloudArcLength,
+  distance2d,
+  ensureCounterClockwise,
+  isRevCloudCloseToStart,
+  rectanglePath,
+  REVCLOUD_BULGE,
+  signedArea
+} from '../src/command/review/AcApRevCloudGeom'
+import {
+  accumulateSketchPoint,
+  simplifySketchPoints
+} from '../src/command/review/AcApSketchCmd'
+
+describe('AcApRevCloudGeom', () => {
+  test('rectanglePath is counterclockwise', () => {
+    const path = rectanglePath({ x: 0, y: 2 }, { x: 4, y: 0 })
+    expect(path).toHaveLength(4)
+    expect(signedArea(path)).toBeGreaterThan(0)
+    expect(path[0]).toEqual(new AcGePoint2d(0, 0))
+    expect(path[2]).toEqual(new AcGePoint2d(4, 2))
+  })
+
+  test('ensureCounterClockwise reverses clockwise polygons', () => {
+    const clockwise = [
+      new AcGePoint2d(0, 0),
+      new AcGePoint2d(0, 2),
+      new AcGePoint2d(2, 2),
+      new AcGePoint2d(2, 0)
+    ]
+    const oriented = ensureCounterClockwise(clockwise)
+    expect(signedArea(oriented)).toBeGreaterThan(0)
+  })
+
+  test('buildRevCloud creates a closed polyline of outward arcs', () => {
+    const cloud = new AcDbPolyline()
+    const path = rectanglePath({ x: 0, y: 0 }, { x: 10, y: 10 })
+    const built = buildRevCloud(cloud, path, true, { arcLength: 2 })
+    expect(built).toBe(true)
+    expect(cloud.closed).toBe(true)
+    expect(cloud.numberOfVertices).toBeGreaterThanOrEqual(3)
+
+    const getBulgeAt = (
+      cloud as unknown as { getBulgeAt?: (index: number) => number }
+    ).getBulgeAt
+    if (getBulgeAt) {
+      expect(getBulgeAt.call(cloud, 0)).toBeCloseTo(REVCLOUD_BULGE)
+    }
+  })
+
+  test('buildRevCloud reverse option negates bulge', () => {
+    const cloud = new AcDbPolyline()
+    const path = rectanglePath({ x: 0, y: 0 }, { x: 10, y: 10 })
+    buildRevCloud(cloud, path, true, { arcLength: 2, reverse: true })
+    const getBulgeAt = (
+      cloud as unknown as { getBulgeAt?: (index: number) => number }
+    ).getBulgeAt
+    if (getBulgeAt) {
+      expect(getBulgeAt.call(cloud, 0)).toBeCloseTo(-REVCLOUD_BULGE)
+    }
+  })
+
+  test('isRevCloudCloseToStart uses half the arc length', () => {
+    expect(isRevCloudCloseToStart({ x: 0, y: 0 }, { x: 0.4, y: 0 }, 1)).toBe(
+      true
+    )
+    expect(isRevCloudCloseToStart({ x: 0, y: 0 }, { x: 0.6, y: 0 }, 1)).toBe(
+      false
+    )
+  })
+
+  test('defaultRevCloudArcLength is a fraction of the view diagonal', () => {
+    const view = {
+      width: 100,
+      height: 100,
+      screenToWorld: ({ x, y }: { x: number; y: number }) => ({ x, y })
+    }
+    const length = defaultRevCloudArcLength(view as never)
+    expect(length).toBeCloseTo(Math.hypot(100, 100) * 0.005)
+  })
+
+  test('distance2d matches hypot', () => {
+    expect(distance2d({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5)
+  })
+})
+
+describe('AcApSketchCmd helpers', () => {
+  test('accumulateSketchPoint ignores moves shorter than the increment', () => {
+    const points = [new AcGePoint2d(0, 0)]
+    expect(accumulateSketchPoint(points, { x: 0.05, y: 0 }, 0.1)).toBe(false)
+    expect(points).toHaveLength(1)
+    expect(accumulateSketchPoint(points, { x: 0.2, y: 0 }, 0.1)).toBe(true)
+    expect(points).toHaveLength(2)
+  })
+
+  test('simplifySketchPoints keeps first, last, and tolerance-spaced points', () => {
+    const simplified = simplifySketchPoints(
+      [
+        { x: 0, y: 0 },
+        { x: 0.1, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1.05, y: 0 },
+        { x: 2, y: 0 }
+      ],
+      0.5
+    )
+    expect(simplified.map(p => [p.x, p.y])).toEqual([
+      [0, 0],
+      [1, 0],
+      [2, 0]
+    ])
+  })
+})

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -65,6 +65,7 @@ import {
   AcApMeasureDistanceCmd,
   AcApMeasurementExportCmd,
   AcApMeasurementImportCmd,
+  AcApMeasurementVisibilityCmd,
   AcApMeasurePointCmd,
   AcApMLineCmd,
   AcApMoveCmd,
@@ -1247,6 +1248,11 @@ export class AcApDocManager {
       'clearmeasurements',
       'clearmeasurements',
       new AcApClearMeasurementsCmd()
+    )
+    addSystemCommand(
+      'measurementvis',
+      'measurementvis',
+      new AcApMeasurementVisibilityCmd()
     )
     addSystemCommand(
       'measurementexport',

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementHistory.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementHistory.ts
@@ -16,7 +16,8 @@ import {
   applyMeasurementStyle,
   getMeasurementStyle,
   MEASUREMENT_LAYER,
-  resetMeasurementStyleState
+  resetMeasurementStyleState,
+  resetMeasurementVisibility
 } from './AcApMeasurementStore'
 
 /**
@@ -296,6 +297,7 @@ export function resetMeasurementSession(): void {
   getMeasurementHistory().clear()
   resetMeasurementStyleState()
   resetMeasurementUnitOverride()
+  resetMeasurementVisibility()
 }
 
 /** Bind this history into session undo (also runs at module load). */

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -22,6 +22,39 @@ export const MEASUREMENT_LAYER = 'measurement'
 /** HTML transient layer for in-progress jig / live preview overlays. */
 export const MEASUREMENT_LIVE_LAYER = 'measurement-live'
 
+/** Session visibility for measurement overlays on the active layout. */
+let measurementVisible = true
+
+/** Whether measurement overlays are currently shown. */
+export function isMeasurementVisible(): boolean {
+  return measurementVisible
+}
+
+/** Restore the default (shown) session flag after a document open / close. */
+export function resetMeasurementVisibility(): void {
+  measurementVisible = true
+}
+
+/**
+ * Show or hide committed measurement overlays on the active layout, plus live
+ * jig overlays.
+ */
+export function setMeasurementVisible(
+  view: AcTrView2d,
+  visible: boolean
+): void {
+  measurementVisible = visible
+  const layoutId = view.activeLayoutBtrId
+  const ht = view.htmlTransientManager
+  for (const group of ht.groupsOnLayer(MEASUREMENT_LAYER)) {
+    if (group.layoutId == null || group.layoutId === layoutId) {
+      group.setVisible(visible)
+    }
+  }
+  ht.setVisible(visible, MEASUREMENT_LIVE_LAYER)
+  view.isDirty = true
+}
+
 /**
  * Optional non-HTML resources attached to a measurement {@link AcTrHtmlGroup}.
  */
@@ -276,5 +309,11 @@ export function commitMeasurementGroup(
   runMeasurementEdit(view, 'Create Measurement', () => {
     view.htmlTransientManager.add(group)
   })
+  if (
+    !measurementVisible &&
+    (group.layoutId == null || group.layoutId === view.activeLayoutBtrId)
+  ) {
+    group.setVisible(false)
+  }
   view.isDirty = true
 }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementVisibilityCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementVisibilityCmd.ts
@@ -1,0 +1,23 @@
+import { AcApContext } from '../../app'
+import { AcEdCommand, AcEdOpenMode } from '../../editor'
+import type { AcTrView2d } from '../../view'
+import {
+  isMeasurementVisible,
+  setMeasurementVisible
+} from './AcApMeasurementStore'
+
+/**
+ * Toggle measurement overlay visibility on the current layout.
+ */
+export class AcApMeasurementVisibilityCmd extends AcEdCommand {
+  constructor() {
+    super()
+    this.mode = AcEdOpenMode.Read
+    this.recordsUndoStack = false
+  }
+
+  async execute(context: AcApContext) {
+    const view = context.view as AcTrView2d
+    setMeasurementVisible(view, !isMeasurementVisible())
+  }
+}

--- a/packages/cad-simple-viewer/src/command/measure/index.ts
+++ b/packages/cad-simple-viewer/src/command/measure/index.ts
@@ -1,5 +1,6 @@
 export * from './AcApClearMeasurementsCmd'
 export * from './AcApMeasurementHistory'
+export * from './AcApMeasurementVisibilityCmd'
 export * from './AcApMeasurementImportExportCmd'
 export * from './AcApMeasurementPlace'
 export * from './AcApMeasurementSidecar'

--- a/packages/cad-simple-viewer/src/command/review/AcApRevCloudCmd.ts
+++ b/packages/cad-simple-viewer/src/command/review/AcApRevCloudCmd.ts
@@ -1,178 +1,157 @@
 import {
+  AcDbEntity,
   AcDbPolyline,
   AcGePoint2d,
-  AcGePoint2dLike
+  AcGePoint2dLike,
+  AcGePoint3d,
+  AcGeTol
 } from '@mlightcad/data-model'
 
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdBaseView,
+  AcEdCommand,
   AcEdOpenMode,
   AcEdPreviewJig,
+  AcEdPromptDistanceOptions,
+  AcEdPromptEntityOptions,
+  AcEdPromptKeywordOptions,
   AcEdPromptPointOptions,
+  AcEdPromptPointResult,
+  AcEdPromptState,
+  AcEdPromptStateMachine,
+  AcEdPromptStateStep,
   AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
-import { AcApBaseRevCmd } from './AcApBaseRevCmd'
+import {
+  type AcApRevCloudStyle,
+  buildRevCloud,
+  defaultRevCloudArcLength,
+  distance2d,
+  isRevCloudCloseToStart,
+  rectanglePath,
+  sampleEntityPath
+} from './AcApRevCloudGeom'
 
-// Cloud line diameter in pixels
-const CLOUD_DIAMETER_PIXELS = 8
+type RevCloudMode = 'rectangular' | 'polygonal' | 'freehand'
+type RevCloudKeywordKey =
+  | 'arcLength'
+  | 'object'
+  | 'rectangular'
+  | 'polygonal'
+  | 'freehand'
+  | 'style'
+  | 'normal'
+  | 'calligraphy'
+  | 'undo'
+  | 'yes'
+  | 'no'
 
-/**
- * Converts pixel distance to world distance using view transformation
- */
-function pixelToWorldDistance(
-  view: AcEdBaseView,
-  pixelDistance: number,
-  referencePoint: AcGePoint2dLike
-): number {
-  const screenPoint1 = view.worldToScreen(referencePoint)
-  const screenPoint2 = new AcGePoint2d(
-    screenPoint1.x + pixelDistance,
-    screenPoint1.y
-  )
-  const worldPoint2 = view.screenToWorld(screenPoint2)
-  return Math.abs(worldPoint2.x - referencePoint.x)
+interface RevCloudSettings {
+  mode: RevCloudMode
+  arcLength?: number
+  style: AcApRevCloudStyle
+  variance: boolean
 }
 
-/**
- * Creates a cloud line (revision cloud) along a rectangular path
- */
-function updateCloud(
-  cloud: AcDbPolyline,
-  firstPoint: AcGePoint2dLike,
-  secondPoint: AcGePoint2dLike,
-  view: AcEdBaseView
+const DEFAULT_SETTINGS: RevCloudSettings = {
+  mode: 'rectangular',
+  style: 'normal',
+  variance: true
+}
+
+function addKeyword(
+  prompt: AcEdPromptPointOptions | AcEdPromptKeywordOptions,
+  key: RevCloudKeywordKey
 ) {
-  // Reset the polyline (using type assertion as reset may not be in type definitions)
-  cloud.reset(false)
-
-  // Calculate rectangle dimensions
-  const minX = Math.min(firstPoint.x, secondPoint.x)
-  const maxX = Math.max(firstPoint.x, secondPoint.x)
-  const minY = Math.min(firstPoint.y, secondPoint.y)
-  const maxY = Math.max(firstPoint.y, secondPoint.y)
-
-  const width = maxX - minX
-  const height = maxY - minY
-
-  // Convert cloud diameter from pixels to world coordinates
-  const centerPoint = new AcGePoint2d((minX + maxX) / 2, (minY + maxY) / 2)
-  const cloudDiameter = pixelToWorldDistance(
-    view,
-    CLOUD_DIAMETER_PIXELS,
-    centerPoint
+  prompt.keywords.add(
+    AcApI18n.t(`jig.revcloud.keywords.${key}.display`),
+    AcApI18n.t(`jig.revcloud.keywords.${key}.global`),
+    AcApI18n.t(`jig.revcloud.keywords.${key}.local`)
   )
-
-  // Calculate chord length for each arc segment
-  // Each arc segment should span approximately the cloud diameter
-  const chordLength = cloudDiameter
-
-  // Calculate the number of segments needed along each edge
-  const numSegmentsX = Math.max(4, Math.ceil(width / chordLength) * 2)
-  const numSegmentsY = Math.max(4, Math.ceil(height / chordLength) * 2)
-
-  // Generate points along the rectangle path with arcs
-  const points: AcGePoint2d[] = []
-  const bulges: (number | undefined)[] = []
-  let segmentIndex = 0
-
-  // Helper function to calculate bulge for a small arc
-  // For cloud effect, use a small bulge value to create gentle arcs
-  // A bulge of 0.3-0.5 creates nice cloud-like arcs
-  const calculateBulge = (outward: boolean): number => {
-    return outward ? 0.4 : -0.4
-  }
-
-  // Bottom edge (left to right)
-  for (let i = 0; i <= numSegmentsX; i++) {
-    const t = i / numSegmentsX
-    const x = minX + width * t
-    const y = minY
-    points.push(new AcGePoint2d(x, y))
-
-    if (i < numSegmentsX) {
-      const outward = segmentIndex % 2 === 0
-      bulges.push(calculateBulge(outward))
-      segmentIndex++
-    } else {
-      bulges.push(undefined)
-    }
-  }
-
-  // Right edge (bottom to top)
-  for (let i = 1; i <= numSegmentsY; i++) {
-    const t = i / numSegmentsY
-    const x = maxX
-    const y = minY + height * t
-    points.push(new AcGePoint2d(x, y))
-
-    if (i < numSegmentsY) {
-      const outward = segmentIndex % 2 === 0
-      bulges.push(calculateBulge(outward))
-      segmentIndex++
-    } else {
-      bulges.push(undefined)
-    }
-  }
-
-  // Top edge (right to left)
-  for (let i = 1; i <= numSegmentsX; i++) {
-    const t = 1 - i / numSegmentsX
-    const x = minX + width * t
-    const y = maxY
-    points.push(new AcGePoint2d(x, y))
-
-    if (i < numSegmentsX) {
-      const outward = segmentIndex % 2 === 0
-      bulges.push(calculateBulge(outward))
-      segmentIndex++
-    } else {
-      bulges.push(undefined)
-    }
-  }
-
-  // Left edge (top to bottom)
-  for (let i = 1; i < numSegmentsY; i++) {
-    const t = 1 - i / numSegmentsY
-    const x = minX
-    const y = minY + height * t
-    points.push(new AcGePoint2d(x, y))
-
-    if (i < numSegmentsY - 1) {
-      const outward = segmentIndex % 2 === 0
-      bulges.push(calculateBulge(outward))
-      segmentIndex++
-    } else {
-      bulges.push(undefined)
-    }
-  }
-
-  // Add vertices to polyline with bulge values
-  for (let i = 0; i < points.length; i++) {
-    const bulge = bulges[i]
-    cloud.addVertexAt(i, points[i], bulge)
-  }
-
-  cloud.closed = true
 }
 
+function toPoint2d(point: AcGePoint2dLike): AcGePoint2d {
+  return new AcGePoint2d(point.x, point.y)
+}
+
+function applyCloud(
+  cloud: AcDbPolyline,
+  path: AcGePoint2dLike[],
+  closed: boolean,
+  settings: RevCloudSettings
+) {
+  return buildRevCloud(cloud, path, closed, {
+    arcLength: settings.arcLength ?? 1,
+    style: settings.style,
+    variance: settings.variance
+  })
+}
+
+/**
+ * Live preview for rectangular / polygonal / freehand revision clouds.
+ */
 export class AcApRevCloudJig extends AcEdPreviewJig<AcGePoint2dLike> {
   private _cloud: AcDbPolyline
-  private _firstPoint: AcGePoint2d
-  private _view: AcEdBaseView
+  private _path: AcGePoint2d[]
+  private _closed: boolean
+  private _settings: RevCloudSettings
 
-  /**
-   * Creates a cloud line jig.
-   *
-   * @param view - The associated view
-   * @param start - The first corner point
-   */
-  constructor(view: AcEdBaseView, start: AcGePoint2dLike) {
+  constructor(
+    view: AcEdBaseView,
+    path: AcGePoint2dLike[],
+    closed: boolean,
+    settings: RevCloudSettings
+  ) {
     super(view)
     this._cloud = new AcDbPolyline()
-    this._firstPoint = new AcGePoint2d(start)
-    this._view = view
+    this._path = path.map(toPoint2d)
+    this._closed = closed
+    this._settings = settings
+    this.rebuild()
+  }
+
+  get entity(): AcDbPolyline {
+    return this._cloud
+  }
+
+  updatePath(path: AcGePoint2dLike[], closed: boolean) {
+    this._path = path.map(toPoint2d)
+    this._closed = closed
+    this.rebuild()
+  }
+
+  update(point: AcGePoint2dLike) {
+    if (this._path.length === 0) return
+    const preview = [...this._path, toPoint2d(point)]
+    const closed = this._closed && preview.length >= 3
+    applyCloud(this._cloud, preview, closed, this._settings)
+  }
+
+  private rebuild() {
+    if (this._path.length < 2) {
+      this._cloud.reset(false)
+      return
+    }
+    applyCloud(this._cloud, this._path, this._closed, this._settings)
+  }
+}
+
+class AcApRevCloudRectJig extends AcEdPreviewJig<AcGePoint2dLike> {
+  private _cloud: AcDbPolyline
+  private _firstPoint: AcGePoint2d
+  private _settings: RevCloudSettings
+
+  constructor(
+    view: AcEdBaseView,
+    start: AcGePoint2dLike,
+    settings: RevCloudSettings
+  ) {
+    super(view)
+    this._cloud = new AcDbPolyline()
+    this._firstPoint = toPoint2d(start)
+    this._settings = settings
   }
 
   get entity(): AcDbPolyline {
@@ -180,42 +159,447 @@ export class AcApRevCloudJig extends AcEdPreviewJig<AcGePoint2dLike> {
   }
 
   update(secondPoint: AcGePoint2dLike) {
-    updateCloud(this._cloud, this._firstPoint, secondPoint, this._view)
+    applyCloud(
+      this._cloud,
+      rectanglePath(this._firstPoint, secondPoint),
+      true,
+      this._settings
+    )
+  }
+}
+
+class AcApRevCloudFreehandJig extends AcEdPreviewJig<AcGePoint2dLike> {
+  private _cloud: AcDbPolyline
+  private _points: AcGePoint2d[]
+  private _settings: RevCloudSettings
+  private _closed = false
+
+  constructor(
+    view: AcEdBaseView,
+    start: AcGePoint2dLike,
+    settings: RevCloudSettings
+  ) {
+    super(view)
+    this._cloud = new AcDbPolyline()
+    this._points = [toPoint2d(start)]
+    this._settings = settings
+  }
+
+  get entity(): AcDbPolyline {
+    return this._cloud
+  }
+
+  get points(): AcGePoint2d[] {
+    return this._points
+  }
+
+  get closed(): boolean {
+    return this._closed
+  }
+
+  addPoint(point: AcGePoint2dLike) {
+    const next = toPoint2d(point)
+    const last = this._points[this._points.length - 1]
+    if (last && distance2d(last, next) < 1e-8) return
+    this._points.push(next)
+  }
+
+  update(current: AcGePoint2dLike) {
+    const arcLength = this._settings.arcLength ?? 1
+    const last = this._points[this._points.length - 1]
+    if (last && distance2d(last, current) >= arcLength) {
+      this._points.push(toPoint2d(current))
+    }
+
+    this._closed =
+      this._points.length >= 3 &&
+      isRevCloudCloseToStart(this._points[0], current, arcLength)
+
+    const preview = this._closed
+      ? this._points
+      : [...this._points, toPoint2d(current)]
+    applyCloud(this._cloud, preview, this._closed, this._settings)
   }
 }
 
 /**
- * Command to create a revision cloud (cloud line) in rectangular shape.
+ * Command to create a revision cloud, aligned with AutoCAD REVCLOUD.
+ *
+ * Supports Rectangular (default), Polygonal, Freehand, Object conversion,
+ * Arc length, Style (Normal/Calligraphy), and Reverse direction.
  */
-export class AcApRevCloudCmd extends AcApBaseRevCmd {
+export class AcApRevCloudCmd extends AcEdCommand {
+  private static _settings: RevCloudSettings = { ...DEFAULT_SETTINGS }
+
   constructor() {
     super()
-    this.mode = AcEdOpenMode.Review
+    this.mode = AcEdOpenMode.Write
   }
 
   async execute(context: AcApContext) {
-    const firstPointPrompt = new AcEdPromptPointOptions(
-      AcApI18n.t('jig.line.firstPoint')
-    )
-    const firstPointResult =
-      await AcApDocManager.instance.editor.getPoint(firstPointPrompt)
-    if (firstPointResult.status !== AcEdPromptStatus.OK) return
-    const firstPoint = firstPointResult.value!
+    const settings = AcApRevCloudCmd._settings
+    if (settings.arcLength == null) {
+      settings.arcLength = defaultRevCloudArcLength(context.view)
+    }
 
-    const secondPointPrompt = new AcEdPromptPointOptions(
-      AcApI18n.t('jig.line.nextPoint')
-    )
-    secondPointPrompt.jig = new AcApRevCloudJig(context.view, firstPoint)
-    secondPointPrompt.useDashedLine = false
-    secondPointPrompt.useBasePoint = true
-    const secondPointResult =
-      await AcApDocManager.instance.editor.getPoint(secondPointPrompt)
-    if (secondPointResult.status !== AcEdPromptStatus.OK) return
-    const secondPoint = secondPointResult.value!
+    while (true) {
+      const prompt = new AcEdPromptPointOptions(
+        AcApI18n.t('jig.revcloud.firstCornerOrOptions')
+      )
+      addKeyword(prompt, 'arcLength')
+      addKeyword(prompt, 'object')
+      const rectangular = prompt.keywords.add(
+        AcApI18n.t('jig.revcloud.keywords.rectangular.display'),
+        AcApI18n.t('jig.revcloud.keywords.rectangular.global'),
+        AcApI18n.t('jig.revcloud.keywords.rectangular.local')
+      )
+      const polygonal = prompt.keywords.add(
+        AcApI18n.t('jig.revcloud.keywords.polygonal.display'),
+        AcApI18n.t('jig.revcloud.keywords.polygonal.global'),
+        AcApI18n.t('jig.revcloud.keywords.polygonal.local')
+      )
+      const freehand = prompt.keywords.add(
+        AcApI18n.t('jig.revcloud.keywords.freehand.display'),
+        AcApI18n.t('jig.revcloud.keywords.freehand.global'),
+        AcApI18n.t('jig.revcloud.keywords.freehand.local')
+      )
+      addKeyword(prompt, 'style')
+      prompt.keywords.default =
+        settings.mode === 'polygonal'
+          ? polygonal
+          : settings.mode === 'freehand'
+            ? freehand
+            : rectangular
 
+      const result = await AcApDocManager.instance.editor.getPoint(prompt)
+      if (result.status === AcEdPromptStatus.Keyword) {
+        const keyword = result.stringResult ?? ''
+        if (keyword === 'ArcLength') {
+          const accepted = await this.promptArcLength(settings)
+          if (!accepted) return
+          continue
+        }
+        if (keyword === 'Object') {
+          await this.convertObject(context, settings)
+          return
+        }
+        if (keyword === 'Rectangular') {
+          settings.mode = 'rectangular'
+          await this.drawRectangular(context, settings)
+          return
+        }
+        if (keyword === 'Polygonal') {
+          settings.mode = 'polygonal'
+          await this.drawPolygonal(context, settings)
+          return
+        }
+        if (keyword === 'Freehand') {
+          settings.mode = 'freehand'
+          await this.drawFreehand(context, settings)
+          return
+        }
+        if (keyword === 'Style') {
+          const accepted = await this.promptStyle(settings)
+          if (!accepted) return
+          continue
+        }
+        continue
+      }
+
+      if (result.status !== AcEdPromptStatus.OK || !result.value) return
+
+      if (settings.mode === 'polygonal') {
+        await this.drawPolygonal(context, settings, result.value)
+      } else if (settings.mode === 'freehand') {
+        await this.drawFreehand(context, settings, result.value)
+      } else {
+        await this.drawRectangular(context, settings, result.value)
+      }
+      return
+    }
+  }
+
+  private async promptArcLength(settings: RevCloudSettings) {
+    const prompt = new AcEdPromptDistanceOptions(
+      AcApI18n.t('jig.revcloud.arcLength')
+    )
+    prompt.allowNegative = false
+    prompt.allowZero = false
+    prompt.useDefaultValue = settings.arcLength != null
+    prompt.defaultValue = settings.arcLength ?? 1
+    const result = await AcApDocManager.instance.editor.getDistance(prompt)
+    if (
+      result.status !== AcEdPromptStatus.OK &&
+      result.status !== AcEdPromptStatus.None
+    ) {
+      return false
+    }
+    const value = result.value ?? prompt.defaultValue
+    if (!AcGeTol.isPositive(value)) {
+      this.showMessage(AcApI18n.t('jig.revcloud.invalidArcLength'), 'warning')
+      return true
+    }
+    settings.arcLength = value
+    return true
+  }
+
+  private async promptStyle(settings: RevCloudSettings) {
+    const prompt = new AcEdPromptKeywordOptions(
+      AcApI18n.t('jig.revcloud.style')
+    )
+    prompt.allowNone = true
+    const normal = prompt.keywords.add(
+      AcApI18n.t('jig.revcloud.keywords.normal.display'),
+      AcApI18n.t('jig.revcloud.keywords.normal.global'),
+      AcApI18n.t('jig.revcloud.keywords.normal.local')
+    )
+    const calligraphy = prompt.keywords.add(
+      AcApI18n.t('jig.revcloud.keywords.calligraphy.display'),
+      AcApI18n.t('jig.revcloud.keywords.calligraphy.global'),
+      AcApI18n.t('jig.revcloud.keywords.calligraphy.local')
+    )
+    prompt.keywords.default =
+      settings.style === 'calligraphy' ? calligraphy : normal
+    const result = await AcApDocManager.instance.editor.getKeywords(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) return false
+    if (
+      result.status === AcEdPromptStatus.OK ||
+      result.status === AcEdPromptStatus.Keyword
+    ) {
+      if (result.stringResult === 'Calligraphy') {
+        settings.style = 'calligraphy'
+      } else if (result.stringResult === 'Normal') {
+        settings.style = 'normal'
+      }
+    }
+    return true
+  }
+
+  private async drawRectangular(
+    context: AcApContext,
+    settings: RevCloudSettings,
+    firstPoint?: AcGePoint2dLike
+  ) {
+    const start = firstPoint ?? (await this.promptPoint('firstCorner'))
+    if (!start) return
+
+    const prompt = new AcEdPromptPointOptions(
+      AcApI18n.t('jig.revcloud.oppositeCorner')
+    )
+    prompt.useBasePoint = true
+    prompt.basePoint = new AcGePoint3d(start.x, start.y, 0)
+    prompt.useDashedLine = false
+    prompt.jig = new AcApRevCloudRectJig(context.view, start, settings)
+    const result = await AcApDocManager.instance.editor.getPoint(prompt)
+    if (result.status !== AcEdPromptStatus.OK || !result.value) return
+
+    const path = rectanglePath(start, result.value)
+    if (
+      AcGeTol.equalToZero(path[0].x - path[1].x) ||
+      AcGeTol.equalToZero(path[0].y - path[3].y)
+    ) {
+      return
+    }
+    await this.commitCloud(context, path, true, settings)
+  }
+
+  private async drawPolygonal(
+    context: AcApContext,
+    settings: RevCloudSettings,
+    firstPoint?: AcGePoint2dLike
+  ) {
+    const start = firstPoint ?? (await this.promptPoint('startPoint'))
+    if (!start) return
+
+    const points: AcGePoint2d[] = [toPoint2d(start)]
+    type PolyState = AcEdPromptState<
+      AcEdPromptPointOptions,
+      AcEdPromptPointResult
+    >
+
+    class NextPointState implements PolyState {
+      buildPrompt() {
+        const prompt = new AcEdPromptPointOptions(
+          AcApI18n.t(
+            points.length >= 2
+              ? 'jig.revcloud.nextPointOrUndo'
+              : 'jig.revcloud.nextPoint'
+          )
+        )
+        if (points.length >= 2) {
+          addKeyword(prompt, 'undo')
+        }
+        prompt.useDashedLine = false
+        prompt.useBasePoint = true
+        const current = points[points.length - 1]
+        prompt.basePoint = new AcGePoint3d(current.x, current.y, 0)
+        prompt.allowNone = points.length >= 3
+        prompt.jig = new AcApRevCloudJig(context.view, points, true, settings)
+        return prompt
+      }
+
+      async handleResult(
+        result: AcEdPromptPointResult
+      ): Promise<AcEdPromptStateStep> {
+        if (result.status === AcEdPromptStatus.Keyword) {
+          if (result.stringResult === 'Undo' && points.length > 1) {
+            points.pop()
+          }
+          return 'continue'
+        }
+        if (result.status === AcEdPromptStatus.OK && result.value) {
+          points.push(toPoint2d(result.value))
+          return 'continue'
+        }
+        return 'finish'
+      }
+    }
+
+    const machine = new AcEdPromptStateMachine<
+      AcEdPromptPointOptions,
+      AcEdPromptPointResult
+    >()
+    machine.setState(new NextPointState())
+    await machine.run(prompt => AcApDocManager.instance.editor.getPoint(prompt))
+
+    if (points.length < 3) return
+    await this.commitCloud(context, points, true, settings)
+  }
+
+  private async drawFreehand(
+    context: AcApContext,
+    settings: RevCloudSettings,
+    firstPoint?: AcGePoint2dLike
+  ) {
+    const start = firstPoint ?? (await this.promptPoint('firstPoint'))
+    if (!start) return
+
+    const jig = new AcApRevCloudFreehandJig(context.view, start, settings)
+    const arcLength = settings.arcLength ?? 1
+
+    while (true) {
+      const prompt = new AcEdPromptPointOptions(
+        AcApI18n.t('jig.revcloud.guideCursor')
+      )
+      prompt.jig = jig
+      prompt.useDashedLine = false
+      prompt.useBasePoint = true
+      prompt.basePoint = new AcGePoint3d(start.x, start.y, 0)
+      prompt.allowNone = true
+      prompt.disableOSnap = true
+      const result = await AcApDocManager.instance.editor.getPoint(prompt)
+      if (result.status === AcEdPromptStatus.Cancel) return
+      if (result.status === AcEdPromptStatus.None) {
+        if (jig.points.length < 2) return
+        await this.commitCloud(context, jig.points, jig.closed, settings)
+        return
+      }
+      if (result.status !== AcEdPromptStatus.OK || !result.value) return
+
+      if (
+        jig.points.length >= 3 &&
+        isRevCloudCloseToStart(jig.points[0], result.value, arcLength)
+      ) {
+        await this.commitCloud(context, jig.points, true, settings)
+        return
+      }
+      jig.addPoint(result.value)
+    }
+  }
+
+  private async convertObject(
+    context: AcApContext,
+    settings: RevCloudSettings
+  ) {
+    while (true) {
+      const prompt = new AcEdPromptEntityOptions(
+        AcApI18n.t('jig.revcloud.selectObject')
+      )
+      prompt.setRejectMessage(AcApI18n.t('jig.revcloud.invalidObject'))
+      prompt.addAllowedClass('Polyline')
+      prompt.addAllowedClass('Circle')
+      prompt.addAllowedClass('Ellipse')
+      prompt.addAllowedClass('Spline')
+      const result = await AcApDocManager.instance.editor.getEntity(prompt)
+      if (result.status !== AcEdPromptStatus.OK || !result.objectId) return
+
+      const entity = context.doc.database.openEntityForRead(result.objectId)
+      if (!entity) return
+      const sampled = sampleEntityPath(entity, (settings.arcLength ?? 1) * 0.5)
+      if (!sampled) {
+        this.showMessage(AcApI18n.t('jig.revcloud.invalidObject'), 'warning')
+        continue
+      }
+
+      const committed = await this.commitCloud(
+        context,
+        sampled.points,
+        sampled.closed,
+        settings
+      )
+      if (committed) {
+        this.eraseEntity(context, entity)
+      }
+      return
+    }
+  }
+
+  private async commitCloud(
+    context: AcApContext,
+    path: AcGePoint2dLike[],
+    closed: boolean,
+    settings: RevCloudSettings
+  ) {
     const db = context.doc.database
     const cloud = new AcDbPolyline()
-    updateCloud(cloud, firstPoint, secondPoint, context.view)
+    if (!applyCloud(cloud, path, closed, settings)) return false
     db.tables.blockTable.modelSpace.appendEntity(cloud)
+
+    const reverse = await this.promptReverse()
+    if (reverse) {
+      buildRevCloud(cloud, path, closed, {
+        arcLength: settings.arcLength ?? 1,
+        style: settings.style,
+        variance: settings.variance,
+        reverse: true
+      })
+    }
+    return true
+  }
+
+  private async promptReverse() {
+    const prompt = new AcEdPromptKeywordOptions(
+      AcApI18n.t('jig.revcloud.reverseDirection')
+    )
+    prompt.allowNone = true
+    addKeyword(prompt, 'yes')
+    const no = prompt.keywords.add(
+      AcApI18n.t('jig.revcloud.keywords.no.display'),
+      AcApI18n.t('jig.revcloud.keywords.no.global'),
+      AcApI18n.t('jig.revcloud.keywords.no.local')
+    )
+    prompt.keywords.default = no
+    const result = await AcApDocManager.instance.editor.getKeywords(prompt)
+    return (
+      (result.status === AcEdPromptStatus.OK ||
+        result.status === AcEdPromptStatus.Keyword) &&
+      result.stringResult === 'Yes'
+    )
+  }
+
+  private async promptPoint(
+    messageKey: 'firstCorner' | 'startPoint' | 'firstPoint'
+  ) {
+    const prompt = new AcEdPromptPointOptions(
+      AcApI18n.t(`jig.revcloud.${messageKey}`)
+    )
+    const result = await AcApDocManager.instance.editor.getPoint(prompt)
+    if (result.status !== AcEdPromptStatus.OK || !result.value) return undefined
+    return result.value
+  }
+
+  private eraseEntity(context: AcApContext, entity: AcDbEntity) {
+    entity.erase()
+    context.view.removeEntity(entity)
   }
 }

--- a/packages/cad-simple-viewer/src/command/review/AcApRevCloudGeom.ts
+++ b/packages/cad-simple-viewer/src/command/review/AcApRevCloudGeom.ts
@@ -1,0 +1,456 @@
+import {
+  AcDbCircle,
+  AcDbEllipse,
+  AcDbEntity,
+  AcDbPolyline,
+  AcDbSpline,
+  AcGePoint2d,
+  AcGePoint2dLike,
+  AcGeTol
+} from '@mlightcad/data-model'
+
+import type { AcEdBaseView } from '../../editor'
+
+/** Classic AutoCAD scallop: 180° arc (`bulge = tan(π/4)`). */
+export const REVCLOUD_BULGE = 1
+
+/** Fraction of the current view diagonal used for the first-time arc length. */
+const DEFAULT_ARC_LENGTH_VIEW_RATIO = 0.005
+
+/** Calligraphy pen end-width as a fraction of the arc chord length. */
+const CALLIGRAPHY_WIDTH_RATIO = 0.1
+
+export type AcApRevCloudStyle = 'normal' | 'calligraphy'
+
+export interface AcApRevCloudBuildOptions {
+  /** Approximate chord length of each cloud arc. */
+  arcLength: number
+  /** When true, arcs bulge inward instead of outward. */
+  reverse?: boolean
+  /** Normal (constant width) or calligraphy (tapered) style. */
+  style?: AcApRevCloudStyle
+  /**
+   * When true, chord lengths vary for a hand-drawn look
+   * (`REVCLOUDARCVARIANCE` On).
+   */
+  variance?: boolean
+}
+
+/**
+ * World distance of the current view diagonal.
+ */
+export function viewDiagonalLength(view: AcEdBaseView): number {
+  const width = Math.max(1, view.width)
+  const height = Math.max(1, view.height)
+  const topLeft = view.screenToWorld({ x: 0, y: 0 })
+  const bottomRight = view.screenToWorld({ x: width, y: height })
+  return Math.hypot(bottomRight.x - topLeft.x, bottomRight.y - topLeft.y)
+}
+
+/**
+ * AutoCAD-like default arc length: a small percentage of the view diagonal.
+ */
+export function defaultRevCloudArcLength(view: AcEdBaseView): number {
+  const diagonal = viewDiagonalLength(view)
+  const length = diagonal * DEFAULT_ARC_LENGTH_VIEW_RATIO
+  return Number.isFinite(length) && length > 0 ? length : 1
+}
+
+export function distance2d(a: AcGePoint2dLike, b: AcGePoint2dLike): number {
+  return Math.hypot(b.x - a.x, b.y - a.y)
+}
+
+/**
+ * Rectangle outline in CCW order from two opposite corners.
+ */
+export function rectanglePath(
+  first: AcGePoint2dLike,
+  second: AcGePoint2dLike
+): AcGePoint2d[] {
+  const minX = Math.min(first.x, second.x)
+  const maxX = Math.max(first.x, second.x)
+  const minY = Math.min(first.y, second.y)
+  const maxY = Math.max(first.y, second.y)
+  return [
+    new AcGePoint2d(minX, minY),
+    new AcGePoint2d(maxX, minY),
+    new AcGePoint2d(maxX, maxY),
+    new AcGePoint2d(minX, maxY)
+  ]
+}
+
+/**
+ * Signed polygon area. Positive means counterclockwise.
+ */
+export function signedArea(points: AcGePoint2dLike[]): number {
+  let area = 0
+  const n = points.length
+  for (let i = 0; i < n; i++) {
+    const a = points[i]
+    const b = points[(i + 1) % n]
+    area += a.x * b.y - b.x * a.y
+  }
+  return area / 2
+}
+
+/**
+ * Returns a CCW copy of a closed path so positive bulges face outward.
+ */
+export function ensureCounterClockwise(
+  points: AcGePoint2dLike[]
+): AcGePoint2d[] {
+  const copy = points.map(p => new AcGePoint2d(p.x, p.y))
+  if (copy.length >= 3 && signedArea(copy) < 0) {
+    copy.reverse()
+  }
+  return copy
+}
+
+function polylineLength(points: AcGePoint2dLike[], closed: boolean): number {
+  if (points.length < 2) return 0
+  let length = 0
+  const last = closed ? points.length : points.length - 1
+  for (let i = 0; i < last; i++) {
+    const a = points[i]
+    const b = points[(i + 1) % points.length]
+    length += distance2d(a, b)
+  }
+  return length
+}
+
+function pointAtLength(
+  points: AcGePoint2dLike[],
+  closed: boolean,
+  distance: number
+): AcGePoint2d {
+  const total = polylineLength(points, closed)
+  let remaining = total > 0 ? ((distance % total) + total) % total : 0
+  const last = closed ? points.length : points.length - 1
+  for (let i = 0; i < last; i++) {
+    const a = points[i]
+    const b = points[(i + 1) % points.length]
+    const seg = distance2d(a, b)
+    if (remaining <= seg || i === last - 1) {
+      const t = seg > 0 ? remaining / seg : 0
+      return new AcGePoint2d(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t)
+    }
+    remaining -= seg
+  }
+  const end = points[closed ? 0 : points.length - 1]
+  return new AcGePoint2d(end.x, end.y)
+}
+
+/**
+ * Deterministic 0.75–1.25 factor so preview does not flicker while dragging.
+ */
+function varianceFactor(index: number, enabled: boolean): number {
+  if (!enabled) return 1
+  const t = Math.sin(index * 12.9898 + 78.233) * 43758.5453
+  return 0.75 + (t - Math.floor(t)) * 0.5
+}
+
+function chordLengths(
+  perimeter: number,
+  arcLength: number,
+  variance: boolean
+): number[] {
+  const minChord = Math.max(arcLength * 0.35, perimeter * 1e-4)
+  const chords: number[] = []
+  let remaining = perimeter
+  let index = 0
+  while (remaining > minChord * 0.5) {
+    let chord = arcLength * varianceFactor(index, variance)
+    chord = Math.min(Math.max(chord, minChord), remaining)
+    if (remaining - chord < minChord * 0.5) {
+      chord = remaining
+    }
+    chords.push(chord)
+    remaining -= chord
+    index++
+    if (chords.length > 4096) break
+  }
+  if (chords.length === 0) {
+    chords.push(perimeter)
+  }
+  return chords
+}
+
+/**
+ * Rebuilds `cloud` as a revision-cloud polyline along `path`.
+ *
+ * @returns `false` when the path is degenerate and no cloud was built.
+ */
+export function buildRevCloud(
+  cloud: AcDbPolyline,
+  path: AcGePoint2dLike[],
+  closed: boolean,
+  options: AcApRevCloudBuildOptions
+): boolean {
+  if (path.length < 2) return false
+
+  const oriented = closed ? ensureCounterClockwise(path) : path
+  const perimeter = polylineLength(oriented, closed)
+  if (!AcGeTol.isPositive(perimeter)) return false
+
+  const arcLength = Math.max(options.arcLength, perimeter * 1e-4)
+  const chords = chordLengths(perimeter, arcLength, options.variance !== false)
+  if (closed && chords.length < 3) {
+    const equal = perimeter / 3
+    chords.length = 0
+    chords.push(equal, equal, equal)
+  }
+
+  const bulge = options.reverse ? -REVCLOUD_BULGE : REVCLOUD_BULGE
+  const calligraphy = options.style === 'calligraphy'
+  const endWidth = calligraphy ? arcLength * CALLIGRAPHY_WIDTH_RATIO : undefined
+
+  cloud.reset(false)
+  let traveled = 0
+  chords.forEach((chord, index) => {
+    const point = pointAtLength(oriented, closed, traveled)
+    if (calligraphy && endWidth != null) {
+      cloud.addVertexAt(index, point, bulge, 0, endWidth)
+    } else {
+      cloud.addVertexAt(index, point, bulge)
+    }
+    traveled += chord
+  })
+  cloud.closed = closed
+  return cloud.numberOfVertices >= 2
+}
+
+function sampleLine(
+  start: AcGePoint2dLike,
+  end: AcGePoint2dLike,
+  spacing: number
+): AcGePoint2d[] {
+  const len = distance2d(start, end)
+  const count = Math.max(1, Math.ceil(len / Math.max(spacing, 1e-8)))
+  const points: AcGePoint2d[] = []
+  for (let i = 0; i < count; i++) {
+    const t = i / count
+    points.push(
+      new AcGePoint2d(
+        start.x + (end.x - start.x) * t,
+        start.y + (end.y - start.y) * t
+      )
+    )
+  }
+  return points
+}
+
+function sampleBulgeArc(
+  start: AcGePoint2dLike,
+  end: AcGePoint2dLike,
+  bulge: number,
+  spacing: number
+): AcGePoint2d[] {
+  if (Math.abs(bulge) < 1e-12) {
+    return sampleLine(start, end, spacing)
+  }
+
+  const dx = end.x - start.x
+  const dy = end.y - start.y
+  const chord = Math.hypot(dx, dy)
+  if (!AcGeTol.isPositive(chord)) {
+    return [new AcGePoint2d(start.x, start.y)]
+  }
+
+  const sign = bulge >= 0 ? 1 : -1
+  const included = 4 * Math.atan(Math.abs(bulge))
+  const radius = chord / (2 * Math.sin(included / 2))
+  const mx = (start.x + end.x) / 2
+  const my = (start.y + end.y) / 2
+  const leftX = -dy / chord
+  const leftY = dx / chord
+  const offset = radius * Math.cos(included / 2)
+  const cx = mx + leftX * offset * sign
+  const cy = my + leftY * offset * sign
+  const startAngle = Math.atan2(start.y - cy, start.x - cx)
+  const sweep = included * sign
+  const arcLen = Math.abs(radius * sweep)
+  const count = Math.max(2, Math.ceil(arcLen / Math.max(spacing, 1e-8)))
+  const points: AcGePoint2d[] = []
+  for (let i = 0; i < count; i++) {
+    const angle = startAngle + (sweep * i) / count
+    points.push(
+      new AcGePoint2d(
+        cx + radius * Math.cos(angle),
+        cy + radius * Math.sin(angle)
+      )
+    )
+  }
+  return points
+}
+
+function polylineVertices(entity: AcDbPolyline): Array<{
+  x: number
+  y: number
+  bulge: number
+}> {
+  const runtimeVertices = (
+    entity as unknown as {
+      _geo?: { vertices?: Array<{ x: number; y: number; bulge?: number }> }
+    }
+  )._geo?.vertices
+
+  if (runtimeVertices && runtimeVertices.length > 1) {
+    return runtimeVertices.map(v => ({
+      x: v.x,
+      y: v.y,
+      bulge: v.bulge ?? 0
+    }))
+  }
+
+  const count = entity.numberOfVertices
+  const getBulgeAt = (
+    entity as unknown as { getBulgeAt?: (index: number) => number }
+  ).getBulgeAt
+  return Array.from({ length: count }, (_, i) => {
+    const p = entity.getPoint2dAt(i)
+    return {
+      x: p.x,
+      y: p.y,
+      bulge: getBulgeAt?.(i) ?? 0
+    }
+  })
+}
+
+function samplePolyline(entity: AcDbPolyline, spacing: number): AcGePoint2d[] {
+  const vertices = polylineVertices(entity)
+  if (vertices.length < 2) return []
+  const points: AcGePoint2d[] = []
+  const last = entity.closed ? vertices.length : vertices.length - 1
+  for (let i = 0; i < last; i++) {
+    const start = vertices[i]
+    const end = vertices[(i + 1) % vertices.length]
+    points.push(...sampleBulgeArc(start, end, start.bulge, spacing))
+  }
+  if (!entity.closed) {
+    const end = vertices[vertices.length - 1]
+    points.push(new AcGePoint2d(end.x, end.y))
+  }
+  return points
+}
+
+function sampleCircle(entity: AcDbCircle, spacing: number): AcGePoint2d[] {
+  const radius = entity.radius
+  if (!AcGeTol.isPositive(radius)) return []
+  const circumference = 2 * Math.PI * radius
+  const count = Math.max(8, Math.ceil(circumference / Math.max(spacing, 1e-8)))
+  const center = entity.center
+  const points: AcGePoint2d[] = []
+  for (let i = 0; i < count; i++) {
+    const angle = (i / count) * Math.PI * 2
+    points.push(
+      new AcGePoint2d(
+        center.x + radius * Math.cos(angle),
+        center.y + radius * Math.sin(angle)
+      )
+    )
+  }
+  return points
+}
+
+function sampleEllipse(entity: AcDbEllipse, spacing: number): AcGePoint2d[] {
+  const a = entity.majorAxisRadius
+  const b = entity.minorAxisRadius
+  if (!AcGeTol.isPositive(a) || !AcGeTol.isPositive(b)) return []
+
+  const geo = (entity as unknown as { _geo?: { majorAxis?: AcGePoint2dLike } })
+    ._geo
+  const major = geo?.majorAxis ?? { x: 1, y: 0 }
+  const majorLen = Math.hypot(major.x, major.y) || 1
+  const ux = major.x / majorLen
+  const uy = major.y / majorLen
+  const vx = -uy
+  const vy = ux
+  const perimeter =
+    Math.PI * (3 * (a + b) - Math.sqrt((3 * a + b) * (a + 3 * b)))
+  const count = Math.max(12, Math.ceil(perimeter / Math.max(spacing, 1e-8)))
+  const center = entity.center
+  const start = entity.startAngle ?? 0
+  const end = entity.endAngle ?? Math.PI * 2
+  let sweep = end - start
+  if (sweep <= 0) sweep += Math.PI * 2
+  const closed = Math.abs(sweep - Math.PI * 2) < 1e-6
+  const steps = closed ? count : count + 1
+  const points: AcGePoint2d[] = []
+  for (let i = 0; i < steps; i++) {
+    const t = start + (sweep * i) / count
+    const x = a * Math.cos(t)
+    const y = b * Math.sin(t)
+    points.push(
+      new AcGePoint2d(center.x + ux * x + vx * y, center.y + uy * x + vy * y)
+    )
+  }
+  return points
+}
+
+function sampleSpline(entity: AcDbSpline, spacing: number): AcGePoint2d[] {
+  const geo = (
+    entity as unknown as {
+      _geo?: {
+        fitPoints?: AcGePoint2dLike[]
+        controlPoints?: AcGePoint2dLike[]
+      }
+    }
+  )._geo
+  const source = geo?.fitPoints?.length ? geo.fitPoints : geo?.controlPoints
+  if (!source || source.length < 2) return []
+
+  const points: AcGePoint2d[] = []
+  const last = entity.closed ? source.length : source.length - 1
+  for (let i = 0; i < last; i++) {
+    const start = source[i]
+    const end = source[(i + 1) % source.length]
+    points.push(...sampleLine(start, end, spacing))
+  }
+  if (!entity.closed) {
+    const end = source[source.length - 1]
+    points.push(new AcGePoint2d(end.x, end.y))
+  }
+  return points
+}
+
+/**
+ * Samples a supported curve into a path that can be turned into a revision cloud.
+ */
+export function sampleEntityPath(
+  entity: AcDbEntity,
+  spacing: number
+): { points: AcGePoint2d[]; closed: boolean } | undefined {
+  if (entity instanceof AcDbPolyline) {
+    const points = samplePolyline(entity, spacing)
+    return points.length >= 2 ? { points, closed: entity.closed } : undefined
+  }
+  if (entity instanceof AcDbCircle) {
+    const points = sampleCircle(entity, spacing)
+    return points.length >= 2 ? { points, closed: true } : undefined
+  }
+  if (entity instanceof AcDbEllipse) {
+    const points = sampleEllipse(entity, spacing)
+    const start = entity.startAngle ?? 0
+    const end = entity.endAngle ?? Math.PI * 2
+    let sweep = end - start
+    while (sweep < 0) sweep += Math.PI * 2
+    const closed = sweep < 1e-6 || Math.abs(sweep - Math.PI * 2) < 1e-3
+    return points.length >= 2 ? { points, closed } : undefined
+  }
+  if (entity instanceof AcDbSpline) {
+    const points = sampleSpline(entity, spacing)
+    return points.length >= 2 ? { points, closed: !!entity.closed } : undefined
+  }
+  return undefined
+}
+
+/**
+ * True when the cursor is close enough to the start point to close a freehand cloud.
+ */
+export function isRevCloudCloseToStart(
+  start: AcGePoint2dLike,
+  current: AcGePoint2dLike,
+  arcLength: number
+): boolean {
+  return distance2d(start, current) <= Math.max(arcLength * 0.5, 1e-6)
+}

--- a/packages/cad-simple-viewer/src/command/review/AcApSketchCmd.ts
+++ b/packages/cad-simple-viewer/src/command/review/AcApSketchCmd.ts
@@ -1,50 +1,135 @@
 import {
+  AcDbLine,
   AcDbPolyline,
+  AcDbSpline,
   AcGePoint2d,
-  AcGePoint2dLike
+  AcGePoint2dLike,
+  AcGePoint3d,
+  AcGeTol
 } from '@mlightcad/data-model'
 
 import { AcApContext, AcApDocManager } from '../../app'
 import {
   AcEdBaseView,
+  AcEdCommand,
   AcEdOpenMode,
   AcEdPreviewJig,
+  AcEdPromptDistanceOptions,
+  AcEdPromptKeywordOptions,
   AcEdPromptPointOptions,
   AcEdPromptStatus
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
-import { AcApBaseRevCmd } from './AcApBaseRevCmd'
 
-// Minimum distance between points to add a new vertex (in world units)
-const MIN_DISTANCE = 0.1
+/** SKPOLY: 0 = lines, 1 = polyline, 2 = spline. */
+export type AcApSketchType = 'line' | 'polyline' | 'spline'
 
-/**
- * Calculates the distance between two points
- */
-function distance(p1: AcGePoint2dLike, p2: AcGePoint2dLike): number {
-  const dx = p2.x - p1.x
-  const dy = p2.y - p1.y
-  return Math.sqrt(dx * dx + dy * dy)
+export interface AcApSketchSettings {
+  type: AcApSketchType
+  /** SKETCHINC — minimum distance between successive sketch vertices. */
+  increment: number
+  /** SKTOLERANCE — how closely a spline fits the freehand points. */
+  tolerance: number
 }
 
+const DEFAULT_SETTINGS: AcApSketchSettings = {
+  type: 'line',
+  increment: 0.1,
+  tolerance: 0.5
+}
+
+type SketchKeywordKey =
+  | 'type'
+  | 'increment'
+  | 'tolerance'
+  | 'line'
+  | 'polyline'
+  | 'spline'
+
+function addKeyword(
+  prompt: AcEdPromptPointOptions | AcEdPromptKeywordOptions,
+  key: SketchKeywordKey
+) {
+  prompt.keywords.add(
+    AcApI18n.t(`jig.sketch.keywords.${key}.display`),
+    AcApI18n.t(`jig.sketch.keywords.${key}.global`),
+    AcApI18n.t(`jig.sketch.keywords.${key}.local`)
+  )
+}
+
+function distance2d(a: AcGePoint2dLike, b: AcGePoint2dLike): number {
+  return Math.hypot(b.x - a.x, b.y - a.y)
+}
+
+function toPoint2d(point: AcGePoint2dLike): AcGePoint2d {
+  return new AcGePoint2d(point.x, point.y)
+}
+
+function toPoint3d(point: AcGePoint2dLike): AcGePoint3d {
+  return new AcGePoint3d(point.x, point.y, 0)
+}
+
+/**
+ * Keeps a vertex when it is at least `increment` from the previous kept point.
+ * The first point is always kept; the last point is appended if distinct.
+ */
+export function accumulateSketchPoint(
+  points: AcGePoint2d[],
+  point: AcGePoint2dLike,
+  increment: number
+): boolean {
+  const next = toPoint2d(point)
+  if (points.length === 0) {
+    points.push(next)
+    return true
+  }
+  const last = points[points.length - 1]
+  if (distance2d(last, next) < increment) return false
+  points.push(next)
+  return true
+}
+
+/**
+ * Downsamples sketch points so consecutive kept vertices are at least
+ * `tolerance` apart, always retaining the first and last points.
+ */
+export function simplifySketchPoints(
+  points: AcGePoint2dLike[],
+  tolerance: number
+): AcGePoint2d[] {
+  if (points.length <= 2) {
+    return points.map(toPoint2d)
+  }
+  const minDist = Math.max(tolerance, 1e-8)
+  const simplified: AcGePoint2d[] = [toPoint2d(points[0])]
+  for (let i = 1; i < points.length - 1; i++) {
+    const last = simplified[simplified.length - 1]
+    if (distance2d(last, points[i]) >= minDist) {
+      simplified.push(toPoint2d(points[i]))
+    }
+  }
+  const end = toPoint2d(points[points.length - 1])
+  const last = simplified[simplified.length - 1]
+  if (distance2d(last, end) > 1e-8) {
+    simplified.push(end)
+  }
+  return simplified
+}
+
+/**
+ * Preview jig that records freehand movement once the pointer travels farther
+ * than the current sketch increment.
+ */
 export class AcApSketchJig extends AcEdPreviewJig<AcGePoint2dLike> {
   private _polyline: AcDbPolyline
   private _points: AcGePoint2d[]
-  private _lastPoint: AcGePoint2d | null = null
+  private _increment: number
 
-  /**
-   * Creates a sketch jig.
-   *
-   * @param view - The associated view
-   * @param start - The first point
-   */
-  constructor(view: AcEdBaseView, start: AcGePoint2dLike) {
+  constructor(view: AcEdBaseView, start: AcGePoint2dLike, increment: number) {
     super(view)
     this._polyline = new AcDbPolyline()
-    this._points = [new AcGePoint2d(start)]
-    this._lastPoint = new AcGePoint2d(start)
-
-    // Add the first point to the polyline
+    this._points = [toPoint2d(start)]
+    this._increment = Math.max(increment, 1e-8)
     this._polyline.addVertexAt(0, this._points[0])
   }
 
@@ -52,79 +137,220 @@ export class AcApSketchJig extends AcEdPreviewJig<AcGePoint2dLike> {
     return this._polyline
   }
 
-  /**
-   * Gets all accumulated points
-   */
   get points(): AcGePoint2d[] {
     return this._points
   }
 
   update(currentPoint: AcGePoint2dLike) {
-    if (this._lastPoint === null) {
+    if (!accumulateSketchPoint(this._points, currentPoint, this._increment)) {
       return
     }
-
-    const current = new AcGePoint2d(currentPoint)
-    const dist = distance(this._lastPoint, current)
-
-    // Only add a new point if the distance is significant enough
-    if (dist >= MIN_DISTANCE) {
-      this._points.push(current)
-      this._lastPoint = current
-      this._polyline.addVertexAt(this._points.length, current)
-    }
+    this._polyline.addVertexAt(
+      this._points.length - 1,
+      this._points[this._points.length - 1]
+    )
   }
 }
 
 /**
- * Command to create a sketch line using polyline.
- * After specifying the first point, continuously tracks mouse movement
- * and adds points to the polyline until the user specifies the second point.
+ * Command to create freehand sketches, aligned with AutoCAD SKETCH.
+ *
+ * Prompts: Specify sketch or [Type/Increment/toLerance]. Click to start a
+ * stroke, move the pointer, click to stop. Enter ends the command.
  */
-export class AcApSketchCmd extends AcApBaseRevCmd {
+export class AcApSketchCmd extends AcEdCommand {
+  private static _settings: AcApSketchSettings = { ...DEFAULT_SETTINGS }
+
   constructor() {
     super()
-    this.mode = AcEdOpenMode.Review
+    this.mode = AcEdOpenMode.Write
   }
 
   async execute(context: AcApContext) {
-    const firstPointPrompt = new AcEdPromptPointOptions(
-      AcApI18n.t('jig.sketch.firstPoint')
+    const settings = AcApSketchCmd._settings
+
+    while (true) {
+      const prompt = new AcEdPromptPointOptions(
+        AcApI18n.t('jig.sketch.specifySketch')
+      )
+      addKeyword(prompt, 'type')
+      addKeyword(prompt, 'increment')
+      addKeyword(prompt, 'tolerance')
+      prompt.allowNone = true
+      prompt.disableOSnap = true
+
+      const result = await AcApDocManager.instance.editor.getPoint(prompt)
+      if (result.status === AcEdPromptStatus.Keyword) {
+        const keyword = result.stringResult ?? ''
+        if (keyword === 'Type') {
+          const accepted = await this.promptType(settings)
+          if (!accepted) return
+          continue
+        }
+        if (keyword === 'Increment') {
+          const accepted = await this.promptIncrement(settings)
+          if (!accepted) return
+          continue
+        }
+        if (keyword === 'Tolerance') {
+          const accepted = await this.promptTolerance(settings)
+          if (!accepted) return
+          continue
+        }
+        continue
+      }
+
+      if (result.status === AcEdPromptStatus.None) return
+      if (result.status !== AcEdPromptStatus.OK || !result.value) return
+
+      const committed = await this.captureStroke(
+        context,
+        settings,
+        result.value
+      )
+      if (!committed) return
+    }
+  }
+
+  private async promptType(settings: AcApSketchSettings) {
+    const prompt = new AcEdPromptKeywordOptions(AcApI18n.t('jig.sketch.type'))
+    prompt.allowNone = true
+    const line = prompt.keywords.add(
+      AcApI18n.t('jig.sketch.keywords.line.display'),
+      AcApI18n.t('jig.sketch.keywords.line.global'),
+      AcApI18n.t('jig.sketch.keywords.line.local')
     )
-    const firstPointResult =
-      await AcApDocManager.instance.editor.getPoint(firstPointPrompt)
-    if (firstPointResult.status !== AcEdPromptStatus.OK) return
-    const firstPoint = firstPointResult.value!
-
-    const jig = new AcApSketchJig(context.view, firstPoint)
-
-    const secondPointPrompt = new AcEdPromptPointOptions(
-      AcApI18n.t('jig.sketch.nextPoint')
+    const polyline = prompt.keywords.add(
+      AcApI18n.t('jig.sketch.keywords.polyline.display'),
+      AcApI18n.t('jig.sketch.keywords.polyline.global'),
+      AcApI18n.t('jig.sketch.keywords.polyline.local')
     )
-    secondPointPrompt.jig = jig
-    secondPointPrompt.useDashedLine = false
-    secondPointPrompt.useBasePoint = true
-    const secondPointResult =
-      await AcApDocManager.instance.editor.getPoint(secondPointPrompt)
-    if (secondPointResult.status !== AcEdPromptStatus.OK) return
-    const secondPoint = secondPointResult.value!
+    const spline = prompt.keywords.add(
+      AcApI18n.t('jig.sketch.keywords.spline.display'),
+      AcApI18n.t('jig.sketch.keywords.spline.global'),
+      AcApI18n.t('jig.sketch.keywords.spline.local')
+    )
+    prompt.keywords.default =
+      settings.type === 'polyline'
+        ? polyline
+        : settings.type === 'spline'
+          ? spline
+          : line
+    const result = await AcApDocManager.instance.editor.getKeywords(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) return false
+    if (
+      result.status === AcEdPromptStatus.OK ||
+      result.status === AcEdPromptStatus.Keyword
+    ) {
+      if (result.stringResult === 'Polyline') settings.type = 'polyline'
+      else if (result.stringResult === 'Spline') settings.type = 'spline'
+      else if (
+        result.stringResult === 'Line' ||
+        result.stringResult === 'Lines'
+      ) {
+        settings.type = 'line'
+      }
+    }
+    return true
+  }
 
-    // Always add the final point
-    const points = jig.points
-    const lastPoint = points[points.length - 1]
-    const finalPoint = new AcGePoint2d(secondPoint)
+  private async promptIncrement(settings: AcApSketchSettings) {
+    const prompt = new AcEdPromptDistanceOptions(
+      AcApI18n.t('jig.sketch.increment')
+    )
+    prompt.allowNegative = false
+    prompt.allowZero = false
+    prompt.useDefaultValue = true
+    prompt.defaultValue = settings.increment
+    const result = await AcApDocManager.instance.editor.getDistance(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) return false
+    const value = result.value ?? settings.increment
+    if (AcGeTol.isPositive(value)) {
+      settings.increment = value
+    }
+    return true
+  }
 
-    // Only add if it's different from the last point
-    if (distance(lastPoint, finalPoint) > 0.01) {
-      points.push(finalPoint)
+  private async promptTolerance(settings: AcApSketchSettings) {
+    const prompt = new AcEdPromptDistanceOptions(
+      AcApI18n.t('jig.sketch.tolerance')
+    )
+    prompt.allowNegative = false
+    prompt.allowZero = true
+    prompt.useDefaultValue = true
+    prompt.defaultValue = settings.tolerance
+    const result = await AcApDocManager.instance.editor.getDistance(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) return false
+    const value = result.value ?? settings.tolerance
+    if (value >= 0 && Number.isFinite(value)) {
+      settings.tolerance = value
+    }
+    return true
+  }
+
+  /**
+   * Records one freehand stroke: click starts, move draws, click or Enter stops.
+   *
+   * @returns `false` when the user cancels the command entirely.
+   */
+  private async captureStroke(
+    context: AcApContext,
+    settings: AcApSketchSettings,
+    start: AcGePoint2dLike
+  ) {
+    const jig = new AcApSketchJig(context.view, start, settings.increment)
+    const prompt = new AcEdPromptPointOptions(
+      AcApI18n.t('jig.sketch.sketching')
+    )
+    prompt.jig = jig
+    prompt.useDashedLine = false
+    prompt.useBasePoint = true
+    prompt.basePoint = toPoint3d(start)
+    prompt.allowNone = true
+    prompt.disableOSnap = true
+
+    const result = await AcApDocManager.instance.editor.getPoint(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) return false
+
+    const points = [...jig.points]
+    if (result.status === AcEdPromptStatus.OK && result.value) {
+      const last = points[points.length - 1]
+      if (!last || distance2d(last, result.value) > 1e-8) {
+        points.push(toPoint2d(result.value))
+      }
     }
 
-    // Create the final polyline
-    const db = context.doc.database
+    if (points.length >= 2) {
+      this.appendStroke(context, settings, points)
+    }
+    return true
+  }
+
+  private appendStroke(
+    context: AcApContext,
+    settings: AcApSketchSettings,
+    points: AcGePoint2d[]
+  ) {
+    const modelSpace = context.doc.database.tables.blockTable.modelSpace
+    if (settings.type === 'line') {
+      for (let i = 1; i < points.length; i++) {
+        modelSpace.appendEntity(
+          new AcDbLine(toPoint3d(points[i - 1]), toPoint3d(points[i]))
+        )
+      }
+      return
+    }
+    if (settings.type === 'spline') {
+      const fitPoints = simplifySketchPoints(points, settings.tolerance)
+      if (fitPoints.length < 2) return
+      const points3d = fitPoints.map(toPoint3d)
+      const degree = Math.min(3, Math.max(1, points3d.length - 1))
+      modelSpace.appendEntity(new AcDbSpline(points3d, 'Chord', degree, false))
+      return
+    }
+
     const polyline = new AcDbPolyline()
-    for (let i = 0; i < points.length; i++) {
-      polyline.addVertexAt(i, points[i])
-    }
-    db.tables.blockTable.modelSpace.appendEntity(polyline)
+    points.forEach((point, index) => polyline.addVertexAt(index, point))
+    modelSpace.appendEntity(polyline)
   }
 }

--- a/packages/cad-simple-viewer/src/command/review/index.ts
+++ b/packages/cad-simple-viewer/src/command/review/index.ts
@@ -1,5 +1,6 @@
 export * from './AcApBaseRevCmd'
 export * from './AcApRevCloudCmd'
+export * from './AcApRevCloudGeom'
 export * from './AcApRevCircleCmd'
 export * from './AcApRevRectCmd'
 export * from './AcApRevVisibilityCmd'

--- a/packages/cad-simple-viewer/src/i18n/cs/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/cs/command.ts
@@ -279,6 +279,9 @@ export default {
     clearmeasurements: {
       description: 'Odstraní všechna měření z aktuálního rozvržení'
     },
+    measurementvis: {
+      description: 'Zobrazí nebo skryje měření na aktuálním rozvržení'
+    },
     measurementexport: {
       description: 'Exportuje měření do sidecar JSON souboru'
     },
@@ -397,7 +400,7 @@ export default {
       description: 'Překreslí aktuální výkres'
     },
     revcloud: {
-      description: 'Vytvoří revizní obláček obdélníkového tvaru'
+      description: 'Vytvoří nebo upraví revizní obláček'
     },
     markuptext: {
       description: 'Umístí textovou poznámku'
@@ -453,8 +456,7 @@ export default {
       description: 'Řídí dostupnost místních nabídek v oblasti výkresu'
     },
     sketch: {
-      description:
-        'Vytvoří skicovací čáru pomocí křivky, která sleduje pohyb myši'
+      description: 'Vytvoří řadu úseček kreslených od ruky'
     },
     spline: {
       description: 'Vytvoří hladkou křivku splajn zadáním řídicích bodů'

--- a/packages/cad-simple-viewer/src/i18n/cs/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/cs/jig.ts
@@ -53,8 +53,7 @@ export default {
         'Neplatný vstup úhlu: středový úhel musí být větší než 0 a menší než 360 stupňů.',
       chordLength:
         'Neplatná délka tětivy: hodnota je mimo rozsah pro aktuální poloměr.',
-      direction:
-        'Neplatný směr: z tohoto směru tečny nelze sestrojit oblouk.',
+      direction: 'Neplatný směr: z tohoto směru tečny nelze sestrojit oblouk.',
       radius:
         'Neplatný poloměr: zadaný poloměr nemůže spojit počáteční a koncový bod.'
     }
@@ -93,8 +92,7 @@ export default {
     displacementOrArray: 'Zadejte přemístění nebo',
     secondPointOrArray: 'Zadejte druhý bod nebo',
     modePrompt: 'Zadejte volbu režimu kopírování',
-    arrayItemCount:
-      'Zadejte počet položek v poli včetně originálu',
+    arrayItemCount: 'Zadejte počet položek v poli včetně originálu',
     arraySecondPointOrFit: 'Zadejte druhý bod nebo',
     arrayFitSecondPoint: 'Zadejte druhý bod',
     keywords: {
@@ -899,8 +897,7 @@ export default {
     areaLengthOrWidth: 'Zadejte délku obdélníku',
     areaSpecifyWidth: 'Zadejte šířku obdélníku',
     invalidPositive: 'Neplatný vstup. Zadejte hodnotu větší než 0.',
-    invalidRect:
-      'Nelze vytvořit obdélník. Zadejte platné rohy nebo rozměry.',
+    invalidRect: 'Nelze vytvořit obdélník. Zadejte platné rohy nebo rozměry.',
     thicknessNotSupported:
       'Tloušťka obdélníku se aktuálně nezapisuje do dat entity. Nastavení tloušťky se ignoruje.',
     keywords: {
@@ -984,9 +981,119 @@ export default {
       referencePoints: 'Neplatné referenční body: body musí být různé.'
     }
   },
-  sketch: {
+  revcloud: {
+    firstCornerOrOptions: 'Zadejte první rohový bod nebo',
+    firstCorner: 'Zadejte první rohový bod',
+    oppositeCorner: 'Zadejte protilehlý roh',
+    startPoint: 'Zadejte počáteční bod',
+    nextPoint: 'Zadejte další bod',
+    nextPointOrUndo: 'Zadejte další bod nebo',
     firstPoint: 'Zadejte první bod',
-    nextPoint: 'Zadejte koncový bod'
+    guideCursor: 'Veďte kurzor podél obláčku (Enter dokončí)',
+    arcLength: 'Zadejte délku oblouku',
+    selectObject: 'Vyberte objekt',
+    style: 'Zadejte styl oblouků revizního obláčku',
+    reverseDirection: 'Obrátit směr',
+    invalidArcLength: 'Délka oblouku musí být větší než 0.',
+    invalidObject: 'Vybraný objekt nelze převést na revizní obláček.',
+    keywords: {
+      arcLength: {
+        display: 'Délka oblouku(A)',
+        local: 'Délka oblouku',
+        global: 'ArcLength'
+      },
+      object: {
+        display: 'Objekt(O)',
+        local: 'Objekt',
+        global: 'Object'
+      },
+      rectangular: {
+        display: 'Obdélníkový(R)',
+        local: 'Obdélníkový',
+        global: 'Rectangular'
+      },
+      polygonal: {
+        display: 'Mnohoúhelníkový(P)',
+        local: 'Mnohoúhelníkový',
+        global: 'Polygonal'
+      },
+      freehand: {
+        display: 'Od ruky(F)',
+        local: 'Od ruky',
+        global: 'Freehand'
+      },
+      style: {
+        display: 'Styl(S)',
+        local: 'Styl',
+        global: 'Style'
+      },
+      normal: {
+        display: 'Normální(N)',
+        local: 'Normální',
+        global: 'Normal'
+      },
+      calligraphy: {
+        display: 'Kaligrafie(C)',
+        local: 'Kaligrafie',
+        global: 'Calligraphy'
+      },
+      undo: {
+        display: 'Zpět(U)',
+        local: 'Zpět',
+        global: 'Undo'
+      },
+      yes: {
+        display: 'Ano(Y)',
+        local: 'Ano',
+        global: 'Yes'
+      },
+      no: {
+        display: 'Ne(N)',
+        local: 'Ne',
+        global: 'No'
+      }
+    }
+  },
+  sketch: {
+    specifySketch: 'Zadejte skicu nebo',
+    sketching: 'Pohybem ukazatele kreslete (kliknutím nebo Enter zastavíte)',
+    type: 'Zadejte typ skici',
+    increment: 'Zadejte přírůstek skici',
+    tolerance: 'Zadejte toleranci splajnu',
+    firstPoint: 'Zadejte první bod',
+    nextPoint: 'Zadejte koncový bod',
+    keywords: {
+      type: {
+        display: 'Typ(T)',
+        local: 'Typ',
+        global: 'Type'
+      },
+      increment: {
+        display: 'Přírůstek(I)',
+        local: 'Přírůstek',
+        global: 'Increment'
+      },
+      tolerance: {
+        display: 'toLerance(L)',
+        local: 'toLerance',
+        global: 'Tolerance'
+      },
+      line: {
+        display: 'Úsečky(L)',
+        local: 'Úsečky',
+        global: 'Lines'
+      },
+      polyline: {
+        display: 'Křivka(P)',
+        local: 'Křivka',
+        global: 'Polyline'
+      },
+      spline: {
+        display: 'Splajn(S)',
+        local: 'Splajn',
+        global: 'Spline'
+      }
+    }
   },
   spline: {
     firstPoint: 'Zadejte první bod',

--- a/packages/cad-simple-viewer/src/i18n/en/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/command.ts
@@ -277,6 +277,9 @@ export default {
     clearmeasurements: {
       description: 'Removes all measurements from the current layout'
     },
+    measurementvis: {
+      description: 'Shows or hides measurements on the current layout'
+    },
     measurementexport: {
       description: 'Exports measurements to a sidecar JSON file'
     },
@@ -396,7 +399,7 @@ export default {
       description: 'Redraws the current drawing'
     },
     revcloud: {
-      description: 'Creates a revision cloud (cloud line) in rectangular shape'
+      description: 'Creates or modifies a revision cloud'
     },
     markuptext: {
       description: 'Places a text markup label'
@@ -453,8 +456,7 @@ export default {
         'Controls the availability of shortcut menus in the drawing area'
     },
     sketch: {
-      description:
-        'Creates a sketch line using polyline that tracks mouse movement'
+      description: 'Creates a series of freehand line segments'
     },
     spline: {
       description: 'Creates a smooth spline curve by specifying control points'

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -984,9 +984,119 @@ export default {
       referencePoints: 'Invalid reference points: points must be different.'
     }
   },
+  revcloud: {
+    firstCornerOrOptions: 'Specify first corner point or',
+    firstCorner: 'Specify first corner point',
+    oppositeCorner: 'Specify opposite corner',
+    startPoint: 'Specify start point',
+    nextPoint: 'Specify next point',
+    nextPointOrUndo: 'Specify next point or',
+    firstPoint: 'Specify first point',
+    guideCursor: 'Guide cursor along cloud path (press Enter to finish)',
+    arcLength: 'Specify arc length',
+    selectObject: 'Select object',
+    style: 'Enter revision cloud arc style',
+    reverseDirection: 'Reverse direction',
+    invalidArcLength: 'Arc length must be greater than 0.',
+    invalidObject: 'Selected object cannot be converted to a revision cloud.',
+    keywords: {
+      arcLength: {
+        display: 'Arc length(A)',
+        local: 'Arc length',
+        global: 'ArcLength'
+      },
+      object: {
+        display: 'Object(O)',
+        local: 'Object',
+        global: 'Object'
+      },
+      rectangular: {
+        display: 'Rectangular(R)',
+        local: 'Rectangular',
+        global: 'Rectangular'
+      },
+      polygonal: {
+        display: 'Polygonal(P)',
+        local: 'Polygonal',
+        global: 'Polygonal'
+      },
+      freehand: {
+        display: 'Freehand(F)',
+        local: 'Freehand',
+        global: 'Freehand'
+      },
+      style: {
+        display: 'Style(S)',
+        local: 'Style',
+        global: 'Style'
+      },
+      normal: {
+        display: 'Normal(N)',
+        local: 'Normal',
+        global: 'Normal'
+      },
+      calligraphy: {
+        display: 'Calligraphy(C)',
+        local: 'Calligraphy',
+        global: 'Calligraphy'
+      },
+      undo: {
+        display: 'Undo(U)',
+        local: 'Undo',
+        global: 'Undo'
+      },
+      yes: {
+        display: 'Yes(Y)',
+        local: 'Yes',
+        global: 'Yes'
+      },
+      no: {
+        display: 'No(N)',
+        local: 'No',
+        global: 'No'
+      }
+    }
+  },
   sketch: {
+    specifySketch: 'Specify sketch or',
+    sketching: 'Move the pointer to sketch (click or press Enter to stop)',
+    type: 'Enter sketch type',
+    increment: 'Specify sketch increment',
+    tolerance: 'Specify spline tolerance',
     firstPoint: 'Specify the first point',
-    nextPoint: 'Specify the end point'
+    nextPoint: 'Specify the end point',
+    keywords: {
+      type: {
+        display: 'Type(T)',
+        local: 'Type',
+        global: 'Type'
+      },
+      increment: {
+        display: 'Increment(I)',
+        local: 'Increment',
+        global: 'Increment'
+      },
+      tolerance: {
+        display: 'toLerance(L)',
+        local: 'toLerance',
+        global: 'Tolerance'
+      },
+      line: {
+        display: 'Lines(L)',
+        local: 'Lines',
+        global: 'Lines'
+      },
+      polyline: {
+        display: 'Polyline(P)',
+        local: 'Polyline',
+        global: 'Polyline'
+      },
+      spline: {
+        display: 'Spline(S)',
+        local: 'Spline',
+        global: 'Spline'
+      }
+    }
   },
   spline: {
     firstPoint: 'Specify the first point',

--- a/packages/cad-simple-viewer/src/i18n/tr/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/tr/command.ts
@@ -288,6 +288,9 @@ export default {
     clearmeasurements: {
       description: 'Geçerli yerleşimdeki tüm ölçümleri kaldırır'
     },
+    measurementvis: {
+      description: 'Geçerli yerleşimdeki ölçümleri gösterir veya gizler'
+    },
     measurementexport: {
       description: 'Ölçümleri sidecar JSON dosyasına dışa aktarır'
     },
@@ -406,8 +409,7 @@ export default {
       description: 'Geçerli çizimi yeniden çizer'
     },
     revcloud: {
-      description:
-        'Dikdörtgen şeklinde bir revizyon bulutu (bulut çizgisi) oluşturur'
+      description: 'Revizyon bulutu oluşturur veya değiştirir'
     },
     markuptext: {
       description: 'Metin işareti yerleştirir'
@@ -464,8 +466,7 @@ export default {
         'Çizim alanındaki kısayol menülerinin kullanılabilirliğini denetler'
     },
     sketch: {
-      description:
-        'Fare hareketini izleyen çoklu çizgi kullanarak bir taslak çizgi oluşturur'
+      description: 'Bir dizi serbest el çizgi parçası oluşturur'
     },
     spline: {
       description:

--- a/packages/cad-simple-viewer/src/i18n/tr/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/tr/jig.ts
@@ -161,15 +161,15 @@ export default {
       }
     },
     invalid: {
-      axis: 'Geçersiz eksen girişi: eksen uzunluğu 0\'dan büyük olmalıdır.',
-      otherAxis: 'Geçersiz diğer eksen girişi: mesafe 0\'dan büyük olmalıdır.',
+      axis: "Geçersiz eksen girişi: eksen uzunluğu 0'dan büyük olmalıdır.",
+      otherAxis: "Geçersiz diğer eksen girişi: mesafe 0'dan büyük olmalıdır.",
       rotation:
-        'Geçersiz döndürme girişi: elde edilen küçük eksen 0\'dan büyük olmalıdır.'
+        "Geçersiz döndürme girişi: elde edilen küçük eksen 0'dan büyük olmalıdır."
     }
   },
   hatch: {
     prompt: 'Sınır nesnesini seçin veya',
-    pickPoint: 'İç noktayı belirtin (bitirmek için Enter\'a basın)',
+    pickPoint: "İç noktayı belirtin (bitirmek için Enter'a basın)",
     select: 'Tarama yapılacak nesneleri seçin',
     patternName: 'Tarama deseni adını girin',
     scale: 'Tarama deseni ölçeğini belirtin',
@@ -665,7 +665,7 @@ export default {
   },
   measureArea: {
     firstPoint: 'İlk noktayı belirtin',
-    nextPoint: 'Sonraki noktayı belirtin (bitirmek için Enter\'a basın)'
+    nextPoint: "Sonraki noktayı belirtin (bitirmek için Enter'a basın)"
   },
   measureDistance: {
     firstPoint: 'İlk noktayı belirtin',
@@ -755,9 +755,9 @@ export default {
   },
   offset: {
     distance: 'Öteleme mesafesini belirtin',
-    selectObject: 'Ötelenecek nesneyi seçin veya bitirmek için Enter\'a basın',
+    selectObject: "Ötelenecek nesneyi seçin veya bitirmek için Enter'a basın",
     sidePoint: 'Ötelenecek tarafta bir nokta belirtin',
-    invalidDistance: 'Öteleme mesafesi 0\'dan büyük olmalıdır.',
+    invalidDistance: "Öteleme mesafesi 0'dan büyük olmalıdır.",
     invalidSelection: 'Seçilen nesne ötelenemez.',
     offsetFailed: 'Belirtilen taraf için bir öteleme eğrisi oluşturulamadı.'
   },
@@ -823,13 +823,13 @@ export default {
     },
     invalid: {
       sides: 'Geçersiz kenar sayısı. 3 ile 1024 arasında bir tam sayı girin.',
-      radius: 'Geçersiz yarıçap. Yarıçap 0\'dan büyük olmalıdır.',
-      edge: 'Geçersiz kenar. Kenar uzunluğu 0\'dan büyük olmalıdır.'
+      radius: "Geçersiz yarıçap. Yarıçap 0'dan büyük olmalıdır.",
+      edge: "Geçersiz kenar. Kenar uzunluğu 0'dan büyük olmalıdır."
     }
   },
   polyline: {
     firstPoint: 'İlk noktayı belirtin',
-    nextPoint: 'Sonraki noktayı belirtin (bitirmek için Enter\'a basın)',
+    nextPoint: "Sonraki noktayı belirtin (bitirmek için Enter'a basın)",
     nextPointWithOptions: 'Sonraki noktayı belirtin veya',
     nextPointWithArcOptions: 'Sonraki noktayı belirtin veya',
     keywords: {
@@ -897,7 +897,7 @@ export default {
     areaValue: 'Dikdörtgen alanını belirtin',
     areaLengthOrWidth: 'Dikdörtgen uzunluğunu belirtin',
     areaSpecifyWidth: 'Dikdörtgen genişliğini belirtin',
-    invalidPositive: 'Geçersiz giriş. Lütfen 0\'dan büyük bir değer girin.',
+    invalidPositive: "Geçersiz giriş. Lütfen 0'dan büyük bir değer girin.",
     invalidRect:
       'Dikdörtgen oluşturulamadı. Lütfen geçerli köşeler veya boyutlar belirtin.',
     thicknessNotSupported:
@@ -983,13 +983,124 @@ export default {
       referencePoints: 'Geçersiz referans noktaları: noktalar farklı olmalıdır.'
     }
   },
-  sketch: {
+  revcloud: {
+    firstCornerOrOptions: 'İlk köşe noktasını belirtin veya',
+    firstCorner: 'İlk köşe noktasını belirtin',
+    oppositeCorner: 'Karşı köşeyi belirtin',
+    startPoint: 'Başlangıç noktasını belirtin',
+    nextPoint: 'Sonraki noktayı belirtin',
+    nextPointOrUndo: 'Sonraki noktayı belirtin veya',
     firstPoint: 'İlk noktayı belirtin',
-    nextPoint: 'Bitiş noktasını belirtin'
+    guideCursor: 'İmleci bulut yolu boyunca götürün (bitirmek için Enter)',
+    arcLength: 'Yay uzunluğunu belirtin',
+    selectObject: 'Nesne seçin',
+    style: 'Revizyon bulutu yay stilini girin',
+    reverseDirection: 'Yönü ters çevir',
+    invalidArcLength: "Yay uzunluğu 0'dan büyük olmalıdır.",
+    invalidObject: 'Seçilen nesne revizyon bulutuna dönüştürülemez.',
+    keywords: {
+      arcLength: {
+        display: 'Yay uzunluğu(A)',
+        local: 'Yay uzunluğu',
+        global: 'ArcLength'
+      },
+      object: {
+        display: 'Nesne(O)',
+        local: 'Nesne',
+        global: 'Object'
+      },
+      rectangular: {
+        display: 'Dikdörtgen(R)',
+        local: 'Dikdörtgen',
+        global: 'Rectangular'
+      },
+      polygonal: {
+        display: 'Çokgen(P)',
+        local: 'Çokgen',
+        global: 'Polygonal'
+      },
+      freehand: {
+        display: 'Serbest(F)',
+        local: 'Serbest',
+        global: 'Freehand'
+      },
+      style: {
+        display: 'Stil(S)',
+        local: 'Stil',
+        global: 'Style'
+      },
+      normal: {
+        display: 'Normal(N)',
+        local: 'Normal',
+        global: 'Normal'
+      },
+      calligraphy: {
+        display: 'Kaligrafi(C)',
+        local: 'Kaligrafi',
+        global: 'Calligraphy'
+      },
+      undo: {
+        display: 'Geri al(U)',
+        local: 'Geri al',
+        global: 'Undo'
+      },
+      yes: {
+        display: 'Evet(Y)',
+        local: 'Evet',
+        global: 'Yes'
+      },
+      no: {
+        display: 'Hayır(N)',
+        local: 'Hayır',
+        global: 'No'
+      }
+    }
+  },
+  sketch: {
+    specifySketch: 'Eskizi belirtin veya',
+    sketching:
+      'Eskiz için işaretçiyi hareket ettirin (durdurmak için tıklayın veya Enter)',
+    type: 'Eskiz türünü girin',
+    increment: 'Eskiz artışını belirtin',
+    tolerance: 'Spline toleransını belirtin',
+    firstPoint: 'İlk noktayı belirtin',
+    nextPoint: 'Bitiş noktasını belirtin',
+    keywords: {
+      type: {
+        display: 'Tür(T)',
+        local: 'Tür',
+        global: 'Type'
+      },
+      increment: {
+        display: 'Artış(I)',
+        local: 'Artış',
+        global: 'Increment'
+      },
+      tolerance: {
+        display: 'toLerance(L)',
+        local: 'toLerance',
+        global: 'Tolerance'
+      },
+      line: {
+        display: 'Çizgiler(L)',
+        local: 'Çizgiler',
+        global: 'Lines'
+      },
+      polyline: {
+        display: 'Çoklu çizgi(P)',
+        local: 'Çoklu çizgi',
+        global: 'Polyline'
+      },
+      spline: {
+        display: 'Spline(S)',
+        local: 'Spline',
+        global: 'Spline'
+      }
+    }
   },
   spline: {
     firstPoint: 'İlk noktayı belirtin',
-    nextPoint: 'Sonraki noktayı belirtin (bitirmek için Enter\'a basın)',
+    nextPoint: "Sonraki noktayı belirtin (bitirmek için Enter'a basın)",
     firstPointWithOptions: 'İlk noktayı belirtin veya',
     nextPointWithFitOptions: 'Sonraki noktayı belirtin veya',
     nextPointWithCvOptions: 'Sonraki kontrol noktasını belirtin veya',

--- a/packages/cad-simple-viewer/src/i18n/tr/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/tr/jig.ts
@@ -161,15 +161,15 @@ export default {
       }
     },
     invalid: {
-      axis: "Geçersiz eksen girişi: eksen uzunluğu 0'dan büyük olmalıdır.",
-      otherAxis: "Geçersiz diğer eksen girişi: mesafe 0'dan büyük olmalıdır.",
+      axis: 'Geçersiz eksen girişi: eksen uzunluğu 0\'dan büyük olmalıdır.',
+      otherAxis: 'Geçersiz diğer eksen girişi: mesafe 0\'dan büyük olmalıdır.',
       rotation:
-        "Geçersiz döndürme girişi: elde edilen küçük eksen 0'dan büyük olmalıdır."
+        'Geçersiz döndürme girişi: elde edilen küçük eksen 0\'dan büyük olmalıdır.'
     }
   },
   hatch: {
     prompt: 'Sınır nesnesini seçin veya',
-    pickPoint: "İç noktayı belirtin (bitirmek için Enter'a basın)",
+    pickPoint: 'İç noktayı belirtin (bitirmek için Enter\'a basın)',
     select: 'Tarama yapılacak nesneleri seçin',
     patternName: 'Tarama deseni adını girin',
     scale: 'Tarama deseni ölçeğini belirtin',
@@ -665,7 +665,7 @@ export default {
   },
   measureArea: {
     firstPoint: 'İlk noktayı belirtin',
-    nextPoint: "Sonraki noktayı belirtin (bitirmek için Enter'a basın)"
+    nextPoint: 'Sonraki noktayı belirtin (bitirmek için Enter\'a basın)'
   },
   measureDistance: {
     firstPoint: 'İlk noktayı belirtin',
@@ -755,9 +755,9 @@ export default {
   },
   offset: {
     distance: 'Öteleme mesafesini belirtin',
-    selectObject: "Ötelenecek nesneyi seçin veya bitirmek için Enter'a basın",
+    selectObject: 'Ötelenecek nesneyi seçin veya bitirmek için Enter\'a basın',
     sidePoint: 'Ötelenecek tarafta bir nokta belirtin',
-    invalidDistance: "Öteleme mesafesi 0'dan büyük olmalıdır.",
+    invalidDistance: 'Öteleme mesafesi 0\'dan büyük olmalıdır.',
     invalidSelection: 'Seçilen nesne ötelenemez.',
     offsetFailed: 'Belirtilen taraf için bir öteleme eğrisi oluşturulamadı.'
   },
@@ -823,13 +823,13 @@ export default {
     },
     invalid: {
       sides: 'Geçersiz kenar sayısı. 3 ile 1024 arasında bir tam sayı girin.',
-      radius: "Geçersiz yarıçap. Yarıçap 0'dan büyük olmalıdır.",
-      edge: "Geçersiz kenar. Kenar uzunluğu 0'dan büyük olmalıdır."
+      radius: 'Geçersiz yarıçap. Yarıçap 0\'dan büyük olmalıdır.',
+      edge: 'Geçersiz kenar. Kenar uzunluğu 0\'dan büyük olmalıdır.'
     }
   },
   polyline: {
     firstPoint: 'İlk noktayı belirtin',
-    nextPoint: "Sonraki noktayı belirtin (bitirmek için Enter'a basın)",
+    nextPoint: 'Sonraki noktayı belirtin (bitirmek için Enter\'a basın)',
     nextPointWithOptions: 'Sonraki noktayı belirtin veya',
     nextPointWithArcOptions: 'Sonraki noktayı belirtin veya',
     keywords: {
@@ -897,7 +897,7 @@ export default {
     areaValue: 'Dikdörtgen alanını belirtin',
     areaLengthOrWidth: 'Dikdörtgen uzunluğunu belirtin',
     areaSpecifyWidth: 'Dikdörtgen genişliğini belirtin',
-    invalidPositive: "Geçersiz giriş. Lütfen 0'dan büyük bir değer girin.",
+    invalidPositive: 'Geçersiz giriş. Lütfen 0\'dan büyük bir değer girin.',
     invalidRect:
       'Dikdörtgen oluşturulamadı. Lütfen geçerli köşeler veya boyutlar belirtin.',
     thicknessNotSupported:
@@ -996,7 +996,7 @@ export default {
     selectObject: 'Nesne seçin',
     style: 'Revizyon bulutu yay stilini girin',
     reverseDirection: 'Yönü ters çevir',
-    invalidArcLength: "Yay uzunluğu 0'dan büyük olmalıdır.",
+    invalidArcLength: 'Yay uzunluğu 0\'dan büyük olmalıdır.',
     invalidObject: 'Seçilen nesne revizyon bulutuna dönüştürülemez.',
     keywords: {
       arcLength: {
@@ -1100,7 +1100,7 @@ export default {
   },
   spline: {
     firstPoint: 'İlk noktayı belirtin',
-    nextPoint: "Sonraki noktayı belirtin (bitirmek için Enter'a basın)",
+    nextPoint: 'Sonraki noktayı belirtin (bitirmek için Enter\'a basın)',
     firstPointWithOptions: 'İlk noktayı belirtin veya',
     nextPointWithFitOptions: 'Sonraki noktayı belirtin veya',
     nextPointWithCvOptions: 'Sonraki kontrol noktasını belirtin veya',

--- a/packages/cad-simple-viewer/src/i18n/zh/command.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/command.ts
@@ -250,6 +250,9 @@ export default {
     clearmeasurements: {
       description: '清除当前布局上的所有测量标注'
     },
+    measurementvis: {
+      description: '显示或隐藏当前布局上的测量标注'
+    },
     measurementexport: {
       description: '将测量标注导出为 sidecar JSON 文件'
     },
@@ -357,7 +360,7 @@ export default {
       description: '重绘图纸'
     },
     revcloud: {
-      description: '创建矩形修订云线'
+      description: '创建或修改修订云线'
     },
     markuptext: {
       description: '放置文字批注'
@@ -412,7 +415,7 @@ export default {
       description: '控制图形区域中快捷菜单的可用性'
     },
     sketch: {
-      description: '使用多段线创建手绘线，跟踪鼠标移动'
+      description: '创建一系列徒手线段'
     },
     spline: {
       description: '通过指定控制点创建平滑的样条曲线'

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -973,9 +973,119 @@ export default {
       }
     }
   },
-  sketch: {
+  revcloud: {
+    firstCornerOrOptions: '指定第一个角点或',
+    firstCorner: '指定第一个角点',
+    oppositeCorner: '指定对角点',
+    startPoint: '指定起点',
+    nextPoint: '指定下一点',
+    nextPointOrUndo: '指定下一点或',
     firstPoint: '指定第一个点',
-    nextPoint: '指定结束点'
+    guideCursor: '沿云线路径移动光标（按 Enter 结束）',
+    arcLength: '指定圆弧长度',
+    selectObject: '选择对象',
+    style: '输入修订云线圆弧样式',
+    reverseDirection: '反转方向',
+    invalidArcLength: '圆弧长度必须大于 0。',
+    invalidObject: '所选对象无法转换为修订云线。',
+    keywords: {
+      arcLength: {
+        display: '圆弧长度(A)',
+        local: '圆弧长度',
+        global: 'ArcLength'
+      },
+      object: {
+        display: '对象(O)',
+        local: '对象',
+        global: 'Object'
+      },
+      rectangular: {
+        display: '矩形(R)',
+        local: '矩形',
+        global: 'Rectangular'
+      },
+      polygonal: {
+        display: '多边形(P)',
+        local: '多边形',
+        global: 'Polygonal'
+      },
+      freehand: {
+        display: '手绘(F)',
+        local: '手绘',
+        global: 'Freehand'
+      },
+      style: {
+        display: '样式(S)',
+        local: '样式',
+        global: 'Style'
+      },
+      normal: {
+        display: '普通(N)',
+        local: '普通',
+        global: 'Normal'
+      },
+      calligraphy: {
+        display: '书法(C)',
+        local: '书法',
+        global: 'Calligraphy'
+      },
+      undo: {
+        display: '放弃(U)',
+        local: '放弃',
+        global: 'Undo'
+      },
+      yes: {
+        display: '是(Y)',
+        local: '是',
+        global: 'Yes'
+      },
+      no: {
+        display: '否(N)',
+        local: '否',
+        global: 'No'
+      }
+    }
+  },
+  sketch: {
+    specifySketch: '指定草图或',
+    sketching: '移动指针进行草图绘制（单击或按 Enter 停止）',
+    type: '输入草图类型',
+    increment: '指定草图增量',
+    tolerance: '指定样条曲线公差',
+    firstPoint: '指定第一个点',
+    nextPoint: '指定结束点',
+    keywords: {
+      type: {
+        display: '类型(T)',
+        local: '类型',
+        global: 'Type'
+      },
+      increment: {
+        display: '增量(I)',
+        local: '增量',
+        global: 'Increment'
+      },
+      tolerance: {
+        display: '公差(L)',
+        local: '公差',
+        global: 'Tolerance'
+      },
+      line: {
+        display: '直线(L)',
+        local: '直线',
+        global: 'Lines'
+      },
+      polyline: {
+        display: '多段线(P)',
+        local: '多段线',
+        global: 'Polyline'
+      },
+      spline: {
+        display: '样条曲线(S)',
+        local: '样条曲线',
+        global: 'Spline'
+      }
+    }
   },
   spline: {
     firstPoint: '指定第一个点',

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -37,6 +37,7 @@ import {
   getMeasurementFontSize,
   getMeasurementLineWeight,
   isMarkupVisible,
+  isMeasurementVisible,
   markupColorToCss,
   measurementColor,
   refreshMeasurementValueLabels,
@@ -140,6 +141,7 @@ import {
   rect,
   revCircle,
   revCloud,
+  revFreeDraw,
   revRect,
   setting,
   splineFitPoints,
@@ -182,6 +184,7 @@ const { isDocumentOpening, openMode: docOpenMode } = useDocument()
 const { canUndo, canRedo } = useUndoRedo()
 const { t, locale } = useI18n()
 const isMarkupOverlayVisible = ref(true)
+const isMeasurementOverlayVisible = ref(true)
 const markupDrawColor = shallowRef(defaultMarkupColor())
 const markupDrawColorDisplay = ref(markupColorToCss(markupDrawColor.value))
 const markupDrawLineWeight = ref<AcGiLineWeight>(getMarkupLineWeight())
@@ -381,6 +384,10 @@ const syncMarkupVisibility = () => {
   isMarkupOverlayVisible.value = isMarkupVisible()
 }
 
+const syncMeasurementVisibility = () => {
+  isMeasurementOverlayVisible.value = isMeasurementVisible()
+}
+
 const handleAnnotationLayerChange = () => {
   syncRibbonProperties(observedDatabase)
 }
@@ -511,6 +518,7 @@ const handleDocumentActivated = () => {
   ribbonLayerIsolationSnapshot.value = null
   ribbonLayerPreviousSnapshot.value = null
   syncMarkupVisibility()
+  syncMeasurementVisibility()
   syncMarkupStyleControls()
   syncMeasurementStyleControls()
   syncMeasurementUnitControls()
@@ -557,6 +565,9 @@ onMounted(() => {
   AcApDocManager.instance.editor.events.commandEnded.addEventListener(
     syncMarkupVisibility
   )
+  AcApDocManager.instance.editor.events.commandEnded.addEventListener(
+    syncMeasurementVisibility
+  )
   AcApDocManager.instance.events.documentActivated.addEventListener(
     handleDocumentActivated
   )
@@ -591,6 +602,9 @@ onUnmounted(() => {
   )
   AcApDocManager.instance.editor.events.commandEnded.removeEventListener(
     syncMarkupVisibility
+  )
+  AcApDocManager.instance.editor.events.commandEnded.removeEventListener(
+    syncMeasurementVisibility
   )
   AcApDocManager.instance.events.documentActivated.removeEventListener(
     handleDocumentActivated
@@ -884,6 +898,7 @@ const handleRibbonLayerStateToggle = (payload: {
 const buildBaseTabs = (
   openMode: AcEdOpenMode,
   markupVisible: boolean,
+  measurementVisible: boolean,
   undoRedoState: { canUndo: boolean; canRedo: boolean },
   agentPluginEnabled: boolean
 ): RibbonTabModel[] => {
@@ -891,6 +906,8 @@ const buildBaseTabs = (
     line: t('main.ribbon.tooltip.line'),
     polyline: t('main.ribbon.tooltip.polyline'),
     spline: t('main.ribbon.tooltip.spline'),
+    sketch: t('main.ribbon.tooltip.sketch'),
+    revcloud: t('main.ribbon.tooltip.revcloud'),
     circle: t('main.ribbon.tooltip.circle'),
     arc: t('main.ribbon.tooltip.arc'),
     mline: t('main.ribbon.tooltip.mline'),
@@ -968,6 +985,8 @@ const buildBaseTabs = (
     layer: t('main.verticalToolbar.layer.description'),
     hideMarkup: t('main.verticalToolbar.hideMarkup.description'),
     showMarkup: t('main.verticalToolbar.showMarkup.description'),
+    hideMeasurements: t('main.verticalToolbar.hideMeasurements.description'),
+    showMeasurements: t('main.verticalToolbar.showMeasurements.description'),
     clearMarkups: t('main.verticalToolbar.clearMarkups.description'),
     markupImport: t('main.verticalToolbar.markupImport.description'),
     markupExport: t('main.verticalToolbar.markupExport.description')
@@ -1180,6 +1199,24 @@ const buildBaseTabs = (
       tooltip: verticalToolbarDescriptions.measurePoint,
       size: 'large',
       props: { icon: measurePoint }
+    },
+    {
+      id: 'cmd-tool-measurement-vis',
+      type: 'toggle',
+      label: t('main.verticalToolbar.showMeasurements.text'),
+      tooltip: measurementVisible
+        ? verticalToolbarDescriptions.hideMeasurements
+        : verticalToolbarDescriptions.showMeasurements,
+      size: 'large',
+      props: {
+        modelValue: measurementVisible,
+        activeIcon: View,
+        inactiveIcon: Hide,
+        activeLabel: t('main.verticalToolbar.showMeasurements.text'),
+        inactiveLabel: t('main.verticalToolbar.hideMeasurements.text'),
+        activeValue: 'cmd-tool-measurement-vis',
+        inactiveValue: 'cmd-tool-measurement-vis'
+      }
     }
   ]
 
@@ -1411,6 +1448,20 @@ const buildBaseTabs = (
               label: t('main.ribbon.command.spline'),
               tooltip: ribbonTooltips.spline,
               props: { icon: splineFitPoints }
+            },
+            {
+              id: 'cmd-sketch',
+              type: 'button',
+              label: t('main.ribbon.command.sketch'),
+              tooltip: ribbonTooltips.sketch,
+              props: { icon: revFreeDraw }
+            },
+            {
+              id: 'cmd-revcloud',
+              type: 'button',
+              label: t('main.ribbon.command.revcloud'),
+              tooltip: ribbonTooltips.revcloud,
+              props: { icon: revCloud }
             },
             {
               id: 'cmd-mline',
@@ -2160,6 +2211,7 @@ const ribbonData = computed(() => {
   store.features.agentPlugin
   const openMode = docOpenMode.value
   const markupVisible = isMarkupOverlayVisible.value
+  const measurementVisible = isMeasurementOverlayVisible.value
   // Track markup draw style so Review ribbon color / lineweight controls refresh.
   markupDrawColor.value
   markupDrawColorDisplay.value
@@ -2178,6 +2230,8 @@ const ribbonData = computed(() => {
   commandByItemId.set('cmd-line', 'line')
   commandByItemId.set('cmd-polyline', 'pline')
   commandByItemId.set('cmd-spline', 'spline')
+  commandByItemId.set('cmd-sketch', 'sketch')
+  commandByItemId.set('cmd-revcloud', 'revcloud')
   commandByItemId.set('cmd-circle', 'circle')
   commandByItemId.set('circle-center-radius', 'circle')
   commandByItemId.set('circle-center-diameter', 'circle\\nDiameter')
@@ -2250,6 +2304,7 @@ const ribbonData = computed(() => {
   commandByItemId.set('cmd-tool-measure-area', 'measurearea')
   commandByItemId.set('cmd-tool-measure-arc', 'measurearc')
   commandByItemId.set('cmd-tool-measure-point', 'measurepoint')
+  commandByItemId.set('cmd-tool-measurement-vis', 'measurementvis')
   commandByItemId.set('cmd-tool-measurement-import', 'measurementimport')
   commandByItemId.set('cmd-tool-measurement-export', 'measurementexport')
   commandByItemId.set('cmd-tool-clear-measurements', 'clearmeasurements')
@@ -2267,6 +2322,7 @@ const ribbonData = computed(() => {
   const tabs: RibbonTabModel[] = buildBaseTabs(
     openMode,
     markupVisible,
+    measurementVisible,
     {
       canUndo: canUndo.value,
       canRedo: canRedo.value

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -273,6 +273,8 @@ export default {
       line: 'Nakreslí jednu úsečku.',
       polyline: 'Nakreslí spojenou řadu úseček nebo oblouků jako jeden objekt.',
       spline: 'Nakreslí hladkou křivku splajn proložením nebo řídicími body.',
+      sketch: 'Vytvoří řadu úseček kreslených od ruky.',
+      revcloud: 'Vytvoří revizní obláček pro zvýraznění oblastí výkresu.',
       circle: 'Nakreslí kružnici několika způsoby konstrukce.',
       arc: 'Nakreslí oblouk několika způsoby konstrukce.',
       mline: 'Nakreslí několik rovnoběžných čar jako jeden objekt.',
@@ -384,6 +386,8 @@ export default {
       xline: 'Přímka',
       ellipse: 'Elipsa',
       spline: 'Splajn',
+      sketch: 'Skica',
+      revcloud: 'Revizní obláček',
       rect: 'Obdélník',
       rectangle: 'Obdélník',
       polygon: 'Mnohoúhelník',
@@ -561,6 +565,14 @@ export default {
     hideMarkup: {
       text: 'Skrýt',
       description: 'Skryje poznámky'
+    },
+    showMeasurements: {
+      text: 'Zobrazit',
+      description: 'Zobrazí měření'
+    },
+    hideMeasurements: {
+      text: 'Skrýt',
+      description: 'Skryje měření'
     },
     clearMarkups: {
       text: 'Vymazat',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -274,6 +274,8 @@ export default {
       polyline:
         'Draw a connected series of line or arc segments as one object.',
       spline: 'Draw a smooth spline curve through fit or control points.',
+      sketch: 'Create a series of freehand line segments.',
+      revcloud: 'Create a revision cloud to highlight drawing areas.',
       circle: 'Draw a circle with multiple construction methods.',
       arc: 'Draw an arc with multiple construction methods.',
       mline: 'Draw multiple parallel lines as a single multiline object.',
@@ -301,7 +303,8 @@ export default {
         'Open Drawing Units to set coordinate formats, precision, and insertion scale.',
       attachDwg:
         'Attach a DWG or DXF drawing as an external reference (XATTACH).',
-      attachImage: 'Attach a raster image as an external reference (IMAGEATTACH).',
+      attachImage:
+        'Attach a raster image as an external reference (IMAGEATTACH).',
       insert:
         'Open the Blocks palette to browse and insert block definitions (INSERT).',
       editAttributes:
@@ -389,6 +392,8 @@ export default {
       xline: 'XLine',
       ellipse: 'Ellipse',
       spline: 'Spline',
+      sketch: 'Sketch',
+      revcloud: 'Revcloud',
       rect: 'Rect',
       rectangle: 'Rectangle',
       polygon: 'Polygon',
@@ -571,6 +576,14 @@ export default {
       text: 'Hide',
       description: 'Hides markups'
     },
+    showMeasurements: {
+      text: 'Show',
+      description: 'Shows measurements'
+    },
+    hideMeasurements: {
+      text: 'Hide',
+      description: 'Hides measurements'
+    },
     clearMarkups: {
       text: 'Clear',
       description: 'Clears all markups on the current layout'
@@ -739,8 +752,7 @@ export default {
       count: 'Count',
       empty: 'No visible blocks found',
       prompt: {
-        firstCorner:
-          'Specify first corner of count area or [Entire]: ',
+        firstCorner: 'Specify first corner of count area or [Entire]: ',
         secondCorner: 'Specify opposite corner: '
       }
     },

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -4,10 +4,10 @@ export default {
     open: 'Çizim Aç',
     drawingUnits: 'Çizim Birimleri',
     exportMenu: 'Dışa Aktar',
-    export: 'DXF\'e Dışa Aktar',
-    exportHtml: 'HTML\'e Dışa Aktar',
-    exportPdf: 'PDF\'e Dışa Aktar',
-    exportSvg: 'SVG\'e Dışa Aktar',
+    export: "DXF'e Dışa Aktar",
+    exportHtml: "HTML'e Dışa Aktar",
+    exportPdf: "PDF'e Dışa Aktar",
+    exportSvg: "SVG'e Dışa Aktar",
     exportImage: 'Görüntüye Dışa Aktar',
     about: 'Hakkında'
   },
@@ -142,9 +142,9 @@ export default {
         obliqueAngle:
           'Seçili karakterler için eğim açısını derece cinsinden ayarlayın (negatif değer diğer yöne eğer).',
         tracking:
-          'Seçili karakterler arasındaki boşluğu artırın veya azaltın (varsayılan 1\'dir).',
+          "Seçili karakterler arasındaki boşluğu artırın veya azaltın (varsayılan 1'dir).",
         widthFactor:
-          'Seçili karakterleri yatay olarak genişletin veya sıkıştırın (varsayılan 1\'dir).',
+          "Seçili karakterleri yatay olarak genişletin veya sıkıştırın (varsayılan 1'dir).",
         attachment: 'Çok satırlı metin bağlantı noktasını ayarlayın.',
         list: 'Madde işaretleri ve numaralandırma ekleyin veya yapılandırın.',
         lineSpacing: 'Satır aralığını ayarlayın.',
@@ -276,6 +276,9 @@ export default {
         'Bağlı bir dizi çizgi veya yay parçasını tek bir nesne olarak çizin.',
       spline:
         'Uyum veya kontrol noktaları üzerinden düzgün bir spline eğrisi çizin.',
+      sketch: 'Bir dizi serbest el çizgi parçası oluşturun.',
+      revcloud:
+        'Çizim alanlarını vurgulamak için bir revizyon bulutu oluşturun.',
       circle: 'Birden fazla oluşturma yöntemiyle bir daire çizin.',
       arc: 'Birden fazla oluşturma yöntemiyle bir yay çizin.',
       mline:
@@ -298,7 +301,8 @@ export default {
       properties: 'Geçerli seçim için Özellikler panelini açın.',
       quickSelect:
         'Ölçütlere göre varlıkları filtrelemek ve seçmek için Hızlı Seçimi açın.',
-      countList: 'Blok sayılarını görüntülemek ve yönetmek için Sayım paletini açın.',
+      countList:
+        'Blok sayılarını görüntülemek ve yönetmek için Sayım paletini açın.',
       missingResources:
         'Yazı tipleri, görseller ve xref’ler için Eksik / Harici Kaynaklar paletini açın.',
       drawingUnits:
@@ -392,6 +396,8 @@ export default {
       xline: 'Sonsuz Çizgi',
       ellipse: 'Elips',
       spline: 'Spline',
+      sketch: 'Eskiz',
+      revcloud: 'Revizyon Bulutu',
       rect: 'Dikdörtgen',
       rectangle: 'Dikdörtgen',
       polygon: 'Çokgen',
@@ -553,8 +559,7 @@ export default {
     },
     measurementColor: {
       text: 'Renk',
-      description:
-        'Seçili ölçümün veya sonraki ölçümlerin rengini ayarlar'
+      description: 'Seçili ölçümün veya sonraki ölçümlerin rengini ayarlar'
     },
     measurementLineWeight: {
       text: 'Çizgi Kalınlığı',
@@ -573,6 +578,14 @@ export default {
     hideMarkup: {
       text: 'Gizle',
       description: 'İşaretleri gizler'
+    },
+    showMeasurements: {
+      text: 'Göster',
+      description: 'Ölçümleri gösterir'
+    },
+    hideMeasurements: {
+      text: 'Gizle',
+      description: 'Ölçümleri gizler'
     },
     clearMarkups: {
       text: 'Temizle',
@@ -744,8 +757,7 @@ export default {
       count: 'Adet',
       empty: 'Görünür blok bulunamadı',
       prompt: {
-        firstCorner:
-          'Sayım alanının ilk köşesini belirtin veya [Entire]: ',
+        firstCorner: 'Sayım alanının ilk köşesini belirtin veya [Entire]: ',
         secondCorner: 'Karşı köşeyi belirtin: '
       }
     },
@@ -886,7 +898,8 @@ export default {
       copyFailed: 'Performans verileri kopyalanamadı',
       collectedAt: 'Toplama zamanı {time}',
       hint: 'Son çizim açılışında otomatik toplanır. OPENPROF=1 konsola da yazar.',
-      noData: 'Henüz profil yok. Önce bir çizim açın, sonra OPENPERF çalıştırın.',
+      noData:
+        'Henüz profil yok. Önce bir çizim açın, sonra OPENPERF çalıştırın.',
       empty: 'Veri yok',
       timing: 'Duvar saati zamanlaması',
       progressive: 'Kademeli açılış',

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -4,10 +4,10 @@ export default {
     open: 'Çizim Aç',
     drawingUnits: 'Çizim Birimleri',
     exportMenu: 'Dışa Aktar',
-    export: "DXF'e Dışa Aktar",
-    exportHtml: "HTML'e Dışa Aktar",
-    exportPdf: "PDF'e Dışa Aktar",
-    exportSvg: "SVG'e Dışa Aktar",
+    export: 'DXF\'e Dışa Aktar',
+    exportHtml: 'HTML\'e Dışa Aktar',
+    exportPdf: 'PDF\'e Dışa Aktar',
+    exportSvg: 'SVG\'e Dışa Aktar',
     exportImage: 'Görüntüye Dışa Aktar',
     about: 'Hakkında'
   },
@@ -142,9 +142,9 @@ export default {
         obliqueAngle:
           'Seçili karakterler için eğim açısını derece cinsinden ayarlayın (negatif değer diğer yöne eğer).',
         tracking:
-          "Seçili karakterler arasındaki boşluğu artırın veya azaltın (varsayılan 1'dir).",
+          'Seçili karakterler arasındaki boşluğu artırın veya azaltın (varsayılan 1\'dir).',
         widthFactor:
-          "Seçili karakterleri yatay olarak genişletin veya sıkıştırın (varsayılan 1'dir).",
+          'Seçili karakterleri yatay olarak genişletin veya sıkıştırın (varsayılan 1\'dir).',
         attachment: 'Çok satırlı metin bağlantı noktasını ayarlayın.',
         list: 'Madde işaretleri ve numaralandırma ekleyin veya yapılandırın.',
         lineSpacing: 'Satır aralığını ayarlayın.',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -270,6 +270,8 @@ export default {
       line: '绘制单段直线。',
       polyline: '以一个对象绘制由直线或圆弧组成的连续线段。',
       spline: '通过拟合点或控制点绘制平滑样条曲线。',
+      sketch: '创建一系列徒手线段。',
+      revcloud: '创建修订云线以突出显示图纸区域。',
       circle: '使用多种构造方式绘制圆。',
       arc: '使用多种构造方式绘制圆弧。',
       mline: '将多条平行线作为一个多线对象进行绘制。',
@@ -354,6 +356,8 @@ export default {
       xline: '构造线',
       ellipse: '椭圆',
       spline: '样条曲线',
+      sketch: '草图',
+      revcloud: '修订云线',
       rect: '矩形',
       rectangle: '矩形',
       polygon: '多边形',
@@ -525,6 +529,14 @@ export default {
     hideMarkup: {
       text: '隐藏批注',
       description: '隐藏批注'
+    },
+    showMeasurements: {
+      text: '显示测量',
+      description: '显示测量标注'
+    },
+    hideMeasurements: {
+      text: '隐藏测量',
+      description: '隐藏测量标注'
     },
     clearMarkups: {
       text: '清除',
@@ -777,8 +789,7 @@ export default {
       hidePie: '隐藏汇总图表',
       collectedAt: '采集时间 {time}',
       heapUsed: 'JS 堆 {used} / {total}',
-      estimateNote:
-        '几何体大小来自缓冲区 byteLength，其余类别为估算值。',
+      estimateNote: '几何体大小来自缓冲区 byteLength，其余类别为估算值。',
       estimated: '估',
       pieTotal: '已统计',
       pieAriaLabel: '按类别划分的内存占用',


### PR DESCRIPTION
## Summary
- Expand REVCLOUD to AutoCAD-like Rectangular, Polygonal, and Freehand modes, plus object conversion, arc length, Normal/Calligraphy style, and reverse direction.
- Expand SKETCH with Type, Increment, and Tolerance so strokes can be committed as lines, a polyline, or a spline.
- Add `measurementvis` and a Measurement ribbon toggle to show or hide overlays on the current layout.

## Test plan
- [ ] Draw rectangular, polygonal, and freehand revision clouds from Home > Draw > Revcloud
- [ ] Convert a polyline or circle with Object, then reverse the cloud direction
- [ ] Sketch with Lines, Polyline, and Spline types and confirm increment/tolerance options
- [ ] Toggle measurement visibility on the Measurement ribbon; confirm current-layout overlays hide/show and new measurements stay hidden while off
- [ ] Confirm Review markup cloud (`markupcloud`) is unchanged