### PR TITLE
refactor: align UI and overlay helpers with aced/acap prefixes

### DIFF
--- a/packages/cad-simple-ui-plugin/README.md
+++ b/packages/cad-simple-ui-plugin/README.md
@@ -32,12 +32,12 @@ pnpm add @mlightcad/cad-simple-ui-plugin @mlightcad/cad-simple-viewer @mlightcad
 Load the plugin after creating the document manager. Apply the initial UI theme on `host` first so theme/locale/placement buttons work even before a drawing is opened:
 
 ```typescript
-import { AcApDocManager, applyUiTheme } from '@mlightcad/cad-simple-viewer'
+import { AcApDocManager, acedApplyUiTheme } from '@mlightcad/cad-simple-viewer'
 import { createSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
 
 const host = document.getElementById('viewer-host')!
 
-applyUiTheme('dark', host)
+acedApplyUiTheme('dark', host)
 
 AcApDocManager.createInstance({ container: host })
 
@@ -70,7 +70,7 @@ await registerSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
 The [vanilla example](../cad-simple-viewer-example) **defers viewer and plugin initialization until the user opens a file** (local upload or predefined sample). That keeps the first paint lightweight:
 
 1. Page load — only file picker UI; no `AcApDocManager` yet.
-2. First open — `applyUiTheme`, `AcApDocManager.createInstance`, lazy export plugins, then `registerSimpleUiPlugin`.
+2. First open — `acedApplyUiTheme`, `AcApDocManager.createInstance`, lazy export plugins, then `registerSimpleUiPlugin`.
 3. Subsequent opens — reuse the same viewer instance.
 
 You can adopt the same pattern or load the plugin at startup (see Quick start above). Both are supported.
@@ -107,7 +107,7 @@ toolbar: {
 }
 ```
 
-The built-in theme toggle button updates `COLORTHEME` when a document is open, or applies `applyUiTheme` on `host` when no document is loaded.
+The built-in theme toggle button updates `COLORTHEME` when a document is open, or applies `acedApplyUiTheme` on `host` when no document is loaded.
 
 ### Layer manager (dock panel)
 
