### PR TITLE
feat: support window/crossing box selection for review overlays

### DIFF
--- a/packages/cad-simple-ui-plugin/__tests__/AcExDockPanel.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcExDockPanel.spec.ts
@@ -24,7 +24,7 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
     ...layout,
     acedIsMobileUiLayout: () =>
       window.matchMedia?.(layout.ML_UI_MOBILE_MEDIA_QUERY).matches ?? false,
-    isCompactUiLayout: () =>
+    acedIsCompactUiLayout: () =>
       window.matchMedia?.(layout.ML_UI_COMPACT_MEDIA_QUERY).matches ?? false,
     AcApI18n: {
       t: (_key: string, opts?: { fallback?: string }) => opts?.fallback ?? _key,

--- a/packages/cad-simple-ui-plugin/__tests__/createSimpleUiPlugin.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/createSimpleUiPlugin.spec.ts
@@ -33,7 +33,7 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
     ...layout,
     acedIsMobileUiLayout: () =>
       window.matchMedia?.(layout.ML_UI_MOBILE_MEDIA_QUERY).matches ?? false,
-    isCompactUiLayout: () =>
+    acedIsCompactUiLayout: () =>
       window.matchMedia?.(layout.ML_UI_COMPACT_MEDIA_QUERY).matches ?? false,
     AcApContext: class {},
     AcApDocManager: {

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -12,7 +12,7 @@ import {
   AcApSettingManager,
   acedApplyUiTheme,
   AcEdOpenMode,
-  isCompactUiLayout,
+  acedIsCompactUiLayout,
   LIBREDWG_PARSER_WORKER_FILE,
   MTEXT_RENDERER_WORKER_FILE
 } from '@mlightcad/cad-simple-viewer'
@@ -929,7 +929,7 @@ class CadViewerApp {
   }
 
   private isMobileLayout() {
-    return isCompactUiLayout()
+    return acedIsCompactUiLayout()
   }
 
   private isFileSidebarOpen(): boolean {

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -11,8 +11,8 @@ import {
   AcApQNewCmd,
   AcApSettingManager,
   acedApplyUiTheme,
-  AcEdOpenMode,
   acedIsCompactUiLayout,
+  AcEdOpenMode,
   LIBREDWG_PARSER_WORKER_FILE,
   MTEXT_RENDERER_WORKER_FILE
 } from '@mlightcad/cad-simple-viewer'

--- a/packages/cad-simple-viewer/__tests__/AcApMarkupGeometry.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupGeometry.spec.ts
@@ -1,4 +1,7 @@
-import { hitTestMarkupGeometry } from '../src/command/markup/AcApMarkupGeometry'
+import {
+  hitTestMarkupGeometry,
+  markupGeometryBounds
+} from '../src/command/markup/AcApMarkupGeometry'
 import type { AcApMarkupGeometry } from '../src/command/markup/AcApMarkupTypes'
 
 const identity = (point: { x: number; y: number }) => point
@@ -81,5 +84,34 @@ describe('hitTestMarkupGeometry', () => {
     expect(
       hitTestMarkupGeometry(geometry, { x: 40, y: 10 }, identity, threshold)
     ).toBe(true)
+  })
+})
+
+describe('markupGeometryBounds', () => {
+  it('returns the AABB of a line', () => {
+    const box = markupGeometryBounds({
+      type: 'line',
+      start: { x: 10, y: 5 },
+      end: { x: 40, y: 25 }
+    })
+    expect(box).toBeDefined()
+    expect(box!.min.x).toBe(10)
+    expect(box!.min.y).toBe(5)
+    expect(box!.max.x).toBe(40)
+    expect(box!.max.y).toBe(25)
+  })
+
+  it('includes circle radius and attached callout', () => {
+    const box = markupGeometryBounds({
+      type: 'circle',
+      center: { x: 0, y: 0 },
+      radius: 10,
+      callout: { tip: { x: 10, y: 0 }, anchor: { x: 50, y: 20 } }
+    })
+    expect(box).toBeDefined()
+    expect(box!.min.x).toBe(-10)
+    expect(box!.min.y).toBe(-10)
+    expect(box!.max.x).toBe(50)
+    expect(box!.max.y).toBe(20)
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementGeometry.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementGeometry.spec.ts
@@ -1,4 +1,7 @@
-import { hitTestMeasurementGeometry } from '../src/command/measure/AcApMeasurementGeometry'
+import {
+  hitTestMeasurementGeometry,
+  measurementGeometryBounds
+} from '../src/command/measure/AcApMeasurementGeometry'
 import type { AcApMeasurementGeometry } from '../src/command/measure/AcApMeasurementTypes'
 
 const identity = (point: { x: number; y: number }) => point
@@ -69,5 +72,35 @@ describe('hitTestMeasurementGeometry', () => {
         threshold
       )
     ).toBe(false)
+  })
+})
+
+describe('measurementGeometryBounds', () => {
+  it('returns the AABB of a distance measurement', () => {
+    const box = measurementGeometryBounds({
+      type: 'distance',
+      start: { x: 0, y: 10 },
+      end: { x: 50, y: 0 }
+    })
+    expect(box).toBeDefined()
+    expect(box!.min.x).toBe(0)
+    expect(box!.min.y).toBe(0)
+    expect(box!.max.x).toBe(50)
+    expect(box!.max.y).toBe(10)
+  })
+
+  it('uses the full circle AABB for an arc', () => {
+    const box = measurementGeometryBounds({
+      type: 'arc',
+      center: { x: 0, y: 0 },
+      radius: 25,
+      start: { x: 25, y: 0 },
+      end: { x: 0, y: 25 }
+    })
+    expect(box).toBeDefined()
+    expect(box!.min.x).toBe(-25)
+    expect(box!.min.y).toBe(-25)
+    expect(box!.max.x).toBe(25)
+    expect(box!.max.y).toBe(25)
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdReviewOverlayPick.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdReviewOverlayPick.spec.ts
@@ -1,11 +1,17 @@
+import { AcGeBox2d } from '@mlightcad/data-model'
+
 import { getMarkupStore } from '../src/command/markup/AcApMarkupStore'
 import type { AcApMarkupRecord } from '../src/command/markup/AcApMarkupTypes'
-import { trySelectReviewOverlay } from '../src/view/AcEdReviewOverlayPick'
+import {
+  collectReviewOverlayIdsByBox,
+  trySelectReviewOverlay,
+  trySelectReviewOverlaysByBox
+} from '../src/view/AcEdReviewOverlayPick'
 import type { AcTrView2d } from '../src/view/AcTrView2d'
 
-function lineRecord(): AcApMarkupRecord {
+function lineRecord(id = 'line-1'): AcApMarkupRecord {
   return {
-    id: 'line-1',
+    id,
     type: 'line',
     layoutId: 'layout-a',
     style: { color: '#ff0000' },
@@ -21,6 +27,8 @@ function lineRecord(): AcApMarkupRecord {
 function mockView(ht: {
   selectGroup: jest.Mock
   deselectGroup: jest.Mock
+  deselectAll?: jest.Mock
+  hasSelection?: jest.Mock
 }): AcTrView2d {
   return {
     selectionBoxSize: 3,
@@ -29,8 +37,10 @@ function mockView(ht: {
     isHtmlDirty: false,
     worldToScreen: (point: { x: number; y: number }) => point,
     htmlTransientManager: {
-      getGroup: () => ({ id: 'line-1', visible: true }),
+      getGroup: (id: string) => ({ id, visible: true }),
       groupsOnLayer: () => [],
+      deselectAll: ht.deselectAll ?? jest.fn(),
+      hasSelection: ht.hasSelection ?? jest.fn(() => false),
       ...ht
     }
   } as unknown as AcTrView2d
@@ -99,6 +109,86 @@ describe('trySelectReviewOverlay', () => {
     expect(trySelectReviewOverlay(view, 50, 0, 'replace')).toBe(true)
     expect(selectGroup).toHaveBeenCalledWith('line-1', true)
     expect(view.isDirty).toBe(false)
+    expect(view.isHtmlDirty).toBe(true)
+  })
+})
+
+describe('trySelectReviewOverlaysByBox', () => {
+  beforeEach(() => {
+    getMarkupStore().reset()
+    getMarkupStore().upsert(lineRecord())
+    getMarkupStore().upsert(
+      lineRecord('line-2')
+    )
+    // Move line-2 far away
+    getMarkupStore().updateGeometry('line-2', {
+      type: 'line',
+      start: { x: 500, y: 500 },
+      end: { x: 600, y: 500 }
+    })
+  })
+
+  afterEach(() => {
+    getMarkupStore().reset()
+  })
+
+  it('collects overlays fully inside a window box', () => {
+    const view = mockView({
+      selectGroup: jest.fn(),
+      deselectGroup: jest.fn()
+    })
+    const box = new AcGeBox2d()
+      .expandByPoint({ x: -10, y: -10 })
+      .expandByPoint({ x: 110, y: 10 })
+    expect(collectReviewOverlayIdsByBox(view, box, 'window')).toEqual([
+      'line-1'
+    ])
+  })
+
+  it('collects overlays that intersect a crossing box', () => {
+    const view = mockView({
+      selectGroup: jest.fn(),
+      deselectGroup: jest.fn()
+    })
+    const box = new AcGeBox2d()
+      .expandByPoint({ x: 50, y: -5 })
+      .expandByPoint({ x: 60, y: 5 })
+    expect(collectReviewOverlayIdsByBox(view, box, 'crossing')).toEqual([
+      'line-1'
+    ])
+    expect(collectReviewOverlayIdsByBox(view, box, 'window')).toEqual([])
+  })
+
+  it('selects matching overlays additively on box select', () => {
+    const selectGroup = jest.fn(() => true)
+    const view = mockView({ selectGroup, deselectGroup: jest.fn() })
+    const box = new AcGeBox2d()
+      .expandByPoint({ x: -10, y: -10 })
+      .expandByPoint({ x: 110, y: 10 })
+
+    expect(trySelectReviewOverlaysByBox(view, box, 'window', 'add')).toBe(true)
+    expect(selectGroup).toHaveBeenCalledWith('line-1', false)
+    expect(view.isHtmlDirty).toBe(true)
+  })
+
+  it('clears prior overlay selection on replace even when the box is empty', () => {
+    const selectGroup = jest.fn(() => true)
+    const deselectAll = jest.fn()
+    const view = mockView({
+      selectGroup,
+      deselectGroup: jest.fn(),
+      deselectAll,
+      hasSelection: jest.fn(() => true)
+    })
+    const box = new AcGeBox2d()
+      .expandByPoint({ x: 1000, y: 1000 })
+      .expandByPoint({ x: 1100, y: 1100 })
+
+    expect(
+      trySelectReviewOverlaysByBox(view, box, 'window', 'replace')
+    ).toBe(true)
+    expect(deselectAll).toHaveBeenCalled()
+    expect(selectGroup).not.toHaveBeenCalled()
     expect(view.isHtmlDirty).toBe(true)
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdUiLayout.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdUiLayout.spec.ts
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
 import {
-  isCompactUiLayout,
+  acedIsCompactUiLayout,
   acedIsMobileUiLayout,
   ML_UI_COMPACT_MAX_WIDTH,
   ML_UI_COMPACT_MEDIA_QUERY,
@@ -37,7 +37,7 @@ describe('AcEdUiLayout', () => {
     })
 
     expect(acedIsMobileUiLayout()).toBe(true)
-    expect(isCompactUiLayout()).toBe(false)
+    expect(acedIsCompactUiLayout()).toBe(false)
 
     if (matchMediaDescriptor) {
       Object.defineProperty(window, 'matchMedia', matchMediaDescriptor)
@@ -60,7 +60,7 @@ describe('AcEdUiLayout', () => {
       })
     })
 
-    expect(isCompactUiLayout()).toBe(true)
+    expect(acedIsCompactUiLayout()).toBe(true)
 
     if (matchMediaDescriptor) {
       Object.defineProperty(window, 'matchMedia', matchMediaDescriptor)

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupGeometry.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupGeometry.ts
@@ -1,3 +1,5 @@
+import { AcGeBox2d } from '@mlightcad/data-model'
+
 import {
   type AcApScreenPoint,
   distPointToCirclePx,
@@ -174,6 +176,64 @@ function hitTestLeader(
     distPointToSegmentPx(canvas.x, canvas.y, tip.x, tip.y, anchor.x, anchor.y) <=
     threshold
   )
+}
+
+function expandAttachedCallout(
+  box: AcGeBox2d,
+  callout: AcApMarkupAttachedCallout | undefined
+): void {
+  if (!callout) return
+  box.expandByPoint(callout.tip)
+  box.expandByPoint(callout.anchor)
+}
+
+/**
+ * Axis-aligned world bounds of a markup's control geometry.
+ *
+ * Used for window / crossing box selection. Point-like markups (text / stamp /
+ * symbol) use their anchor; shapes include attached callout tip and anchor.
+ */
+export function markupGeometryBounds(
+  geometry: AcApMarkupGeometry
+): AcGeBox2d | undefined {
+  const box = new AcGeBox2d()
+  switch (geometry.type) {
+    case 'line':
+    case 'arrow':
+      box.expandByPoint(geometry.start).expandByPoint(geometry.end)
+      break
+    case 'rect':
+    case 'cloud':
+      box.expandByPoint(geometry.corner1).expandByPoint(geometry.corner2)
+      expandAttachedCallout(box, geometry.callout)
+      break
+    case 'highlight':
+      box.expandByPoint(geometry.corner1).expandByPoint(geometry.corner2)
+      break
+    case 'circle':
+      box
+        .expandByPoint({
+          x: geometry.center.x - geometry.radius,
+          y: geometry.center.y - geometry.radius
+        })
+        .expandByPoint({
+          x: geometry.center.x + geometry.radius,
+          y: geometry.center.y + geometry.radius
+        })
+      expandAttachedCallout(box, geometry.callout)
+      break
+    case 'callout':
+      box.expandByPoint(geometry.tip).expandByPoint(geometry.anchor)
+      break
+    case 'text':
+    case 'stamp':
+    case 'symbol':
+      box.expandByPoint(geometry.position)
+      break
+    default:
+      return undefined
+  }
+  return box.isEmpty() ? undefined : box
 }
 
 /**

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementGeometry.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementGeometry.ts
@@ -1,3 +1,5 @@
+import { AcGeBox2d } from '@mlightcad/data-model'
+
 import {
   type AcApScreenPoint,
   distPointToArcPx,
@@ -14,6 +16,51 @@ const TWO_PI = Math.PI * 2
 
 function normaliseAngle(a: number): number {
   return ((a % TWO_PI) + TWO_PI) % TWO_PI
+}
+
+/**
+ * Axis-aligned world bounds of a measurement's control geometry.
+ *
+ * Used for window / crossing box selection. Point measurements use their
+ * position; arcs use the full circle AABB of `center` ± `radius`.
+ */
+export function measurementGeometryBounds(
+  geometry: AcApMeasurementGeometry
+): AcGeBox2d | undefined {
+  const box = new AcGeBox2d()
+  switch (geometry.type) {
+    case 'distance':
+      box.expandByPoint(geometry.start).expandByPoint(geometry.end)
+      break
+    case 'angle':
+      box
+        .expandByPoint(geometry.vertex)
+        .expandByPoint(geometry.arm1)
+        .expandByPoint(geometry.arm2)
+      break
+    case 'area':
+      for (const point of geometry.points) {
+        box.expandByPoint(point)
+      }
+      break
+    case 'arc':
+      box
+        .expandByPoint({
+          x: geometry.center.x - geometry.radius,
+          y: geometry.center.y - geometry.radius
+        })
+        .expandByPoint({
+          x: geometry.center.x + geometry.radius,
+          y: geometry.center.y + geometry.radius
+        })
+      break
+    case 'point':
+      box.expandByPoint(geometry.position)
+      break
+    default:
+      return undefined
+  }
+  return box.isEmpty() ? undefined : box
 }
 
 /**

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -315,6 +315,13 @@ export function commitMeasurementGroup(
   view.isHtmlDirty = true
 }
 
+/** Snapshot geometry for a committed measurement group, if available. */
+export function getMeasurementGeometry(
+  id: string
+): AcApMeasurementRecord['geometry'] | undefined {
+  return extrasById.get(id)?.snapshot?.geometry
+}
+
 /**
  * Pick a visible measurement group by clicking its drawn stroke / fill.
  *
@@ -334,7 +341,7 @@ export function pickMeasurementAt(
   for (let i = groups.length - 1; i >= 0; i--) {
     const group = groups[i]
     if (!group.visible) continue
-    const geom = extrasById.get(group.id)?.snapshot?.geometry
+    const geom = getMeasurementGeometry(group.id)
     if (!geom) continue
     if (hitTestMeasurementGeometry(geom, canvas, worldToScreen, threshold)) {
       return group.id

--- a/packages/cad-simple-viewer/src/editor/global/AcEdUiLayout.ts
+++ b/packages/cad-simple-viewer/src/editor/global/AcEdUiLayout.ts
@@ -16,6 +16,6 @@ export const ML_UI_COMPACT_MAX_WIDTH = 960
 export const ML_UI_COMPACT_MEDIA_QUERY = `(max-width: ${ML_UI_COMPACT_MAX_WIDTH}px)`
 
 /** Whether the current viewport matches the compact app-shell layout. */
-export function isCompactUiLayout(): boolean {
+export function acedIsCompactUiLayout(): boolean {
   return window.matchMedia?.(ML_UI_COMPACT_MEDIA_QUERY).matches ?? false
 }

--- a/packages/cad-simple-viewer/src/view/AcEdReviewOverlayPick.ts
+++ b/packages/cad-simple-viewer/src/view/AcEdReviewOverlayPick.ts
@@ -1,11 +1,59 @@
-import { hitTestMarkupGeometry } from '../command/markup/AcApMarkupGeometry'
+import { AcGeBox2d } from '@mlightcad/data-model'
+
+import {
+  hitTestMarkupGeometry,
+  markupGeometryBounds
+} from '../command/markup/AcApMarkupGeometry'
 import { getMarkupStore } from '../command/markup/AcApMarkupStore'
-import { pickMeasurementAt } from '../command/measure/AcApMeasurementStore'
-import type { AcEdSelectionAction } from '../editor'
+import { measurementGeometryBounds } from '../command/measure/AcApMeasurementGeometry'
+import {
+  getMeasurementGeometry,
+  isMeasurementVisible,
+  MEASUREMENT_LAYER,
+  pickMeasurementAt
+} from '../command/measure/AcApMeasurementStore'
+import type { AcEdSelectionAction, AcEdSelectionMode } from '../editor'
+import {
+  isSpatialBoxFullyInside,
+  type AcTrSpatialIndexBBox
+} from '../spatialIndex/AcTrSpatialIndex'
 import type { AcTrView2d } from './AcTrView2d'
 
 /** Pixel radius used when clicking markup / measurement strokes. */
 export const REVIEW_OVERLAY_HIT_THRESHOLD_PX = 10
+
+function toSpatialBBox(box: AcGeBox2d): AcTrSpatialIndexBBox {
+  return {
+    minX: box.min.x,
+    minY: box.min.y,
+    maxX: box.max.x,
+    maxY: box.max.y
+  }
+}
+
+function boxesIntersect(
+  a: AcTrSpatialIndexBBox,
+  b: AcTrSpatialIndexBBox
+): boolean {
+  return !(
+    a.maxX < b.minX ||
+    a.minX > b.maxX ||
+    a.maxY < b.minY ||
+    a.minY > b.maxY
+  )
+}
+
+function overlayMatchesBox(
+  bounds: AcGeBox2d,
+  selection: AcTrSpatialIndexBBox,
+  mode: AcEdSelectionMode
+): boolean {
+  const item = toSpatialBBox(bounds)
+  if (mode === 'window') {
+    return isSpatialBoxFullyInside(item, selection)
+  }
+  return boxesIntersect(item, selection)
+}
 
 function pickMarkupAt(
   view: AcTrView2d,
@@ -33,6 +81,49 @@ function pickMarkupAt(
 }
 
 /**
+ * Collect markup / measurement group ids whose geometry AABB matches the
+ * selection box (window = fully inside, crossing = intersects).
+ */
+export function collectReviewOverlayIdsByBox(
+  view: AcTrView2d,
+  box: AcGeBox2d,
+  mode: AcEdSelectionMode
+): string[] {
+  const selection = toSpatialBBox(box)
+  const layoutId = view.activeLayoutBtrId
+  const ids: string[] = []
+
+  for (const record of getMarkupStore().list()) {
+    if (record.layoutId != null && record.layoutId !== layoutId) continue
+    const group = view.htmlTransientManager.getGroup(record.id)
+    if (!group?.visible) continue
+    const bounds = markupGeometryBounds(record.geometry)
+    if (!bounds) continue
+    if (overlayMatchesBox(bounds, selection, mode)) {
+      ids.push(record.id)
+    }
+  }
+
+  if (!isMeasurementVisible()) return ids
+
+  for (const group of view.htmlTransientManager.groupsOnLayer(
+    MEASUREMENT_LAYER
+  )) {
+    if (!group.visible) continue
+    if (group.layoutId != null && group.layoutId !== layoutId) continue
+    const geometry = getMeasurementGeometry(group.id)
+    if (!geometry) continue
+    const bounds = measurementGeometryBounds(geometry)
+    if (!bounds) continue
+    if (overlayMatchesBox(bounds, selection, mode)) {
+      ids.push(group.id)
+    }
+  }
+
+  return ids
+}
+
+/**
  * Apply a click to one overlay group.
  *
  * @returns `true` when this click should consume the pick (skip CAD entities).
@@ -54,6 +145,38 @@ function applyOverlaySelection(
   }
   ht.selectGroup(id, true)
   return true
+}
+
+function applyOverlayBoxSelection(
+  view: AcTrView2d,
+  ids: string[],
+  action: AcEdSelectionAction
+): boolean {
+  const ht = view.htmlTransientManager
+  let changed = false
+
+  if (action === 'replace') {
+    const hadSelection = ht.hasSelection()
+    ht.deselectAll()
+    for (const id of ids) {
+      if (ht.selectGroup(id, false)) changed = true
+    }
+    return hadSelection || changed
+  }
+
+  if (ids.length === 0) return false
+
+  if (action === 'add') {
+    for (const id of ids) {
+      if (ht.selectGroup(id, false)) changed = true
+    }
+    return changed
+  }
+
+  for (const id of ids) {
+    if (ht.deselectGroup(id)) changed = true
+  }
+  return changed
 }
 
 /**
@@ -80,4 +203,21 @@ export function trySelectReviewOverlay(
   const consumed = applyOverlaySelection(view, id, action)
   if (consumed) view.isHtmlDirty = true
   return consumed
+}
+
+/**
+ * Select markup / measurement overlays by window or crossing box.
+ *
+ * @returns `true` when HTML selection state changed.
+ */
+export function trySelectReviewOverlaysByBox(
+  view: AcTrView2d,
+  box: AcGeBox2d,
+  mode: AcEdSelectionMode,
+  action: AcEdSelectionAction
+): boolean {
+  const ids = collectReviewOverlayIdsByBox(view, box, mode)
+  const changed = applyOverlayBoxSelection(view, ids, action)
+  if (changed) view.isHtmlDirty = true
+  return changed
 }

--- a/packages/cad-simple-viewer/src/view/AcEdReviewOverlayPick.ts
+++ b/packages/cad-simple-viewer/src/view/AcEdReviewOverlayPick.ts
@@ -14,8 +14,8 @@ import {
 } from '../command/measure/AcApMeasurementStore'
 import type { AcEdSelectionAction, AcEdSelectionMode } from '../editor'
 import {
-  isSpatialBoxFullyInside,
-  type AcTrSpatialIndexBBox
+  type AcTrSpatialIndexBBox,
+  isSpatialBoxFullyInside
 } from '../spatialIndex/AcTrSpatialIndex'
 import type { AcTrView2d } from './AcTrView2d'
 

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -62,7 +62,10 @@ import { isEffectiveSpatialQueryHit } from '../editor/view/AcEdSpatialQueryResul
 import type { AcTrSpatialSearchOptions } from '../spatialIndex/AcTrSpatialIndex'
 import { AcTrGeometryUtil } from '../util'
 import { acapRunDatabaseEdit } from '../util/AcApDatabaseEdit'
-import { trySelectReviewOverlay } from './AcEdReviewOverlayPick'
+import {
+  trySelectReviewOverlay,
+  trySelectReviewOverlaysByBox
+} from './AcEdReviewOverlayPick'
 import { AcEdViewKeyHandler } from './AcEdViewKeyHandler'
 import {
   shouldExtendBboxForDirectEntity,
@@ -460,6 +463,7 @@ export class AcTrView2d extends AcEdBaseView {
           .expandByPoint(endWcs)
         const mode = this.getSelectionMode(selectionStartCanvas, endCanvas)
         this.selectByBoxWithMode(box, mode, action)
+        trySelectReviewOverlaysByBox(this, box, mode, action)
       }
 
       selectionStartWcs = null


### PR DESCRIPTION
## Summary
- Add AABB-based window/crossing box selection for markup and measurement review overlays, wired into `AcTrView2d` alongside CAD entity box select.
- Export `markupGeometryBounds` / `measurementGeometryBounds` (and `getMeasurementGeometry`) so overlay picking can match AutoCAD-style window vs crossing rules.
- Rename `isCompactUiLayout` to `acedIsCompactUiLayout` for consistency with other `aced*` UI helpers.

## Test plan
- [ ] Drag a window box around a markup line and confirm it is selected; partial overlap should not select in window mode.
- [ ] Drag a crossing box that intersects a markup/measurement stroke and confirm selection.
- [ ] Replace box select with no overlays clears prior overlay selection; Shift-add keeps prior overlays.
- [ ] Click stroke selection still works and still clears CAD selection on replace.
- [ ] Compact layout breakpoint still switches correctly after the `acedIsCompactUiLayout` rename.
