### PR TITLE
refactor: draw markup and measure overlays on HTML canvas only

### DIFF
--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupArrowCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupArrowCmd.ts
@@ -1,8 +1,4 @@
-import {
-  AcCmColor,
-  AcDbLine,
-  AcGePoint3dLike
-} from '@mlightcad/data-model'
+import { AcCmColor, AcGePoint3dLike } from '@mlightcad/data-model'
 
 import { AcApContext } from '../../app'
 import {
@@ -14,36 +10,60 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
+import { AcApHtmlLivePreview, acapStrokeLiveSegment } from '../overlay'
 import {
   configureMarkupCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
 import { commitMarkup } from './AcApMarkupPresenter'
+import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight
+  getMarkupLineWeight,
+  markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
 class AcApMarkupArrowJig extends AcEdPreviewJig<AcGePoint3dLike> {
-  private readonly _line: AcDbLine
+  private readonly _view: AcTrView2d
+  private readonly _p1: AcGePoint3dLike
+  private readonly _preview: AcApHtmlLivePreview
+  private _color: AcCmColor
+  private _p2: AcGePoint3dLike
 
   constructor(view: AcEdBaseView, p1: AcGePoint3dLike, color: AcCmColor) {
     super(view)
-    this._line = new AcDbLine(p1, p1)
-    this._line.color = color
-    this._line.lineWeight = getMarkupLineWeight()
+    this._view = view as AcTrView2d
+    this._p1 = p1
+    this._p2 = p1
+    this._color = color
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-markup-arrow-${Date.now()}`,
+      MARKUP_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbLine {
-    return this._line
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(p2: AcGePoint3dLike) {
-    this._line.endPoint = p2
-    this._line.color = defaultMarkupColor()
-    this._line.lineWeight = getMarkupLineWeight()
+    this._p2 = p2
+    this._color = defaultMarkupColor()
+    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    this._preview.acapSetDraw((ctx, view) => {
+      acapStrokeLiveSegment(ctx, view, this._p1, this._p2, this._color, lineWidth, {
+        arrow: true
+      })
+    })
+  }
+
+  end() {
+    super.end()
+    this._preview.acapDispose()
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupArrowCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupArrowCmd.ts
@@ -10,7 +10,10 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
-import { AcApHtmlLivePreview, acapStrokeLiveSegment } from '../overlay'
+import {
+  AcApHtmlLivePreview,
+  acapStrokeLiveSegment
+} from '../overlay/AcApHtmlLivePreview'
 import {
   configureMarkupCommand,
   createMarkupMeta,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
@@ -19,7 +19,10 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
-import { AcApHtmlLivePreview, acapStrokeLiveSegment } from '../overlay'
+import {
+  AcApHtmlLivePreview,
+  acapStrokeLiveSegment
+} from '../overlay/AcApHtmlLivePreview'
 import {
   configureMarkupCommand,
   createMarkupMeta,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
@@ -1,12 +1,10 @@
 import {
   AcCmColor,
-  AcDbLine,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
   AcTrHtmlCallout,
-  AcTrHtmlCanvasOverlay,
   AcTrHtmlDot,
   AcTrHtmlTransientManager
 } from '@mlightcad/three-renderer'
@@ -21,6 +19,7 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
+import { AcApHtmlLivePreview, acapStrokeLiveSegment } from '../overlay'
 import {
   configureMarkupCommand,
   createMarkupMeta,
@@ -34,57 +33,9 @@ import {
   defaultMarkupColor,
   getMarkupFontSize,
   getMarkupLineWeight,
-  markupColorToCss,
+  markupCanvasLineWidth,
   subscribeMarkupDrawStyle
 } from './AcApMarkupUtil'
-
-function fitCanvas(
-  canvas: HTMLCanvasElement,
-  container: HTMLElement
-): CanvasRenderingContext2D | null {
-  const rect = container.getBoundingClientRect()
-  const dpr = window.devicePixelRatio || 1
-  canvas.style.left = '0'
-  canvas.style.top = '0'
-  canvas.style.width = `${rect.width}px`
-  canvas.style.height = `${rect.height}px`
-  canvas.width = Math.max(1, Math.floor(rect.width * dpr))
-  canvas.height = Math.max(1, Math.floor(rect.height * dpr))
-  const ctx = canvas.getContext('2d')
-  if (!ctx) return null
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-  ctx.clearRect(0, 0, rect.width, rect.height)
-  return ctx
-}
-
-function drawArrowHead(
-  ctx: CanvasRenderingContext2D,
-  from: { x: number; y: number },
-  to: { x: number; y: number },
-  color: string
-): void {
-  const dx = to.x - from.x
-  const dy = to.y - from.y
-  const len = Math.hypot(dx, dy) || 1
-  const ux = dx / len
-  const uy = dy / len
-  const size = 12
-  const left = {
-    x: to.x - ux * size - uy * size * 0.45,
-    y: to.y - uy * size + ux * size * 0.45
-  }
-  const right = {
-    x: to.x - ux * size + uy * size * 0.45,
-    y: to.y - uy * size - ux * size * 0.45
-  }
-  ctx.fillStyle = color
-  ctx.beginPath()
-  ctx.moveTo(to.x, to.y)
-  ctx.lineTo(left.x, left.y)
-  ctx.lineTo(right.x, right.y)
-  ctx.closePath()
-  ctx.fill()
-}
 
 /**
  * Live preview while placing a callout text bubble:
@@ -92,18 +43,15 @@ function drawArrowHead(
  */
 class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
   private readonly _tip: AcGePoint3dLike
-  private readonly _line: AcDbLine
   private readonly _view: AcTrView2d
   private readonly _ht: AcTrHtmlTransientManager
   private readonly _tipDot: AcTrHtmlDot
   private readonly _bubble: AcTrHtmlCallout
-  private readonly _overlay: AcTrHtmlCanvasOverlay
+  private readonly _preview: AcApHtmlLivePreview
   private readonly _tipDotId: string
   private readonly _bubbleId: string
-  private readonly _canvasId: string
-  private _colorCss: string
+  private _color: AcCmColor
   private _anchor: AcGePoint3dLike
-  private _onViewChanged?: () => void
   private _unsubDrawStyle?: () => void
 
   constructor(
@@ -116,18 +64,13 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._view = view as AcTrView2d
     this._tip = { x: tip.x, y: tip.y, z: tip.z ?? 0 }
     this._anchor = { ...this._tip }
-    this._colorCss = markupColorToCss(color)
+    this._color = color
     this._ht = this._view.htmlTransientManager
-
-    this._line = new AcDbLine(this._tip, this._tip)
-    this._line.color = color
-    this._line.lineWeight = getMarkupLineWeight()
 
     const layoutId = this._view.activeLayoutBtrId
     const stamp = Date.now()
     this._tipDotId = `live-markup-callout-tip-${stamp}`
     this._bubbleId = `live-markup-callout-bubble-${stamp}`
-    this._canvasId = `live-markup-callout-canvas-${stamp}`
 
     this._tipDot = new AcTrHtmlDot({
       id: this._tipDotId,
@@ -149,16 +92,12 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     })
     this._ht.add(this._bubble)
 
-    this._overlay = new AcTrHtmlCanvasOverlay({
-      id: this._canvasId,
-      container: this._view.container,
-      layer: MARKUP_LIVE_LAYER,
-      layoutId
-    })
-    this._ht.add(this._overlay)
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-markup-callout-leader-${stamp}`,
+      MARKUP_LIVE_LAYER
+    )
 
-    this._onViewChanged = () => this.paintArrow()
-    this._view.events.viewChanged.addEventListener(this._onViewChanged)
     this._unsubDrawStyle = subscribeMarkupDrawStyle(() =>
       this.applyCurrentStyle()
     )
@@ -166,24 +105,17 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._view.isHtmlDirty = true
   }
 
-  get entity(): AcDbLine {
-    return this._line
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(anchor: AcGePoint3dLike) {
     this._anchor = { x: anchor.x, y: anchor.y, z: anchor.z ?? 0 }
-    this._line.endPoint = this._anchor
-    this._line.color = defaultMarkupColor()
-    this._line.lineWeight = getMarkupLineWeight()
+    this._color = defaultMarkupColor()
     this._bubble.setPosition(this._anchor)
     this._bubble.setFontSize(getMarkupFontSize())
-    this.paintArrow()
-    this._view.isHtmlDirty = true
-  }
-
-  override render(): void {
-    super.render()
-    this.paintArrow()
+    this.paintLeader()
     this._view.isHtmlDirty = true
   }
 
@@ -197,46 +129,40 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
    * types callout text; {@link disposePreview} cleans up afterwards.
    */
   end() {
-    // Intentionally do not remove the line / HTML overlays.
+    // Intentionally do not remove the HTML overlays.
   }
 
   /** Remove frozen preview graphics after text entry (or cancel). */
   disposePreview() {
     this._unsubDrawStyle?.()
     this._unsubDrawStyle = undefined
-    this._view.removeTransientEntity(this._line.objectId)
-    if (this._onViewChanged) {
-      this._view.events.viewChanged.removeEventListener(this._onViewChanged)
-      this._onViewChanged = undefined
-    }
+    this._preview.acapDispose()
     this._ht.remove(this._tipDotId)
     this._ht.remove(this._bubbleId)
-    this._ht.remove(this._canvasId)
     this._view.isHtmlDirty = true
   }
 
   /** Apply session draw style to the frozen preview (including during text entry). */
   private applyCurrentStyle(): void {
-    const color = defaultMarkupColor()
-    this._colorCss = markupColorToCss(color)
-    this._line.color = color
-    this._line.lineWeight = getMarkupLineWeight()
-    this._view.removeTransientEntity(this._line.objectId)
-    this._view.addTransientEntity(this._line)
-    this._tipDot.setColor(color)
-    this._bubble.setColor(color)
+    this._color = defaultMarkupColor()
+    this._tipDot.setColor(this._color)
+    this._bubble.setColor(this._color)
     this._bubble.setFontSize(getMarkupFontSize())
-    this.paintArrow()
+    this.paintLeader()
     this._view.isHtmlDirty = true
   }
 
-  private paintArrow(): void {
-    const ctx = fitCanvas(this._overlay.canvas, this._view.container)
-    if (!ctx) return
-    const tipScreen = this._view.worldToScreen(this._tip)
-    const anchorScreen = this._view.worldToScreen(this._anchor)
-    // CAD transient line draws the shaft; canvas only adds the arrowhead.
-    drawArrowHead(ctx, anchorScreen, tipScreen, this._colorCss)
+  private paintLeader(): void {
+    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const color = this._color
+    const tip = this._tip
+    const anchor = this._anchor
+    this._preview.acapSetDraw((ctx, view) => {
+      // Arrow at tip (leader begins at tip, bubble at anchor).
+      acapStrokeLiveSegment(ctx, view, anchor, tip, color, lineWidth, {
+        arrow: true
+      })
+    })
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCircleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCircleCmd.ts
@@ -14,7 +14,10 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
-import { AcApHtmlLivePreview, acapStrokeLiveCircle } from '../overlay'
+import {
+  AcApHtmlLivePreview,
+  acapStrokeLiveCircle
+} from '../overlay/AcApHtmlLivePreview'
 import {
   configureMarkupCommand,
   createMarkupMeta,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCircleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCircleCmd.ts
@@ -1,6 +1,5 @@
 import {
   AcCmColor,
-  AcDbCircle,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
@@ -15,6 +14,7 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
+import { AcApHtmlLivePreview, acapStrokeLiveCircle } from '../overlay'
 import {
   configureMarkupCommand,
   createMarkupMeta,
@@ -25,30 +25,57 @@ import {
   promptAttachedCallout,
   promptShapeFirstCorner
 } from './AcApMarkupShapeCallout'
+import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight
+  getMarkupLineWeight,
+  markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
 class AcApMarkupCircleJig extends AcEdPreviewJig<number> {
-  private readonly _circle: AcDbCircle
+  private readonly _view: AcTrView2d
+  private readonly _center: AcGePoint3dLike
+  private readonly _preview: AcApHtmlLivePreview
+  private _color: AcCmColor
+  private _radius = 0
 
   constructor(view: AcEdBaseView, center: AcGePoint3dLike, color: AcCmColor) {
     super(view)
-    this._circle = new AcDbCircle(center, 0)
-    this._circle.color = color
-    this._circle.lineWeight = getMarkupLineWeight()
+    this._view = view as AcTrView2d
+    this._center = center
+    this._color = color
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-markup-circle-${Date.now()}`,
+      MARKUP_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbCircle {
-    return this._circle
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(radius: number) {
-    this._circle.color = defaultMarkupColor()
-    this._circle.lineWeight = getMarkupLineWeight()
-    this._circle.radius = Math.max(radius, 0)
+    this._radius = Math.max(radius, 0)
+    this._color = defaultMarkupColor()
+    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    this._preview.acapSetDraw((ctx, view) => {
+      acapStrokeLiveCircle(
+        ctx,
+        view,
+        this._center,
+        this._radius,
+        this._color,
+        lineWidth
+      )
+    })
+  }
+
+  end() {
+    super.end()
+    this._preview.acapDispose()
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCloudCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCloudCmd.ts
@@ -1,6 +1,5 @@
 import {
   AcCmColor,
-  AcDbPolyline,
   AcGePoint2dLike
 } from '@mlightcad/data-model'
 
@@ -15,46 +14,81 @@ import {
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
 import {
+  type AcApHtmlLivePoint,
+  AcApHtmlLivePreview,
+  acapStrokeLivePolyline
+} from '../overlay'
+import {
   configureMarkupCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
+import { commitMarkup } from './AcApMarkupPresenter'
 import {
-  buildMarkupCloud,
-  commitMarkup
-} from './AcApMarkupPresenter'
+  markupCloudVertices,
+  tessellateMarkupCloud
+} from './AcApMarkupShapeBuilder'
 import {
   promptAttachedCallout,
   promptShapeFirstCorner
 } from './AcApMarkupShapeCallout'
+import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight
+  getMarkupLineWeight,
+  markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
+/** Build tessellated cloud outline (HTML stroke; no AcDb). */
+function cloudLivePoints(
+  first: AcGePoint2dLike,
+  second: AcGePoint2dLike,
+  view: AcEdBaseView
+): AcApHtmlLivePoint[] {
+  return tessellateMarkupCloud(markupCloudVertices(first, second, view))
+}
+
 class AcApMarkupCloudJig extends AcEdPreviewJig<AcGePoint2dLike> {
-  private readonly _cloud: AcDbPolyline
+  private readonly _view: AcTrView2d
   private readonly _first: AcGePoint2dLike
-  private readonly _view: AcEdBaseView
+  private readonly _preview: AcApHtmlLivePreview
+  private _color: AcCmColor
+  private _second: AcGePoint2dLike
 
   constructor(view: AcEdBaseView, start: AcGePoint2dLike, color: AcCmColor) {
     super(view)
-    this._view = view
+    this._view = view as AcTrView2d
     this._first = start
-    this._cloud = new AcDbPolyline()
-    this._cloud.color = color
-    this._cloud.lineWeight = getMarkupLineWeight()
+    this._second = start
+    this._color = color
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-markup-cloud-${Date.now()}`,
+      MARKUP_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbPolyline {
-    return this._cloud
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(second: AcGePoint2dLike) {
-    this._cloud.color = defaultMarkupColor()
-    this._cloud.lineWeight = getMarkupLineWeight()
-    buildMarkupCloud(this._cloud, this._first, second, this._view)
+    this._second = second
+    this._color = defaultMarkupColor()
+    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const points = cloudLivePoints(this._first, this._second, this._view)
+    this._preview.acapSetDraw((ctx, view) => {
+      acapStrokeLivePolyline(ctx, view, points, this._color, lineWidth, {
+        closed: true
+      })
+    })
+  }
+
+  end() {
+    super.end()
+    this._preview.acapDispose()
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCloudCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCloudCmd.ts
@@ -17,7 +17,7 @@ import {
   type AcApHtmlLivePoint,
   AcApHtmlLivePreview,
   acapStrokeLivePolyline
-} from '../overlay'
+} from '../overlay/AcApHtmlLivePreview'
 import {
   configureMarkupCommand,
   createMarkupMeta,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCmdUtil.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCmdUtil.ts
@@ -67,10 +67,10 @@ export async function promptMarkupText(
   const prompt = new AcEdPromptStringOptions(AcApI18n.t(messageKey))
   prompt.allowEmpty = true
   prompt.allowSpaces = true
-  if (defaultValue) {
-    prompt.defaultValue = defaultValue
-    prompt.useDefaultValue = true
-  }
+  // Enter with no typing must accept the default (including empty) — floating
+  // input only commits blank Enter when useDefaultValue is true.
+  prompt.defaultValue = defaultValue
+  prompt.useDefaultValue = true
   const result = await context.view.editor.getString(prompt)
   if (result.status !== AcEdPromptStatus.OK) return undefined
   return (result.stringResult ?? defaultValue).trim()

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
@@ -11,8 +11,8 @@ import {
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
 import {
-  AcApHtmlLivePreview,
-  acapFillLiveHighlight
+  acapFillLiveHighlight,
+  AcApHtmlLivePreview
 } from '../overlay/AcApHtmlLivePreview'
 import {
   configureMarkupCommand,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
@@ -1,9 +1,4 @@
-import {
-  AcCmColor,
-  AcDbPolyline,
-  AcGePoint2d,
-  AcGePoint3dLike
-} from '@mlightcad/data-model'
+import { AcCmColor, AcGePoint3dLike } from '@mlightcad/data-model'
 
 import { AcApContext } from '../../app'
 import {
@@ -15,55 +10,66 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
+import { acapFillLiveHighlight,AcApHtmlLivePreview } from '../overlay'
 import {
   configureMarkupCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
 import { commitMarkup } from './AcApMarkupPresenter'
+import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
   getMarkupLineWeight,
+  markupCanvasLineWidth,
   markupColorToCss
 } from './AcApMarkupUtil'
 
-function setRect(
-  poly: AcDbPolyline,
-  a: AcGePoint3dLike,
-  b: AcGePoint3dLike
-): void {
-  poly.reset(false)
-  const minX = Math.min(a.x, b.x)
-  const maxX = Math.max(a.x, b.x)
-  const minY = Math.min(a.y, b.y)
-  const maxY = Math.max(a.y, b.y)
-  poly.addVertexAt(0, new AcGePoint2d(minX, minY))
-  poly.addVertexAt(1, new AcGePoint2d(maxX, minY))
-  poly.addVertexAt(2, new AcGePoint2d(maxX, maxY))
-  poly.addVertexAt(3, new AcGePoint2d(minX, maxY))
-  poly.closed = true
-}
-
 class AcApMarkupHighlightJig extends AcEdPreviewJig<AcGePoint3dLike> {
+  private readonly _view: AcTrView2d
   private readonly _first: AcGePoint3dLike
-  private readonly _poly: AcDbPolyline
+  private readonly _preview: AcApHtmlLivePreview
+  private _second: AcGePoint3dLike
+  private _colorCss: string
 
   constructor(view: AcEdBaseView, start: AcGePoint3dLike, color: AcCmColor) {
     super(view)
+    this._view = view as AcTrView2d
     this._first = start
-    this._poly = new AcDbPolyline()
-    this._poly.color = color
-    this._poly.lineWeight = getMarkupLineWeight()
-    setRect(this._poly, start, start)
+    this._second = start
+    this._colorCss = markupColorToCss(color)
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-markup-highlight-${Date.now()}`,
+      MARKUP_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbPolyline {
-    return this._poly
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(second: AcGePoint3dLike) {
-    setRect(this._poly, this._first, second)
+    this._second = second
+    this._colorCss = markupColorToCss(defaultMarkupColor())
+    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    this._preview.acapSetDraw((ctx, view) => {
+      acapFillLiveHighlight(
+        ctx,
+        view,
+        this._first,
+        this._second,
+        this._colorCss,
+        lineWidth
+      )
+    })
+  }
+
+  end() {
+    super.end()
+    this._preview.acapDispose()
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
@@ -10,7 +10,10 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
-import { acapFillLiveHighlight,AcApHtmlLivePreview } from '../overlay'
+import {
+  AcApHtmlLivePreview,
+  acapFillLiveHighlight
+} from '../overlay/AcApHtmlLivePreview'
 import {
   configureMarkupCommand,
   createMarkupMeta,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupLineCmd.ts
@@ -1,8 +1,4 @@
-import {
-  AcCmColor,
-  AcDbLine,
-  AcGePoint3dLike
-} from '@mlightcad/data-model'
+import { AcCmColor, AcGePoint3dLike } from '@mlightcad/data-model'
 import {
   AcTrHtmlBadge,
   AcTrHtmlTransientManager
@@ -18,6 +14,7 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
+import { AcApHtmlLivePreview, acapStrokeLiveSegment } from '../overlay'
 import {
   configureMarkupCommand,
   createMarkupMeta,
@@ -29,14 +26,19 @@ import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
   getMarkupLineWeight,
+  markupCanvasLineWidth,
   markupColorToCss
 } from './AcApMarkupUtil'
 
 class AcApMarkupLineJig extends AcEdPreviewJig<AcGePoint3dLike> {
-  private readonly _line: AcDbLine
+  private readonly _view: AcTrView2d
+  private readonly _p1: AcGePoint3dLike
   private readonly _ht: AcTrHtmlTransientManager
   private readonly _badge: AcTrHtmlBadge
   private readonly _badgeId: string
+  private readonly _preview: AcApHtmlLivePreview
+  private _color: AcCmColor
+  private _p2: AcGePoint3dLike
 
   constructor(
     view: AcEdBaseView,
@@ -45,10 +47,11 @@ class AcApMarkupLineJig extends AcEdPreviewJig<AcGePoint3dLike> {
     label: string
   ) {
     super(view)
-    this._line = new AcDbLine(p1, p1)
-    this._line.color = color
-    this._line.lineWeight = getMarkupLineWeight()
-    this._ht = (view as AcTrView2d).htmlTransientManager
+    this._view = view as AcTrView2d
+    this._p1 = p1
+    this._p2 = p1
+    this._color = color
+    this._ht = this._view.htmlTransientManager
     this._badgeId = `live-markup-line-${Date.now()}`
     this._badge = new AcTrHtmlBadge({
       id: this._badgeId,
@@ -56,27 +59,43 @@ class AcApMarkupLineJig extends AcEdPreviewJig<AcGePoint3dLike> {
       text: label,
       worldPosition: p1,
       layer: MARKUP_LIVE_LAYER,
-      layoutId: (view as AcTrView2d).activeLayoutBtrId
+      layoutId: this._view.activeLayoutBtrId
     })
     this._badge.object.visible = false
     this._ht.add(this._badge)
+
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-markup-line-stroke-${Date.now()}`,
+      MARKUP_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbLine {
-    return this._line
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(p2: AcGePoint3dLike) {
-    this._line.endPoint = p2
+    this._p2 = p2
+    this._color = defaultMarkupColor()
+    this._badge.setColor(this._color)
+
+    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    this._preview.acapSetDraw((ctx, view) => {
+      acapStrokeLiveSegment(ctx, view, this._p1, this._p2, this._color, lineWidth)
+    })
+
     this._badge.setPosition({
-      x: (this._line.startPoint.x + p2.x) / 2,
-      y: (this._line.startPoint.y + p2.y) / 2
+      x: (this._p1.x + p2.x) / 2,
+      y: (this._p1.y + p2.y) / 2
     })
     this._badge.object.visible = true
   }
 
   end() {
     super.end()
+    this._preview.acapDispose()
     this._ht.remove(this._badgeId)
   }
 }

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupLineCmd.ts
@@ -14,7 +14,10 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
-import { AcApHtmlLivePreview, acapStrokeLiveSegment } from '../overlay'
+import {
+  AcApHtmlLivePreview,
+  acapStrokeLiveSegment
+} from '../overlay/AcApHtmlLivePreview'
 import {
   configureMarkupCommand,
   createMarkupMeta,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
@@ -18,14 +18,21 @@ import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import { createMarkupEntityFromRecord } from './entity'
 
 // Re-export shape builders for commands / jigs that imported them from here.
-export { buildMarkupCloud, buildMarkupRect } from './AcApMarkupShapeBuilder'
+export {
+  markupCloudVertices,
+  markupRectCorners,
+  strokeMarkupCloud,
+  tessellateMarkupCloud,
+  buildMarkupCloud,
+  buildMarkupRect
+} from './AcApMarkupShapeBuilder'
 
 function asView2d(view: AcEdBaseView): AcTrView2d {
   return view as AcTrView2d
 }
 
 /**
- * Maps markup records to HTML / CAD transient visuals and keeps them in sync
+ * Maps markup records to HTML overlay visuals and keeps them in sync
  * with {@link getMarkupStore}.
  *
  * Per-type draw / grip behavior lives on {@link AcApMarkupEntity} subclasses;

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupRectCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupRectCmd.ts
@@ -14,7 +14,7 @@ import {
   AcApHtmlLivePreview,
   acapLiveRectCorners,
   acapStrokeLivePolyline
-} from '../overlay'
+} from '../overlay/AcApHtmlLivePreview'
 import {
   configureMarkupCommand,
   createMarkupMeta,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupRectCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupRectCmd.ts
@@ -1,8 +1,4 @@
-import {
-  AcCmColor,
-  AcDbPolyline,
-  AcGePoint2dLike
-} from '@mlightcad/data-model'
+import { AcCmColor, AcGePoint2dLike } from '@mlightcad/data-model'
 
 import { AcApContext } from '../../app'
 import {
@@ -15,41 +11,68 @@ import {
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
 import {
+  AcApHtmlLivePreview,
+  acapLiveRectCorners,
+  acapStrokeLivePolyline
+} from '../overlay'
+import {
   configureMarkupCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
-import { buildMarkupRect, commitMarkup } from './AcApMarkupPresenter'
+import { commitMarkup } from './AcApMarkupPresenter'
 import {
   promptAttachedCallout,
   promptShapeFirstCorner
 } from './AcApMarkupShapeCallout'
+import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight
+  getMarkupLineWeight,
+  markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
 class AcApMarkupRectJig extends AcEdPreviewJig<AcGePoint2dLike> {
-  private readonly _rect: AcDbPolyline
+  private readonly _view: AcTrView2d
   private readonly _first: AcGePoint2dLike
+  private readonly _preview: AcApHtmlLivePreview
+  private _color: AcCmColor
+  private _second: AcGePoint2dLike
 
   constructor(view: AcEdBaseView, start: AcGePoint2dLike, color: AcCmColor) {
     super(view)
+    this._view = view as AcTrView2d
     this._first = start
-    this._rect = new AcDbPolyline()
-    this._rect.color = color
-    this._rect.lineWeight = getMarkupLineWeight()
+    this._second = start
+    this._color = color
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-markup-rect-${Date.now()}`,
+      MARKUP_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbPolyline {
-    return this._rect
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(second: AcGePoint2dLike) {
-    this._rect.color = defaultMarkupColor()
-    this._rect.lineWeight = getMarkupLineWeight()
-    buildMarkupRect(this._rect, this._first, second)
+    this._second = second
+    this._color = defaultMarkupColor()
+    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const corners = acapLiveRectCorners(this._first, this._second)
+    this._preview.acapSetDraw((ctx, view) => {
+      acapStrokeLivePolyline(ctx, view, corners, this._color, lineWidth, {
+        closed: true
+      })
+    })
+  }
+
+  end() {
+    super.end()
+    this._preview.acapDispose()
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeBuilder.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeBuilder.ts
@@ -1,12 +1,8 @@
 /**
- * Markup shape polyline builders (revision cloud and rectangle).
+ * Markup shape geometry builders (revision cloud and rectangle) for HTML canvas.
  */
 
-import {
-  AcDbPolyline,
-  AcGePoint2d,
-  type AcGePoint2dLike
-} from '@mlightcad/data-model'
+import type { AcGePoint2dLike } from '@mlightcad/data-model'
 
 import type { AcEdBaseView } from '../../editor'
 
@@ -14,6 +10,19 @@ import type { AcEdBaseView } from '../../editor'
  * Target screen diameter in CSS pixels for each revision-cloud lobe.
  */
 const CLOUD_DIAMETER_PIXELS = 8
+
+/** World-space vertex with AutoCAD-style bulge to the next vertex. */
+export interface AcApMarkupCloudVertex {
+  /** World X. */
+  x: number
+  /** World Y. */
+  y: number
+  /**
+   * Bulge to the next vertex (`tan(includedAngle/4)`).
+   * Zero means a straight segment; the last vertex's bulge closes to the first.
+   */
+  bulge: number
+}
 
 /**
  * Convert a screen-space pixel length to world distance at a reference point.
@@ -35,31 +44,27 @@ function pixelToWorldDistance(
 }
 
 /**
- * Rebuild a closed revision-cloud polyline between two opposite corners.
+ * Build closed revision-cloud vertices (points + bulges) between two corners.
  *
- * Vertices and bulges are regenerated so lobe size tracks the current view
- * scale ({@link CLOUD_DIAMETER_PIXELS}).
+ * Lobe size tracks the current view scale ({@link CLOUD_DIAMETER_PIXELS}).
  *
- * @param cloud - Polyline to reset and fill.
  * @param firstPoint - One corner of the cloud AABB.
  * @param secondPoint - Opposite corner of the cloud AABB.
  * @param view - View used to size lobes in screen pixels.
+ * @returns Closed ring of vertices (last segment uses the last bulge → first point).
  */
-export function buildMarkupCloud(
-  cloud: AcDbPolyline,
+export function markupCloudVertices(
   firstPoint: AcGePoint2dLike,
   secondPoint: AcGePoint2dLike,
   view: AcEdBaseView
-): void {
-  cloud.reset(false)
-
+): AcApMarkupCloudVertex[] {
   const minX = Math.min(firstPoint.x, secondPoint.x)
   const maxX = Math.max(firstPoint.x, secondPoint.x)
   const minY = Math.min(firstPoint.y, secondPoint.y)
   const maxY = Math.max(firstPoint.y, secondPoint.y)
   const width = maxX - minX
   const height = maxY - minY
-  const centerPoint = new AcGePoint2d((minX + maxX) / 2, (minY + maxY) / 2)
+  const centerPoint = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
   const cloudDiameter = pixelToWorldDistance(
     view,
     CLOUD_DIAMETER_PIXELS,
@@ -69,8 +74,7 @@ export function buildMarkupCloud(
   const numSegmentsX = Math.max(4, Math.ceil(width / chordLength) * 2)
   const numSegmentsY = Math.max(4, Math.ceil(height / chordLength) * 2)
 
-  const points: AcGePoint2d[] = []
-  const bulges: (number | undefined)[] = []
+  const vertices: AcApMarkupCloudVertex[] = []
   let segmentIndex = 0
   /**
    * Alternating bulge for scalloped cloud edges.
@@ -82,57 +86,208 @@ export function buildMarkupCloud(
 
   for (let i = 0; i <= numSegmentsX; i++) {
     const t = i / numSegmentsX
-    points.push(new AcGePoint2d(minX + width * t, minY))
-    bulges.push(
-      i < numSegmentsX ? calculateBulge(segmentIndex++ % 2 === 0) : undefined
-    )
+    vertices.push({
+      x: minX + width * t,
+      y: minY,
+      bulge: i < numSegmentsX ? calculateBulge(segmentIndex++ % 2 === 0) : 0
+    })
   }
   for (let i = 1; i <= numSegmentsY; i++) {
     const t = i / numSegmentsY
-    points.push(new AcGePoint2d(maxX, minY + height * t))
-    bulges.push(
-      i < numSegmentsY ? calculateBulge(segmentIndex++ % 2 === 0) : undefined
-    )
+    vertices.push({
+      x: maxX,
+      y: minY + height * t,
+      bulge: i < numSegmentsY ? calculateBulge(segmentIndex++ % 2 === 0) : 0
+    })
   }
   for (let i = 1; i <= numSegmentsX; i++) {
     const t = 1 - i / numSegmentsX
-    points.push(new AcGePoint2d(minX + width * t, maxY))
-    bulges.push(
-      i < numSegmentsX ? calculateBulge(segmentIndex++ % 2 === 0) : undefined
-    )
+    vertices.push({
+      x: minX + width * t,
+      y: maxY,
+      bulge: i < numSegmentsX ? calculateBulge(segmentIndex++ % 2 === 0) : 0
+    })
   }
   for (let i = 1; i < numSegmentsY; i++) {
     const t = 1 - i / numSegmentsY
-    points.push(new AcGePoint2d(minX, minY + height * t))
-    bulges.push(
-      i < numSegmentsY - 1
-        ? calculateBulge(segmentIndex++ % 2 === 0)
-        : undefined
-    )
+    vertices.push({
+      x: minX,
+      y: minY + height * t,
+      bulge:
+        i < numSegmentsY - 1 ? calculateBulge(segmentIndex++ % 2 === 0) : 0
+    })
   }
 
-  for (let i = 0; i < points.length; i++) {
-    cloud.addVertexAt(i, points[i], bulges[i])
-  }
-  cloud.closed = true
+  // Closing segment (last → first) uses bulge 0, matching the prior polyline builder.
+  return vertices
 }
 
 /**
- * Build a closed rectangle polyline between two opposite corners.
+ * Axis-aligned rectangle corners as a closed polyline (world).
  *
- * @param rect - Polyline to reset and fill with four corners.
- * @param first - One corner of the rectangle.
- * @param second - Opposite corner of the rectangle.
+ * @param first - One corner.
+ * @param second - Opposite corner.
+ * @returns Four corners in order from `first`.
+ */
+export function markupRectCorners(
+  first: AcGePoint2dLike,
+  second: AcGePoint2dLike
+): Array<{ x: number; y: number }> {
+  return [
+    { x: first.x, y: first.y },
+    { x: second.x, y: first.y },
+    { x: second.x, y: second.y },
+    { x: first.x, y: second.y }
+  ]
+}
+
+/**
+ * Tessellate one bulged segment into world points (excluding `p1`, including end).
+ *
+ * @param p1 - Segment start.
+ * @param p2 - Segment end.
+ * @param bulge - AutoCAD bulge (`tan(includedAngle/4)`).
+ * @param samples - Interior samples along the arc (≥ 1 when bulged).
+ */
+function tessellateBulgeSegment(
+  p1: { x: number; y: number },
+  p2: { x: number; y: number },
+  bulge: number,
+  samples = 6
+): Array<{ x: number; y: number }> {
+  if (Math.abs(bulge) < 1e-8) {
+    return [{ x: p2.x, y: p2.y }]
+  }
+  const dx = p2.x - p1.x
+  const dy = p2.y - p1.y
+  const d = Math.hypot(dx, dy)
+  if (d < 1e-12) {
+    return [{ x: p2.x, y: p2.y }]
+  }
+  const cx =
+    (p1.x + p2.x) / 2 - (dy * (1 - bulge * bulge)) / (4 * bulge)
+  const cy =
+    (p1.y + p2.y) / 2 + (dx * (1 - bulge * bulge)) / (4 * bulge)
+  const r = Math.hypot(p1.x - cx, p1.y - cy)
+  const a0 = Math.atan2(p1.y - cy, p1.x - cx)
+  const a1 = Math.atan2(p2.y - cy, p2.x - cx)
+  let delta = a1 - a0
+  // Positive bulge → CCW (left of chord); negative → CW.
+  if (bulge > 0) {
+    if (delta <= 0) delta += Math.PI * 2
+  } else {
+    if (delta >= 0) delta -= Math.PI * 2
+  }
+  const out: Array<{ x: number; y: number }> = []
+  const steps = Math.max(2, samples)
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps
+    const a = a0 + delta * t
+    out.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
+  }
+  return out
+}
+
+/**
+ * Expand cloud vertices to a dense polyline suitable for canvas stroke.
+ *
+ * @param vertices - Closed cloud ring with bulges.
+ * @returns Tessellated world points (closed ring, first point not repeated).
+ */
+export function tessellateMarkupCloud(
+  vertices: AcApMarkupCloudVertex[]
+): Array<{ x: number; y: number }> {
+  if (vertices.length < 2) return vertices.map(v => ({ x: v.x, y: v.y }))
+  const points: Array<{ x: number; y: number }> = [
+    { x: vertices[0].x, y: vertices[0].y }
+  ]
+  for (let i = 0; i < vertices.length; i++) {
+    const a = vertices[i]
+    const b = vertices[(i + 1) % vertices.length]
+    const seg = tessellateBulgeSegment(
+      { x: a.x, y: a.y },
+      { x: b.x, y: b.y },
+      a.bulge
+    )
+    for (const p of seg) points.push(p)
+  }
+  return points
+}
+
+/**
+ * Stroke a revision cloud on a canvas context (screen projection).
+ *
+ * @param ctx - Canvas 2D context in CSS pixel space.
+ * @param view - View for world → screen.
+ * @param first - One AABB corner (world).
+ * @param second - Opposite AABB corner (world).
+ * @param color - CSS stroke color.
+ * @param lineWidth - Stroke width in CSS pixels.
+ * @param offset - Optional live drag translation in world space.
+ */
+export function strokeMarkupCloud(
+  ctx: CanvasRenderingContext2D,
+  view: AcEdBaseView,
+  first: AcGePoint2dLike,
+  second: AcGePoint2dLike,
+  color: string,
+  lineWidth: number,
+  offset?: { dx: number; dy: number }
+): void {
+  const dx = offset?.dx ?? 0
+  const dy = offset?.dy ?? 0
+  const vertices = markupCloudVertices(first, second, view)
+  const world = tessellateMarkupCloud(vertices).map(p => ({
+    x: p.x + dx,
+    y: p.y + dy
+  }))
+  if (world.length < 2) return
+  const screen = world.map(p => view.worldToScreen(p))
+  ctx.strokeStyle = color
+  ctx.lineWidth = lineWidth
+  ctx.beginPath()
+  ctx.moveTo(screen[0].x, screen[0].y)
+  for (let i = 1; i < screen.length; i++) {
+    ctx.lineTo(screen[i].x, screen[i].y)
+  }
+  ctx.closePath()
+  ctx.stroke()
+}
+
+/**
+ * @deprecated Prefer {@link markupCloudVertices} / {@link strokeMarkupCloud}.
+ * Kept for callers that still need an in-memory vertex list via the old name.
+ */
+export function buildMarkupCloud(
+  _cloud: { reset: (v: boolean) => void; addVertexAt: (i: number, p: { x: number; y: number }, b?: number) => void; closed: boolean },
+  firstPoint: AcGePoint2dLike,
+  secondPoint: AcGePoint2dLike,
+  view: AcEdBaseView
+): void {
+  const vertices = markupCloudVertices(firstPoint, secondPoint, view)
+  _cloud.reset(false)
+  for (let i = 0; i < vertices.length; i++) {
+    _cloud.addVertexAt(i, { x: vertices[i].x, y: vertices[i].y }, vertices[i].bulge)
+  }
+  _cloud.closed = true
+}
+
+/**
+ * @deprecated Prefer {@link markupRectCorners}.
  */
 export function buildMarkupRect(
-  rect: AcDbPolyline,
+  rect: {
+    reset: (v: boolean) => void
+    addVertexAt: (i: number, p: { x: number; y: number }) => void
+    closed: boolean
+  },
   first: AcGePoint2dLike,
   second: AcGePoint2dLike
 ): void {
+  const corners = markupRectCorners(first, second)
   rect.reset(false)
-  rect.addVertexAt(0, new AcGePoint2d(first.x, first.y))
-  rect.addVertexAt(1, new AcGePoint2d(second.x, first.y))
-  rect.addVertexAt(2, new AcGePoint2d(second.x, second.y))
-  rect.addVertexAt(3, new AcGePoint2d(first.x, second.y))
+  for (let i = 0; i < corners.length; i++) {
+    rect.addVertexAt(i, corners[i])
+  }
   rect.closed = true
 }

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeCallout.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeCallout.ts
@@ -12,10 +12,6 @@
 
 import {
   AcCmColor,
-  AcDbCircle,
-  AcDbEntity,
-  AcDbLine,
-  AcDbPolyline,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
@@ -33,10 +29,18 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
+import {
+  type AcApHtmlLivePoint,
+  AcApHtmlLivePreview,
+  acapLiveRectCorners,
+  acapStrokeLiveCircle,
+  acapStrokeLivePolyline,
+  acapStrokeLiveSegment
+} from '../overlay'
 import { promptMarkupCapsuleText } from './AcApMarkupCmdUtil'
 import {
-  buildMarkupCloud,
-  buildMarkupRect
+  markupCloudVertices,
+  tessellateMarkupCloud
 } from './AcApMarkupShapeBuilder'
 import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type {
@@ -47,6 +51,7 @@ import {
   defaultMarkupColor,
   getMarkupFontSize,
   getMarkupLineWeight,
+  markupCanvasLineWidth,
   subscribeMarkupDrawStyle
 } from './AcApMarkupUtil'
 
@@ -173,30 +178,13 @@ export function computeLeaderTipOnShape(
   return { x: cx + dx * s, y: cy + dy * s }
 }
 
-function createShapePreviewEntity(
-  outline: AcApMarkupShapeOutline,
-  color: AcCmColor,
+/** Collect tessellated cloud outline vertices (HTML stroke; no AcDb). */
+function cloudLivePoints(
+  corner1: AcApMarkupPoint2d,
+  corner2: AcApMarkupPoint2d,
   view: AcEdBaseView
-): AcDbEntity {
-  if (outline.kind === 'circle') {
-    const circle = new AcDbCircle(
-      { x: outline.center.x, y: outline.center.y, z: 0 },
-      Math.max(outline.radius, 0)
-    )
-    circle.color = color
-    circle.lineWeight = getMarkupLineWeight()
-    return circle
-  }
-
-  const poly = new AcDbPolyline()
-  poly.color = color
-  poly.lineWeight = getMarkupLineWeight()
-  if (outline.kind === 'cloud') {
-    buildMarkupCloud(poly, outline.corner1, outline.corner2, view)
-  } else {
-    buildMarkupRect(poly, outline.corner1, outline.corner2)
-  }
-  return poly
+): AcApHtmlLivePoint[] {
+  return tessellateMarkupCloud(markupCloudVertices(corner1, corner2, view))
 }
 
 /**
@@ -206,15 +194,16 @@ function createShapePreviewEntity(
  */
 class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
   private readonly _outline: AcApMarkupShapeOutline
-  private readonly _line: AcDbLine
-  private readonly _shape: AcDbEntity
   private readonly _ht: AcTrHtmlTransientManager
   private readonly _tipDot: AcTrHtmlDot
   private readonly _bubble: AcTrHtmlCallout
+  private readonly _preview: AcApHtmlLivePreview
   private readonly _tipDotId: string
   private readonly _bubbleId: string
   private readonly _view: AcTrView2d
   private _tip: AcApMarkupPoint2d
+  private _anchor: AcApMarkupPoint2d
+  private _color: AcCmColor
   private _unsubDrawStyle?: () => void
 
   constructor(
@@ -225,22 +214,15 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
     super(view)
     this._view = view as AcTrView2d
     this._outline = outline
+    this._color = color
     this._ht = this._view.htmlTransientManager
-
-    this._shape = createShapePreviewEntity(outline, color, view)
-    this._view.addTransientEntity(this._shape)
 
     const center = shapeCenter(outline)
     this._tip = computeLeaderTipOnShape(outline, {
       x: center.x + 1,
       y: center.y
     })
-    this._line = new AcDbLine(
-      { x: this._tip.x, y: this._tip.y, z: 0 },
-      { x: this._tip.x, y: this._tip.y, z: 0 }
-    )
-    this._line.color = color
-    this._line.lineWeight = getMarkupLineWeight()
+    this._anchor = { ...this._tip }
 
     const stamp = Date.now()
     this._tipDotId = `live-shape-callout-tip-${stamp}`
@@ -265,24 +247,32 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
       layoutId
     })
     this._ht.add(this._bubble)
+
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-shape-callout-stroke-${stamp}`,
+      MARKUP_LIVE_LAYER
+    )
     this._unsubDrawStyle = subscribeMarkupDrawStyle(() =>
       this.applyCurrentStyle()
     )
+    this.paintPreview()
     this._view.isHtmlDirty = true
   }
 
-  get entity(): AcDbLine {
-    return this._line
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(anchor: AcGePoint3dLike) {
     const toward = { x: anchor.x, y: anchor.y }
     this._tip = computeLeaderTipOnShape(this._outline, toward)
-    this._line.startPoint = { x: this._tip.x, y: this._tip.y, z: 0 }
-    this._line.endPoint = { x: anchor.x, y: anchor.y, z: anchor.z ?? 0 }
+    this._anchor = toward
 
     this._tipDot.setPosition(this._tip)
     this._bubble.setPosition(toward)
+    this.paintPreview()
     this._view.isHtmlDirty = true
   }
 
@@ -296,15 +286,14 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
    * Cleanup is done by {@link disposePreview}.
    */
   end() {
-    // Intentionally do not remove the line / HTML overlays / shape.
+    // Intentionally do not remove the HTML overlays.
   }
 
   /** Remove frozen preview graphics after text entry (or cancel). */
   disposePreview() {
     this._unsubDrawStyle?.()
     this._unsubDrawStyle = undefined
-    this._view.removeTransientEntity(this._line.objectId)
-    this._view.removeTransientEntity(this._shape.objectId)
+    this._preview.acapDispose()
     this._ht.remove(this._tipDotId)
     this._ht.remove(this._bubbleId)
     this._view.isHtmlDirty = true
@@ -312,19 +301,54 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
 
   /** Apply session draw style to the frozen preview (including during text entry). */
   private applyCurrentStyle(): void {
-    const color = defaultMarkupColor()
-    this._line.color = color
-    this._line.lineWeight = getMarkupLineWeight()
-    this._shape.color = color
-    this._shape.lineWeight = getMarkupLineWeight()
-    this._view.removeTransientEntity(this._line.objectId)
-    this._view.addTransientEntity(this._line)
-    this._view.removeTransientEntity(this._shape.objectId)
-    this._view.addTransientEntity(this._shape)
-    this._tipDot.setColor(color)
-    this._bubble.setColor(color)
+    this._color = defaultMarkupColor()
+    this._tipDot.setColor(this._color)
+    this._bubble.setColor(this._color)
     this._bubble.setFontSize(getMarkupFontSize())
+    this.paintPreview()
     this._view.isHtmlDirty = true
+  }
+
+  private paintPreview(): void {
+    const outline = this._outline
+    const color = this._color
+    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const tip = this._tip
+    const anchor = this._anchor
+    const viewForCloud = this._view
+
+    this._preview.acapSetDraw((ctx, view) => {
+      if (outline.kind === 'circle') {
+        acapStrokeLiveCircle(
+          ctx,
+          view,
+          outline.center,
+          outline.radius,
+          color,
+          lineWidth
+        )
+      } else if (outline.kind === 'cloud') {
+        const points = cloudLivePoints(
+          outline.corner1,
+          outline.corner2,
+          viewForCloud
+        )
+        acapStrokeLivePolyline(ctx, view, points, color, lineWidth, {
+          closed: true
+        })
+      } else {
+        acapStrokeLivePolyline(
+          ctx,
+          view,
+          acapLiveRectCorners(outline.corner1, outline.corner2),
+          color,
+          lineWidth,
+          { closed: true }
+        )
+      }
+      // Design Review style: leader without arrowhead.
+      acapStrokeLiveSegment(ctx, view, tip, anchor, color, lineWidth)
+    })
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeCallout.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeCallout.ts
@@ -36,7 +36,7 @@ import {
   acapStrokeLiveCircle,
   acapStrokeLivePolyline,
   acapStrokeLiveSegment
-} from '../overlay'
+} from '../overlay/AcApHtmlLivePreview'
 import { promptMarkupCapsuleText } from './AcApMarkupCmdUtil'
 import {
   markupCloudVertices,

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupCalloutEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupCalloutEntity.ts
@@ -223,7 +223,6 @@ export class AcApMarkupCalloutEntity extends AcApMarkupEntity {
           view,
           recordId: this.record.id,
           centerEl: centerDot,
-          entityIds: [],
           attached: {
             live,
             redraw,

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
@@ -2,7 +2,6 @@
  * Shared markup grip / attached-callout helpers used by concrete markup entities.
  */
 
-import { type AcDbObjectId,AcGeMatrix3d } from '@mlightcad/data-model'
 import {
   AcTrHtmlCallout,
   AcTrHtmlCanvasOverlay,
@@ -224,8 +223,11 @@ export interface AcApMarkupCenterMoveOptions {
   recordId: string
   /** Center grip HTML element. */
   centerEl: AcTrHtmlElement
-  /** CAD transient ids preview-transformed during drag. */
-  entityIds: AcDbObjectId[]
+  /**
+   * Called during drag with the world-space translation from drag origin.
+   * Used to live-preview HTML canvas shapes (no CAD transients).
+   */
+  onLiveOffset?: (dx: number, dy: number) => void
   /** Optional attached callout to keep in sync while moving. */
   attached?: AcApMarkupAttachedCalloutVisual
 }
@@ -233,16 +235,17 @@ export interface AcApMarkupCenterMoveOptions {
 /**
  * Whole-markup drag via a center grip element.
  *
- * Live-previews CAD transients with a translation matrix and optionally moves
- * an attached callout; commits via {@link translateMarkupGeometry}.
+ * Live-previews canvas geometry via {@link AcApMarkupCenterMoveOptions.onLiveOffset}
+ * and optionally moves an attached callout; commits via
+ * {@link translateMarkupGeometry}.
  *
- * @param options - Center handle, entity ids, and optional attached callout.
+ * @param options - Center handle and optional attached callout.
  * @returns Cleanup that unbinds the pointer drag.
  */
 export function bindMarkupCenterMove(
   options: AcApMarkupCenterMoveOptions
 ): () => void {
-  const { view, recordId, centerEl, entityIds, attached } = options
+  const { view, recordId, centerEl, onLiveOffset, attached } = options
   /** World origin captured at drag start (geometry center or element position). */
   let origin = {
     x: centerEl.object.position.x,
@@ -276,12 +279,7 @@ export function bindMarkupCenterMove(
       last = point
       const dx = point.x - origin.x
       const dy = point.y - origin.y
-      if (entityIds.length > 0) {
-        const matrix = new AcGeMatrix3d().makeTranslation(dx, dy, 0)
-        view.updateTransientPreviewTransforms(
-          entityIds.map(objectId => ({ objectId, matrix }))
-        )
-      }
+      onLiveOffset?.(dx, dy)
       placeOverlayHtml(view, centerEl, point)
       if (attached && originalCallout) {
         attached.live.tip = translateMarkupPoint(originalCallout.tip, dx, dy)
@@ -298,7 +296,10 @@ export function bindMarkupCenterMove(
     onCommit: () => {
       const dx = last.x - origin.x
       const dy = last.y - origin.y
-      if (Math.hypot(dx, dy) < 1e-9) return
+      if (Math.hypot(dx, dy) < 1e-9) {
+        onLiveOffset?.(0, 0)
+        return
+      }
       runMarkupEdit(view, 'Move Markup', () => {
         const current = getMarkupStore().get(recordId)
         if (!current) return

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupSegmentEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupSegmentEntity.ts
@@ -1,6 +1,4 @@
 import {
-  AcDbLine,
-  type AcDbObjectId,
   AcGePoint3d,
   type AcGeVector3dLike
 } from '@mlightcad/data-model'
@@ -15,7 +13,8 @@ import {
   bindOverlayPointerDrag,
   drawOverlayArrowHead,
   fitOverlayCanvas,
-  placeOverlayHtml} from '../../overlay'
+  placeOverlayHtml
+} from '../../overlay'
 import { runMarkupEdit } from '../AcApMarkupHistory'
 import { republishMarkup } from '../AcApMarkupRepublish'
 import { getMarkupStore } from '../AcApMarkupStore'
@@ -26,8 +25,8 @@ import { selectMarkupGroup } from './AcApMarkupEntityGrips'
 /**
  * Line or arrow markup with endpoint grips.
  *
- * Draws a CAD transient line, endpoint HTML dots, and (for arrows) a canvas
- * arrow head. Endpoint drags hide the CAD line and preview a canvas stroke.
+ * Draws an HTML canvas stroke (and arrow head when applicable) plus endpoint
+ * HTML dots. No CAD transient entities.
  */
 export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
   /**
@@ -84,7 +83,7 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
   }
 
   /**
-   * Publish CAD line, endpoint dots, optional arrow canvas, and endpoint grips.
+   * Publish canvas stroke, endpoint dots, optional arrow head, and endpoint grips.
    *
    * @param view - Active 2D view.
    * @returns Built visuals; {@link AcApOverlayWorldDrawResult.bindGrips} binds
@@ -95,12 +94,10 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
     if (geom.type !== 'line' && geom.type !== 'arrow') {
       return this.emptyResult(this.createGroup())
     }
-    const { color, lineWeight, canvasLineWidth, layer, layoutId } = this.style()
+    const { color, canvasLineWidth, layer, layoutId } = this.style()
     const group = this.createGroup()
-    /** Unbinders for viewChanged, pointer drags, and CAD removal. */
+    /** Unbinders for viewChanged and pointer drags. */
     const cleanups: Array<() => void> = []
-    /** CAD transient object ids for highlight / visibility. */
-    const entityIds: AcDbObjectId[] = []
     /** Grip binders deferred until after manager.add(group). */
     const pendingGrips: Array<() => void> = []
 
@@ -109,15 +106,6 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
       start: { ...geom.start },
       end: { ...geom.end }
     }
-    const line = new AcDbLine(
-      { x: live.start.x, y: live.start.y, z: 0 },
-      { x: live.end.x, y: live.end.y, z: 0 }
-    )
-    line.color = color
-    line.lineWeight = lineWeight
-    view.addTransientEntity(line)
-    entityIds.push(line.objectId)
-    cleanups.push(() => view.removeTransientEntity(line.objectId))
 
     const startDot = new AcTrHtmlDot({
       id: `${this.record.id}-dot1`,
@@ -143,9 +131,7 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
       layoutId
     })
     group.addCanvas(overlay)
-    /** When true, CAD line is hidden and the canvas shows the live segment. */
-    let draggingEndpoints = false
-    /** Endpoints captured when an endpoint drag starts (for zero-delta / restore). */
+    /** Endpoints captured when an endpoint drag starts (for zero-delta). */
     let dragStart = {
       start: { ...live.start },
       end: { ...live.end }
@@ -160,14 +146,12 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
       if (!ctx) return
       const a = view.worldToScreen(live.start)
       const b = view.worldToScreen(live.end)
-      if (draggingEndpoints) {
-        ctx.strokeStyle = this.record.style.color
-        ctx.lineWidth = canvasLineWidth
-        ctx.beginPath()
-        ctx.moveTo(a.x, a.y)
-        ctx.lineTo(b.x, b.y)
-        ctx.stroke()
-      }
+      ctx.strokeStyle = this.record.style.color
+      ctx.lineWidth = canvasLineWidth
+      ctx.beginPath()
+      ctx.moveTo(a.x, a.y)
+      ctx.lineTo(b.x, b.y)
+      ctx.stroke()
       if (isArrow) {
         drawOverlayArrowHead(ctx, a, b, this.record.style.color)
       }
@@ -179,15 +163,7 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
     )
 
     /**
-     * Show the CAD line again and clear the canvas stroke preview.
-     */
-    const restoreCadLine = () => {
-      draggingEndpoints = false
-      view.setTransientEntityVisible(line.objectId, true)
-      redrawStroke()
-    }
-    /**
-     * Select the markup and switch to canvas stroke preview while dragging.
+     * Select the markup when an endpoint drag begins.
      */
     const beginEndpointDrag = () => {
       selectMarkupGroup(view, this.record.id)
@@ -195,13 +171,9 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
         start: { ...live.start },
         end: { ...live.end }
       }
-      draggingEndpoints = true
-      view.setTransientEntityVisible(line.objectId, false)
-      redrawStroke()
     }
     /**
      * Commit live endpoints to the store and republish.
-     * Restores CAD visibility when the drag is a no-op or the store update fails.
      */
     const commitEndpoints = () => {
       const startDelta = Math.hypot(
@@ -213,10 +185,9 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
         live.end.y - dragStart.end.y
       )
       if (startDelta < 1e-9 && endDelta < 1e-9) {
-        restoreCadLine()
+        redrawStroke()
         return
       }
-      let republished = false
       runMarkupEdit(view, isArrow ? 'Move Arrow' : 'Move Line', () => {
         const updated = getMarkupStore().updateGeometry(
           this.record.id,
@@ -234,10 +205,8 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
         )
         if (updated) {
           republishMarkup(view, updated)
-          republished = true
         }
       })
-      if (!republished) restoreCadLine()
     }
     pendingGrips.push(() => {
       cleanups.push(
@@ -268,7 +237,7 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
 
     return {
       group,
-      entityIds,
+      entityIds: [],
       dispose: () => {
         for (const fn of cleanups) {
           try {

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupShapeEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupShapeEntity.ts
@@ -1,14 +1,15 @@
-import {
-  AcDbCircle,
-  type AcDbObjectId,
-  AcDbPolyline,
-  AcGePoint3d
-} from '@mlightcad/data-model'
-import { AcTrHtmlDot } from '@mlightcad/three-renderer'
+import { AcGePoint3d } from '@mlightcad/data-model'
+import { AcTrHtmlCanvasOverlay, AcTrHtmlDot } from '@mlightcad/three-renderer'
 
 import type { AcTrView2d } from '../../../view'
-import type { AcApOverlayWorldDrawResult } from '../../overlay'
-import { buildMarkupCloud, buildMarkupRect } from '../AcApMarkupShapeBuilder'
+import {
+  acapLiveRectCorners,
+  type AcApOverlayWorldDrawResult,
+  acapStrokeLiveCircle,
+  acapStrokeLivePolyline,
+  fitOverlayCanvas
+} from '../../overlay'
+import { strokeMarkupCloud } from '../AcApMarkupShapeBuilder'
 import type { AcApMarkupShapeOutline } from '../AcApMarkupShapeCallout'
 import type { AcApMarkupRecord } from '../AcApMarkupTypes'
 import { AcApMarkupEntity } from './AcApMarkupEntity'
@@ -20,8 +21,9 @@ import {
 /**
  * Cloud / rect / circle markup with optional attached callout.
  *
- * Builds a CAD transient shape, a center move grip, and optionally a
+ * Builds an HTML canvas shape, a center move grip, and optionally a
  * shape-attached leader + bubble via {@link publishAttachedCallout}.
+ * No CAD transient entities.
  */
 export class AcApMarkupShapeEntity extends AcApMarkupEntity {
   /**
@@ -41,7 +43,7 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
   }
 
   /**
-   * Publish CAD shape, center dot, optional attached callout, and center move.
+   * Publish canvas shape, center dot, optional attached callout, and center move.
    *
    * @param view - Active 2D view.
    * @returns Built visuals with deferred center-move grip binding.
@@ -55,12 +57,10 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
     ) {
       return this.emptyResult(this.createGroup())
     }
-    const { color, lineWeight, layer, layoutId } = this.style()
+    const { color, canvasLineWidth, layer, layoutId } = this.style()
     const group = this.createGroup()
-    /** Unbinders for CAD removal, viewChanged, and grips. */
+    /** Unbinders for viewChanged and grips. */
     const cleanups: Array<() => void> = []
-    /** CAD transient object ids for highlight / preview transforms. */
-    const entityIds: AcDbObjectId[] = []
     /** Grip binders deferred until after manager.add(group). */
     const pendingGrips: Array<() => void> = []
 
@@ -68,15 +68,10 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
     let centerPos: { x: number; y: number }
     /** Outline used to constrain an attached callout tip. */
     let outline: AcApMarkupShapeOutline
+    /** Live drag translation applied while moving the center grip. */
+    let liveOffset = { dx: 0, dy: 0 }
 
     if (geom.type === 'cloud') {
-      const cloud = new AcDbPolyline()
-      cloud.color = color
-      cloud.lineWeight = lineWeight
-      buildMarkupCloud(cloud, geom.corner1, geom.corner2, view)
-      view.addTransientEntity(cloud)
-      entityIds.push(cloud.objectId)
-      cleanups.push(() => view.removeTransientEntity(cloud.objectId))
       centerPos = {
         x: (geom.corner1.x + geom.corner2.x) / 2,
         y: (geom.corner1.y + geom.corner2.y) / 2
@@ -87,13 +82,6 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
         corner2: geom.corner2
       }
     } else if (geom.type === 'rect') {
-      const rect = new AcDbPolyline()
-      rect.color = color
-      rect.lineWeight = lineWeight
-      buildMarkupRect(rect, geom.corner1, geom.corner2)
-      view.addTransientEntity(rect)
-      entityIds.push(rect.objectId)
-      cleanups.push(() => view.removeTransientEntity(rect.objectId))
       centerPos = {
         x: (geom.corner1.x + geom.corner2.x) / 2,
         y: (geom.corner1.y + geom.corner2.y) / 2
@@ -104,15 +92,6 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
         corner2: geom.corner2
       }
     } else {
-      const circle = new AcDbCircle(
-        { x: geom.center.x, y: geom.center.y, z: 0 },
-        geom.radius
-      )
-      circle.color = color
-      circle.lineWeight = lineWeight
-      view.addTransientEntity(circle)
-      entityIds.push(circle.objectId)
-      cleanups.push(() => view.removeTransientEntity(circle.objectId))
       centerPos = { ...geom.center }
       outline = {
         kind: 'circle',
@@ -120,6 +99,62 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
         radius: geom.radius
       }
     }
+
+    const container = view.container
+    const overlay = new AcTrHtmlCanvasOverlay({
+      id: `${this.record.id}-shape`,
+      container,
+      layer,
+      layoutId
+    })
+    group.addCanvas(overlay)
+
+    /**
+     * Redraw the shape stroke with the current {@link liveOffset}.
+     */
+    const redrawShape = () => {
+      const ctx = fitOverlayCanvas(overlay.canvas, container)
+      if (!ctx) return
+      const css = this.record.style.color
+      if (geom.type === 'cloud') {
+        strokeMarkupCloud(
+          ctx,
+          view,
+          geom.corner1,
+          geom.corner2,
+          css,
+          canvasLineWidth,
+          liveOffset
+        )
+      } else if (geom.type === 'rect') {
+        const corners = acapLiveRectCorners(geom.corner1, geom.corner2).map(
+          p => ({
+            x: p.x + liveOffset.dx,
+            y: p.y + liveOffset.dy
+          })
+        )
+        acapStrokeLivePolyline(ctx, view, corners, css, canvasLineWidth, {
+          closed: true
+        })
+      } else {
+        acapStrokeLiveCircle(
+          ctx,
+          view,
+          {
+            x: geom.center.x + liveOffset.dx,
+            y: geom.center.y + liveOffset.dy
+          },
+          geom.radius,
+          css,
+          canvasLineWidth
+        )
+      }
+    }
+    redrawShape()
+    view.events.viewChanged.addEventListener(redrawShape)
+    cleanups.push(() =>
+      view.events.viewChanged.removeEventListener(redrawShape)
+    )
 
     const centerDot = new AcTrHtmlDot({
       id: `${this.record.id}-dot`,
@@ -149,15 +184,18 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
           view,
           recordId: this.record.id,
           centerEl: centerDot,
-          entityIds,
-          attached
+          attached,
+          onLiveOffset: (dx, dy) => {
+            liveOffset = { dx, dy }
+            redrawShape()
+          }
         })
       )
     })
 
     return {
       group,
-      entityIds,
+      entityIds: [],
       dispose: () => {
         for (const fn of cleanups) {
           try {

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupShapeEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupShapeEntity.ts
@@ -3,12 +3,14 @@ import { AcTrHtmlCanvasOverlay, AcTrHtmlDot } from '@mlightcad/three-renderer'
 
 import type { AcTrView2d } from '../../../view'
 import {
-  acapLiveRectCorners,
   type AcApOverlayWorldDrawResult,
-  acapStrokeLiveCircle,
-  acapStrokeLivePolyline,
   fitOverlayCanvas
 } from '../../overlay'
+import {
+  acapLiveRectCorners,
+  acapStrokeLiveCircle,
+  acapStrokeLivePolyline
+} from '../../overlay/AcApHtmlLivePreview'
 import { strokeMarkupCloud } from '../AcApMarkupShapeBuilder'
 import type { AcApMarkupShapeOutline } from '../AcApMarkupShapeCallout'
 import type { AcApMarkupRecord } from '../AcApMarkupTypes'

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupStampEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupStampEntity.ts
@@ -4,9 +4,12 @@ import type { AcTrView2d } from '../../../view'
 import type { AcApOverlayWorldDrawResult } from '../../overlay'
 import type { AcApMarkupRecord } from '../AcApMarkupTypes'
 import { AcApMarkupEntity } from './AcApMarkupEntity'
+import { bindMarkupCenterMove } from './AcApMarkupEntityGrips'
 
 /**
  * Stamp or symbol markup rendered as an {@link AcTrHtmlStamp}.
+ *
+ * Drag the stamp to move it.
  */
 export class AcApMarkupStampEntity extends AcApMarkupEntity {
   /**
@@ -17,40 +20,61 @@ export class AcApMarkupStampEntity extends AcApMarkupEntity {
   }
 
   /**
-   * Stamps currently have no move grips in the presenter UX.
+   * Publish a stamp / symbol image overlay and bind drag-to-move.
    *
-   * @returns Empty grip list.
+   * @param view - Active 2D view.
+   * @returns Group with the stamp and dispose / grip binders.
    */
-  override subGetGripPoints() {
-    return []
-  }
-
-  /**
-   * Publish a stamp / symbol image overlay at the record position.
-   *
-   * @param _view - Active 2D view (unused; stamp needs no view listeners).
-   * @returns Group containing the stamp leaf.
-   */
-  protected subWorldDraw(_view: AcTrView2d): AcApOverlayWorldDrawResult {
+  protected subWorldDraw(view: AcTrView2d): AcApOverlayWorldDrawResult {
     const geom = this.record.geometry
     if (geom.type !== 'stamp' && geom.type !== 'symbol') {
       return this.emptyResult(this.createGroup())
     }
     const { color, layer, layoutId } = this.style()
     const group = this.createGroup()
+    /** Unbinders for center-move drag. */
+    const cleanups: Array<() => void> = []
+    /** Grip binders deferred until after manager.add(group). */
+    const pendingGrips: Array<() => void> = []
+
     const stampId = geom.type === 'stamp' ? geom.stampId : geom.symbolId
-    group.add(
-      new AcTrHtmlStamp({
-        id: `${this.record.id}-stamp`,
-        color,
-        stampId,
-        text: this.record.text,
-        imageUrl: geom.imageUrl,
-        worldPosition: geom.position,
-        layer,
-        layoutId
-      })
-    )
-    return this.emptyResult(group)
+    const stamp = new AcTrHtmlStamp({
+      id: `${this.record.id}-stamp`,
+      color,
+      stampId,
+      text: this.record.text,
+      imageUrl: geom.imageUrl,
+      worldPosition: geom.position,
+      layer,
+      layoutId
+    })
+    group.add(stamp)
+
+    pendingGrips.push(() => {
+      cleanups.push(
+        bindMarkupCenterMove({
+          view,
+          recordId: this.record.id,
+          centerEl: stamp
+        })
+      )
+    })
+
+    return {
+      group,
+      entityIds: [],
+      dispose: () => {
+        for (const fn of cleanups) {
+          try {
+            fn()
+          } catch {
+            // ignore
+          }
+        }
+      },
+      bindGrips: () => {
+        for (const bind of pendingGrips) bind()
+      }
+    }
   }
 }

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupTextEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupTextEntity.ts
@@ -5,9 +5,12 @@ import type { AcApOverlayWorldDrawResult } from '../../overlay'
 import { bindMarkupInlineTextEdit } from '../AcApMarkupTextEdit'
 import type { AcApMarkupRecord } from '../AcApMarkupTypes'
 import { AcApMarkupEntity } from './AcApMarkupEntity'
+import { bindMarkupCenterMove } from './AcApMarkupEntityGrips'
 
 /**
  * Text note markup rendered as an {@link AcTrHtmlBadge}.
+ *
+ * Drag the badge to move; double-click to edit text inline.
  */
 export class AcApMarkupTextEntity extends AcApMarkupEntity {
   /**
@@ -18,19 +21,10 @@ export class AcApMarkupTextEntity extends AcApMarkupEntity {
   }
 
   /**
-   * Text notes have no move grip in the presenter UX (inline edit only).
-   *
-   * @returns Empty grip list.
-   */
-  override subGetGripPoints() {
-    return []
-  }
-
-  /**
-   * Publish a badge at the text position and bind inline edit.
+   * Publish a badge at the text position, bind drag-to-move and inline edit.
    *
    * @param view - Active 2D view.
-   * @returns Group with the badge and dispose for the edit binder.
+   * @returns Group with the badge and dispose / grip binders.
    */
   protected subWorldDraw(view: AcTrView2d): AcApOverlayWorldDrawResult {
     const geom = this.record.geometry
@@ -39,8 +33,10 @@ export class AcApMarkupTextEntity extends AcApMarkupEntity {
     }
     const { color, layer, layoutId } = this.style()
     const group = this.createGroup()
-    /** Unbinders for inline text edit and other listeners. */
+    /** Unbinders for inline text edit and center-move drag. */
     const cleanups: Array<() => void> = []
+    /** Grip binders deferred until after manager.add(group). */
+    const pendingGrips: Array<() => void> = []
 
     const badge = new AcTrHtmlBadge({
       id: `${this.record.id}-badge`,
@@ -60,6 +56,16 @@ export class AcApMarkupTextEntity extends AcApMarkupEntity {
       })
     )
 
+    pendingGrips.push(() => {
+      cleanups.push(
+        bindMarkupCenterMove({
+          view,
+          recordId: this.record.id,
+          centerEl: badge
+        })
+      )
+    })
+
     return {
       group,
       entityIds: [],
@@ -71,6 +77,9 @@ export class AcApMarkupTextEntity extends AcApMarkupEntity {
             // ignore
           }
         }
+      },
+      bindGrips: () => {
+        for (const bind of pendingGrips) bind()
       }
     }
   }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
@@ -1,12 +1,10 @@
 import {
   AcCmColor,
   AcDbDatabase,
-  AcDbLine,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
   AcTrHtmlBadge,
-  AcTrHtmlCanvasOverlay,
   AcTrHtmlTransientManager
 } from '@mlightcad/three-renderer'
 
@@ -23,7 +21,6 @@ import {
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
 import {
-  acapCssColor,
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
@@ -33,6 +30,10 @@ import {
   formatMeasurementAngle
 } from '../../util'
 import { AcTrView2d } from '../../view'
+import {
+  AcApHtmlLivePreview,
+  acapStrokeLiveSegment
+} from '../overlay'
 import { MEASUREMENT_LIVE_LAYER } from './AcApMeasurementStore'
 import { AcApMeasureAngleEntity } from './entity'
 
@@ -50,56 +51,6 @@ function calcAngleDeg(
   const cross = dx1 * dy2 - dy1 * dx2
   const rad = Math.atan2(Math.abs(cross), dot)
   return (rad * 180) / Math.PI
-}
-
-/**
- * Draws the first arm (vertex->arm1) as a dashed line on a canvas overlay,
- * used during second arm selection so the user can see the first arm.
- */
-function drawArm1OnCanvas(
-  canvas: HTMLCanvasElement,
-  view: AcEdBaseView,
-  vertex: AcGePoint3dLike,
-  arm1: AcGePoint3dLike,
-  color: AcCmColor,
-  lineWidth = 2
-): void {
-  const rect = view.canvas.getBoundingClientRect()
-  const dpr = window.devicePixelRatio || 1
-  const w = Math.round(rect.width)
-  const h = Math.round(rect.height)
-
-  const origin = view.canvasToContainer({ x: 0, y: 0 })
-  canvas.style.left = `${origin.x}px`
-  canvas.style.top = `${origin.y}px`
-  canvas.style.width = `${w}px`
-  canvas.style.height = `${h}px`
-
-  if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
-    canvas.width = w * dpr
-    canvas.height = h * dpr
-  }
-
-  const ctx = canvas.getContext('2d')
-  if (!ctx) return
-
-  ctx.clearRect(0, 0, canvas.width, canvas.height)
-  ctx.save()
-  ctx.scale(dpr, dpr)
-
-  const sv = view.worldToScreen(vertex)
-  const sa = view.worldToScreen(arm1)
-
-  ctx.beginPath()
-  ctx.moveTo(sv.x, sv.y)
-  ctx.lineTo(sa.x, sa.y)
-  ctx.strokeStyle = acapCssColor(color)
-  ctx.lineWidth = lineWidth
-  ctx.setLineDash([8, 5])
-  ctx.stroke()
-  ctx.setLineDash([])
-
-  ctx.restore()
 }
 
 /**
@@ -121,96 +72,141 @@ export function placeAngleMeasurement(
 }
 
 /**
- * Simple rubber-band jig for picking arm1: draws a transient line
- * from vertex to cursor.
+ * Rubber-band jig for picking arm1: solid HTML preview from vertex to cursor.
  */
 class AcApMeasureArm1Jig extends AcEdPreviewJig<AcGePoint3dLike> {
-  private _line: AcDbLine
+  private readonly _vertex: AcGePoint3dLike
+  private readonly _preview: AcApHtmlLivePreview
+  private readonly _color: AcCmColor
+  private _cursor: AcGePoint3dLike
 
   constructor(view: AcEdBaseView, vertex: AcGePoint3dLike, color: AcCmColor) {
     super(view)
-    this._line = new AcDbLine(vertex, vertex)
-    this._line.color = color
-    this._line.lineWeight = acapGetMeasurementLineWeight()
+    this._vertex = vertex
+    this._cursor = vertex
+    this._color = color
+
+    this._preview = new AcApHtmlLivePreview(
+      view as AcTrView2d,
+      `live-angle-arm1-${Date.now()}`,
+      MEASUREMENT_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbLine {
-    return this._line
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(p: AcGePoint3dLike) {
-    this._line.endPoint = p
+    this._cursor = p
+    const lineWidth = acapMeasurementCanvasLineWidth(
+      acapGetMeasurementLineWeight()
+    )
+    this._preview.acapSetDraw((ctx, view) => {
+      acapStrokeLiveSegment(
+        ctx,
+        view,
+        this._vertex,
+        this._cursor,
+        this._color,
+        lineWidth
+      )
+    })
+  }
+
+  end() {
+    super.end()
+    this._preview.acapDispose()
   }
 }
 
 /**
- * Preview jig for picking arm2: draws a transient line from vertex to
- * cursor, redraws the first arm as a dashed canvas line, and shows a live
- * angle badge.
+ * Preview jig for picking arm2: dashed arm1 + solid arm2 on one HTML canvas,
+ * plus a live angle badge.
  */
 class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
-  private _line: AcDbLine
-  private _vertex: AcGePoint3dLike
-  private _arm1: AcGePoint3dLike
-  private _view: AcEdBaseView
-  private _badge: AcTrHtmlBadge
-  private _htManager: AcTrHtmlTransientManager
+  private readonly _view: AcTrView2d
+  private readonly _vertex: AcGePoint3dLike
+  private readonly _arm1: AcGePoint3dLike
+  private readonly _db: AcDbDatabase
+  private readonly _badge: AcTrHtmlBadge
+  private readonly _htManager: AcTrHtmlTransientManager
   private readonly _badgeId: string
-  private _canvas: HTMLCanvasElement
+  private readonly _preview: AcApHtmlLivePreview
   private _color: AcCmColor
-  private _db: AcDbDatabase
+  private _arm2: AcGePoint3dLike
 
   constructor(
     view: AcEdBaseView,
     db: AcDbDatabase,
     vertex: AcGePoint3dLike,
     arm1: AcGePoint3dLike,
-    canvas: HTMLCanvasElement,
     color: AcCmColor
   ) {
     super(view)
+    this._view = view as AcTrView2d
     this._vertex = vertex
     this._arm1 = arm1
-    this._view = view
-    this._canvas = canvas
+    this._arm2 = vertex
     this._color = color
     this._db = db
-    this._line = new AcDbLine(vertex, vertex)
-    this._line.color = color
-    this._line.lineWeight = acapGetMeasurementLineWeight()
 
     this._badgeId = `live-angle-badge-${Date.now()}`
-    this._htManager = (view as AcTrView2d).htmlTransientManager
+    this._htManager = this._view.htmlTransientManager
     this._badge = new AcTrHtmlBadge({
       id: this._badgeId,
       color,
       worldPosition: vertex,
       layer: MEASUREMENT_LIVE_LAYER,
-      layoutId: (view as AcTrView2d).activeLayoutBtrId,
+      layoutId: this._view.activeLayoutBtrId,
       fontSize: acapGetMeasurementFontSize(),
       // Keep the label slightly above the vertex (was -30px screen offset).
       transform: 'translate(-50%, calc(-50% - 30px))'
     })
     this._badge.object.visible = false
     this._htManager.add(this._badge)
+
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-angle-arm2-${Date.now()}`,
+      MEASUREMENT_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbLine {
-    return this._line
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(p: AcGePoint3dLike) {
-    this._line.endPoint = p
+    this._arm2 = p
+    this._color = acapGetMeasurementColor(this._db)
+    this._badge.setColor(this._color)
+    this._badge.setFontSize(acapGetMeasurementFontSize())
 
-    // Redraw the first arm dashed line (stays in sync with pan/zoom)
-    drawArm1OnCanvas(
-      this._canvas,
-      this._view,
-      this._vertex,
-      this._arm1,
-      this._color,
-      acapMeasurementCanvasLineWidth(acapGetMeasurementLineWeight())
+    const lineWidth = acapMeasurementCanvasLineWidth(
+      acapGetMeasurementLineWeight()
     )
+    this._preview.acapSetDraw((ctx, view) => {
+      acapStrokeLiveSegment(
+        ctx,
+        view,
+        this._vertex,
+        this._arm1,
+        this._color,
+        lineWidth,
+        { dashed: true }
+      )
+      acapStrokeLiveSegment(
+        ctx,
+        view,
+        this._vertex,
+        this._arm2,
+        this._color,
+        lineWidth
+      )
+    })
 
     const deg = calcAngleDeg(this._vertex, this._arm1, p)
     this._badge.setText(
@@ -222,6 +218,7 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
 
   end() {
     super.end()
+    this._preview.acapDispose()
     this._htManager.remove(this._badgeId)
   }
 }
@@ -230,9 +227,9 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
  * Command that measures the angle between two arms sharing a common vertex.
  *
  * Prompts the user to pick three world points: the vertex, a point on the
- * first arm, and a point on the second arm. After the second arm is confirmed,
- * transient CAD lines are added for both arms and persistent DOM overlays
- * (arc canvas + dots + badge) are placed via {@link AcTrHtmlTransientManager}.
+ * first arm, and a point on the second arm. Interactive preview is HTML-only
+ * (canvas strokes + badge). Committed overlay is placed via
+ * {@link placeAngleMeasurement}.
  */
 export class AcApMeasureAngleCmd extends AcEdCommand {
   constructor() {
@@ -244,8 +241,6 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
     const editor = context.view.editor
     const db = context.doc.database
     const color = acapGetMeasurementColor(db)
-    const style = acapGetCurrentMeasurementStyle(db)
-    const canvasLineWidth = acapMeasurementCanvasLineWidth(style.lineWeight)
 
     await context.view.withMode(AcEdViewMode.SELECTION, () =>
       editor.withCursor(AcEdCorsorType.Crosshair, async () => {
@@ -257,7 +252,7 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
         if (vertexResult.status !== AcEdPromptStatus.OK) return
         const vertex = vertexResult.value!
 
-        // Pick first arm endpoint (jig provides preview line from vertex)
+        // Pick first arm endpoint (jig provides HTML rubber-band from vertex)
         const arm1Prompt = new AcEdPromptPointOptions(
           AcApI18n.t('jig.measureAngle.arm1')
         )
@@ -267,36 +262,7 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
         if (arm1Result.status !== AcEdPromptStatus.OK) return
         const arm1 = arm1Result.value!
 
-        // Construction-phase canvas for the first arm dashed line
-        const armOverlay = new AcTrHtmlCanvasOverlay({
-          id: `live-angle-arm-${Date.now()}`,
-          container: context.view.container,
-          layer: MEASUREMENT_LIVE_LAYER,
-          layoutId: (context.view as AcTrView2d).activeLayoutBtrId
-        })
-        const htLive = (context.view as AcTrView2d).htmlTransientManager
-        htLive.add(armOverlay)
-        drawArm1OnCanvas(
-          armOverlay.canvas,
-          context.view,
-          vertex,
-          arm1,
-          color,
-          canvasLineWidth
-        )
-
-        const redrawOnViewChange = () =>
-          drawArm1OnCanvas(
-            armOverlay.canvas,
-            context.view,
-            vertex,
-            arm1,
-            color,
-            canvasLineWidth
-          )
-        context.view.events.viewChanged.addEventListener(redrawOnViewChange)
-
-        // Pick second arm endpoint with live preview (jig provides line + angle badge)
+        // Pick second arm endpoint with live preview (dashed arm1 + solid arm2 + badge)
         const arm2Prompt = new AcEdPromptPointOptions(
           AcApI18n.t('jig.measureAngle.arm2')
         )
@@ -305,34 +271,12 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
           db,
           vertex,
           arm1,
-          armOverlay.canvas,
           color
         )
 
-        let arm2: AcGePoint3dLike
-        try {
-          const arm2Result = await editor.getPoint(arm2Prompt)
-          if (arm2Result.status !== AcEdPromptStatus.OK) {
-            // User pressed ESC / cancelled — clean up construction-phase DOM
-            context.view.events.viewChanged.removeEventListener(
-              redrawOnViewChange
-            )
-            htLive.remove(armOverlay.id)
-            return
-          }
-          arm2 = arm2Result.value!
-        } catch {
-          // User pressed ESC / cancelled — clean up construction-phase DOM
-          context.view.events.viewChanged.removeEventListener(
-            redrawOnViewChange
-          )
-          htLive.remove(armOverlay.id)
-          return
-        }
-
-        // Clean up construction-phase canvas
-        context.view.events.viewChanged.removeEventListener(redrawOnViewChange)
-        htLive.remove(armOverlay.id)
+        const arm2Result = await editor.getPoint(arm2Prompt)
+        if (arm2Result.status !== AcEdPromptStatus.OK) return
+        const arm2 = arm2Result.value!
 
         placeAngleMeasurement(
           context.view as AcTrView2d,

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
@@ -33,7 +33,7 @@ import { AcTrView2d } from '../../view'
 import {
   AcApHtmlLivePreview,
   acapStrokeLiveSegment
-} from '../overlay'
+} from '../overlay/AcApHtmlLivePreview'
 import { MEASUREMENT_LIVE_LAYER } from './AcApMeasurementStore'
 import { AcApMeasureAngleEntity } from './entity'
 

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
@@ -3,7 +3,6 @@ import {
   AcDbArc,
   AcDbCircle,
   AcDbDatabase,
-  AcDbLine,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
@@ -168,7 +167,6 @@ export function placeArcMeasurement(
  * cursor hovers over a circle or arc entity. Notifies the caller via onSnap.
  */
 class AcApArcSnapJig extends AcEdPreviewJig<AcGePoint3dLike> {
-  private _dummy: AcDbLine
   private _ctx: AcApContext
   private _indicator: AcTrHtmlSnapIndicator
   private _htManager: AcTrHtmlTransientManager
@@ -188,7 +186,6 @@ class AcApArcSnapJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._onSnap = onSnap
 
     const o = { x: 0, y: 0, z: 0 }
-    this._dummy = new AcDbLine(o, o)
 
     this._indicatorId = `live-arc-snap-${Date.now()}`
     this._htManager = (context.view as AcTrView2d).htmlTransientManager
@@ -203,8 +200,9 @@ class AcApArcSnapJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._htManager.add(this._indicator)
   }
 
-  get entity(): AcDbLine {
-    return this._dummy
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(p: AcGePoint3dLike) {
@@ -273,7 +271,6 @@ class AcApArcSnapJig extends AcEdPreviewJig<AcGePoint3dLike> {
  * square snap indicator, and fires onMove with the already-snapped point.
  */
 class AcApArcEndSnapJig extends AcEdPreviewJig<AcGePoint3dLike> {
-  private _dummy: AcDbLine
   private _geom: CircleGeom
   private _indicator: AcTrHtmlSnapIndicator
   private _htManager: AcTrHtmlTransientManager
@@ -291,7 +288,6 @@ class AcApArcEndSnapJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._onMove = onMove
 
     const o = { x: 0, y: 0, z: 0 }
-    this._dummy = new AcDbLine(o, o)
 
     this._indicatorId = `live-arc-end-snap-${Date.now()}`
     this._htManager = (view as AcTrView2d).htmlTransientManager
@@ -305,8 +301,9 @@ class AcApArcEndSnapJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._htManager.add(this._indicator)
   }
 
-  get entity(): AcDbLine {
-    return this._dummy
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(p: AcGePoint3dLike) {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
@@ -1,4 +1,4 @@
-import { AcCmColor, AcDbDatabase, AcDbLine, AcGePoint3dLike } from '@mlightcad/data-model'
+import { AcCmColor, AcDbDatabase, AcGePoint3dLike } from '@mlightcad/data-model'
 import {
   AcTrHtmlBadge,
   AcTrHtmlCanvasOverlay
@@ -21,7 +21,6 @@ import {
   acapCssColor,
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
-  acapGetMeasurementLineWeight,
   acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
   formatMeasurementLength
@@ -31,32 +30,28 @@ import { MEASUREMENT_LIVE_LAYER } from './AcApMeasurementStore'
 import { AcApMeasureAreaEntity } from './entity'
 
 /**
- * Rubber-band jig: shows a preview line from the last confirmed
- * vertex to the current cursor position and fires onMove on each update.
+ * Rubber-band jig: fires onMove on each cursor update so the command can
+ * redraw the live polygon fill / outline (HTML-only — no CAD transient).
  */
 class AcApMeasureAreaJig extends AcEdPreviewJig<AcGePoint3dLike> {
-  private _line: AcDbLine
   private _onMove: (p: AcGePoint3dLike) => void
 
   constructor(
     view: AcEdBaseView,
-    from: AcGePoint3dLike,
-    color: AcCmColor,
+    _from: AcGePoint3dLike,
+    _color: AcCmColor,
     onMove: (p: AcGePoint3dLike) => void
   ) {
     super(view)
-    this._line = new AcDbLine(from, from)
-    this._line.color = color
-    this._line.lineWeight = acapGetMeasurementLineWeight()
     this._onMove = onMove
   }
 
-  get entity(): AcDbLine {
-    return this._line
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(p: AcGePoint3dLike) {
-    this._line.endPoint = p
     this._onMove(p)
   }
 }
@@ -221,6 +216,18 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
         ctx.setLineDash([])
       }
 
+      // Rubber-band from last confirmed vertex to cursor (solid)
+      if (cursor && confirmedSpts.length >= 1) {
+        const last = confirmedSpts[confirmedSpts.length - 1]
+        const sc = context.view.worldToScreen(cursor)
+        ctx.beginPath()
+        ctx.moveTo(last.x, last.y)
+        ctx.lineTo(sc.x, sc.y)
+        ctx.strokeStyle = acapCssColor(color)
+        ctx.lineWidth = canvasLineWidth
+        ctx.stroke()
+      }
+
       ctx.restore()
     }
 
@@ -255,7 +262,11 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
               prompt.allowNone = true
 
               const onMove = (cursor: AcGePoint3dLike) => {
-                if (points.length < 2) return
+                if (points.length < 2) {
+                  // Still stroke rubber-band from first point while picking 2nd
+                  drawPolygon(cursor)
+                  return
+                }
                 const tempPts = [...points, cursor]
                 const area = shoelaceArea(tempPts)
                 liveBadge.setText(

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
@@ -33,7 +33,7 @@ import { AcTrView2d } from '../../view'
 import {
   AcApHtmlLivePreview,
   acapStrokeLiveSegment
-} from '../overlay'
+} from '../overlay/AcApHtmlLivePreview'
 import { MEASUREMENT_LIVE_LAYER } from './AcApMeasurementStore'
 import { AcApMeasureDistanceEntity } from './entity'
 

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
@@ -1,7 +1,6 @@
 import {
   AcCmColor,
   AcDbDatabase,
-  AcDbLine,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
@@ -26,10 +25,15 @@ import {
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
   acapGetMeasurementLineWeight,
+  acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
   formatMeasurementLength
 } from '../../util'
 import { AcTrView2d } from '../../view'
+import {
+  AcApHtmlLivePreview,
+  acapStrokeLiveSegment
+} from '../overlay'
 import { MEASUREMENT_LIVE_LAYER } from './AcApMeasurementStore'
 import { AcApMeasureDistanceEntity } from './entity'
 
@@ -57,18 +61,18 @@ export function placeDistanceMeasurement(
 /**
  * Preview jig for the distance measurement command.
  *
- * Renders a live rubber-band line from the fixed first point to the current
- * cursor position. The badge showing the live distance is rendered by the
- * jig itself and is removed when the jig ends — it is intentionally short-lived
- * and intrinsic to the interactive input UX.
+ * Renders a live HTML rubber-band segment and length badge (no AcDb preview).
  */
 export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
-  private _line: AcDbLine
-  private _p1: AcGePoint3dLike
-  private _db: AcDbDatabase
-  private _htManager: AcTrHtmlTransientManager
-  private _badge: AcTrHtmlBadge
+  private readonly _view: AcTrView2d
+  private readonly _p1: AcGePoint3dLike
+  private readonly _db: AcDbDatabase
+  private readonly _htManager: AcTrHtmlTransientManager
+  private readonly _badge: AcTrHtmlBadge
   private readonly _badgeId: string
+  private readonly _preview: AcApHtmlLivePreview
+  private _color: AcCmColor
+  private _p2: AcGePoint3dLike
 
   constructor(
     view: AcEdBaseView,
@@ -77,38 +81,51 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
     color: AcCmColor
   ) {
     super(view)
+    this._view = view as AcTrView2d
     this._p1 = p1
+    this._p2 = p1
     this._db = db
-    this._line = new AcDbLine(p1, p1)
-    this._line.color = color
-    this._line.lineWeight = acapGetMeasurementLineWeight()
+    this._color = color
 
     this._badgeId = `live-dist-badge-${Date.now()}`
-    this._htManager = (view as AcTrView2d).htmlTransientManager
+    this._htManager = this._view.htmlTransientManager
     this._badge = new AcTrHtmlBadge({
       id: this._badgeId,
       color,
       worldPosition: p1,
       layer: MEASUREMENT_LIVE_LAYER,
-      layoutId: (view as AcTrView2d).activeLayoutBtrId,
+      layoutId: this._view.activeLayoutBtrId,
       fontSize: acapGetMeasurementFontSize()
     })
     this._badge.object.visible = false
     this._htManager.add(this._badge)
+
+    this._preview = new AcApHtmlLivePreview(
+      this._view,
+      `live-dist-stroke-${Date.now()}`,
+      MEASUREMENT_LIVE_LAYER
+    )
   }
 
-  get entity(): AcDbLine {
-    return this._line
+  /** HTML-only preview — no CAD transient. */
+  get entity(): null {
+    return null
   }
 
   update(p2: AcGePoint3dLike) {
-    this._line.endPoint = p2
-    this._line.color = acapGetMeasurementColor(this._db)
-    this._line.lineWeight = acapGetMeasurementLineWeight()
-    this._badge.setColor(this._line.color)
+    this._p2 = p2
+    this._color = acapGetMeasurementColor(this._db)
+    this._badge.setColor(this._color)
     this._badge.setFontSize(acapGetMeasurementFontSize())
 
     const dist = calcDist(this._p1, p2)
+    const lineWidth = acapMeasurementCanvasLineWidth(
+      acapGetMeasurementLineWeight()
+    )
+    this._preview.acapSetDraw((ctx, view) => {
+      acapStrokeLiveSegment(ctx, view, this._p1, this._p2, this._color, lineWidth)
+    })
+
     if (dist < 0.0001) {
       this._badge.object.visible = false
       return
@@ -124,6 +141,7 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
 
   end() {
     super.end()
+    this._preview.acapDispose()
     this._htManager.remove(this._badgeId)
   }
 }
@@ -131,10 +149,8 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
 /**
  * Command that measures the straight-line distance between two points.
  *
- * Prompts the user to pick two world points, then registers a transient CAD
- * line between them. Persistent DOM overlays (dots + badge) are placed via
- * {@link AcTrHtmlTransientManager} using CSS2DObject, so they track zoom/pan
- * automatically without manual viewChanged listeners.
+ * Prompts for two world points, then commits a measurement overlay.
+ * Interactive preview is HTML-only (canvas stroke + badge).
  */
 export class AcApMeasureDistanceCmd extends AcEdCommand {
   constructor() {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -60,9 +60,15 @@ export function setMeasurementVisible(
  * Optional non-HTML resources attached to a measurement {@link AcTrHtmlGroup}.
  */
 export interface AcApMeasurementGroupExtras {
-  /** CAD transient entity object ids (lines, etc.). */
+  /**
+   * @deprecated CAD transients are no longer used for measurements; kept empty
+   * for backward-compatible call sites.
+   */
   entityIds?: AcDbObjectId[]
-  /** Live CAD entity refs so color / line weight can be updated in place. */
+  /**
+   * @deprecated CAD entity refs are no longer used; style updates go through
+   * {@link redraw}.
+   */
   entities?: AcDbEntity[]
   /** Style used when the group was committed (and after later style edits). */
   style?: AcApMeasurementStyle
@@ -73,7 +79,7 @@ export interface AcApMeasurementGroupExtras {
   /** Redraw canvas overlays after a style change (color / line weight). */
   redraw?: (style: AcApMeasurementStyle) => void
   /**
-   * Removes non-HTML resources (CAD transients, viewChanged listeners).
+   * Removes non-HTML resources (viewChanged listeners).
    * HTML children and group-owned canvases are removed by the html
    * transient manager / group dispose.
    */
@@ -121,7 +127,7 @@ function rememberStyle(id: string, style: AcApMeasurementStyle): void {
 }
 
 /**
- * Apply a style patch to one measurement group (HTML, CAD transients, canvases).
+ * Apply a style patch to one measurement group (HTML badges/dots and canvases).
  * Does not record undo; wrap with {@link runMeasurementEdit} from UI.
  */
 export function applyMeasurementStyle(
@@ -184,16 +190,6 @@ function paintMeasurementGroup(
   }
 
   const extras = extrasById.get(group.id)
-  const selected = group.selected
-  for (const entity of extras?.entities ?? []) {
-    entity.color = style.color.clone()
-    entity.lineWeight = style.lineWeight
-    view.removeTransientEntity(entity.objectId)
-    view.addTransientEntity(entity)
-  }
-  if (selected && (extras?.entityIds?.length ?? 0) > 0) {
-    view.highlight(extras!.entityIds!)
-  }
   extras?.redraw?.(style)
   view.isHtmlDirty = true
 }
@@ -248,7 +244,7 @@ export function resetMeasurementStyleState(): void {
 
 /**
  * Publishes a measurement {@link AcTrHtmlGroup} and wires measurement-specific
- * selection extras (CAD entity highlight).
+ * selection state.
  *
  * The group itself (children, canvases, click selection, Delete, layout
  * visibility) is handled by {@link AcTrHtmlTransientManager}.

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureAngleEntity.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureAngleEntity.ts
@@ -1,6 +1,5 @@
 import {
   type AcDbDatabase,
-  AcDbLine,
   type AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
@@ -12,7 +11,8 @@ import {
 import {
   acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
-  formatMeasurementAngle} from '../../../util'
+  formatMeasurementAngle
+} from '../../../util'
 import type { AcTrView2d } from '../../../view'
 import { serializeMeasurementStyle } from '../AcApMeasurementSidecar'
 import {
@@ -33,9 +33,9 @@ import {
 /**
  * Angle measurement overlay entity.
  *
- * Renders two transient CAD arm lines from the vertex, HTML dots at vertex and
- * arm ends, a canvas arc between the arms, and a degree badge along the angle
- * bisector. Redraws the arc on view changes.
+ * Renders two arm lines and an angle arc on an HTML canvas, HTML dots at the
+ * vertex and arm ends, and a degree badge along the angle bisector.
+ * No CAD transient entities.
  */
 export class AcApMeasureAngleEntity extends AcApMeasureEntity {
   /** Angle vertex in world coordinates. */
@@ -124,12 +124,12 @@ export class AcApMeasureAngleEntity extends AcApMeasureEntity {
   }
 
   /**
-   * Draws arm lines, dots, angle arc canvas, badge, and commit extras.
+   * Draws arm lines + arc canvas, dots, badge, and commit extras.
    *
-   * Registers a `viewChanged` listener to repaint the persistent arc; dispose
-   * extras remove the listener and transient lines.
+   * Registers a `viewChanged` listener to repaint the persistent canvas;
+   * dispose removes the listener.
    *
-   * @param view - Active 2D view for transients and HTML overlays
+   * @param view - Active 2D view for HTML overlays
    * @param db - Database used to format the angle label
    * @returns World-draw result including redraw/dispose hooks
    */
@@ -139,23 +139,14 @@ export class AcApMeasureAngleEntity extends AcApMeasureEntity {
   ): AcApMeasureWorldDrawResult {
     const color = this.style.color
     const degrees = measureAngleDeg(this.vertex, this.arm1, this.arm2)
-    const line1 = new AcDbLine(this.vertex, this.arm1)
-    line1.color = color
-    line1.lineWeight = this.style.lineWeight
-    view.addTransientEntity(line1)
-    const line2 = new AcDbLine(this.vertex, this.arm2)
-    line2.color = color
-    line2.lineWeight = this.style.lineWeight
-    view.addTransientEntity(line2)
-
     const layoutId = this.resolveLayoutId(view)
     const persistOverlay = new AcTrHtmlCanvasOverlay({
-      id: `angle-arc-${this.entityId}`,
+      id: `angle-canvas-${this.entityId}`,
       container: view.container,
       layer: MEASUREMENT_LAYER,
       layoutId
     })
-    const paintArc = (paintStyle = this.style) =>
+    const paintAngle = (paintStyle = this.style) =>
       drawMeasureAngleArcOnCanvas(
         persistOverlay.canvas,
         view,
@@ -165,9 +156,9 @@ export class AcApMeasureAngleEntity extends AcApMeasureEntity {
         paintStyle.color,
         acapMeasurementCanvasLineWidth(paintStyle.lineWeight)
       )
-    paintArc()
+    paintAngle()
     const redrawPersist = () =>
-      paintArc(getMeasurementStyle(this.entityId) ?? this.style)
+      paintAngle(getMeasurementStyle(this.entityId) ?? this.style)
     view.events.viewChanged.addEventListener(redrawPersist)
 
     const dx1 = this.arm1.x - this.vertex.x
@@ -232,19 +223,15 @@ export class AcApMeasureAngleEntity extends AcApMeasureEntity {
 
     return {
       group,
-      entityIds: [line1.objectId, line2.objectId],
+      entityIds: [],
       dispose: () => {
-        view.removeTransientEntity(line1.objectId)
-        view.removeTransientEntity(line2.objectId)
         view.events.viewChanged.removeEventListener(redrawPersist)
       },
       extras: {
-        entityIds: [line1.objectId, line2.objectId],
-        entities: [line1, line2],
         style: this.style,
         value: { kind: 'angle', radians: (degrees * Math.PI) / 180 },
         snapshot: this.toRecord(layoutId),
-        redraw: paintArc
+        redraw: paintAngle
       }
     }
   }

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDistanceEntity.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDistanceEntity.ts
@@ -1,17 +1,22 @@
 import {
   type AcDbDatabase,
-  AcDbLine,
   type AcGePoint3dLike
 } from '@mlightcad/data-model'
-import { AcTrHtmlBadge, AcTrHtmlDot } from '@mlightcad/three-renderer'
+import { AcTrHtmlBadge, AcTrHtmlCanvasOverlay, AcTrHtmlDot } from '@mlightcad/three-renderer'
 
 import {
+  acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
-  formatMeasurementLength} from '../../../util'
+  formatMeasurementLength
+} from '../../../util'
 import type { AcTrView2d } from '../../../view'
 import { serializeMeasurementStyle } from '../AcApMeasurementSidecar'
-import { MEASUREMENT_LAYER } from '../AcApMeasurementStore'
+import {
+  getMeasurementStyle,
+  MEASUREMENT_LAYER
+} from '../AcApMeasurementStore'
 import type { AcApMeasurementRecord } from '../AcApMeasurementTypes'
+import { drawMeasureSegmentOnCanvas } from './AcApMeasureDrawUtil'
 import {
   AcApMeasureEntity,
   type AcApMeasureEntityOptions,
@@ -34,9 +39,8 @@ function calcDist(p1: AcGePoint3dLike, p2: AcGePoint3dLike): number {
 /**
  * Distance measurement overlay entity.
  *
- * Renders a transient CAD line between two endpoints, HTML dots at each end,
- * and a length badge at the midpoint. Commits length value and snapshot to
- * the measurement store.
+ * Renders an HTML canvas segment between two endpoints, HTML dots at each end,
+ * and a length badge at the midpoint. No CAD transient entities.
  */
 export class AcApMeasureDistanceEntity extends AcApMeasureEntity {
   /** First endpoint of the measured segment in world coordinates. */
@@ -121,11 +125,11 @@ export class AcApMeasureDistanceEntity extends AcApMeasureEntity {
   }
 
   /**
-   * Draws the distance line, endpoint dots, length badge, and commit extras.
+   * Draws the distance canvas stroke, endpoint dots, length badge, and extras.
    *
-   * @param view - Active 2D view for transients and HTML overlays
+   * @param view - Active 2D view for HTML overlays
    * @param db - Database used to format the length label
-   * @returns World-draw result with dispose hooks for the transient line
+   * @returns World-draw result with dispose for the viewChanged listener
    */
   protected subWorldDrawWithDb(
     view: AcTrView2d,
@@ -133,48 +137,65 @@ export class AcApMeasureDistanceEntity extends AcApMeasureEntity {
   ): AcApMeasureWorldDrawResult {
     const dist = calcDist(this.p1, this.p2)
     const color = this.style.color
-    const line = new AcDbLine(this.p1, this.p2)
-    line.color = color
-    line.lineWeight = this.style.lineWeight
-    view.addTransientEntity(line)
-
     const layoutId = this.resolveLayoutId(view)
     const mid = this.primaryPoint()!
-    const group = this.createGroup(view).add(
-      new AcTrHtmlDot({
-        id: `${this.entityId}-dot1`,
-        color,
-        worldPosition: this.p1,
-        layer: MEASUREMENT_LAYER
-      }),
-      new AcTrHtmlDot({
-        id: `${this.entityId}-dot2`,
-        color,
-        worldPosition: this.p2,
-        layer: MEASUREMENT_LAYER
-      }),
-      new AcTrHtmlBadge({
-        id: `${this.entityId}-badge`,
-        color,
-        text: formatMeasurementLength(db, dist),
-        worldPosition: mid,
-        layer: MEASUREMENT_LAYER,
-        fontSize: this.style.fontSize
-      })
-    )
+
+    const persistOverlay = new AcTrHtmlCanvasOverlay({
+      id: `dist-canvas-${this.entityId}`,
+      container: view.container,
+      layer: MEASUREMENT_LAYER,
+      layoutId
+    })
+    const paintSegment = (paintStyle = this.style) =>
+      drawMeasureSegmentOnCanvas(
+        persistOverlay.canvas,
+        view,
+        this.p1,
+        this.p2,
+        paintStyle.color,
+        acapMeasurementCanvasLineWidth(paintStyle.lineWeight)
+      )
+    paintSegment()
+    const redrawPersist = () =>
+      paintSegment(getMeasurementStyle(this.entityId) ?? this.style)
+    view.events.viewChanged.addEventListener(redrawPersist)
+
+    const group = this.createGroup(view)
+      .add(
+        new AcTrHtmlDot({
+          id: `${this.entityId}-dot1`,
+          color,
+          worldPosition: this.p1,
+          layer: MEASUREMENT_LAYER
+        }),
+        new AcTrHtmlDot({
+          id: `${this.entityId}-dot2`,
+          color,
+          worldPosition: this.p2,
+          layer: MEASUREMENT_LAYER
+        }),
+        new AcTrHtmlBadge({
+          id: `${this.entityId}-badge`,
+          color,
+          text: formatMeasurementLength(db, dist),
+          worldPosition: mid,
+          layer: MEASUREMENT_LAYER,
+          fontSize: this.style.fontSize
+        })
+      )
+      .addCanvas(persistOverlay)
 
     return {
       group,
-      entityIds: [line.objectId],
+      entityIds: [],
       dispose: () => {
-        view.removeTransientEntity(line.objectId)
+        view.events.viewChanged.removeEventListener(redrawPersist)
       },
       extras: {
-        entityIds: [line.objectId],
-        entities: [line],
         style: this.style,
         value: { kind: 'length', value: dist },
-        snapshot: this.toRecord(layoutId)
+        snapshot: this.toRecord(layoutId),
+        redraw: paintSegment
       }
     }
   }

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDrawUtil.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDrawUtil.ts
@@ -62,11 +62,43 @@ const normaliseAngle = (a: number) =>
   ((a % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)
 
 /**
- * Draws a persistent angle arc between two arms on a measure overlay canvas.
+ * Strokes a single world-space segment onto a measure overlay canvas.
  *
- * Converts `vertex`, `arm1`, and `arm2` to screen space, chooses an arc radius
- * from the shorter arm length (with a minimum), and strokes the shorter angular
- * sector in the given color.
+ * @param canvas - Overlay canvas to paint
+ * @param view - View for world-to-screen conversion and canvas sizing
+ * @param p1 - Segment start in world coordinates
+ * @param p2 - Segment end in world coordinates
+ * @param color - Stroke color
+ * @param lineWidth - Stroke width in CSS pixels (default `2`)
+ */
+export function drawMeasureSegmentOnCanvas(
+  canvas: HTMLCanvasElement,
+  view: AcEdBaseView,
+  p1: Point2,
+  p2: Point2,
+  color: AcCmColor,
+  lineWidth = 2
+): void {
+  const prepared = prepareMeasureCanvas(canvas, view)
+  if (!prepared) return
+  const { ctx } = prepared
+  const a = view.worldToScreen(p1)
+  const b = view.worldToScreen(p2)
+  ctx.beginPath()
+  ctx.moveTo(a.x, a.y)
+  ctx.lineTo(b.x, b.y)
+  ctx.strokeStyle = acapCssColor(color)
+  ctx.lineWidth = lineWidth
+  ctx.stroke()
+  ctx.restore()
+}
+
+/**
+ * Draws angle arm lines plus the measurement arc on a measure overlay canvas.
+ *
+ * Converts `vertex`, `arm1`, and `arm2` to screen space, strokes both arms,
+ * then draws the shorter angular sector with a radius derived from the shorter
+ * arm length (with a minimum).
  *
  * @param canvas - Overlay canvas to paint
  * @param view - View for world-to-screen conversion and canvas sizing
@@ -93,6 +125,15 @@ export function drawMeasureAngleArcOnCanvas(
   const sa1 = view.worldToScreen(arm1)
   const sa2 = view.worldToScreen(arm2)
 
+  ctx.strokeStyle = acapCssColor(color)
+  ctx.lineWidth = lineWidth
+  ctx.beginPath()
+  ctx.moveTo(sv.x, sv.y)
+  ctx.lineTo(sa1.x, sa1.y)
+  ctx.moveTo(sv.x, sv.y)
+  ctx.lineTo(sa2.x, sa2.y)
+  ctx.stroke()
+
   const len1 = Math.hypot(sa1.x - sv.x, sa1.y - sv.y)
   const len2 = Math.hypot(sa2.x - sv.x, sa2.y - sv.y)
   const arcR = Math.max(Math.min(len1, len2) * 0.3, 15)
@@ -103,8 +144,6 @@ export function drawMeasureAngleArcOnCanvas(
 
   ctx.beginPath()
   ctx.arc(sv.x, sv.y, arcR, startAngle, endAngle, antiClockwise)
-  ctx.strokeStyle = acapCssColor(color)
-  ctx.lineWidth = lineWidth
   ctx.stroke()
   ctx.restore()
 }

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureEntity.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureEntity.ts
@@ -53,8 +53,8 @@ export interface AcApMeasureWorldDrawResult extends AcApOverlayWorldDrawResult {
 /**
  * Base class for measurement overlays (distance / angle / area / arc / point).
  *
- * Not an HTML leaf — composes {@link AcTrHtmlGroup} and optional CAD
- * transients. Subclasses implement {@link toRecord} and
+ * Not an HTML leaf — composes {@link AcTrHtmlGroup} and canvas / badge / dot
+ * children. Subclasses implement {@link toRecord} and
  * {@link subWorldDrawWithDb}; callers should use {@link commit} rather than
  * the generic overlay `worldDraw` path because unit labels need the database.
  *
@@ -65,7 +65,7 @@ export abstract class AcApMeasureEntity
   extends AcApOverlayEntity
   implements AcApOverlaySerializable<AcApMeasurementRecord>
 {
-  /** Visual style applied to CAD transients and HTML badges/dots. */
+  /** Visual style applied to HTML badges/dots and canvas strokes. */
   protected readonly style: AcApMeasurementStyle
   /** Stable measurement id used for HTML group, store, and sidecar records. */
   protected readonly entityId: string

--- a/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
@@ -1,0 +1,254 @@
+/**
+ * HTML-only live preview stroke for markup / measure jigs.
+ *
+ * Uses {@link AcTrHtmlCanvasOverlay} on a live layer; never adds AcDb entities.
+ * Updates set {@link AcTrView2d.isHtmlDirty} only (not {@link AcTrView2d.isDirty}),
+ * so jig rubber-bands no longer force a WebGL redraw.
+ */
+
+import type { AcCmColor } from '@mlightcad/data-model'
+import { AcTrHtmlCanvasOverlay } from '@mlightcad/three-renderer'
+
+import { acapCssColor } from '../../util'
+import type { AcTrView2d } from '../../view'
+import {
+  drawOverlayArrowHead,
+  drawOverlayHighlight,
+  fitOverlayCanvas
+} from './AcApOverlayDrawUtil'
+
+/** World-space 2D point for live preview strokes. */
+export interface AcApHtmlLivePoint {
+  /** World X. */
+  x: number
+  /** World Y. */
+  y: number
+}
+
+/**
+ * Drawable content for one live-preview frame.
+ */
+export type AcApHtmlLiveDrawFn = (
+  ctx: CanvasRenderingContext2D,
+  view: AcTrView2d
+) => void
+
+/**
+ * Full-viewport HTML canvas used as a jig rubber-band / shape preview.
+ */
+export class AcApHtmlLivePreview {
+  /** Host view. */
+  private readonly view: AcTrView2d
+  /** Screen-space canvas overlay on the live layer. */
+  private readonly overlay: AcTrHtmlCanvasOverlay
+  /** Current frame drawer; `null` clears the canvas. */
+  private drawFn: AcApHtmlLiveDrawFn | null = null
+  /** Bound viewChanged listener. */
+  private readonly onViewChanged = () => this.acapPaint()
+
+  /**
+   * @param view - Active 2D view.
+   * @param id - Unique overlay id.
+   * @param layer - HTML transient live layer name.
+   */
+  constructor(view: AcTrView2d, id: string, layer: string) {
+    this.view = view
+    this.overlay = new AcTrHtmlCanvasOverlay({
+      id,
+      container: view.container,
+      layer,
+      layoutId: view.activeLayoutBtrId
+    })
+    view.htmlTransientManager.add(this.overlay)
+    view.events.viewChanged.addEventListener(this.onViewChanged)
+  }
+
+  /** Overlay id (for manager remove). */
+  get id(): string {
+    return this.overlay.id
+  }
+
+  /**
+   * Replace the draw callback and immediately paint.
+   *
+   * Marks {@link AcTrView2d.isHtmlDirty} so CSS2D siblings (badges / dots)
+   * updated in the same jig tick are reprojected. Canvas strokes themselves
+   * are painted synchronously and do not need a WebGL pass.
+   *
+   * @param drawFn - Frame drawer, or `null` to clear.
+   */
+  acapSetDraw(drawFn: AcApHtmlLiveDrawFn | null): void {
+    this.drawFn = drawFn
+    this.acapPaint()
+    this.view.isHtmlDirty = true
+  }
+
+  /** Clear the canvas without disposing the overlay. */
+  acapClear(): void {
+    this.acapSetDraw(null)
+  }
+
+  /**
+   * Remove overlay and viewChanged listener.
+   *
+   * Sets {@link AcTrView2d.isHtmlDirty} so CSS2D can drop related live badges.
+   */
+  acapDispose(): void {
+    this.view.events.viewChanged.removeEventListener(this.onViewChanged)
+    this.view.htmlTransientManager.remove(this.overlay.id)
+    this.view.isHtmlDirty = true
+  }
+
+  /** Paint the current frame onto the overlay canvas. */
+  private acapPaint(): void {
+    const ctx = fitOverlayCanvas(this.overlay.canvas, this.view.container)
+    if (!ctx) return
+    this.drawFn?.(ctx, this.view)
+  }
+}
+
+/**
+ * Stroke a world-space segment in screen space.
+ *
+ * @param ctx - Canvas context in CSS pixels.
+ * @param view - View for world → screen.
+ * @param a - Segment start (world).
+ * @param b - Segment end (world).
+ * @param color - CSS or AcCmColor stroke color.
+ * @param lineWidth - Stroke width in CSS pixels.
+ * @param options - Optional dash pattern and arrow head at `b`.
+ */
+export function acapStrokeLiveSegment(
+  ctx: CanvasRenderingContext2D,
+  view: AcTrView2d,
+  a: AcApHtmlLivePoint,
+  b: AcApHtmlLivePoint,
+  color: string | AcCmColor,
+  lineWidth: number,
+  options?: { dashed?: boolean; arrow?: boolean }
+): void {
+  const css = typeof color === 'string' ? color : acapCssColor(color)
+  const sa = view.worldToScreen(a)
+  const sb = view.worldToScreen(b)
+  ctx.strokeStyle = css
+  ctx.lineWidth = lineWidth
+  if (options?.dashed) ctx.setLineDash([8, 5])
+  ctx.beginPath()
+  ctx.moveTo(sa.x, sa.y)
+  ctx.lineTo(sb.x, sb.y)
+  ctx.stroke()
+  if (options?.dashed) ctx.setLineDash([])
+  if (options?.arrow) {
+    drawOverlayArrowHead(ctx, sa, sb, css)
+  }
+}
+
+/**
+ * Stroke a world-space closed polyline (screen projection).
+ *
+ * @param ctx - Canvas context in CSS pixels.
+ * @param view - View for world → screen.
+ * @param points - World vertices in order.
+ * @param color - CSS or AcCmColor stroke color.
+ * @param lineWidth - Stroke width in CSS pixels.
+ * @param options - Optional dash / closePath.
+ */
+export function acapStrokeLivePolyline(
+  ctx: CanvasRenderingContext2D,
+  view: AcTrView2d,
+  points: AcApHtmlLivePoint[],
+  color: string | AcCmColor,
+  lineWidth: number,
+  options?: { dashed?: boolean; closed?: boolean }
+): void {
+  if (points.length < 2) return
+  const css = typeof color === 'string' ? color : acapCssColor(color)
+  const screen = points.map(p => view.worldToScreen(p))
+  ctx.strokeStyle = css
+  ctx.lineWidth = lineWidth
+  if (options?.dashed) ctx.setLineDash([8, 5])
+  ctx.beginPath()
+  ctx.moveTo(screen[0].x, screen[0].y)
+  for (let i = 1; i < screen.length; i++) {
+    ctx.lineTo(screen[i].x, screen[i].y)
+  }
+  if (options?.closed) ctx.closePath()
+  ctx.stroke()
+  if (options?.dashed) ctx.setLineDash([])
+}
+
+/**
+ * Stroke a world-space circle as a screen-space arc.
+ *
+ * @param ctx - Canvas context in CSS pixels.
+ * @param view - View for world → screen.
+ * @param center - Circle center (world).
+ * @param radius - Circle radius (world).
+ * @param color - CSS or AcCmColor stroke color.
+ * @param lineWidth - Stroke width in CSS pixels.
+ */
+export function acapStrokeLiveCircle(
+  ctx: CanvasRenderingContext2D,
+  view: AcTrView2d,
+  center: AcApHtmlLivePoint,
+  radius: number,
+  color: string | AcCmColor,
+  lineWidth: number
+): void {
+  if (radius <= 0) return
+  const css = typeof color === 'string' ? color : acapCssColor(color)
+  const sc = view.worldToScreen(center)
+  const rim = view.worldToScreen({ x: center.x + radius, y: center.y })
+  const screenR = Math.hypot(rim.x - sc.x, rim.y - sc.y)
+  ctx.strokeStyle = css
+  ctx.lineWidth = lineWidth
+  ctx.beginPath()
+  ctx.arc(sc.x, sc.y, screenR, 0, Math.PI * 2)
+  ctx.stroke()
+}
+
+/**
+ * Draw a highlight rectangle preview (matches committed highlight look).
+ *
+ * @param ctx - Canvas context in CSS pixels.
+ * @param view - View for world → screen.
+ * @param corner1 - One corner (world).
+ * @param corner2 - Opposite corner (world).
+ * @param color - CSS color string.
+ * @param lineWidth - Outline width in CSS pixels.
+ */
+export function acapFillLiveHighlight(
+  ctx: CanvasRenderingContext2D,
+  view: AcTrView2d,
+  corner1: AcApHtmlLivePoint,
+  corner2: AcApHtmlLivePoint,
+  color: string,
+  lineWidth: number
+): void {
+  drawOverlayHighlight(
+    ctx,
+    view.worldToScreen(corner1),
+    view.worldToScreen(corner2),
+    color,
+    lineWidth
+  )
+}
+
+/**
+ * Axis-aligned rectangle corners as a closed polyline (world).
+ *
+ * @param first - One corner.
+ * @param second - Opposite corner.
+ * @returns Four corners in clockwise order from `first`'s x/y mix.
+ */
+export function acapLiveRectCorners(
+  first: AcApHtmlLivePoint,
+  second: AcApHtmlLivePoint
+): AcApHtmlLivePoint[] {
+  return [
+    { x: first.x, y: first.y },
+    { x: second.x, y: first.y },
+    { x: second.x, y: second.y },
+    { x: first.x, y: second.y }
+  ]
+}

--- a/packages/cad-simple-viewer/src/command/overlay/index.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/index.ts
@@ -1,4 +1,12 @@
-export * from './AcApHtmlLivePreview'
+/**
+ * Shared overlay entity protocol, canvas helpers, and HTML grip host for
+ * markup and measure composites.
+ *
+ * Live jig previews (`AcApHtmlLivePreview`) are NOT re-exported here: that
+ * module pulls in `@mlightcad/three-renderer` as a value dependency. Import it
+ * from `./AcApHtmlLivePreview` so light grip helpers stay loadable under jsdom.
+ */
+
 export * from './AcApOverlayDrawUtil'
 export * from './AcApOverlayEntity'
 export * from './AcApOverlayGripHost'

--- a/packages/cad-simple-viewer/src/command/overlay/index.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/index.ts
@@ -1,8 +1,4 @@
-/**
- * Shared overlay entity protocol, canvas helpers, and HTML grip host for
- * markup and measure composites.
- */
-
+export * from './AcApHtmlLivePreview'
 export * from './AcApOverlayDrawUtil'
 export * from './AcApOverlayEntity'
 export * from './AcApOverlayGripHost'


### PR DESCRIPTION
## Summary
- Introduce `AcApHtmlLivePreview` so markup/measure jig rubber-bands paint on an HTML canvas live layer instead of CAD transients
- Migrate committed segment/shape/angle/distance overlay strokes to canvas (plus cloud tessellation helpers), with center-move live offset via `onLiveOffset`
- Drop measurement CAD entity highlight/style paths; keep empty `entityIds` for API compatibility; fix empty Enter accepting markup text defaults

## Test plan
- [ ] Markup tools (line, arrow, rect, circle, cloud, highlight, callout): rubber-band preview tracks cursor; pan/zoom while placing; cancel cleans up
- [ ] Commit each markup type and verify stroke/arrow/cloud look; drag center/endpoint grips with live preview; style color/weight updates
- [ ] Measure distance/angle/area/arc: live preview + badges; committed overlays redraw on zoom/pan and style change
- [ ] Confirm overlay-only updates do not force a full WebGL redraw (`isHtmlDirty` path)
- [ ] Callout / shape-callout text entry: Enter with empty input accepts default; Esc cancels and removes frozen preview
