### PR TITLE
fix: keep markup overlay drags tracking after CSS2D repositions grips

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApMarkupCalloutDrag.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupCalloutDrag.spec.ts
@@ -1,0 +1,108 @@
+/** @jest-environment jsdom */
+
+jest.mock('../src/command/markup/AcApMarkupShapeCallout', () => ({
+  computeLeaderTipOnShape: (
+    _outline: unknown,
+    point: { x: number; y: number }
+  ) => point
+}))
+
+import { bindMarkupPointerDrag } from '../src/command/markup/AcApMarkupCalloutDrag'
+import type { AcTrView2d } from '../src/view'
+
+function mockView(): AcTrView2d {
+  return {
+    viewportToCanvas: ({ x, y }: { x: number; y: number }) => ({ x, y }),
+    screenToWorld: ({ x, y }: { x: number; y: number }) => ({ x, y }),
+    isDirty: false
+  } as unknown as AcTrView2d
+}
+
+function dispatchPointer(
+  target: EventTarget,
+  type: string,
+  clientX: number,
+  clientY: number,
+  extra?: { button?: number; detail?: number; pointerId?: number }
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button: extra?.button ?? 0,
+    clientX,
+    clientY,
+    detail: extra?.detail ?? 0
+  })
+  Object.assign(event, { pointerId: extra?.pointerId ?? 1 })
+  target.dispatchEvent(event)
+}
+
+describe('bindMarkupPointerDrag', () => {
+  it('tracks a second drag across the window after the handle leaves the pointer', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const view = mockView()
+    const moves: Array<{ x: number; y: number }> = []
+    const commits: number[] = []
+
+    const unbind = bindMarkupPointerDrag({
+      view,
+      el,
+      onMove: world => {
+        moves.push({ x: world.x, y: world.y })
+      },
+      onCommit: () => {
+        commits.push(moves.length)
+      }
+    })
+
+    const dragFar = (
+      startX: number,
+      startY: number,
+      endX: number,
+      endY: number
+    ) => {
+      dispatchPointer(el, 'pointerdown', startX, startY)
+      dispatchPointer(window, 'pointermove', startX + 10, startY)
+      dispatchPointer(window, 'pointermove', endX, endY)
+      dispatchPointer(window, 'pointerup', endX, endY)
+    }
+
+    dragFar(20, 20, 400, 300)
+    dragFar(400, 300, 50, 80)
+
+    expect(commits).toEqual([2, 4])
+    expect(moves[0]).toEqual({ x: 30, y: 20 })
+    expect(moves[1]).toEqual({ x: 400, y: 300 })
+    expect(moves[2]).toEqual({ x: 410, y: 300 })
+    expect(moves[3]).toEqual({ x: 50, y: 80 })
+
+    unbind()
+    el.remove()
+  })
+
+  it('does not start a drag for a click below the move threshold', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const view = mockView()
+    const onMove = jest.fn()
+    const onCommit = jest.fn()
+
+    const unbind = bindMarkupPointerDrag({
+      view,
+      el,
+      onMove,
+      onCommit
+    })
+
+    dispatchPointer(el, 'pointerdown', 10, 10)
+    dispatchPointer(window, 'pointermove', 12, 11)
+    dispatchPointer(window, 'pointerup', 12, 11)
+
+    expect(onMove).not.toHaveBeenCalled()
+    expect(onCommit).not.toHaveBeenCalled()
+
+    unbind()
+    el.remove()
+  })
+})

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutDrag.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutDrag.ts
@@ -33,10 +33,19 @@ export function pointerEventToMarkupWorld(
 
 const DRAG_THRESHOLD_PX = 4
 
+const windowListenerOptions: AddEventListenerOptions = {
+  capture: true,
+  passive: false
+}
+
 /**
  * Bind pointer-drag on one HTML overlay handle.
  * Hover + drag works without selecting the markup first.
  * Drag starts only after a small move so a double-click can still edit text.
+ *
+ * Move / up listeners are attached to `window`, not the handle. CSS2D
+ * repositions the handle under the cursor every frame; listening on the
+ * element (or capturing pointer on it) loses events after the first drag.
  */
 export function bindMarkupPointerDrag(options: {
   view: AcTrView2d
@@ -51,6 +60,10 @@ export function bindMarkupPointerDrag(options: {
 
   el.style.pointerEvents = 'auto'
   el.style.cursor = idleCursor
+  el.style.touchAction = 'none'
+  el.style.userSelect = 'none'
+
+  let detachActiveDrag: (() => void) | undefined
 
   const onPointerDown = (e: PointerEvent) => {
     if (e.button !== 0) return
@@ -64,11 +77,32 @@ export function bindMarkupPointerDrag(options: {
       return
     }
 
+    const pointerId = e.pointerId
     const startX = e.clientX
     const startY = e.clientY
     let dragging = false
 
+    const detach = () => {
+      window.removeEventListener(
+        'pointermove',
+        onPointerMove,
+        windowListenerOptions
+      )
+      window.removeEventListener(
+        'pointerup',
+        onPointerUp,
+        windowListenerOptions
+      )
+      window.removeEventListener(
+        'pointercancel',
+        onPointerUp,
+        windowListenerOptions
+      )
+      if (detachActiveDrag === detach) detachActiveDrag = undefined
+    }
+
     const onPointerMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return
       if (!dragging) {
         const dx = ev.clientX - startX
         const dy = ev.clientY - startY
@@ -77,7 +111,6 @@ export function bindMarkupPointerDrag(options: {
         }
         dragging = true
         ev.preventDefault()
-        el.setPointerCapture(ev.pointerId)
         el.style.cursor = 'grabbing'
         onDragStart?.()
       }
@@ -86,26 +119,25 @@ export function bindMarkupPointerDrag(options: {
     }
 
     const onPointerUp = (ev: PointerEvent) => {
-      el.removeEventListener('pointermove', onPointerMove)
-      el.removeEventListener('pointerup', onPointerUp)
-      el.removeEventListener('pointercancel', onPointerUp)
+      if (ev.pointerId !== pointerId) return
+      detach()
       if (!dragging) return
-      try {
-        el.releasePointerCapture(ev.pointerId)
-      } catch {
-        // Capture may already have been released.
-      }
       el.style.cursor = idleCursor
       onCommit()
     }
 
-    el.addEventListener('pointermove', onPointerMove)
-    el.addEventListener('pointerup', onPointerUp)
-    el.addEventListener('pointercancel', onPointerUp)
+    detachActiveDrag?.()
+    detachActiveDrag = detach
+    window.addEventListener('pointermove', onPointerMove, windowListenerOptions)
+    window.addEventListener('pointerup', onPointerUp, windowListenerOptions)
+    window.addEventListener('pointercancel', onPointerUp, windowListenerOptions)
   }
 
   el.addEventListener('pointerdown', onPointerDown)
-  return () => el.removeEventListener('pointerdown', onPointerDown)
+  return () => {
+    el.removeEventListener('pointerdown', onPointerDown)
+    detachActiveDrag?.()
+  }
 }
 
 /**
@@ -145,6 +177,7 @@ export function bindMarkupCalloutGrips(options: {
     onDragStart,
     onMove: point => {
       state.tip = outline ? computeLeaderTipOnShape(outline, point) : point
+      view.htmlTransientManager.updatePosition(tipEl.id, state.tip)
       tipEl.setPosition(state.tip)
       onLiveChange()
     },
@@ -159,6 +192,7 @@ export function bindMarkupCalloutGrips(options: {
     onDragStart,
     onMove: point => {
       state.anchor = point
+      view.htmlTransientManager.updatePosition(bubbleEl.id, state.anchor)
       bubbleEl.setPosition(state.anchor)
       onLiveChange()
     },

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
@@ -28,6 +28,7 @@ import {
   bindMarkupPointerDrag
 } from './AcApMarkupCalloutDrag'
 import {
+  markupGeometryCenter,
   translateMarkupGeometry,
   translateMarkupPoint
 } from './AcApMarkupGeometry'
@@ -160,12 +161,18 @@ function fitCanvas(
 ): CanvasRenderingContext2D | null {
   const rect = container.getBoundingClientRect()
   const dpr = window.devicePixelRatio || 1
+  const cssWidth = `${rect.width}px`
+  const cssHeight = `${rect.height}px`
+  const bufferWidth = Math.max(1, Math.floor(rect.width * dpr))
+  const bufferHeight = Math.max(1, Math.floor(rect.height * dpr))
   canvas.style.left = '0'
   canvas.style.top = '0'
-  canvas.style.width = `${rect.width}px`
-  canvas.style.height = `${rect.height}px`
-  canvas.width = Math.max(1, Math.floor(rect.width * dpr))
-  canvas.height = Math.max(1, Math.floor(rect.height * dpr))
+  if (canvas.style.width !== cssWidth) canvas.style.width = cssWidth
+  if (canvas.style.height !== cssHeight) canvas.style.height = cssHeight
+  // Assigning canvas.width/height clears the buffer and reallocates GPU
+  // backing store — skip when the size has not changed.
+  if (canvas.width !== bufferWidth) canvas.width = bufferWidth
+  if (canvas.height !== bufferHeight) canvas.height = bufferHeight
   const ctx = canvas.getContext('2d')
   if (!ctx) return null
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
@@ -352,7 +359,7 @@ function publishAttachedCallout(
           return
         }
         runMarkupEdit(view2d, 'Move Callout', () => {
-          getMarkupStore().updateGeometry(record.id, {
+          const updated = getMarkupStore().updateGeometry(record.id, {
             ...geom,
             callout: {
               tip: next.tip,
@@ -360,12 +367,22 @@ function publishAttachedCallout(
               text: geom.callout?.text ?? callout.text
             }
           })
+          if (updated) getMarkupPresenter().publish(view2d, updated)
         })
       }
     })
   )
 
   return { live, redraw, tipDot, bubble }
+}
+
+function placeMarkupHtml(
+  view: AcTrView2d,
+  el: AcTrHtmlElement,
+  point: AcApMarkupPoint2d
+): void {
+  view.htmlTransientManager.updatePosition(el.id, point)
+  el.setPosition(point)
 }
 
 function bindMarkupCenterMove(options: {
@@ -388,7 +405,9 @@ function bindMarkupCenterMove(options: {
     cursor: 'move',
     onDragStart: () => {
       selectMarkupGroup(view, recordId)
-      origin = {
+      const stored = getMarkupStore().get(recordId)
+      const center = stored ? markupGeometryCenter(stored.geometry) : undefined
+      origin = center ?? {
         x: centerEl.object.position.x,
         y: centerEl.object.position.y
       }
@@ -410,7 +429,7 @@ function bindMarkupCenterMove(options: {
           entityIds.map(objectId => ({ objectId, matrix }))
         )
       }
-      centerEl.setPosition(point)
+      placeMarkupHtml(view, centerEl, point)
       if (attached && originalCallout) {
         attached.live.tip = translateMarkupPoint(originalCallout.tip, dx, dy)
         attached.live.anchor = translateMarkupPoint(
@@ -418,8 +437,8 @@ function bindMarkupCenterMove(options: {
           dx,
           dy
         )
-        attached.tipDot.setPosition(attached.live.tip)
-        attached.bubble.setPosition(attached.live.anchor)
+        placeMarkupHtml(view, attached.tipDot, attached.live.tip)
+        placeMarkupHtml(view, attached.bubble, attached.live.anchor)
         attached.redraw()
       }
     },
@@ -545,43 +564,51 @@ export class AcApMarkupPresenter {
         })
         group.add(startDot, endDot)
 
-        let redrawArrow: (() => void) | undefined
-        if (geom.type === 'arrow') {
-          const container = view2d.container
-          const overlay = new AcTrHtmlCanvasOverlay({
-            id: `${record.id}-arrow`,
-            container,
-            layer,
-            layoutId
-          })
-          group.addCanvas(overlay)
-          redrawArrow = () => {
-            const ctx = fitCanvas(overlay.canvas, container)
-            if (!ctx) return
-            const a = view2d.worldToScreen(live.start)
-            const b = view2d.worldToScreen(live.end)
+        const container = view2d.container
+        const overlay = new AcTrHtmlCanvasOverlay({
+          id: `${record.id}-stroke`,
+          container,
+          layer,
+          layoutId
+        })
+        group.addCanvas(overlay)
+        let draggingEndpoints = false
+        const redrawStroke = () => {
+          const ctx = fitCanvas(overlay.canvas, container)
+          if (!ctx) return
+          const a = view2d.worldToScreen(live.start)
+          const b = view2d.worldToScreen(live.end)
+          if (draggingEndpoints) {
+            ctx.strokeStyle = record.style.color
+            ctx.lineWidth = canvasLineWidth
+            ctx.beginPath()
+            ctx.moveTo(a.x, a.y)
+            ctx.lineTo(b.x, b.y)
+            ctx.stroke()
+          }
+          if (geom.type === 'arrow') {
             drawArrowHead(ctx, a, b, record.style.color)
           }
-          redrawArrow()
-          view2d.events.viewChanged.addEventListener(redrawArrow)
-          cleanups.push(() =>
-            view2d.events.viewChanged.removeEventListener(redrawArrow!)
-          )
         }
+        redrawStroke()
+        view2d.events.viewChanged.addEventListener(redrawStroke)
+        cleanups.push(() =>
+          view2d.events.viewChanged.removeEventListener(redrawStroke)
+        )
 
-        const refreshEndpoints = () => {
-          line.startPoint = { x: live.start.x, y: live.start.y, z: 0 }
-          line.endPoint = { x: live.end.x, y: live.end.y, z: 0 }
-          view2d.removeTransientEntity(line.objectId)
-          view2d.addTransientEntity(line)
-          redrawArrow?.()
+        const beginEndpointDrag = () => {
+          selectMarkupGroup(view2d, record.id)
+          draggingEndpoints = true
+          view2d.setTransientEntityVisible(line.objectId, false)
+          redrawStroke()
         }
         const commitEndpoints = () => {
+          draggingEndpoints = false
           runMarkupEdit(
             view2d,
             geom.type === 'arrow' ? 'Move Arrow' : 'Move Line',
             () => {
-              getMarkupStore().updateGeometry(
+              const updated = getMarkupStore().updateGeometry(
                 record.id,
                 geom.type === 'arrow'
                   ? {
@@ -595,6 +622,7 @@ export class AcApMarkupPresenter {
                       end: { ...live.end }
                     }
               )
+              if (updated) getMarkupPresenter().publish(view2d, updated)
             }
           )
         }
@@ -603,22 +631,22 @@ export class AcApMarkupPresenter {
             bindMarkupPointerDrag({
               view: view2d,
               el: startDot.element,
-              onDragStart: () => selectMarkupGroup(view2d, record.id),
+              onDragStart: beginEndpointDrag,
               onMove: point => {
                 live.start = point
-                startDot.setPosition(point)
-                refreshEndpoints()
+                placeMarkupHtml(view2d, startDot, point)
+                redrawStroke()
               },
               onCommit: commitEndpoints
             }),
             bindMarkupPointerDrag({
               view: view2d,
               el: endDot.element,
-              onDragStart: () => selectMarkupGroup(view2d, record.id),
+              onDragStart: beginEndpointDrag,
               onMove: point => {
                 live.end = point
-                endDot.setPosition(point)
-                refreshEndpoints()
+                placeMarkupHtml(view2d, endDot, point)
+                redrawStroke()
               },
               onCommit: commitEndpoints
             })
@@ -887,7 +915,7 @@ export class AcApMarkupPresenter {
         )
 
         const syncCenter = () => {
-          centerDot.setPosition({
+          placeMarkupHtml(view2d, centerDot, {
             x: (live.tip.x + live.anchor.x) / 2,
             y: (live.tip.y + live.anchor.y) / 2
           })
@@ -907,11 +935,12 @@ export class AcApMarkupPresenter {
               },
               onCommit: next => {
                 runMarkupEdit(view2d, 'Move Callout', () => {
-                  getMarkupStore().updateGeometry(record.id, {
+                  const updated = getMarkupStore().updateGeometry(record.id, {
                     type: 'callout',
                     tip: next.tip,
                     anchor: next.anchor
                   })
+                  if (updated) getMarkupPresenter().publish(view2d, updated)
                 })
               }
             }),

--- a/packages/three-renderer/src/html/AcTrHtmlElement.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlElement.ts
@@ -111,6 +111,7 @@ export class AcTrHtmlElement {
     )
     this.object.matrixAutoUpdate = true
     this.object.updateMatrix()
+    this.object.updateMatrixWorld(true)
     // Re-anchor view scale so the next zoom is relative to this placement.
     this.baseZoom = undefined
   }


### PR DESCRIPTION
## Summary
- Bind markup grip `pointermove` / `pointerup` on `window` instead of the handle (and drop `setPointerCapture`), so a second drag still tracks after CSS2D repositions the overlay under the cursor.
- Keep HTML transient world positions and matrices in sync during drag (`updatePosition` + `updateMatrixWorld`), and preview line/arrow endpoint edits on a canvas overlay while the CAD stroke is hidden.
- Skip canvas buffer reallocations when the overlay size has not changed, and cover the second-drag regression with a jsdom test.

## Test plan
- [ ] Drag a callout tip/bubble twice in a row (including far across the view) and confirm the second drag still follows the pointer.
- [ ] Drag line and arrow endpoints; the stroke should preview live and commit on pointer up without a stuck hidden CAD entity.
- [ ] Drag a cloud/rect/circle center handle and confirm the shape and attached callout move together.
- [ ] Double-click callout text still enters inline edit (drag threshold is unchanged).
- [ ] `pnpm test -- packages/cad-simple-viewer/__tests__/AcApMarkupCalloutDrag.spec.ts`