@@ -456,12 +456,12 @@ Disabling the toolbar also disables the layer dock UI, because the layer list is
 ### Complete example
 
 ```typescript
-import { AcApDocManager, AcEdOpenMode, applyUiTheme } from '@mlightcad/cad-simple-viewer'
+import { AcApDocManager, AcEdOpenMode, acedApplyUiTheme } from '@mlightcad/cad-simple-viewer'
 import { createSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
 
 const viewerPane = document.getElementById('viewerPane')!
 
-applyUiTheme('dark', viewerPane)
+acedApplyUiTheme('dark', viewerPane)
 
 AcApDocManager.createInstance({ container: document.getElementById('cad-container')! })
 

--- a/packages/cad-simple-ui-plugin/__tests__/AcExDockPanel.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcExDockPanel.spec.ts
@@ -22,7 +22,7 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
 
   return {
     ...layout,
-    isMobileUiLayout: () =>
+    acedIsMobileUiLayout: () =>
       window.matchMedia?.(layout.ML_UI_MOBILE_MEDIA_QUERY).matches ?? false,
     isCompactUiLayout: () =>
       window.matchMedia?.(layout.ML_UI_COMPACT_MEDIA_QUERY).matches ?? false,

--- a/packages/cad-simple-ui-plugin/__tests__/createSimpleUiPlugin.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/createSimpleUiPlugin.spec.ts
@@ -31,7 +31,7 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
 
   return {
     ...layout,
-    isMobileUiLayout: () =>
+    acedIsMobileUiLayout: () =>
       window.matchMedia?.(layout.ML_UI_MOBILE_MEDIA_QUERY).matches ?? false,
     isCompactUiLayout: () =>
       window.matchMedia?.(layout.ML_UI_COMPACT_MEDIA_QUERY).matches ?? false,
@@ -97,7 +97,7 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
       Write: 8
     },
     AcEdUiTheme: {},
-    applyUiTheme: jest.fn(),
+    acedApplyUiTheme: jest.fn(),
     isLightColorTheme: jest.fn(() => false),
     eventBus: {
       on: jest.fn(),

--- a/packages/cad-simple-ui-plugin/src/theme/AcExUiThemeSync.ts
+++ b/packages/cad-simple-ui-plugin/src/theme/AcExUiThemeSync.ts
@@ -1,7 +1,7 @@
 import {
   AcApDocManager,
+  acedApplyUiTheme,
   type AcEdUiTheme,
-  applyUiTheme,
   isLightColorTheme
 } from '@mlightcad/cad-simple-viewer'
 import {
@@ -62,7 +62,7 @@ export class AcExUiThemeSync {
   }
 
   /**
-   * @param host - Element receiving `applyUiTheme` and `data-ml-ui-theme`.
+   * @param host - Element receiving `acedApplyUiTheme` and `data-ml-ui-theme`.
    * @param onThemeChanged - Optional callback after each theme application (e.g. toolbar refresh).
    */
   constructor(
@@ -134,12 +134,12 @@ export class AcExUiThemeSync {
   }
 
   /**
-   * Calls {@link applyUiTheme} and notifies {@link onThemeChanged}.
+   * Calls {@link acedApplyUiTheme} and notifies {@link onThemeChanged}.
    *
    * @param theme - Theme to apply.
    */
   private applyTheme(theme: AcEdUiTheme) {
-    applyUiTheme(theme, this.host)
+    acedApplyUiTheme(theme, this.host)
     this.onThemeChanged?.()
   }
 }

--- a/packages/cad-simple-ui-plugin/src/ui/AcExDockPanel.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExDockPanel.ts
@@ -1,4 +1,4 @@
-import { isMobileUiLayout } from '@mlightcad/cad-simple-viewer'
+import { acedIsMobileUiLayout } from '@mlightcad/cad-simple-viewer'
 
 import {
   createIconElement,
@@ -686,7 +686,7 @@ export class AcExDockPanel {
     if (this.side !== 'left' && this.side !== 'right') {
       return false
     }
-    return isMobileUiLayout()
+    return acedIsMobileUiLayout()
   }
 
   private toggleSideMenu() {

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -10,8 +10,8 @@ import {
   AcApOpenDatabaseOptions,
   AcApQNewCmd,
   AcApSettingManager,
+  acedApplyUiTheme,
   AcEdOpenMode,
-  applyUiTheme,
   isCompactUiLayout,
   LIBREDWG_PARSER_WORKER_FILE,
   MTEXT_RENDERER_WORKER_FILE
@@ -793,7 +793,7 @@ class CadViewerApp {
     if (this.isInitialized) return
 
     try {
-      applyUiTheme('dark', this.viewerPane)
+      acedApplyUiTheme('dark', this.viewerPane)
 
       const openProf = isOpenProfMode()
       const useWorkers = openProf ? isWorkerOpenMode() : true

--- a/packages/cad-simple-viewer/__tests__/AcEdUiLayout.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdUiLayout.spec.ts
@@ -2,7 +2,7 @@
 
 import {
   isCompactUiLayout,
-  isMobileUiLayout,
+  acedIsMobileUiLayout,
   ML_UI_COMPACT_MAX_WIDTH,
   ML_UI_COMPACT_MEDIA_QUERY,
   ML_UI_MOBILE_MAX_WIDTH,
@@ -36,7 +36,7 @@ describe('AcEdUiLayout', () => {
       })
     })
 
-    expect(isMobileUiLayout()).toBe(true)
+    expect(acedIsMobileUiLayout()).toBe(true)
     expect(isCompactUiLayout()).toBe(false)
 
     if (matchMediaDescriptor) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutDrag.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutDrag.ts
@@ -9,13 +9,13 @@ import type { AcTrHtmlElement, AcTrHtmlGroup } from '@mlightcad/three-renderer'
 
 import type { AcTrView2d } from '../../view'
 import {
+  acapBindOverlayCalloutGrips,
+  acapBindOverlayPointerDrag,
   type AcApOverlayCalloutGripState,
   type AcApOverlayPoint2d,
   type AcApOverlayPointerDragOptions,
-  bindOverlayCalloutGrips,
-  bindOverlayPointerDrag,
-  placeOverlayHtml,
-  pointerEventToOverlayWorld} from '../overlay'
+  acapPlaceOverlayHtml,
+  acapPointerEventToOverlayWorld} from '../overlay'
 import {
   type AcApMarkupShapeOutline,
   computeLeaderTipOnShape
@@ -30,7 +30,7 @@ export type AcApMarkupCalloutGripState = AcApOverlayCalloutGripState
 /**
  * Convert a pointer event to a world-space 2D point on the view.
  *
- * @deprecated Prefer {@link pointerEventToOverlayWorld}.
+ * @deprecated Prefer {@link acapPointerEventToOverlayWorld}.
  * @param view - Active 2D view.
  * @param ev - Pointer event in viewport client coordinates.
  * @returns World XY under the pointer.
@@ -39,13 +39,13 @@ export function pointerEventToMarkupWorld(
   view: AcTrView2d,
   ev: PointerEvent
 ): AcApMarkupPoint2d {
-  return pointerEventToOverlayWorld(view, ev)
+  return acapPointerEventToOverlayWorld(view, ev)
 }
 
 /**
  * Move a published HTML overlay and refresh its transform baseline.
  *
- * @deprecated Prefer {@link placeOverlayHtml}.
+ * @deprecated Prefer {@link acapPlaceOverlayHtml}.
  * @param view - Active 2D view.
  * @param el - Published CSS2D overlay.
  * @param point - New world-space anchor.
@@ -55,20 +55,20 @@ export function placeMarkupHtml(
   el: AcTrHtmlElement,
   point: AcApOverlayPoint2d
 ): void {
-  placeOverlayHtml(view, el, point)
+  acapPlaceOverlayHtml(view, el, point)
 }
 
 /**
  * Bind pointer-drag on one HTML overlay handle.
  *
- * @deprecated Prefer {@link bindOverlayPointerDrag}.
+ * @deprecated Prefer {@link acapBindOverlayPointerDrag}.
  * @param options - Same as {@link AcApOverlayPointerDragOptions}.
  * @returns Cleanup that removes listeners.
  */
 export function bindMarkupPointerDrag(
   options: AcApOverlayPointerDragOptions
 ): () => void {
-  return bindOverlayPointerDrag(options)
+  return acapBindOverlayPointerDrag(options)
 }
 
 /**
@@ -111,7 +111,7 @@ export function bindMarkupCalloutGrips(
   options: AcApMarkupCalloutGripBindOptions
 ): () => void {
   const { outline, ...rest } = options
-  return bindOverlayCalloutGrips({
+  return acapBindOverlayCalloutGrips({
     ...rest,
     constrainTip: outline
       ? point => computeLeaderTipOnShape(outline, point)

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupCalloutEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupCalloutEntity.ts
@@ -7,11 +7,11 @@ import {
 
 import type { AcTrView2d } from '../../../view'
 import {
+  acapBindOverlayCalloutGrips,
+  acapDrawOverlayLeader,
+  acapFitOverlayCanvas,
   type AcApOverlayWorldDrawResult,
-  bindOverlayCalloutGrips,
-  drawOverlayLeader,
-  fitOverlayCanvas,
-  placeOverlayHtml} from '../../overlay'
+  acapPlaceOverlayHtml} from '../../overlay'
 import { runMarkupEdit } from '../AcApMarkupHistory'
 import { republishMarkup } from '../AcApMarkupRepublish'
 import { getMarkupStore } from '../AcApMarkupStore'
@@ -133,9 +133,9 @@ export class AcApMarkupCalloutEntity extends AcApMarkupEntity {
      * Redraw the leader (with arrow) from {@link live}.
      */
     const redraw = () => {
-      const ctx = fitOverlayCanvas(overlay.canvas, container)
+      const ctx = acapFitOverlayCanvas(overlay.canvas, container)
       if (!ctx) return
-      drawOverlayLeader(
+      acapDrawOverlayLeader(
         ctx,
         view.worldToScreen(live.tip),
         view.worldToScreen(live.anchor),
@@ -190,14 +190,14 @@ export class AcApMarkupCalloutEntity extends AcApMarkupEntity {
      * Keep the center grip halfway between tip and bubble during live drag.
      */
     const syncCenter = () => {
-      placeOverlayHtml(view, centerDot, {
+      acapPlaceOverlayHtml(view, centerDot, {
         x: (live.tip.x + live.anchor.x) / 2,
         y: (live.tip.y + live.anchor.y) / 2
       })
     }
     pendingGrips.push(() => {
       cleanups.push(
-        bindOverlayCalloutGrips({
+        acapBindOverlayCalloutGrips({
           view,
           group,
           tipEl: tipDot,

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
@@ -12,11 +12,11 @@ import {
 
 import type { AcTrView2d } from '../../../view'
 import {
-  bindOverlayCalloutGrips,
-  bindOverlayPointerDrag,
-  drawOverlayLeader,
-  fitOverlayCanvas,
-  placeOverlayHtml
+  acapBindOverlayCalloutGrips,
+  acapBindOverlayPointerDrag,
+  acapDrawOverlayLeader,
+  acapFitOverlayCanvas,
+  acapPlaceOverlayHtml
 } from '../../overlay'
 import {
   markupGeometryCenter,
@@ -122,9 +122,9 @@ export function publishAttachedCallout(
    * Redraw the leader stroke from {@link live} tip / anchor.
    */
   const redraw = () => {
-    const ctx = fitOverlayCanvas(overlay.canvas, container)
+    const ctx = acapFitOverlayCanvas(overlay.canvas, container)
     if (!ctx) return
-    drawOverlayLeader(
+    acapDrawOverlayLeader(
       ctx,
       view2d.worldToScreen(live.tip),
       view2d.worldToScreen(live.anchor),
@@ -174,7 +174,7 @@ export function publishAttachedCallout(
    */
   const bindGrips = () => {
     cleanups.push(
-      bindOverlayCalloutGrips({
+      acapBindOverlayCalloutGrips({
         view: view2d,
         group,
         tipEl: tipDot,
@@ -255,7 +255,7 @@ export function bindMarkupCenterMove(
   let last = { ...origin }
   /** Attached callout tip/anchor at drag start, for relative preview. */
   let originalCallout: AcApMarkupAttachedCallout | undefined
-  return bindOverlayPointerDrag({
+  return acapBindOverlayPointerDrag({
     view,
     el: centerEl.element,
     cursor: 'move',
@@ -280,7 +280,7 @@ export function bindMarkupCenterMove(
       const dx = point.x - origin.x
       const dy = point.y - origin.y
       onLiveOffset?.(dx, dy)
-      placeOverlayHtml(view, centerEl, point)
+      acapPlaceOverlayHtml(view, centerEl, point)
       if (attached && originalCallout) {
         attached.live.tip = translateMarkupPoint(originalCallout.tip, dx, dy)
         attached.live.anchor = translateMarkupPoint(
@@ -288,8 +288,8 @@ export function bindMarkupCenterMove(
           dx,
           dy
         )
-        placeOverlayHtml(view, attached.tipDot, attached.live.tip)
-        placeOverlayHtml(view, attached.bubble, attached.live.anchor)
+        acapPlaceOverlayHtml(view, attached.tipDot, attached.live.tip)
+        acapPlaceOverlayHtml(view, attached.bubble, attached.live.anchor)
         attached.redraw()
       }
     },

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupHighlightEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupHighlightEntity.ts
@@ -2,9 +2,8 @@ import { AcTrHtmlCanvasOverlay, AcTrHtmlDot } from '@mlightcad/three-renderer'
 
 import type { AcTrView2d } from '../../../view'
 import {
-  type AcApOverlayWorldDrawResult,
-  drawOverlayHighlight,
-  fitOverlayCanvas} from '../../overlay'
+  acapDrawOverlayHighlight,
+  acapFitOverlayCanvas,  type AcApOverlayWorldDrawResult} from '../../overlay'
 import type { AcApMarkupRecord } from '../AcApMarkupTypes'
 import { AcApMarkupEntity } from './AcApMarkupEntity'
 
@@ -56,9 +55,9 @@ export class AcApMarkupHighlightEntity extends AcApMarkupEntity {
      * Redraw the highlight rectangle in screen space.
      */
     const redraw = () => {
-      const ctx = fitOverlayCanvas(overlay.canvas, container)
+      const ctx = acapFitOverlayCanvas(overlay.canvas, container)
       if (!ctx) return
-      drawOverlayHighlight(
+      acapDrawOverlayHighlight(
         ctx,
         view.worldToScreen(geom.corner1),
         view.worldToScreen(geom.corner2),

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupSegmentEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupSegmentEntity.ts
@@ -9,11 +9,11 @@ import {
 
 import type { AcTrView2d } from '../../../view'
 import {
+  acapBindOverlayPointerDrag,
+  acapDrawOverlayArrowHead,
+  acapFitOverlayCanvas,
   type AcApOverlayWorldDrawResult,
-  bindOverlayPointerDrag,
-  drawOverlayArrowHead,
-  fitOverlayCanvas,
-  placeOverlayHtml
+  acapPlaceOverlayHtml
 } from '../../overlay'
 import { runMarkupEdit } from '../AcApMarkupHistory'
 import { republishMarkup } from '../AcApMarkupRepublish'
@@ -142,7 +142,7 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
      * Redraw canvas stroke / arrow head from {@link live} endpoints.
      */
     const redrawStroke = () => {
-      const ctx = fitOverlayCanvas(overlay.canvas, container)
+      const ctx = acapFitOverlayCanvas(overlay.canvas, container)
       if (!ctx) return
       const a = view.worldToScreen(live.start)
       const b = view.worldToScreen(live.end)
@@ -153,7 +153,7 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
       ctx.lineTo(b.x, b.y)
       ctx.stroke()
       if (isArrow) {
-        drawOverlayArrowHead(ctx, a, b, this.record.style.color)
+        acapDrawOverlayArrowHead(ctx, a, b, this.record.style.color)
       }
     }
     redrawStroke()
@@ -210,24 +210,24 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
     }
     pendingGrips.push(() => {
       cleanups.push(
-        bindOverlayPointerDrag({
+        acapBindOverlayPointerDrag({
           view,
           el: startDot.element,
           onDragStart: beginEndpointDrag,
           onMove: point => {
             live.start = point
-            placeOverlayHtml(view, startDot, point)
+            acapPlaceOverlayHtml(view, startDot, point)
             redrawStroke()
           },
           onCommit: commitEndpoints
         }),
-        bindOverlayPointerDrag({
+        acapBindOverlayPointerDrag({
           view,
           el: endDot.element,
           onDragStart: beginEndpointDrag,
           onMove: point => {
             live.end = point
-            placeOverlayHtml(view, endDot, point)
+            acapPlaceOverlayHtml(view, endDot, point)
             redrawStroke()
           },
           onCommit: commitEndpoints

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupShapeEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupShapeEntity.ts
@@ -3,9 +3,8 @@ import { AcTrHtmlCanvasOverlay, AcTrHtmlDot } from '@mlightcad/three-renderer'
 
 import type { AcTrView2d } from '../../../view'
 import {
-  type AcApOverlayWorldDrawResult,
-  fitOverlayCanvas
-} from '../../overlay'
+  acapFitOverlayCanvas,
+  type AcApOverlayWorldDrawResult} from '../../overlay'
 import {
   acapLiveRectCorners,
   acapStrokeLiveCircle,
@@ -115,7 +114,7 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
      * Redraw the shape stroke with the current {@link liveOffset}.
      */
     const redrawShape = () => {
-      const ctx = fitOverlayCanvas(overlay.canvas, container)
+      const ctx = acapFitOverlayCanvas(overlay.canvas, container)
       if (!ctx) return
       const css = this.record.style.color
       if (geom.type === 'cloud') {

--- a/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
@@ -12,9 +12,9 @@ import { AcTrHtmlCanvasOverlay } from '@mlightcad/three-renderer'
 import { acapCssColor } from '../../util'
 import type { AcTrView2d } from '../../view'
 import {
-  drawOverlayArrowHead,
-  drawOverlayHighlight,
-  fitOverlayCanvas
+  acapDrawOverlayArrowHead,
+  acapDrawOverlayHighlight,
+  acapFitOverlayCanvas
 } from './AcApOverlayDrawUtil'
 
 /** World-space 2D point for live preview strokes. */
@@ -101,7 +101,7 @@ export class AcApHtmlLivePreview {
 
   /** Paint the current frame onto the overlay canvas. */
   private acapPaint(): void {
-    const ctx = fitOverlayCanvas(this.overlay.canvas, this.view.container)
+    const ctx = acapFitOverlayCanvas(this.overlay.canvas, this.view.container)
     if (!ctx) return
     this.drawFn?.(ctx, this.view)
   }
@@ -139,7 +139,7 @@ export function acapStrokeLiveSegment(
   ctx.stroke()
   if (options?.dashed) ctx.setLineDash([])
   if (options?.arrow) {
-    drawOverlayArrowHead(ctx, sa, sb, css)
+    acapDrawOverlayArrowHead(ctx, sa, sb, css)
   }
 }
 
@@ -225,7 +225,7 @@ export function acapFillLiveHighlight(
   color: string,
   lineWidth: number
 ): void {
-  drawOverlayHighlight(
+  acapDrawOverlayHighlight(
     ctx,
     view.worldToScreen(corner1),
     view.worldToScreen(corner2),

--- a/packages/cad-simple-viewer/src/command/overlay/AcApOverlayDrawUtil.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApOverlayDrawUtil.ts
@@ -12,7 +12,7 @@
  * @param container - View container used for size measurement.
  * @returns A 2D context ready to draw, or `null` if unavailable.
  */
-export function fitOverlayCanvas(
+export function acapFitOverlayCanvas(
   canvas: HTMLCanvasElement,
   container: HTMLElement
 ): CanvasRenderingContext2D | null {
@@ -43,7 +43,7 @@ export function fitOverlayCanvas(
  * @param to - Arrow tip in screen space.
  * @param color - CSS fill color.
  */
-export function drawOverlayArrowHead(
+export function acapDrawOverlayArrowHead(
   ctx: CanvasRenderingContext2D,
   from: { x: number; y: number },
   to: { x: number; y: number },
@@ -82,7 +82,7 @@ export function drawOverlayArrowHead(
  * @param withArrow - When `true`, draws an arrow head at `tip`.
  * @param lineWidth - Stroke width in CSS pixels.
  */
-export function drawOverlayLeader(
+export function acapDrawOverlayLeader(
   ctx: CanvasRenderingContext2D,
   tip: { x: number; y: number },
   anchor: { x: number; y: number },
@@ -97,7 +97,7 @@ export function drawOverlayLeader(
   ctx.lineTo(anchor.x, anchor.y)
   ctx.stroke()
   if (withArrow) {
-    drawOverlayArrowHead(ctx, anchor, tip, color)
+    acapDrawOverlayArrowHead(ctx, anchor, tip, color)
   }
 }
 
@@ -110,7 +110,7 @@ export function drawOverlayLeader(
  * @param color - CSS fill / stroke color.
  * @param lineWidth - Outline stroke width in CSS pixels.
  */
-export function drawOverlayHighlight(
+export function acapDrawOverlayHighlight(
   ctx: CanvasRenderingContext2D,
   a: { x: number; y: number },
   b: { x: number; y: number },

--- a/packages/cad-simple-viewer/src/command/overlay/AcApOverlayGripHost.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApOverlayGripHost.ts
@@ -24,7 +24,7 @@ export interface AcApOverlayPoint2d {
  * @param ev - Pointer event in viewport client coordinates.
  * @returns World XY point under the pointer.
  */
-export function pointerEventToOverlayWorld(
+export function acapPointerEventToOverlayWorld(
   view: AcTrView2d,
   ev: PointerEvent
 ): AcApOverlayPoint2d {
@@ -43,7 +43,7 @@ export function pointerEventToOverlayWorld(
  * @param el - Published CSS2D overlay to reposition.
  * @param point - New world-space anchor.
  */
-export function placeOverlayHtml(
+export function acapPlaceOverlayHtml(
   view: AcTrView2d,
   el: AcTrHtmlElement,
   point: AcApOverlayPoint2d
@@ -66,7 +66,7 @@ const windowListenerOptions: AddEventListenerOptions = {
 }
 
 /**
- * Options for {@link bindOverlayPointerDrag}.
+ * Options for {@link acapBindOverlayPointerDrag}.
  */
 export interface AcApOverlayPointerDragOptions {
   /** Active 2D view used for world conversion and dirty flags. */
@@ -93,7 +93,7 @@ export interface AcApOverlayPointerDragOptions {
  * @param options - Handle element and drag callbacks.
  * @returns Cleanup that removes listeners and cancels an in-progress drag.
  */
-export function bindOverlayPointerDrag(
+export function acapBindOverlayPointerDrag(
   options: AcApOverlayPointerDragOptions
 ): () => void {
   const { view, el, onDragStart, onMove, onCommit } = options
@@ -156,7 +156,7 @@ export function bindOverlayPointerDrag(
         el.style.cursor = 'grabbing'
         onDragStart?.()
       }
-      onMove(pointerEventToOverlayWorld(view, ev), ev)
+      onMove(acapPointerEventToOverlayWorld(view, ev), ev)
       view.isHtmlDirty = true
     }
 
@@ -193,7 +193,7 @@ export interface AcApOverlayCalloutGripState {
 }
 
 /**
- * Options for {@link bindOverlayCalloutGrips}.
+ * Options for {@link acapBindOverlayCalloutGrips}.
  */
 export interface AcApOverlayCalloutGripOptions {
   /** Active 2D view. */
@@ -228,7 +228,7 @@ export interface AcApOverlayCalloutGripOptions {
  * @param options - Tip / bubble elements and callbacks.
  * @returns Cleanup that unbinds both grips.
  */
-export function bindOverlayCalloutGrips(
+export function acapBindOverlayCalloutGrips(
   options: AcApOverlayCalloutGripOptions
 ): () => void {
   const {
@@ -265,7 +265,7 @@ export function bindOverlayCalloutGrips(
     )
   }
 
-  const unbindTip = bindOverlayPointerDrag({
+  const unbindTip = acapBindOverlayPointerDrag({
     view,
     el: tipEl.element,
     onDragStart: () => {
@@ -277,7 +277,7 @@ export function bindOverlayCalloutGrips(
     },
     onMove: point => {
       state.tip = constrainTip ? constrainTip(point) : point
-      placeOverlayHtml(view, tipEl, state.tip)
+      acapPlaceOverlayHtml(view, tipEl, state.tip)
       onLiveChange()
     },
     onCommit: () => {
@@ -287,7 +287,7 @@ export function bindOverlayCalloutGrips(
     }
   })
 
-  const unbindBubble = bindOverlayPointerDrag({
+  const unbindBubble = acapBindOverlayPointerDrag({
     view,
     el: bubbleEl.element,
     onDragStart: () => {
@@ -299,7 +299,7 @@ export function bindOverlayCalloutGrips(
     },
     onMove: point => {
       state.anchor = point
-      placeOverlayHtml(view, bubbleEl, state.anchor)
+      acapPlaceOverlayHtml(view, bubbleEl, state.anchor)
       onLiveChange()
     },
     onCommit: () => {

--- a/packages/cad-simple-viewer/src/editor/global/AcEdUiLayout.ts
+++ b/packages/cad-simple-viewer/src/editor/global/AcEdUiLayout.ts
@@ -5,7 +5,7 @@ export const ML_UI_MOBILE_MAX_WIDTH = 600
 export const ML_UI_MOBILE_MEDIA_QUERY = `(max-width: ${ML_UI_MOBILE_MAX_WIDTH}px)`
 
 /** Whether the current viewport matches the narrow mobile UI layout. */
-export function isMobileUiLayout(): boolean {
+export function acedIsMobileUiLayout(): boolean {
   return window.matchMedia?.(ML_UI_MOBILE_MEDIA_QUERY).matches ?? false
 }
 

--- a/packages/cad-simple-viewer/src/editor/global/AcEdUiTheme.ts
+++ b/packages/cad-simple-viewer/src/editor/global/AcEdUiTheme.ts
@@ -37,7 +37,7 @@ const THEME_TOKENS: Record<AcEdUiTheme, Record<string, string>> = {
   }
 }
 
-export function applyUiTheme(
+export function acedApplyUiTheme(
   theme: AcEdUiTheme,
   target: HTMLElement = document.documentElement
 ) {

--- a/packages/cad-simple-viewer/src/ui/AcApDrawStyleToolbar.ts
+++ b/packages/cad-simple-viewer/src/ui/AcApDrawStyleToolbar.ts
@@ -25,7 +25,7 @@ import {
   getActiveMeasurementStyle
 } from '../command/measure/AcApMeasurementStore'
 import type { AcEdCommandEventArgs } from '../editor'
-import { applyUiTheme, resolveUiTheme } from '../editor/global/AcEdUiTheme'
+import { acedApplyUiTheme, resolveUiTheme } from '../editor/global/AcEdUiTheme'
 import { AcApI18n } from '../i18n'
 import {
   acapCssColor,
@@ -302,7 +302,7 @@ export class AcApDrawStyleToolbar {
     this.root = document.createElement('div')
     this.root.className = 'ml-draw-style-toolbar'
     this.root.setAttribute('role', 'toolbar')
-    applyUiTheme(resolveUiTheme(view.container), this.root)
+    acedApplyUiTheme(resolveUiTheme(view.container), this.root)
 
     this.colorWrap = document.createElement('div')
     this.colorWrap.className = 'ml-draw-style-toolbar__color'

--- a/packages/cad-simple-viewer/src/ui/AcUiDialog.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiDialog.ts
@@ -1,6 +1,6 @@
 import {
+  acedApplyUiTheme,
   type AcEdUiTheme,
-  applyUiTheme,
   resolveUiTheme
 } from '../editor/global/AcEdUiTheme'
 
@@ -106,7 +106,7 @@ export class AcUiDialog {
 
     this.backdrop = document.createElement('div')
     this.backdrop.className = 'ml-ui-dialog-backdrop'
-    applyUiTheme(options.theme ?? resolveUiTheme(host), this.backdrop)
+    acedApplyUiTheme(options.theme ?? resolveUiTheme(host), this.backdrop)
     if (options.closeOnBackdrop ?? true) {
       this.backdrop.addEventListener('mousedown', event => {
         if (event.target === this.backdrop) this.close()


### PR DESCRIPTION
## Summary
- Rename editor UI helpers to the `aced*` prefix (`applyUiTheme` → `acedApplyUiTheme`, `isMobileUiLayout` → `acedIsMobileUiLayout`).
- Rename overlay draw/grip helpers to the `acap*` prefix (e.g. `fitOverlayCanvas` → `acapFitOverlayCanvas`, `bindOverlayPointerDrag` → `acapBindOverlayPointerDrag`).
- Update call sites, tests, example app, and simple-ui plugin docs to match.

## Test plan
- [ ] Run unit tests for `cad-simple-viewer` and `cad-simple-ui-plugin` (layout / dock / plugin specs).
- [ ] Open simple-viewer example, toggle theme, confirm UI theme still applies.
- [ ] Exercise markup grips (callout tip/bubble, segment endpoints, center move) and confirm drag still works.