### PR TITLE
fix: skip WebGL redraw for HTML overlay-only updates

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementHistory.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementHistory.spec.ts
@@ -61,6 +61,7 @@ function createView() {
   const view = {
     htmlTransientManager: manager,
     isDirty: false,
+    isHtmlDirty: false,
     removeTransientEntity: jest.fn(),
     addTransientEntity: jest.fn(),
     highlight: jest.fn(),

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementVisibility.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementVisibility.spec.ts
@@ -29,6 +29,7 @@ function createView(groups: AcTrHtmlGroup[], layoutId: string) {
   const view = {
     activeLayoutBtrId: layoutId,
     isDirty: false,
+    isHtmlDirty: false,
     htmlTransientManager: {
       groupsOnLayer(layer: string) {
         return groups.filter(group => group.layer === layer)
@@ -60,7 +61,8 @@ describe('AcApMeasurementVisibility', () => {
     expect(unscoped.setVisible).toHaveBeenCalledWith(false)
     expect(other.setVisible).not.toHaveBeenCalled()
     expect(setVisible).toHaveBeenCalledWith(false, MEASUREMENT_LIVE_LAYER)
-    expect(view.isDirty).toBe(true)
+    expect(view.isDirty).toBe(false)
+    expect(view.isHtmlDirty).toBe(true)
   })
 
   it('shows measurements on the active layout without revealing other layouts', () => {

--- a/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdMTextEditor.spec.ts
@@ -171,7 +171,8 @@ function createView() {
         removeEventListener: jest.fn()
       }
     },
-    isDirty: false
+    isDirty: false,
+    isHtmlDirty: false
   }
 }
 

--- a/packages/cad-simple-viewer/__tests__/AcEdReviewOverlayPick.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdReviewOverlayPick.spec.ts
@@ -26,6 +26,7 @@ function mockView(ht: {
     selectionBoxSize: 3,
     activeLayoutBtrId: 'layout-a',
     isDirty: false,
+    isHtmlDirty: false,
     worldToScreen: (point: { x: number; y: number }) => point,
     htmlTransientManager: {
       getGroup: () => ({ id: 'line-1', visible: true }),
@@ -54,6 +55,7 @@ describe('trySelectReviewOverlay', () => {
     expect(selectGroup).not.toHaveBeenCalled()
     expect(deselectGroup).not.toHaveBeenCalled()
     expect(view.isDirty).toBe(false)
+    expect(view.isHtmlDirty).toBe(false)
   })
 
   it('consumes an additive hit only when the overlay is newly selected', () => {
@@ -62,12 +64,13 @@ describe('trySelectReviewOverlay', () => {
 
     expect(trySelectReviewOverlay(view, 50, 0, 'add')).toBe(true)
     expect(selectGroup).toHaveBeenCalledWith('line-1', false)
-    expect(view.isDirty).toBe(true)
+    expect(view.isDirty).toBe(false)
+    expect(view.isHtmlDirty).toBe(true)
 
     selectGroup.mockReturnValue(false)
-    view.isDirty = false
+    view.isHtmlDirty = false
     expect(trySelectReviewOverlay(view, 50, 0, 'add')).toBe(false)
-    expect(view.isDirty).toBe(false)
+    expect(view.isHtmlDirty).toBe(false)
   })
 
   it('lets Shift-remove fall through when the overlay was not selected', () => {
@@ -77,6 +80,7 @@ describe('trySelectReviewOverlay', () => {
     expect(trySelectReviewOverlay(view, 50, 0, 'remove')).toBe(false)
     expect(deselectGroup).toHaveBeenCalledWith('line-1')
     expect(view.isDirty).toBe(false)
+    expect(view.isHtmlDirty).toBe(false)
   })
 
   it('consumes Shift-remove when the overlay is deselected', () => {
@@ -84,7 +88,8 @@ describe('trySelectReviewOverlay', () => {
     const view = mockView({ selectGroup: jest.fn(), deselectGroup })
 
     expect(trySelectReviewOverlay(view, 50, 0, 'remove')).toBe(true)
-    expect(view.isDirty).toBe(true)
+    expect(view.isDirty).toBe(false)
+    expect(view.isHtmlDirty).toBe(true)
   })
 
   it('always consumes a replace click on a hit overlay', () => {
@@ -93,6 +98,7 @@ describe('trySelectReviewOverlay', () => {
 
     expect(trySelectReviewOverlay(view, 50, 0, 'replace')).toBe(true)
     expect(selectGroup).toHaveBeenCalledWith('line-1', true)
-    expect(view.isDirty).toBe(true)
+    expect(view.isDirty).toBe(false)
+    expect(view.isHtmlDirty).toBe(true)
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdViewKeyHandler.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdViewKeyHandler.spec.ts
@@ -50,7 +50,8 @@ function createMockView(
       groupsOnLayer: jest.fn(() => []),
       has: jest.fn(() => false)
     },
-    isDirty: false
+    isDirty: false,
+    isHtmlDirty: false
   } as unknown as AcTrView2d
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
@@ -163,7 +163,7 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
       this.applyCurrentStyle()
     )
 
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 
   get entity(): AcDbLine {
@@ -178,13 +178,13 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._bubble.setPosition(this._anchor)
     this._bubble.setFontSize(getMarkupFontSize())
     this.paintArrow()
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 
   override render(): void {
     super.render()
     this.paintArrow()
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 
   /** Capsule used for in-place text entry after the bubble is placed. */
@@ -212,7 +212,7 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._ht.remove(this._tipDotId)
     this._ht.remove(this._bubbleId)
     this._ht.remove(this._canvasId)
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 
   /** Apply session draw style to the frozen preview (including during text entry). */
@@ -227,7 +227,7 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._bubble.setColor(color)
     this._bubble.setFontSize(getMarkupFontSize())
     this.paintArrow()
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 
   private paintArrow(): void {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutDrag.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutDrag.ts
@@ -31,6 +31,15 @@ export function pointerEventToMarkupWorld(
   return { x: world.x, y: world.y }
 }
 
+/** Move a published HTML overlay and refresh its transform baseline. */
+export function placeMarkupHtml(
+  view: AcTrView2d,
+  el: AcTrHtmlElement,
+  point: AcApMarkupPoint2d
+): void {
+  view.htmlTransientManager.updatePosition(el.id, point)
+}
+
 const DRAG_THRESHOLD_PX = 4
 
 const windowListenerOptions: AddEventListenerOptions = {
@@ -115,7 +124,7 @@ export function bindMarkupPointerDrag(options: {
         onDragStart?.()
       }
       onMove(pointerEventToMarkupWorld(view, ev), ev)
-      view.isDirty = true
+      view.isHtmlDirty = true
     }
 
     const onPointerUp = (ev: PointerEvent) => {
@@ -177,8 +186,7 @@ export function bindMarkupCalloutGrips(options: {
     onDragStart,
     onMove: point => {
       state.tip = outline ? computeLeaderTipOnShape(outline, point) : point
-      view.htmlTransientManager.updatePosition(tipEl.id, state.tip)
-      tipEl.setPosition(state.tip)
+      placeMarkupHtml(view, tipEl, state.tip)
       onLiveChange()
     },
     onCommit: () => {
@@ -192,8 +200,7 @@ export function bindMarkupCalloutGrips(options: {
     onDragStart,
     onMove: point => {
       state.anchor = point
-      view.htmlTransientManager.updatePosition(bubbleEl.id, state.anchor)
-      bubbleEl.setPosition(state.anchor)
+      placeMarkupHtml(view, bubbleEl, state.anchor)
       onLiveChange()
     },
     onCommit: () => {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
@@ -25,7 +25,8 @@ import { acapNotifyUndoStackChanged } from '../../util/AcApDatabaseEdit'
 import type { AcTrView2d } from '../../view'
 import {
   bindMarkupCalloutGrips,
-  bindMarkupPointerDrag
+  bindMarkupPointerDrag,
+  placeMarkupHtml
 } from './AcApMarkupCalloutDrag'
 import {
   markupGeometryCenter,
@@ -374,15 +375,6 @@ function publishAttachedCallout(
   )
 
   return { live, redraw, tipDot, bubble }
-}
-
-function placeMarkupHtml(
-  view: AcTrView2d,
-  el: AcTrHtmlElement,
-  point: AcApMarkupPoint2d
-): void {
-  view.htmlTransientManager.updatePosition(el.id, point)
-  el.setPosition(point)
 }
 
 function bindMarkupCenterMove(options: {
@@ -1024,7 +1016,7 @@ export class AcApMarkupPresenter {
 
     view2d.htmlTransientManager.add(group)
     for (const bind of pendingGrips) bind()
-    view2d.isDirty = true
+    view2d.isHtmlDirty = true
     this.published.add(record.id)
 
     // Preserve selection across republish (style / label / geometry edits).
@@ -1069,7 +1061,7 @@ export class AcApMarkupPresenter {
     } finally {
       this.suppressingStoreRemove = false
     }
-    view2d.isDirty = true
+    view2d.isHtmlDirty = true
   }
 
   /** Clear all markup visuals (and optionally store records). */
@@ -1100,7 +1092,7 @@ export class AcApMarkupPresenter {
       for (const id of ids) {
         this.unpublish(view, id, { keepInStore: !shouldClearStore })
       }
-      asView2d(view).isDirty = true
+      asView2d(view).isHtmlDirty = true
     }
     if (shouldClearStore && !getMarkupHistory().isBusy) {
       runMarkupEdit(view, 'Clear Markups', apply)
@@ -1126,7 +1118,7 @@ export class AcApMarkupPresenter {
     if (shouldClearStore) {
       getMarkupStore().clear({ markDirty: true })
     }
-    view2d.isDirty = true
+    view2d.isHtmlDirty = true
   }
 
   /** Drop published-id tracking after the view/scene was discarded. */

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeCallout.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeCallout.ts
@@ -268,7 +268,7 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._unsubDrawStyle = subscribeMarkupDrawStyle(() =>
       this.applyCurrentStyle()
     )
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 
   get entity(): AcDbLine {
@@ -283,7 +283,7 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
 
     this._tipDot.setPosition(this._tip)
     this._bubble.setPosition(toward)
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 
   /** Capsule used for in-place text entry after the bubble is placed. */
@@ -307,7 +307,7 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._view.removeTransientEntity(this._shape.objectId)
     this._ht.remove(this._tipDotId)
     this._ht.remove(this._bubbleId)
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 
   /** Apply session draw style to the frozen preview (including during text entry). */
@@ -324,7 +324,7 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._tipDot.setColor(color)
     this._bubble.setColor(color)
     this._bubble.setFontSize(getMarkupFontSize())
-    this._view.isDirty = true
+    this._view.isHtmlDirty = true
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupTextCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupTextCmd.ts
@@ -49,7 +49,7 @@ export class AcApMarkupTextCmd extends AcEdCommand {
         layoutId: view.activeLayoutBtrId
       })
       view.htmlTransientManager.add(badge)
-      view.isDirty = true
+      view.isHtmlDirty = true
 
       let text = 'Note'
       try {
@@ -60,7 +60,7 @@ export class AcApMarkupTextCmd extends AcEdCommand {
           )) || 'Note'
       } finally {
         view.htmlTransientManager.remove(badgeId)
-        view.isDirty = true
+        view.isHtmlDirty = true
       }
 
       const meta = createMarkupMeta('text', view, context, { text })

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupVisibilityCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupVisibilityCmd.ts
@@ -18,7 +18,7 @@ export function setMarkupVisible(view: AcTrView2d, visible: boolean): void {
   markupVisible = visible
   view.htmlTransientManager.setVisible(visible, MARKUP_LAYER)
   view.htmlTransientManager.setVisible(visible, MARKUP_LIVE_LAYER)
-  view.isDirty = true
+  view.isHtmlDirty = true
 }
 
 /**

--- a/packages/cad-simple-viewer/src/command/measure/AcApClearMeasurementsCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApClearMeasurementsCmd.ts
@@ -30,7 +30,7 @@ export function clearLayoutMeasurements(view: AcTrView2d): void {
     }
   })
   ht.clear(MEASUREMENT_LIVE_LAYER)
-  view.isDirty = true
+  view.isHtmlDirty = true
 }
 
 /**

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementHistory.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementHistory.ts
@@ -199,7 +199,7 @@ export class AcApMeasurementHistory {
         const style = styles[group.id]
         if (style) applyMeasurementStyle(entry.view, group, style)
       }
-      entry.view.isDirty = true
+      entry.view.isHtmlDirty = true
     } finally {
       this.depth--
     }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -53,7 +53,7 @@ export function setMeasurementVisible(
     }
   }
   ht.setVisible(visible, MEASUREMENT_LIVE_LAYER)
-  view.isDirty = true
+  view.isHtmlDirty = true
 }
 
 /**
@@ -195,7 +195,7 @@ function paintMeasurementGroup(
     view.highlight(extras!.entityIds!)
   }
   extras?.redraw?.(style)
-  view.isDirty = true
+  view.isHtmlDirty = true
 }
 
 /**
@@ -214,7 +214,7 @@ export function refreshMeasurementValueLabels(
       badge.setText?.(text)
     }
   }
-  view.isDirty = true
+  view.isHtmlDirty = true
 }
 
 /** Serializable snapshots of committed measurements currently on the view. */
@@ -316,7 +316,7 @@ export function commitMeasurementGroup(
   ) {
     group.setVisible(false)
   }
-  view.isDirty = true
+  view.isHtmlDirty = true
 }
 
 /**

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMTextEditor.ts
@@ -491,7 +491,7 @@ export class AcEdMTextEditor {
       const onRenderFrame = () => {
         if (done) return
         mtextInputBox.update()
-        view.isDirty = true
+        view.isHtmlDirty = true
       }
 
       const onSysVarChanged = (args: { name: string; database: unknown }) => {
@@ -502,7 +502,7 @@ export class AcEdMTextEditor {
           return
         }
         mtextInputBox.setToolbarTheme(getToolbarTheme())
-        view.isDirty = true
+        view.isHtmlDirty = true
       }
 
       const cleanup = () => {
@@ -517,7 +517,7 @@ export class AcEdMTextEditor {
         AcDbSysVarManager.instance().events.sysVarChanged.removeEventListener(
           onSysVarChanged
         )
-        view.isDirty = true
+        view.isHtmlDirty = true
       }
 
       const finish = (result: AcEdMTextEditorResult | null) => {

--- a/packages/cad-simple-viewer/src/view/AcEdReviewOverlayPick.ts
+++ b/packages/cad-simple-viewer/src/view/AcEdReviewOverlayPick.ts
@@ -78,6 +78,6 @@ export function trySelectReviewOverlay(
   const id = markupId ?? measurementId
   if (!id) return false
   const consumed = applyOverlaySelection(view, id, action)
-  if (consumed) view.isDirty = true
+  if (consumed) view.isHtmlDirty = true
   return consumed
 }

--- a/packages/cad-simple-viewer/src/view/AcEdViewKeyHandler.ts
+++ b/packages/cad-simple-viewer/src/view/AcEdViewKeyHandler.ts
@@ -58,7 +58,7 @@ export class AcEdViewKeyHandler {
       case 'Escape':
         this.view.selectionSet.clear()
         this.view.htmlTransientManager.deselectAll()
-        this.view.isDirty = true
+        this.view.isHtmlDirty = true
         return false
 
       case 'Delete':
@@ -92,7 +92,7 @@ export class AcEdViewKeyHandler {
             }
           }
           if (removed) {
-            this.view.isDirty = true
+            this.view.isHtmlDirty = true
             e.preventDefault()
             return true
           }

--- a/packages/cad-simple-viewer/src/view/AcTrScene.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrScene.ts
@@ -464,17 +464,21 @@ export class AcTrScene {
    *
    * Also forwards matching ids to {@link AcTrHtmlTransientManager} so HTML
    * overlays receive the same delta as WebGL transients.
+   *
+   * @returns Which renderer layers actually changed, so the view can dirty
+   *   WebGL and CSS2D independently.
    */
   updateTransientPreviewTransforms(
     transforms: ReadonlyArray<{ objectId: AcDbObjectId; matrix: THREE.Matrix4 }>
-  ): boolean {
+  ): { webgl: boolean; html: boolean } {
     const mapped = transforms.map(entry => ({
       id: entry.objectId,
       matrix: entry.matrix
     }))
-    const webglUpdated = this._transientManager.applyTransforms(mapped)
-    const htmlUpdated = this._htmlTransientManager.applyTransforms(mapped)
-    return webglUpdated || htmlUpdated
+    return {
+      webgl: this._transientManager.applyTransforms(mapped),
+      html: this._htmlTransientManager.applyTransforms(mapped)
+    }
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -147,8 +147,10 @@ export class AcTrView2d extends AcEdBaseView {
   private _layoutViewManager: AcTrLayoutViewManager
   /** The 3D scene containing all CAD entities organized by layouts and layers */
   private _scene: AcTrScene
-  /** Flag indicating if the view needs to be re-rendered */
+  /** Flag indicating if the WebGL scene needs to be re-rendered */
   private _isDirty: boolean
+  /** Flag indicating if CSS2D / HTML overlays need a CSS2DRenderer pass */
+  private _htmlDirty: boolean
   /** Performance monitoring statistics display */
   private _stats: Stats
   /** Map of missing raster images during rendering */
@@ -540,6 +542,7 @@ export class AcTrView2d extends AcEdBaseView {
     this.initialize()
     this.onWindowResize()
     this._isDirty = true
+    this._htmlDirty = false
     this.startAnimationLoop()
     this._numOfEntitiesToProcess = 0
     this._pendingGeometryJobs = 0
@@ -598,9 +601,13 @@ export class AcTrView2d extends AcEdBaseView {
   }
 
   /**
-   * Gets whether the view needs to be re-rendered.
+   * Gets whether the WebGL scene needs to be re-rendered.
    *
-   * @returns True if the view is dirty and needs re-rendering
+   * Camera, CAD entities, and WebGL transients set this flag. CSS2D / HTML
+   * overlay mutations should use {@link isHtmlDirty} instead so a badge or
+   * markup DOM change does not clear and redraw the drawing.
+   *
+   * @returns True if the WebGL view is dirty and needs re-rendering
    */
   get isDirty() {
     return this._isDirty
@@ -693,12 +700,37 @@ export class AcTrView2d extends AcEdBaseView {
   }
 
   /**
-   * Sets whether the view needs to be re-rendered.
+   * Sets whether the WebGL scene needs to be re-rendered.
    *
-   * @param value - True to mark the view as needing re-rendering
+   * When true, the animation loop also runs CSS2DRenderer so HTML
+   * overlays reproject after pan / zoom. HTML-only changes should set
+   * {@link isHtmlDirty} instead.
+   *
+   * @param value - True to mark the WebGL view as needing re-rendering
    */
   set isDirty(value: boolean) {
     this._isDirty = value
+  }
+
+  /**
+   * Gets whether CSS2D / HTML overlays need a CSS2DRenderer pass.
+   *
+   * @returns True if HTML overlays changed without a WebGL scene change
+   */
+  get isHtmlDirty() {
+    return this._htmlDirty
+  }
+
+  /**
+   * Sets whether CSS2D / HTML overlays need a CSS2DRenderer pass.
+   *
+   * Does not force a WebGL redraw. Camera changes still go through
+   * {@link isDirty}, which also refreshes overlay projection.
+   *
+   * @param value - True to mark HTML overlays as needing a CSS2D pass
+   */
+  set isHtmlDirty(value: boolean) {
+    this._htmlDirty = value
   }
 
   /**
@@ -1589,16 +1621,14 @@ export class AcTrView2d extends AcEdBaseView {
       matrix: AcGeMatrix3d
     }>
   ): void {
-    if (
-      this._scene.updateTransientPreviewTransforms(
-        transforms.map(entry => ({
-          objectId: entry.objectId,
-          matrix: AcTrMatrixUtil.createMatrix4(entry.matrix)
-        }))
-      )
-    ) {
-      this._isDirty = true
-    }
+    const updated = this._scene.updateTransientPreviewTransforms(
+      transforms.map(entry => ({
+        objectId: entry.objectId,
+        matrix: AcTrMatrixUtil.createMatrix4(entry.matrix)
+      }))
+    )
+    if (updated.webgl) this._isDirty = true
+    if (updated.html) this._htmlDirty = true
   }
 
   /**
@@ -1997,15 +2027,21 @@ export class AcTrView2d extends AcEdBaseView {
 
     const stillLoading = this._numOfEntitiesToProcess > 0
     const deferRenderWhileLoading = stillLoading && !this._progressiveRendering
-    if (!this._isDirty && !stillLoading) return
+    if (!this._isDirty && !this._htmlDirty && !stillLoading) return
     if (deferRenderWhileLoading) return
-    if (!this._isDirty) return
+    if (!this._isDirty && !this._htmlDirty) return
 
-    if (this._progressiveRendering && stillLoading) {
-      this._progressivePaintCount++
+    let needsRedraw = false
+    if (this._isDirty) {
+      if (this._progressiveRendering && stillLoading) {
+        this._progressivePaintCount++
+      }
+      needsRedraw = this._layoutViewManager.render(this._scene)
     }
-    const needsRedraw = this._layoutViewManager.render(this._scene)
-    if (this.internalCamera) {
+    // Camera / WebGL dirty also reprojects CSS2D overlays. HTML-only dirty
+    // skips the WebGL pass so measurement badges and markup DOM can update
+    // without clearing and redrawing the drawing.
+    if (this.internalCamera && (this._isDirty || this._htmlDirty)) {
       this._css2dRenderer.render(this._scene.internalScene, this.internalCamera)
     }
     this._stats?.update()
@@ -2013,6 +2049,7 @@ export class AcTrView2d extends AcEdBaseView {
     // from geometry batches to keep total open time down. Counter hitting 0
     // still forces a final dirty in decreaseNumOfEntitiesToProcess().
     this._isDirty = needsRedraw
+    this._htmlDirty = false
   }
 
   private startAnimationLoop() {
@@ -2755,7 +2792,8 @@ export class AcTrView2d extends AcEdBaseView {
     } else if (this._numOfEntitiesToProcess === 0) {
       // Always mark dirty when the queue drains. Progressive open throttles
       // mid-open paints, so the last batch would otherwise never redraw until
-      // the user pans/zooms (animate bails when !_isDirty && !stillLoading).
+      // the user pans/zooms (animate bails when !_isDirty && !_htmlDirty &&
+      // !stillLoading).
       this._isDirty = true
     }
   }


### PR DESCRIPTION
## Summary
- Split view dirty tracking so WebGL (`isDirty`) and CSS2D/HTML overlays (`isHtmlDirty`) can refresh independently.
- Markup, measurement, MText, and overlay selection paths now mark HTML-only changes without clearing and redrawing the CAD scene.
- Transient preview transforms report WebGL vs HTML updates separately so mixed markup drags still dirty the right renderer.

## Test plan
- [ ] Pan/zoom a drawing and confirm CAD + markup/measurement overlays still reproject together.
- [ ] Toggle measurement/markup visibility, select/deselect overlays, and delete with Delete/Backspace — overlays update without a full drawing flicker.
- [ ] Drag a callout bubble/tip and a shape-attached callout; leader and CAD transients stay in sync.
- [ ] Edit MText in place and confirm the drawing is not fully redrawn on every keystroke.
- [ ] Escape clears CAD selection highlights and overlay selection together.