### PR TITLE
feat: add Design Review markup and measurement sidecar to HTML viewer

### DIFF
--- a/packages/cad-html-plugin/README.md
+++ b/packages/cad-html-plugin/README.md
@@ -16,7 +16,7 @@ The plugin path is designed for **lazy loading** so the export bundle is only do
 
 - **Display-only snapshot** — layers, layouts, line/mesh batches, extents, and drawing units (no editable DXF/DWG payload)
 - **Self-contained HTML** — gzip/base64 snapshot + inline viewer runtime; opens offline in any modern browser
-- **Offline viewer** — pan/zoom (OrbitControls), layer panel, layout switching, measurement, object snap (OSNAP)
+- **Offline viewer** — pan/zoom (OrbitControls), layer panel, layout switching, measurement, Design Review markup annotations, object snap (OSNAP)
 - **i18n** — embedded English / Chinese / Czech / Turkish UI; initial language follows the browser (`zh*` → Chinese, `cs*` → Czech, `tr*` → Turkish, otherwise English); the toolbar language button cycles through the supported locales, and the choice persists in `localStorage`
 - **Plugin API** — implements `AcApPlugin`; register once with `registerLazyHtmlPlugin`
 - **Composable API** — build snapshots from your own pipeline or call `packHtml` with a pre-built snapshot
@@ -187,6 +187,8 @@ import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.j
 | `src/AcExHtmlShell.ts` | Static HTML/CSS shell markup |
 | `src/AcExOsnap*.ts` | Object snap index and primitives |
 | `src/AcExMeasurement.ts` | Distance/area measurement in the offline viewer |
+| `src/AcExMeasurementSidecar.ts` | Measurement sidecar JSON import/export (`*.measurement.json`, compatible with cad-simple-viewer) |
+| `src/AcExMarkup.ts` | Design Review markup tools (cloud, callout, text, rect, circle, arrow, stamp) with sidecar JSON import/export |
 | `src/AcExHtmlI18n.ts` | English / Chinese / Czech / Turkish UI messages |
 
 ## Role in MLightCAD

--- a/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
@@ -12,23 +12,43 @@ describe('buildAcExHtmlShellBody', () => {
     expect(html).toContain('id="mlcad-layers-btn"')
     expect(html).toContain('id="mlcad-lang-btn"')
     expect(html).not.toContain('data-measure-mode=')
+    expect(html).not.toContain('id="mlcad-measure-menu-btn"')
+    expect(html).not.toContain('id="mlcad-markup-menu-btn"')
     expect(html).not.toContain('id="mlcad-settings-btn"')
     expect(html).not.toContain('id="mlcad-settings-wrap"')
     expect(html).not.toContain('mlcad-tool-separator')
     expect(html).not.toContain('id="mlcad-status-bar"')
   })
 
-  it('includes measurement toolbar controls in measure mode', () => {
+  it('uses Measurement / Review / Settings parent strips in measure mode', () => {
     const html = buildAcExHtmlShellBody('#000000', 'measure')
 
-    expect(html).toContain('data-measure-mode="distance"')
+    expect(html).toContain('id="mlcad-measure-menu-btn"')
+    expect(html).toContain('id="mlcad-markup-menu-btn"')
     expect(html).toContain('id="mlcad-settings-btn"')
+    expect(html).toContain('has-children')
+    expect(html).toContain('id="mlcad-measure-strip-wrap"')
+    expect(html).toContain('id="mlcad-markup-strip-wrap"')
     expect(html).toContain('id="mlcad-settings-wrap"')
-    expect(html).toContain('id="mlcad-lang-btn"')
+    expect(html).not.toContain('mlcad-measure-submenu-template')
+    expect(html).not.toContain('mlcad-markup-submenu-template')
+    expect(html).toContain('data-measure-mode="distance"')
+    expect(html).toContain('data-action="measure-import"')
+    expect(html).toContain('data-markup-mode="cloud"')
+    expect(html).toContain('data-action="clear-markups"')
     expect(html).toContain('id="mlcad-status-bar"')
-    expect(html.match(/mlcad-tool-separator/g)?.length).toBe(2)
-    expect(html.indexOf('id="mlcad-layers-btn"')).toBeLessThan(
-      html.indexOf('id="mlcad-settings-btn"')
-    )
+    expect(html.match(/mlcad-tool-separator/g)?.length).toBeGreaterThanOrEqual(2)
+    // Child tools live in strips, not as first-level toolbar buttons.
+    const toolbarHtml = html.match(/<nav id="mlcad-toolbar"[\s\S]*?<\/nav>/)?.[0]
+    expect(toolbarHtml).toBeTruthy()
+    expect(toolbarHtml).not.toContain('data-measure-mode')
+    expect(toolbarHtml).not.toContain('data-markup-mode')
+    expect(toolbarHtml).toContain('title="Settings"')
+  })
+
+  it('omits markup toolbar controls in view mode', () => {
+    const html = buildAcExHtmlShellBody('#000000', 'view')
+    expect(html).not.toContain('data-markup-mode=')
+    expect(html).not.toContain('data-action="clear-markups"')
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExMarkupGeometry.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMarkupGeometry.spec.ts
@@ -1,0 +1,27 @@
+import {
+  acExComputeLeaderTipOnShape
+} from '../src/AcExMarkupGeometry'
+
+describe('acExComputeLeaderTipOnShape', () => {
+  it('places tip on circle perimeter toward the cursor', () => {
+    const tip = acExComputeLeaderTipOnShape(
+      { kind: 'circle', center: { x: 0, y: 0 }, radius: 10 },
+      { x: 100, y: 0 }
+    )
+    expect(tip.x).toBeCloseTo(10)
+    expect(tip.y).toBeCloseTo(0)
+  })
+
+  it('places tip on AABB edge for rect/cloud', () => {
+    const tip = acExComputeLeaderTipOnShape(
+      {
+        kind: 'rect',
+        corner1: { x: -5, y: -2 },
+        corner2: { x: 5, y: 2 }
+      },
+      { x: 50, y: 0 }
+    )
+    expect(tip.x).toBeCloseTo(5)
+    expect(tip.y).toBeCloseTo(0)
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExMarkupSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMarkupSidecar.spec.ts
@@ -1,0 +1,65 @@
+import {
+  acExMarkupSidecarFileName,
+  parseAcExMarkupSidecar,
+  stringifyAcExMarkupSidecar
+} from '../src/AcExMarkupSidecar'
+import type { AcExMarkupSidecarFile } from '../src/AcExMarkupTypes'
+
+describe('AcExMarkupSidecar', () => {
+  const sample: AcExMarkupSidecarFile = {
+    version: 1,
+    drawingName: 'plan.dwg',
+    markups: [
+      {
+        id: 'm1',
+        type: 'arrow',
+        style: { color: '#e53935', lineWeight: 70 },
+        comment: '',
+        status: 'open',
+        author: '',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        geometry: {
+          type: 'arrow',
+          start: { x: 0, y: 0 },
+          end: { x: 10, y: 5 }
+        }
+      },
+      {
+        id: 'm2',
+        type: 'text',
+        style: { color: '#e53935', fontSize: 12 },
+        text: 'Note',
+        comment: 'hello',
+        status: 'question',
+        author: 'reviewer',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        geometry: { type: 'text', position: { x: 1, y: 2 } }
+      }
+    ]
+  }
+
+  it('round-trips sidecar JSON', () => {
+    const text = stringifyAcExMarkupSidecar(sample)
+    const parsed = parseAcExMarkupSidecar(text)
+    expect(parsed.version).toBe(1)
+    expect(parsed.drawingName).toBe('plan.dwg')
+    expect(parsed.markups).toHaveLength(2)
+    expect(parsed.markups[0]?.type).toBe('arrow')
+    expect(parsed.markups[1]?.text).toBe('Note')
+  })
+
+  it('rejects invalid payloads', () => {
+    expect(() => parseAcExMarkupSidecar('not-json')).toThrow(/not JSON/)
+    expect(() => parseAcExMarkupSidecar('{"version":2,"markups":[]}')).toThrow(
+      /version 1/
+    )
+  })
+
+  it('suggests sidecar file names', () => {
+    expect(acExMarkupSidecarFileName('plan.dwg')).toBe('plan.markup.json')
+    expect(acExMarkupSidecarFileName('plan.html')).toBe('plan.markup.json')
+    expect(acExMarkupSidecarFileName()).toBe('drawing.markup.json')
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
@@ -1,0 +1,71 @@
+import {
+  acExMeasurementSidecarFileName,
+  parseAcExMeasurementSidecar,
+  stringifyAcExMeasurementSidecar
+} from '../src/AcExMeasurementSidecar'
+import type { AcExMeasurementSidecarFile } from '../src/AcExMeasurementTypes'
+
+describe('AcExMeasurementSidecar', () => {
+  const sample: AcExMeasurementSidecarFile = {
+    version: 1,
+    drawingName: 'plan.dwg',
+    measurements: [
+      {
+        id: 'm1',
+        type: 'distance',
+        style: { color: '#08e8de', lineWeight: 70, fontSize: 13 },
+        geometry: {
+          type: 'distance',
+          start: { x: 0, y: 0 },
+          end: { x: 10, y: 0 }
+        }
+      },
+      {
+        id: 'm2',
+        type: 'point',
+        style: { color: '#08e8de', lineWeight: 70, fontSize: 13 },
+        geometry: { type: 'point', position: { x: 3, y: 4 } }
+      },
+      {
+        id: 'm3',
+        type: 'arc',
+        style: { color: '#ff0000', lineWeight: 70, fontSize: 13 },
+        geometry: {
+          type: 'arc',
+          center: { x: 0, y: 0 },
+          radius: 5,
+          start: { x: 5, y: 0 },
+          end: { x: 0, y: 5 }
+        }
+      }
+    ]
+  }
+
+  it('round-trips sidecar JSON', () => {
+    const text = stringifyAcExMeasurementSidecar(sample)
+    const parsed = parseAcExMeasurementSidecar(text)
+    expect(parsed.version).toBe(1)
+    expect(parsed.drawingName).toBe('plan.dwg')
+    expect(parsed.measurements).toHaveLength(3)
+    expect(parsed.measurements[0]?.type).toBe('distance')
+    expect(parsed.measurements[1]?.type).toBe('point')
+    expect(parsed.measurements[2]?.geometry.type).toBe('arc')
+  })
+
+  it('rejects invalid payloads', () => {
+    expect(() => parseAcExMeasurementSidecar('not-json')).toThrow(/not JSON/)
+    expect(() =>
+      parseAcExMeasurementSidecar('{"version":2,"measurements":[]}')
+    ).toThrow(/version 1/)
+  })
+
+  it('suggests sidecar file names', () => {
+    expect(acExMeasurementSidecarFileName('plan.dwg')).toBe(
+      'plan.measurement.json'
+    )
+    expect(acExMeasurementSidecarFileName('plan.html')).toBe(
+      'plan.measurement.json'
+    )
+    expect(acExMeasurementSidecarFileName()).toBe('drawing.measurement.json')
+  })
+})

--- a/packages/cad-html-plugin/src/AcApHtmlExportOptions.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlExportOptions.ts
@@ -23,8 +23,8 @@ export interface AcApHtmlExportOptions {
    */
   initialView?: AcExInitialViewMode
   /**
-   * Offline viewer capability profile. `'view'` omits OSNAP data and measurement
-   * UI for a smaller, faster HTML file. Defaults to `'measure'`.
+   * Offline viewer capability profile. `'view'` omits OSNAP data, measurement,
+   * and markup UI for a smaller, faster HTML file. Defaults to `'measure'`.
    */
   viewerMode?: AcExViewerMode
 }

--- a/packages/cad-html-plugin/src/AcExDrawStyleToolbar.ts
+++ b/packages/cad-html-plugin/src/AcExDrawStyleToolbar.ts
@@ -1,0 +1,447 @@
+/**
+ * Canvas-top drawing style overlay (color / line weight / font size).
+ * Mirrors `@mlightcad/cad-simple-viewer` {@link AcApDrawStyleToolbar}.
+ *
+ * @module AcExDrawStyleToolbar
+ * @packageDocumentation
+ */
+
+import { AcCmColor, AcGiLineWeight } from '@mlightcad/data-model'
+
+import type { AcExHtmlI18n } from './AcExHtmlI18n'
+
+/** Active tool kind that owns the overlay. */
+export type AcExDrawStyleKind = 'measure' | 'markup'
+
+/** Style snapshot shown in / written by the overlay. */
+export interface AcExDrawStyleValues {
+  /** CSS color string. */
+  color: string
+  /** CAD line weight in hundredths of a millimeter (e.g. 70 = 0.70 mm). */
+  lineWeight: number
+  /** Badge / text font size in CSS pixels. */
+  fontSize: number
+}
+
+/** Partial style update from the overlay controls. */
+export interface AcExDrawStylePatch {
+  color?: string
+  lineWeight?: number
+  fontSize?: number
+}
+
+/** Dependencies for {@link setupAcExDrawStyleToolbar}. */
+export interface AcExDrawStyleToolbarContext {
+  /** Host element (`#mlcad-root`); must be positioned. */
+  root: HTMLElement
+  i18n: AcExHtmlI18n
+  /** Current kind, or `undefined` when no draw tool is active. */
+  getKind: () => AcExDrawStyleKind | undefined
+  /** Style to paint into the controls for the active kind. */
+  getStyle: (kind: AcExDrawStyleKind) => AcExDrawStyleValues
+  /** Apply a patch to session defaults and any selection for `kind`. */
+  applyStyle: (kind: AcExDrawStyleKind, patch: AcExDrawStylePatch) => void
+}
+
+/** Font-size choices shown in the overlay dropdown (CSS px). */
+const FONT_SIZE_OPTIONS = [10, 12, 13, 14, 16, 18, 20, 24, 28, 32]
+
+const STYLE_ID = 'mlcad-draw-style-toolbar-styles'
+
+const TOOLBAR_CSS = `
+.mlcad-draw-style-toolbar {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  background: rgba(28, 32, 40, 0.92);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  color: #e8eaed;
+  pointer-events: auto;
+}
+.mlcad-draw-style-toolbar.is-visible {
+  display: inline-flex;
+}
+.mlcad-draw-style-toolbar__swatch {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+}
+.mlcad-draw-style-toolbar__swatch-fill {
+  display: block;
+  width: 14px;
+  height: 14px;
+  margin: 0 auto;
+  border-radius: 50%;
+  border: 1px solid #999;
+}
+.mlcad-draw-style-toolbar__select {
+  height: 28px;
+  min-width: 92px;
+  max-width: 140px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 4px;
+  background: rgba(18, 22, 28, 0.95);
+  color: inherit;
+  font-size: 12px;
+  padding: 0 6px;
+}
+.mlcad-draw-style-toolbar__color {
+  position: relative;
+}
+.mlcad-draw-style-toolbar__color-panel {
+  display: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 1;
+  padding: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  background: rgba(28, 32, 40, 0.98);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  --mlcad-draw-style-aci-cell: 11px;
+}
+.mlcad-draw-style-toolbar__color-panel.is-open {
+  display: block;
+}
+.mlcad-draw-style-toolbar__aci-large {
+  display: grid;
+  grid-template-columns: repeat(24, var(--mlcad-draw-style-aci-cell));
+  gap: 1px;
+  margin-bottom: 6px;
+}
+.mlcad-draw-style-toolbar__aci-small {
+  display: grid;
+  grid-template-columns: repeat(9, var(--mlcad-draw-style-aci-cell));
+  gap: 1px;
+  margin-bottom: 6px;
+}
+.mlcad-draw-style-toolbar__aci-gray {
+  display: flex;
+  gap: 4px;
+}
+.mlcad-draw-style-toolbar__aci-cell {
+  width: var(--mlcad-draw-style-aci-cell);
+  height: var(--mlcad-draw-style-aci-cell);
+  padding: 0;
+  border: 1px solid #666;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.mlcad-draw-style-toolbar__aci-cell:hover {
+  outline: 1px solid #00a8ff;
+}
+.mlcad-draw-style-toolbar__aci-cell.is-selected {
+  outline: 2px solid #08e8de;
+  outline-offset: -1px;
+}
+`
+
+const SMALL_ACI = Array.from({ length: 9 }, (_, i) => i + 1)
+const LARGE_ACI = Array.from({ length: 240 }, (_, i) => i + 10)
+const GRAY_ACI = Array.from({ length: 6 }, (_, i) => i + 250)
+
+function colorFromAci(index: number): AcCmColor {
+  const color = new AcCmColor()
+  color.colorIndex = index
+  return color
+}
+
+function aciCss(index: number): string {
+  return colorFromAci(index).cssColor || '#ffffff'
+}
+
+function cssColor(color: AcCmColor): string {
+  return color.cssColor ?? `rgb(${color.red}, ${color.green}, ${color.blue})`
+}
+
+function cssToColor(css: string): AcCmColor {
+  const fromString = AcCmColor.fromString(css)
+  if (fromString) return fromString
+  try {
+    return new AcCmColor().setRGBFromCss(css)
+  } catch {
+    const fallback = new AcCmColor()
+    fallback.setRGB(8, 232, 222)
+    return fallback
+  }
+}
+
+function aciIndexOf(color: AcCmColor): number | undefined {
+  if (color.isByACI && color.colorIndex != null && color.colorIndex >= 1) {
+    return color.colorIndex
+  }
+  return undefined
+}
+
+function numericLineWeights(): number[] {
+  return Array.from(
+    new Set(
+      Object.values(AcGiLineWeight).filter(
+        (value): value is number => typeof value === 'number' && value > 0
+      )
+    )
+  ).sort((a, b) => a - b)
+}
+
+function formatLineWeight(value: number): string {
+  return `${(value / 100).toFixed(2)} mm`
+}
+
+function ensureStyles(): void {
+  if (typeof document === 'undefined') return
+  let style = document.getElementById(STYLE_ID) as HTMLStyleElement | null
+  if (!style) {
+    style = document.createElement('style')
+    style.id = STYLE_ID
+    document.head.appendChild(style)
+  }
+  style.textContent = TOOLBAR_CSS
+}
+
+/** Controller returned by {@link setupAcExDrawStyleToolbar}. */
+export interface AcExDrawStyleToolbarController {
+  /** Show/hide and sync controls from the active tool. */
+  refresh: () => void
+  /** Reapply i18n titles after locale change. */
+  refreshLabels: () => void
+  /** Tear down DOM listeners. */
+  dispose: () => void
+}
+
+/**
+ * Creates the drawing-style overlay on the canvas host.
+ */
+export function setupAcExDrawStyleToolbar(
+  ctx: AcExDrawStyleToolbarContext
+): AcExDrawStyleToolbarController {
+  ensureStyles()
+
+  const root = document.createElement('div')
+  root.className = 'mlcad-draw-style-toolbar'
+  root.setAttribute('role', 'toolbar')
+
+  const colorWrap = document.createElement('div')
+  colorWrap.className = 'mlcad-draw-style-toolbar__color'
+
+  const swatch = document.createElement('button')
+  swatch.type = 'button'
+  swatch.className = 'mlcad-draw-style-toolbar__swatch'
+  const swatchFill = document.createElement('span')
+  swatchFill.className = 'mlcad-draw-style-toolbar__swatch-fill'
+  swatch.appendChild(swatchFill)
+
+  const colorPanel = document.createElement('div')
+  colorPanel.className = 'mlcad-draw-style-toolbar__color-panel'
+
+  const createAciPalette = (indices: number[], className: string) => {
+    const palette = document.createElement('div')
+    palette.className = className
+    for (const index of indices) {
+      const cell = document.createElement('button')
+      cell.type = 'button'
+      cell.className = 'mlcad-draw-style-toolbar__aci-cell'
+      cell.dataset.aci = String(index)
+      cell.style.background = aciCss(index)
+      cell.title = String(index)
+      cell.addEventListener('click', event => {
+        event.preventDefault()
+        event.stopPropagation()
+        applyColor(cssColor(colorFromAci(index)))
+        hideColorPanel()
+      })
+      palette.appendChild(cell)
+    }
+    return palette
+  }
+
+  colorPanel.appendChild(
+    createAciPalette(LARGE_ACI, 'mlcad-draw-style-toolbar__aci-large')
+  )
+  colorPanel.appendChild(
+    createAciPalette(SMALL_ACI, 'mlcad-draw-style-toolbar__aci-small')
+  )
+  colorPanel.appendChild(
+    createAciPalette(GRAY_ACI, 'mlcad-draw-style-toolbar__aci-gray')
+  )
+
+  colorWrap.appendChild(swatch)
+  colorWrap.appendChild(colorPanel)
+  root.appendChild(colorWrap)
+
+  const lineWeightSelect = document.createElement('select')
+  lineWeightSelect.className = 'mlcad-draw-style-toolbar__select'
+  for (const weight of numericLineWeights()) {
+    const option = document.createElement('option')
+    option.value = String(weight)
+    option.textContent = formatLineWeight(weight)
+    lineWeightSelect.appendChild(option)
+  }
+  root.appendChild(lineWeightSelect)
+
+  const fontSizeSelect = document.createElement('select')
+  fontSizeSelect.className = 'mlcad-draw-style-toolbar__select'
+  root.appendChild(fontSizeSelect)
+
+  let colorPanelOpen = false
+  let colorLeaveTimer: number | undefined
+  let currentKind: AcExDrawStyleKind | undefined
+
+  const clearColorLeaveTimer = () => {
+    if (colorLeaveTimer == null) return
+    window.clearTimeout(colorLeaveTimer)
+    colorLeaveTimer = undefined
+  }
+
+  const hideColorPanel = () => {
+    clearColorLeaveTimer()
+    colorPanelOpen = false
+    colorPanel.classList.remove('is-open')
+  }
+
+  const showColorPanel = () => {
+    clearColorLeaveTimer()
+    colorPanelOpen = true
+    colorPanel.classList.add('is-open')
+  }
+
+  const scheduleHideColorPanel = () => {
+    clearColorLeaveTimer()
+    colorLeaveTimer = window.setTimeout(() => hideColorPanel(), 220)
+  }
+
+  const markSelectedAci = (index: number | undefined) => {
+    colorPanel
+      .querySelectorAll('.mlcad-draw-style-toolbar__aci-cell')
+      .forEach(el => {
+        const aci = Number((el as HTMLElement).dataset.aci)
+        el.classList.toggle('is-selected', index != null && aci === index)
+      })
+  }
+
+  const paint = (style: AcExDrawStyleValues) => {
+    const color = cssToColor(style.color)
+    swatchFill.style.background = cssColor(color)
+    markSelectedAci(aciIndexOf(color))
+
+    const weightValue = String(style.lineWeight)
+    if (
+      !Array.from(lineWeightSelect.options).some(
+        option => option.value === weightValue
+      )
+    ) {
+      const option = document.createElement('option')
+      option.value = weightValue
+      option.textContent = formatLineWeight(style.lineWeight)
+      lineWeightSelect.appendChild(option)
+    }
+    lineWeightSelect.value = weightValue
+
+    const sizes = new Set(FONT_SIZE_OPTIONS)
+    if (Number.isFinite(style.fontSize) && style.fontSize > 0) {
+      sizes.add(Math.round(style.fontSize))
+    }
+    const sorted = [...sizes].sort((a, b) => a - b)
+    fontSizeSelect.replaceChildren()
+    for (const size of sorted) {
+      const option = document.createElement('option')
+      option.value = String(size)
+      option.textContent = `${size} px`
+      fontSizeSelect.appendChild(option)
+    }
+    fontSizeSelect.value = String(
+      Number.isFinite(style.fontSize) && style.fontSize > 0
+        ? Math.round(style.fontSize)
+        : 12
+    )
+  }
+
+  const applyColor = (css: string) => {
+    if (!currentKind) return
+    swatchFill.style.background = css
+    markSelectedAci(aciIndexOf(cssToColor(css)))
+    ctx.applyStyle(currentKind, { color: css })
+  }
+
+  const applyLineWeight = (weight: number) => {
+    if (!currentKind || !(weight > 0)) return
+    ctx.applyStyle(currentKind, { lineWeight: weight })
+  }
+
+  const applyFontSize = (size: number) => {
+    if (!currentKind || !(size > 0)) return
+    ctx.applyStyle(currentKind, { fontSize: size })
+  }
+
+  const relabel = () => {
+    swatch.title = ctx.i18n.t('drawStyle.color')
+    lineWeightSelect.title = ctx.i18n.t('drawStyle.lineWeight')
+    fontSizeSelect.title = ctx.i18n.t('drawStyle.fontSize')
+  }
+
+  const refresh = () => {
+    currentKind = ctx.getKind()
+    if (!currentKind) {
+      hideColorPanel()
+      root.classList.remove('is-visible')
+      return
+    }
+    root.classList.add('is-visible')
+    paint(ctx.getStyle(currentKind))
+    relabel()
+  }
+
+  swatch.addEventListener('click', event => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (colorPanelOpen) hideColorPanel()
+    else showColorPanel()
+  })
+  colorWrap.addEventListener('mouseenter', () => clearColorLeaveTimer())
+  colorWrap.addEventListener('mouseleave', () => scheduleHideColorPanel())
+  lineWeightSelect.addEventListener('change', () => {
+    applyLineWeight(Number(lineWeightSelect.value))
+  })
+  fontSizeSelect.addEventListener('change', () => {
+    applyFontSize(Number(fontSizeSelect.value))
+  })
+  root.addEventListener('pointerdown', event => event.stopPropagation())
+  root.addEventListener('mousedown', event => event.stopPropagation())
+
+  const onDocumentPointerDown = (event: PointerEvent) => {
+    if (!colorPanelOpen) return
+    const target = event.target as Node | null
+    if (target && colorWrap.contains(target)) return
+    hideColorPanel()
+  }
+  document.addEventListener('pointerdown', onDocumentPointerDown, true)
+
+  ctx.root.appendChild(root)
+  relabel()
+
+  return {
+    refresh,
+    refreshLabels: () => {
+      relabel()
+    },
+    dispose: () => {
+      document.removeEventListener('pointerdown', onDocumentPointerDown, true)
+      clearColorLeaveTimer()
+      root.remove()
+    }
+  }
+}

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -35,6 +35,24 @@ export type AcExHtmlMessageKey =
   | 'toolbar.measureArea'
   | 'toolbar.measureCoordinate'
   | 'toolbar.clearMeasurements'
+  | 'toolbar.measureHide'
+  | 'toolbar.measureShow'
+  | 'toolbar.measureImport'
+  | 'toolbar.measureExport'
+  | 'toolbar.measure'
+  | 'toolbar.annotation'
+  | 'toolbar.markupCloud'
+  | 'toolbar.markupCallout'
+  | 'toolbar.markupText'
+  | 'toolbar.markupRect'
+  | 'toolbar.markupCircle'
+  | 'toolbar.markupArrow'
+  | 'toolbar.markupStamp'
+  | 'toolbar.markupHide'
+  | 'toolbar.markupShow'
+  | 'toolbar.clearMarkups'
+  | 'toolbar.markupImport'
+  | 'toolbar.markupExport'
   | 'toolbar.settings'
   | 'toolbar.layers'
   | 'toolbar.language'
@@ -42,10 +60,12 @@ export type AcExHtmlMessageKey =
   | 'toolbar.collapse'
   | 'toolbar.expand'
   | 'settings.toolbar'
-  | 'settings.measureColor'
   | 'settings.ortho'
   | 'settings.polar'
   | 'settings.polarAngles'
+  | 'drawStyle.color'
+  | 'drawStyle.lineWeight'
+  | 'drawStyle.fontSize'
   | 'layers.title'
   | 'layers.close'
   | 'layers.showAll'
@@ -57,6 +77,30 @@ export type AcExHtmlMessageKey =
   | 'status.measureArcHint'
   | 'status.measureAreaHint'
   | 'status.measureCoordinateHint'
+  | 'status.measureExported'
+  | 'status.measureImported'
+  | 'status.measureImportFailed'
+  | 'status.markupCloudHint'
+  | 'status.markupCalloutHint'
+  | 'status.markupTextHint'
+  | 'status.markupRectHint'
+  | 'status.markupCircleHint'
+  | 'status.markupArrowHint'
+  | 'status.markupStampHint'
+  | 'status.markupArrowEndHint'
+  | 'status.markupRectCornerHint'
+  | 'status.markupCloudCornerHint'
+  | 'status.markupCalloutAnchorHint'
+  | 'status.markupCircleRadiusHint'
+  | 'status.markupTextPrompt'
+  | 'status.markupTextEditHint'
+  | 'status.markupShapeCalloutHint'
+  | 'status.markupDefaultLabel'
+  | 'status.markupSelected'
+  | 'status.markupCount'
+  | 'status.markupExported'
+  | 'status.markupImported'
+  | 'status.markupImportFailed'
   | 'status.distance'
   | 'status.coordinates'
   | 'status.angle'
@@ -87,7 +131,25 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       measureArea: 'Measure area',
       measureCoordinate: 'Measure coordinates',
       clearMeasurements: 'Clear measurements',
-      settings: 'Measure settings',
+      measureHide: 'Hide measurements',
+      measureShow: 'Show measurements',
+      measureImport: 'Import measurements',
+      measureExport: 'Export measurements',
+      measure: 'Measurement',
+      annotation: 'Review',
+      markupCloud: 'Cloud',
+      markupCallout: 'Callout',
+      markupText: 'Text',
+      markupRect: 'Rectangle',
+      markupCircle: 'Circle',
+      markupArrow: 'Arrow',
+      markupStamp: 'Stamp',
+      markupHide: 'Hide markups',
+      markupShow: 'Show markups',
+      clearMarkups: 'Clear markups',
+      markupImport: 'Import markups',
+      markupExport: 'Export markups',
+      settings: 'Settings',
       layers: 'Layers',
       language: 'Language',
       languageSwitch: 'Switch language',
@@ -95,11 +157,15 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       expand: 'Expand toolbar'
     },
     settings: {
-      toolbar: 'Measure settings',
-      measureColor: 'Measure color',
+      toolbar: 'Settings',
       ortho: 'Toggle orthogonal mode',
       polar: 'Polar tracking angles',
       polarAngles: 'Polar tracking angles'
+    },
+    drawStyle: {
+      color: 'Color',
+      lineWeight: 'Lineweight',
+      fontSize: 'Text height'
     },
     layers: {
       title: 'Layers',
@@ -120,6 +186,31 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
         'Click polygon vertices; click near the first point or press Enter to finish.',
       measureCoordinateHint:
         'Click a point to read its X/Y coordinates (object snap enabled).',
+      measureExported: 'Exported {count} measurement(s).',
+      measureImported: 'Imported {count} measurement(s).',
+      measureImportFailed: 'Failed to import measurements: {error}',
+      markupCloudHint: 'Click two corners to draw a revision cloud.',
+      markupCalloutHint: 'Click the leader tip, then the text anchor.',
+      markupTextHint: 'Click a point to place text.',
+      markupRectHint: 'Click two corners to draw a rectangle.',
+      markupCircleHint: 'Click the center, then a point on the circumference.',
+      markupArrowHint: 'Click the start point, then the arrow tip.',
+      markupStampHint: 'Click to place a stamp (cycles approved / rejected / …).',
+      markupArrowEndHint: 'Click the arrow tip.',
+      markupRectCornerHint: 'Click the opposite corner.',
+      markupCloudCornerHint: 'Click the opposite corner.',
+      markupCalloutAnchorHint: 'Click the text bubble position.',
+      markupCircleRadiusHint: 'Click a point on the circumference.',
+      markupTextPrompt: 'Enter markup text',
+      markupTextEditHint: 'Type text on the canvas. Enter to finish, Esc to cancel.',
+      markupShapeCalloutHint:
+        'Click to place the text box (leader attaches to the shape). Esc cancels the callout.',
+      markupDefaultLabel: 'Note',
+      markupSelected: 'Selected markup: {type}',
+      markupCount: 'Markups: {count}',
+      markupExported: 'Exported {count} markup(s).',
+      markupImported: 'Imported {count} markup(s).',
+      markupImportFailed: 'Failed to import markups: {error}',
       distance: 'Distance: {value}',
       coordinates: 'X: {x}  Y: {y}',
       angle: 'Angle: {value}',
@@ -142,7 +233,25 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       measureArea: '测量面积',
       measureCoordinate: '测量坐标',
       clearMeasurements: '清除测量',
-      settings: '测量设置',
+      measureHide: '隐藏测量',
+      measureShow: '显示测量',
+      measureImport: '导入测量',
+      measureExport: '导出测量',
+      measure: '测量',
+      annotation: '审阅',
+      markupCloud: '云线',
+      markupCallout: '标注',
+      markupText: '文字',
+      markupRect: '矩形',
+      markupCircle: '圆',
+      markupArrow: '箭头',
+      markupStamp: '图章',
+      markupHide: '隐藏批注',
+      markupShow: '显示批注',
+      clearMarkups: '清除批注',
+      markupImport: '导入批注',
+      markupExport: '导出批注',
+      settings: '设置',
       layers: '图层',
       language: '语言',
       languageSwitch: '切换语言',
@@ -150,11 +259,15 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       expand: '展开工具栏'
     },
     settings: {
-      toolbar: '测量设置',
-      measureColor: '测量颜色',
+      toolbar: '设置',
       ortho: '切换正交模式',
       polar: '极轴追踪角度',
       polarAngles: '极轴追踪角度'
+    },
+    drawStyle: {
+      color: '颜色',
+      lineWeight: '线宽',
+      fontSize: '字高'
     },
     layers: {
       title: '图层',
@@ -170,6 +283,31 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       measureArcHint: '依次点击弧起点、弧上一点与弧端点（已启用对象捕捉）。',
       measureAreaHint: '依次点击多边形顶点；靠近首点或按 Enter 完成。',
       measureCoordinateHint: '点击一点以读取其 X/Y 坐标（已启用对象捕捉）。',
+      measureExported: '已导出 {count} 条测量。',
+      measureImported: '已导入 {count} 条测量。',
+      measureImportFailed: '导入测量失败：{error}',
+      markupCloudHint: '点击两个对角点绘制修订云线。',
+      markupCalloutHint: '先点击引线端点，再点击文字位置。',
+      markupTextHint: '点击一点放置文字。',
+      markupRectHint: '点击两个对角点绘制矩形。',
+      markupCircleHint: '先点击圆心，再点击圆周上一点。',
+      markupArrowHint: '先点击起点，再点击箭头端点。',
+      markupStampHint: '点击放置图章（在批准/拒绝等之间循环）。',
+      markupArrowEndHint: '点击箭头端点。',
+      markupRectCornerHint: '点击对角点。',
+      markupCloudCornerHint: '点击对角点。',
+      markupCalloutAnchorHint: '点击文字气泡位置。',
+      markupCircleRadiusHint: '点击圆周上一点。',
+      markupTextPrompt: '输入批注文字',
+      markupTextEditHint: '在画布上输入文字。Enter 完成，Esc 取消。',
+      markupShapeCalloutHint:
+        '点击放置文本框（引线自动贴到图形）。Esc 取消引线和文本框。',
+      markupDefaultLabel: '批注',
+      markupSelected: '已选批注：{type}',
+      markupCount: '批注数：{count}',
+      markupExported: '已导出 {count} 条批注。',
+      markupImported: '已导入 {count} 条批注。',
+      markupImportFailed: '导入批注失败：{error}',
       distance: '距离：{value}',
       coordinates: 'X：{x}  Y：{y}',
       angle: '角度：{value}',
@@ -192,7 +330,25 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       measureArea: 'Změřit plochu',
       measureCoordinate: 'Změřit souřadnice',
       clearMeasurements: 'Vymazat měření',
-      settings: 'Nastavení měření',
+      measureHide: 'Skrýt měření',
+      measureShow: 'Zobrazit měření',
+      measureImport: 'Importovat měření',
+      measureExport: 'Exportovat měření',
+      measure: 'Měření',
+      annotation: 'Kontrola',
+      markupCloud: 'Obláček',
+      markupCallout: 'Odkaz',
+      markupText: 'Text',
+      markupRect: 'Obdélník',
+      markupCircle: 'Kružnice',
+      markupArrow: 'Šipka',
+      markupStamp: 'Razítko',
+      markupHide: 'Skrýt poznámky',
+      markupShow: 'Zobrazit poznámky',
+      clearMarkups: 'Vymazat poznámky',
+      markupImport: 'Importovat poznámky',
+      markupExport: 'Exportovat poznámky',
+      settings: 'Nastavení',
       layers: 'Hladiny',
       language: 'Jazyk',
       languageSwitch: 'Přepnout jazyk',
@@ -200,11 +356,15 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       expand: 'Rozbalit panel nástrojů'
     },
     settings: {
-      toolbar: 'Nastavení měření',
-      measureColor: 'Barva měření',
+      toolbar: 'Nastavení',
       ortho: 'Přepnout ortogonální režim',
       polar: 'Úhly polárního trasování',
       polarAngles: 'Úhly polárního trasování'
+    },
+    drawStyle: {
+      color: 'Barva',
+      lineWeight: 'Tloušťka čáry',
+      fontSize: 'Výška textu'
     },
     layers: {
       title: 'Hladiny',
@@ -225,6 +385,32 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
         'Klikejte na vrcholy mnohoúhelníku; dokončete kliknutím poblíž prvního bodu nebo stiskem Enter.',
       measureCoordinateHint:
         'Klikněte na bod pro zobrazení jeho souřadnic X/Y (uchopení objektů zapnuto).',
+      measureExported: 'Exportováno {count} měření.',
+      measureImported: 'Importováno {count} měření.',
+      measureImportFailed: 'Import měření selhal: {error}',
+      markupCloudHint: 'Klikněte na dva rohy pro nakreslení obláčku.',
+      markupCalloutHint: 'Klikněte na hrot vodítka a poté na kotvu textu.',
+      markupTextHint: 'Klikněte pro umístění textu.',
+      markupRectHint: 'Klikněte na dva rohy pro nakreslení obdélníku.',
+      markupCircleHint: 'Klikněte na střed a poté na bod na kružnici.',
+      markupArrowHint: 'Klikněte na začátek a poté na hrot šipky.',
+      markupStampHint: 'Klikněte pro umístění razítka (schváleno / zamítnuto / …).',
+      markupArrowEndHint: 'Klikněte na hrot šipky.',
+      markupRectCornerHint: 'Klikněte na protilehlý roh.',
+      markupCloudCornerHint: 'Klikněte na protilehlý roh.',
+      markupCalloutAnchorHint: 'Klikněte na pozici textové bubliny.',
+      markupCircleRadiusHint: 'Klikněte na bod na kružnici.',
+      markupTextPrompt: 'Zadejte text poznámky',
+      markupTextEditHint:
+        'Pište text přímo na plátno. Enter dokončí, Esc zruší.',
+      markupShapeCalloutHint:
+        'Klikněte pro umístění textového pole (vodítko se připojí k tvaru). Esc zruší odkaz.',
+      markupDefaultLabel: 'Poznámka',
+      markupSelected: 'Vybraná poznámka: {type}',
+      markupCount: 'Poznámky: {count}',
+      markupExported: 'Exportováno {count} poznámek.',
+      markupImported: 'Importováno {count} poznámek.',
+      markupImportFailed: 'Import poznámek selhal: {error}',
       distance: 'Vzdálenost: {value}',
       coordinates: 'X: {x}  Y: {y}',
       angle: 'Úhel: {value}',
@@ -247,7 +433,25 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       measureArea: 'Alan ölç',
       measureCoordinate: 'Koordinat ölç',
       clearMeasurements: 'Ölçümleri temizle',
-      settings: 'Ölçüm ayarları',
+      measureHide: 'Ölçümleri gizle',
+      measureShow: 'Ölçümleri göster',
+      measureImport: 'Ölçümleri içe aktar',
+      measureExport: 'Ölçümleri dışa aktar',
+      measure: 'Ölçüm',
+      annotation: 'İnceleme',
+      markupCloud: 'Bulut',
+      markupCallout: 'Çağrı',
+      markupText: 'Metin',
+      markupRect: 'Dikdörtgen',
+      markupCircle: 'Daire',
+      markupArrow: 'Ok',
+      markupStamp: 'Damga',
+      markupHide: 'İşaretlemeleri gizle',
+      markupShow: 'İşaretlemeleri göster',
+      clearMarkups: 'İşaretlemeleri temizle',
+      markupImport: 'İşaretlemeleri içe aktar',
+      markupExport: 'İşaretlemeleri dışa aktar',
+      settings: 'Ayarlar',
       layers: 'Katmanlar',
       language: 'Dil',
       languageSwitch: 'Dili değiştir',
@@ -255,11 +459,15 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       expand: 'Araç çubuğunu genişlet'
     },
     settings: {
-      toolbar: 'Ölçüm ayarları',
-      measureColor: 'Ölçüm rengi',
+      toolbar: 'Ayarlar',
       ortho: 'Dik modu aç/kapat',
       polar: 'Kutupsal izleme açıları',
       polarAngles: 'Kutupsal izleme açıları'
+    },
+    drawStyle: {
+      color: 'Renk',
+      lineWeight: 'Çizgi kalınlığı',
+      fontSize: 'Yazı yüksekliği'
     },
     layers: {
       title: 'Katmanlar',
@@ -280,6 +488,32 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
         'Çokgen köşelerini tıklayın; bitirmek için ilk noktanın yakınına tıklayın veya Enter’a basın.',
       measureCoordinateHint:
         'X/Y koordinatlarını okumak için bir nokta tıklayın (nesne yakalama etkin).',
+      measureExported: '{count} ölçüm dışa aktarıldı.',
+      measureImported: '{count} ölçüm içe aktarıldı.',
+      measureImportFailed: 'Ölçüm içe aktarılamadı: {error}',
+      markupCloudHint: 'Revizyon bulutu çizmek için iki köşe tıklayın.',
+      markupCalloutHint: 'Önce lider ucunu, sonra metin konumunu tıklayın.',
+      markupTextHint: 'Metin yerleştirmek için bir nokta tıklayın.',
+      markupRectHint: 'Dikdörtgen çizmek için iki köşe tıklayın.',
+      markupCircleHint: 'Önce merkezi, sonra çevre üzerindeki bir noktayı tıklayın.',
+      markupArrowHint: 'Önce başlangıcı, sonra ok ucunu tıklayın.',
+      markupStampHint: 'Damga yerleştirmek için tıklayın (onaylandı / reddedildi / …).',
+      markupArrowEndHint: 'Ok ucunu tıklayın.',
+      markupRectCornerHint: 'Karşı köşeyi tıklayın.',
+      markupCloudCornerHint: 'Karşı köşeyi tıklayın.',
+      markupCalloutAnchorHint: 'Metin balonu konumunu tıklayın.',
+      markupCircleRadiusHint: 'Çevre üzerindeki bir noktayı tıklayın.',
+      markupTextPrompt: 'İşaretleme metnini girin',
+      markupTextEditHint:
+        'Metni tuval üzerinde yazın. Enter ile bitirin, Esc ile iptal edin.',
+      markupShapeCalloutHint:
+        'Metin kutusunu yerleştirmek için tıklayın (lider şekle bağlanır). Esc çağrıyı iptal eder.',
+      markupDefaultLabel: 'Not',
+      markupSelected: 'Seçili işaretleme: {type}',
+      markupCount: 'İşaretlemeler: {count}',
+      markupExported: '{count} işaretleme dışa aktarıldı.',
+      markupImported: '{count} işaretleme içe aktarıldı.',
+      markupImportFailed: 'İşaretleme içe aktarılamadı: {error}',
       distance: 'Mesafe: {value}',
       coordinates: 'X: {x}  Y: {y}',
       angle: 'Açı: {value}',

--- a/packages/cad-html-plugin/src/AcExHtmlIcons.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlIcons.ts
@@ -18,8 +18,9 @@ const ICON_MEASURE_AREA =
 const ICON_MEASURE_COORDINATE =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M9.25 2h1.5v5.25H16v1.5h-5.25V16h-1.5v-7.25H4v-1.5h5.25V2Z"/><circle fill="currentColor" cx="10" cy="10" r="1.75"/></svg>'
 
-const ICON_CLEAR_MEASUREMENTS =
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4a1 1 0 011-1h4a1 1 0 011 1v2"/></svg>'
+/** Shared trash icon for clear-measurements / clear-markups (matched size). */
+const ICON_CLEAR =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M7.5 3.5h5v1.2h3.2v1.4H4.3V4.7h3.2V3.5zm-2 4.1h9.2l-.7 8.2a1.5 1.5 0 0 1-1.5 1.4H7.5a1.5 1.5 0 0 1-1.5-1.4L5.5 7.6zm2.2 1.6-.4 5.4h1.4l.4-5.4H7.7zm3.6 0-.4 5.4h1.4l.4-5.4h-1.4z"/></svg>'
 
 const ICON_LAYER =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="m434.8 137.65-149.36-68.1c-16.19-7.4-42.69-7.4-58.88 0L77.3 137.65c-17.6 8-17.6 21.09 0 29.09l148 67.5c16.89 7.7 44.69 7.7 61.58 0l148-67.5c17.52-8 17.52-21.1-.08-29.09M160 308.52l-82.7 37.11c-17.6 8-17.6 21.1 0 29.1l148 67.5c16.89 7.69 44.69 7.69 61.58 0l148-67.5c17.6-8 17.6-21.1 0-29.1l-79.94-38.47"/><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="m160 204.48-82.8 37.16c-17.6 8-17.6 21.1 0 29.1l148 67.49c16.89 7.7 44.69 7.7 61.58 0l148-67.49c17.7-8 17.7-21.1.1-29.1L352 204.48"/></svg>'
@@ -54,6 +55,45 @@ const ICON_CHEVRON_UP =
 const ICON_CHEVRON_DOWN =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M10 13.5 14.5 9h-9L10 13.5Z"/></svg>'
 
+const ICON_MEASURE =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M1.5 7h17v6h-17ZM4.25 7h1v2.5h-1ZM7.5 7h.75v1.5H7.5ZM10.25 7h1v2.5h-1ZM13.5 7h.75v1.5H13.5ZM16.25 7h1v2.5h-1Z"/></svg>'
+
+const ICON_ANNOTATION =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12.4 3.25H5.5A2.25 2.25 0 0 0 3.25 5.5v9A2.25 2.25 0 0 0 5.5 16.75h9A2.25 2.25 0 0 0 16.75 14.5V8.6"/><g transform="rotate(45 13.2 6.7)"><rect x="11.7" y="1.55" width="3" height="7.45" rx="1.45"/><path d="M11.7 3.2h3"/><path d="M11.7 9 13.2 12.15 14.7 9"/><rect x="12.8" y="7.05" width="0.8" height="1.2" rx="0.4"/></g></g></svg>'
+
+const ICON_MARKUP_CLOUD =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M4.2 13.2c-1.1 0-2-.9-2-2 0-.9.6-1.7 1.4-1.9C3.5 7.6 4.9 6.5 6.6 6.5c.5 0 1 .1 1.4.3C8.6 5.4 9.9 4.7 11.4 4.7c2.3 0 4.2 1.7 4.5 3.9.9.3 1.6 1.2 1.6 2.2 0 1.3-1 2.4-2.3 2.4H4.2z"/></svg>'
+
+const ICON_MARKUP_CALLOUT =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M3.5 3.5h13v9H8.2L5 15.2V12.5H3.5v-9zm1.5 1.5v6h1.5v1.6L8.8 11H15V5H5zm2 2.5h6v1.2H7V7.5zm0 2.5h4.5v1.2H7V10z"/></svg>'
+
+const ICON_MARKUP_TEXT =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M4 4.5h12v1.6H11.2V15.5H8.8V6.1H4V4.5z"/></svg>'
+
+const ICON_MARKUP_RECT =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M3.5 4.5h13v11h-13v-11zm1.5 1.5v8h10v-8H5z"/></svg>'
+
+const ICON_MARKUP_CIRCLE =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M10 3.2a6.8 6.8 0 1 1 0 13.6 6.8 6.8 0 0 1 0-13.6zm0 1.5a5.3 5.3 0 1 0 0 10.6 5.3 5.3 0 0 0 0-10.6z"/></svg>'
+
+const ICON_MARKUP_ARROW =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M3.5 9.25h9.2L9.4 6 10.5 5l5 5-5 5-1.1-1 3.3-3.25H3.5v-1.5z"/></svg>'
+
+const ICON_MARKUP_STAMP =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M7.2 3.5a2.8 2.8 0 0 1 5.6 0v3.2h1.4A2.2 2.2 0 0 1 16.4 9v2.2H3.6V9a2.2 2.2 0 0 1 2.2-2.3h1.4V3.5zm1.5 0v3.2h2.6V3.5a1.3 1.3 0 0 0-2.6 0zM3.5 14.2h13v2.3h-13v-2.3z"/></svg>'
+
+const ICON_MARKUP_IMPORT =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M9.25 3.5h1.5v7.2l2.4-2.4 1.05 1.05L10 14.05 5.8 9.85l1.05-1.05 2.4 2.4V3.5zM3.5 15.5h13v1.5h-13v-1.5z"/></svg>'
+
+const ICON_MARKUP_EXPORT =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M9.25 12.5h1.5V5.3l2.4 2.4 1.05-1.05L10 2.95 5.8 7.15l1.05 1.05 2.4-2.4V12.5zM3.5 15.5h13v1.5h-13v-1.5z"/></svg>'
+
+const ICON_MARKUP_SHOW =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" aria-hidden="true"><path fill="currentColor" d="M512 160c320 0 512 352 512 352S832 864 512 864 0 512 0 512s192-352 512-352m0 64c-225.28 0-384.128 208.064-436.8 288 52.608 79.872 211.456 288 436.8 288 225.28 0 384.128-208.064 436.8-288-52.608-79.872-211.456-288-436.8-288m0 64a224 224 0 1 1 0 448 224 224 0 0 1 0-448m0 64a160.19 160.19 0 0 0-160 160c0 88.192 71.744 160 160 160s160-71.808 160-160-71.744-160-160-160"/></svg>'
+
+const ICON_MARKUP_HIDE =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" aria-hidden="true"><path fill="currentColor" d="M876.8 156.8c0-9.6-3.2-16-9.6-22.4s-12.8-9.6-22.4-9.6-16 3.2-22.4 9.6L736 220.8c-64-32-137.6-51.2-224-60.8-160 16-288 73.6-377.6 176S0 496 0 512s48 73.6 134.4 176c22.4 25.6 44.8 48 73.6 67.2l-86.4 89.6c-6.4 6.4-9.6 12.8-9.6 22.4s3.2 16 9.6 22.4 12.8 9.6 22.4 9.6 16-3.2 22.4-9.6l704-710.4c3.2-6.4 6.4-12.8 6.4-22.4m-646.4 528Q115.2 579.2 76.8 512q43.2-72 153.6-172.8C304 272 400 230.4 512 224c64 3.2 124.8 19.2 176 44.8l-54.4 54.4C598.4 300.8 560 288 512 288c-64 0-115.2 22.4-160 64s-64 96-64 160c0 48 12.8 89.6 35.2 124.8L256 707.2c-9.6-6.4-19.2-16-25.6-22.4m140.8-96Q352 555.2 352 512c0-44.8 16-83.2 48-112s67.2-48 112-48c28.8 0 54.4 6.4 73.6 19.2zM889.599 336c-12.8-16-28.8-28.8-41.6-41.6l-48 48c73.6 67.2 124.8 124.8 150.4 169.6q-43.2 72-153.6 172.8c-73.6 67.2-172.8 108.8-284.8 115.2-51.2-3.2-99.2-12.8-140.8-28.8l-48 48c57.6 22.4 118.4 38.4 188.8 44.8 160-16 288-73.6 377.6-176S1024 528 1024 512s-48.001-73.6-134.401-176"/><path fill="currentColor" d="M511.998 672c-12.8 0-25.6-3.2-38.4-6.4l-51.2 51.2c28.8 12.8 57.6 19.2 89.6 19.2 64 0 115.2-22.4 160-64 41.6-41.6 64-96 64-160 0-32-6.4-64-19.2-89.6l-51.2 51.2c3.2 12.8 6.4 25.6 6.4 38.4 0 44.8-16 83.2-48 112s-67.2 48-112 48"/></svg>'
+
 /**
  * Inline SVG markup keyed by toolbar / layer UI usage.
  * Each value is a complete `<svg>…</svg>` string using `currentColor`.
@@ -71,8 +111,8 @@ export const acExHtmlIcons = {
   measureArea: ICON_MEASURE_AREA,
   /** Measure-coordinate toolbar icon. */
   measureCoordinate: ICON_MEASURE_COORDINATE,
-  /** Clear-measurements toolbar icon. */
-  clearMeasurements: ICON_CLEAR_MEASUREMENTS,
+  /** Clear-measurements toolbar icon (same glyph as clear markups). */
+  clearMeasurements: ICON_CLEAR,
   /** Open layer drawer toolbar icon. */
   layer: ICON_LAYER,
   /** Per-layer zoom-to-box button icon. */
@@ -94,7 +134,37 @@ export const acExHtmlIcons = {
   /** Collapse toolbar (chevron up). */
   chevronUp: ICON_CHEVRON_UP,
   /** Expand toolbar (chevron down). */
-  chevronDown: ICON_CHEVRON_DOWN
+  chevronDown: ICON_CHEVRON_DOWN,
+  /** Measure tools parent menu icon. */
+  measure: ICON_MEASURE,
+  /** Review / annotation tools parent menu icon. */
+  annotation: ICON_ANNOTATION,
+  /** Markup revision cloud. */
+  markupCloud: ICON_MARKUP_CLOUD,
+  /** Markup callout. */
+  markupCallout: ICON_MARKUP_CALLOUT,
+  /** Markup text. */
+  markupText: ICON_MARKUP_TEXT,
+  /** Markup rectangle. */
+  markupRect: ICON_MARKUP_RECT,
+  /** Markup circle. */
+  markupCircle: ICON_MARKUP_CIRCLE,
+  /** Markup arrow. */
+  markupArrow: ICON_MARKUP_ARROW,
+  /** Markup stamp. */
+  markupStamp: ICON_MARKUP_STAMP,
+  /** Import markup sidecar JSON. */
+  markupImport: ICON_MARKUP_IMPORT,
+  /** Export markup sidecar JSON. */
+  markupExport: ICON_MARKUP_EXPORT,
+  /** Show markups (open eye). */
+  markupShow: ICON_MARKUP_SHOW,
+  /** Hide markups (slashed eye). */
+  markupHide: ICON_MARKUP_HIDE,
+  /** @deprecated Prefer {@link markupHide} / {@link markupShow}. */
+  markupVisibility: ICON_MARKUP_HIDE,
+  /** Clear all markups. */
+  clearMarkups: ICON_CLEAR
 } as const
 
 /**
@@ -114,6 +184,28 @@ export function acExToolbarButton(
     .map(([key, value]) => `${key}="${escapeAttr(value)}"`)
     .join(' ')
   return `<button type="button" class="mlcad-tool-btn" title="${escapeAttr(title)}" aria-label="${escapeAttr(title)}" ${attrStr}>${icon}</button>`
+}
+
+/**
+ * Builds a flyout menu item with icon + label (cad-simple-ui-plugin style).
+ *
+ * @param icon - SVG markup from {@link acExHtmlIcons}.
+ * @param label - Default visible label before i18n overrides.
+ * @param attrs - Additional attributes (e.g. `data-action`, `data-i18n-key`).
+ */
+export function acExDropdownItem(
+  icon: string,
+  label: string,
+  attrs: Record<string, string>
+): string {
+  const attrStr = Object.entries(attrs)
+    .map(([key, value]) => `${key}="${escapeAttr(value)}"`)
+    .join(' ')
+  const i18nKey = attrs['data-i18n-key']
+  const labelAttrs = i18nKey
+    ? ` data-i18n-key="${escapeAttr(i18nKey)}" data-i18n-text`
+    : ''
+  return `<button type="button" class="mlcad-dropdown-item" role="menuitem" title="${escapeAttr(label)}" ${attrStr}><span class="mlcad-dropdown-icon" aria-hidden="true">${icon}</span><span class="mlcad-dropdown-label"${labelAttrs}>${escapeAttr(label)}</span></button>`
 }
 
 function escapeAttr(value: string): string {

--- a/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
@@ -39,6 +39,8 @@ export interface AcExHtmlMeasureSettingsContext {
   measure: AcExMeasureController
   angbase: number
   angdir: number
+  /** Close sibling sidebar panels (tool strips) when settings opens. */
+  onOpen?: () => void
 }
 
 function hexToCss(hex: number): string {
@@ -160,11 +162,7 @@ export function buildAcExHtmlSettingsStrip(): string {
 
   return `
       <div id="mlcad-settings-wrap" hidden>
-        <div id="mlcad-settings-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="settings.toolbar" aria-label="Measure settings">
-          <button type="button" class="mlcad-tool-btn mlcad-color-btn" id="mlcad-measure-color-btn" data-i18n-key="settings.measureColor" data-i18n-attr="title aria-label" title="Measure color" aria-label="Measure color">
-            ${acExHtmlIcons.color}
-          </button>
-          <input type="color" id="mlcad-measure-color-input" class="mlcad-color-input" value="${hexToCss(ACEX_DEFAULT_MEASURE_COLOR)}" tabindex="-1" aria-hidden="true" />
+        <div id="mlcad-settings-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="settings.toolbar" aria-label="Settings">
           ${acExToolbarButton(acExHtmlIcons.orthoMode, 'Orthogonal mode', {
             id: 'mlcad-ortho-btn',
             'data-toggle': 'ortho',
@@ -193,10 +191,13 @@ export interface AcExHtmlMeasureSettingsController {
   getTrackingOptions(): AcExTrackingOptions
   /** Reapplies i18n labels after locale change. */
   refreshLabels: () => void
+  /** Closes the settings strip (and polar panel). */
+  close: () => void
 }
 
 /**
- * Wires the measure settings strip: color picker, ortho, and polar tracking.
+ * Wires the measure settings strip: ortho and polar tracking.
+ * Drawing color / line weight / font size live on the canvas draw-style toolbar.
  */
 export function setupAcExHtmlMeasureSettings(
   ctx: AcExHtmlMeasureSettingsContext
@@ -215,16 +216,12 @@ export function setupAcExHtmlMeasureSettings(
   const polarPanel = document.getElementById('mlcad-polar-angles')
   const orthoBtn = document.getElementById('mlcad-ortho-btn')
   const polarBtn = document.getElementById('mlcad-polar-btn')
-  const colorBtn = document.getElementById('mlcad-measure-color-btn')
-  const colorInput = document.getElementById(
-    'mlcad-measure-color-input'
-  ) as HTMLInputElement | null
 
   const persist = () => savePersistedSettings(state)
 
   const syncMeasureColor = () => {
     applyMeasureColorCss(state.measureColor)
-    ctx.measure.setMeasureColor(state.measureColor)
+    ctx.measure.setDrawStyle({ colorHex: state.measureColor })
   }
 
   const syncTrackingButtons = () => {
@@ -255,8 +252,10 @@ export function setupAcExHtmlMeasureSettings(
   }
 
   const setSettingsOpen = (open: boolean) => {
+    if (open) ctx.onOpen?.()
     if (settingsWrap) settingsWrap.hidden = !open
     settingsBtn?.classList.toggle('active', open)
+    settingsBtn?.classList.toggle('is-menu-open', open)
     settingsBtn?.setAttribute('aria-expanded', String(open))
     if (!open) setPolarPanelOpen(false)
   }
@@ -309,25 +308,11 @@ export function setupAcExHtmlMeasureSettings(
   syncMeasureColor()
   syncTrackingButtons()
   syncPolarAngleButtons()
-  if (colorInput) colorInput.value = hexToCss(state.measureColor)
 
   settingsBtn?.addEventListener('click', event => {
     event.stopPropagation()
     const open = settingsWrap?.hidden !== false
     setSettingsOpen(open)
-  })
-
-  colorBtn?.addEventListener('click', event => {
-    event.stopPropagation()
-    colorInput?.click()
-  })
-
-  colorInput?.addEventListener('input', () => {
-    const hex = Number.parseInt(colorInput.value.slice(1), 16)
-    if (!Number.isFinite(hex)) return
-    state.measureColor = hex
-    syncMeasureColor()
-    persist()
   })
 
   orthoBtn?.addEventListener('click', event => {
@@ -360,14 +345,8 @@ export function setupAcExHtmlMeasureSettings(
       })
     })
 
-  document.addEventListener('click', event => {
-    if (settingsWrap?.hidden) return
-    const target = event.target
-    if (!(target instanceof Node)) return
-    const sidebar = document.getElementById('mlcad-sidebar')
-    if (sidebar?.contains(target)) return
-    setSettingsOpen(false)
-  })
+  // Settings strip stays open until the Settings button is clicked again
+  // (or another parent strip opens). Canvas clicks must not dismiss it.
 
   const refreshLabels = () => {
     ctx.i18n.applyToDocument(
@@ -389,6 +368,7 @@ export function setupAcExHtmlMeasureSettings(
         angdir: ctx.angdir
       }
     },
-    refreshLabels
+    refreshLabels,
+    close: () => setSettingsOpen(false)
   }
 }

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -23,6 +23,8 @@ export const ACEX_HTML_SHELL_CSS = `
     --mlcad-measure-accent: #08e8de;
     --mlcad-measure-accent-border: rgba(8, 232, 222, 0.45);
     --mlcad-measure-accent-fill: rgba(8, 232, 222, 0.2);
+    --mlcad-markup-accent: #e53935;
+    --mlcad-markup-accent-border: rgba(229, 57, 53, 0.45);
     --mlcad-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
     --mlcad-toolbar-width: 44px;
     --mlcad-drawer-width: 220px;
@@ -30,6 +32,7 @@ export const ACEX_HTML_SHELL_CSS = `
     --mlcad-ui-inset: 12px;
     --mlcad-z-chrome: 7;
     --mlcad-z-measure: 5;
+    --mlcad-z-markup: 6;
   }
   html, body {
     margin: 0; height: 100%; overflow: hidden;
@@ -71,6 +74,7 @@ export const ACEX_HTML_SHELL_CSS = `
     backdrop-filter: blur(12px);
   }
   .mlcad-tool-btn {
+    position: relative;
     display: flex; align-items: center; justify-content: center;
     width: var(--mlcad-toolbar-width); height: var(--mlcad-toolbar-width);
     margin: 0; padding: 0;
@@ -85,13 +89,85 @@ export const ACEX_HTML_SHELL_CSS = `
     background: rgba(255, 255, 255, 0.08);
     border-color: var(--mlcad-ui-border);
   }
-  .mlcad-tool-btn.active {
+  .mlcad-tool-btn.active,
+  .mlcad-tool-btn.is-menu-open {
     background: rgba(26, 140, 255, 0.22);
     border-color: rgba(26, 140, 255, 0.55);
     color: #fff;
   }
   .mlcad-tool-btn svg {
     width: 20px; height: 20px; display: block; flex-shrink: 0;
+  }
+  /* Flyout mark: opaque corner triangle (cad-simple-ui-plugin is-left style). */
+  .mlcad-tool-btn.has-children::after {
+    content: '';
+    position: absolute;
+    right: 1px;
+    bottom: 1px;
+    width: 6px;
+    height: 6px;
+    background: currentColor;
+    clip-path: polygon(100% 100%, 0 100%, 100% 0);
+    pointer-events: none;
+  }
+  .mlcad-dropdown {
+    position: fixed;
+    z-index: 40;
+    min-width: 180px;
+    padding: 4px;
+    background: var(--mlcad-ui-bg-elevated);
+    border: 1px solid var(--mlcad-ui-border);
+    border-radius: 8px;
+    box-shadow: var(--mlcad-shadow);
+    backdrop-filter: blur(12px);
+  }
+  .mlcad-dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 6px 8px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--mlcad-ui-text);
+    font-size: 12px;
+    font-weight: 500;
+    text-align: left;
+    cursor: pointer;
+  }
+  .mlcad-dropdown-item:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+  .mlcad-dropdown-item.active,
+  .mlcad-dropdown-item.is-toggled {
+    background: rgba(26, 140, 255, 0.22);
+    color: #fff;
+  }
+  .mlcad-dropdown-icon {
+    display: inline-flex;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+  }
+  .mlcad-dropdown-icon svg {
+    width: 18px;
+    height: 18px;
+    display: block;
+  }
+  .mlcad-dropdown-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mlcad-dropdown-separator {
+    height: 1px;
+    margin: 4px 6px;
+    background: var(--mlcad-ui-border);
   }
   #mlcad-toolbar-toggle {
     height: calc(var(--mlcad-toolbar-width) / 2);
@@ -218,6 +294,8 @@ export const ACEX_HTML_SHELL_CSS = `
   }
 
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-settings-wrap,
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-measure-strip-wrap,
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-markup-strip-wrap,
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-layer-drawer {
     display: none !important;
   }
@@ -228,7 +306,9 @@ export const ACEX_HTML_SHELL_CSS = `
     display: none;
   }
 
-  #mlcad-settings-wrap {
+  #mlcad-settings-wrap,
+  #mlcad-measure-strip-wrap,
+  #mlcad-markup-strip-wrap {
     flex-shrink: 0;
     min-width: 0;
     display: flex;
@@ -236,9 +316,13 @@ export const ACEX_HTML_SHELL_CSS = `
     align-items: flex-start;
     gap: var(--mlcad-drawer-gap);
   }
-  #mlcad-settings-wrap[hidden] { display: none; }
+  #mlcad-settings-wrap[hidden],
+  #mlcad-measure-strip-wrap[hidden],
+  #mlcad-markup-strip-wrap[hidden] { display: none; }
 
-  #mlcad-settings-strip {
+  #mlcad-settings-strip,
+  #mlcad-measure-strip,
+  #mlcad-markup-strip {
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
@@ -250,6 +334,10 @@ export const ACEX_HTML_SHELL_CSS = `
     border-radius: 8px;
     box-shadow: var(--mlcad-shadow);
     backdrop-filter: blur(12px);
+  }
+  #mlcad-measure-strip .mlcad-tool-separator,
+  #mlcad-markup-strip .mlcad-tool-separator {
+    margin: 2px 4px;
   }
 
   #mlcad-polar-angles {
@@ -348,15 +436,24 @@ export const ACEX_HTML_SHELL_CSS = `
     transform: translate(-50%, calc(-50% - 16px));
   }
   .mlcad-measure-dot.mlcad-measure-selected {
-    border-color: #ffd54f;
-    box-shadow: 0 0 0 2px rgba(255, 213, 79, 0.55);
+    box-shadow:
+      0 0 0 2px rgba(255, 213, 79, 0.75),
+      0 0 10px rgba(255, 213, 79, 0.95),
+      0 0 18px rgba(255, 213, 79, 0.55);
   }
   .mlcad-measure-badge.mlcad-measure-selected {
-    border-color: rgba(255, 213, 79, 0.75);
-    color: #ffd54f;
+    outline: 2px solid rgba(255, 213, 79, 0.85);
+    outline-offset: 1px;
+    box-shadow:
+      0 0 0 2px rgba(255, 213, 79, 0.4),
+      0 0 12px rgba(255, 213, 79, 0.75),
+      0 2px 8px rgba(0, 0, 0, 0.35);
   }
   .mlcad-measure-canvas.mlcad-measure-selected {
-    filter: drop-shadow(0 0 3px #ffd54f);
+    filter:
+      drop-shadow(0 0 1.5px #ffd54f)
+      drop-shadow(0 0 4px rgba(255, 213, 79, 0.95))
+      drop-shadow(0 0 8px rgba(255, 213, 79, 0.55));
   }
   .mlcad-measure-live-label {
     position: absolute;
@@ -368,6 +465,82 @@ export const ACEX_HTML_SHELL_CSS = `
     transform: translate(-50%, -120%);
     display: none;
   }
+
+  #mlcad-markup-overlays {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: var(--mlcad-z-markup);
+    overflow: hidden;
+  }
+  .mlcad-markup-canvas {
+    position: absolute;
+    left: 0;
+    top: 0;
+    pointer-events: none;
+  }
+  .mlcad-markup-badge,
+  .mlcad-markup-stamp {
+    position: absolute;
+    padding: 3px 10px;
+    border-radius: 14px;
+    background: var(--mlcad-ui-bg-elevated);
+    border: 1px solid var(--mlcad-markup-accent-border);
+    color: var(--mlcad-markup-accent);
+    font-size: 12px;
+    font-weight: 600;
+    white-space: pre-wrap;
+    max-width: 240px;
+    transform: translate(-50%, -50%);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    pointer-events: auto;
+    cursor: grab;
+    touch-action: none;
+    user-select: none;
+  }
+  .mlcad-markup-stamp {
+    border-radius: 4px;
+    border-width: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 11px;
+    white-space: nowrap;
+  }
+  .mlcad-markup-dot {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--mlcad-markup-accent);
+    border: 2px solid rgba(255, 255, 255, 0.9);
+    box-sizing: border-box;
+    transform: translate(-50%, -50%);
+    pointer-events: auto;
+    cursor: grab;
+    touch-action: none;
+  }
+  .mlcad-markup-dot.mlcad-markup-selected {
+    box-shadow:
+      0 0 0 2px rgba(255, 213, 79, 0.75),
+      0 0 10px rgba(255, 213, 79, 0.95),
+      0 0 18px rgba(255, 213, 79, 0.55);
+  }
+  .mlcad-markup-badge.mlcad-markup-selected,
+  .mlcad-markup-stamp.mlcad-markup-selected {
+    outline: 2px solid rgba(255, 213, 79, 0.85);
+    outline-offset: 1px;
+    box-shadow:
+      0 0 0 2px rgba(255, 213, 79, 0.4),
+      0 0 12px rgba(255, 213, 79, 0.75),
+      0 2px 8px rgba(0, 0, 0, 0.35);
+  }
+  .mlcad-markup-canvas.mlcad-markup-selected {
+    filter:
+      drop-shadow(0 0 1.5px #ffd54f)
+      drop-shadow(0 0 4px rgba(255, 213, 79, 0.95))
+      drop-shadow(0 0 8px rgba(255, 213, 79, 0.55));
+  }
+
   #mlcad-loading {
     position: fixed; inset: 0; z-index: 100;
     display: flex; align-items: center; justify-content: center;
@@ -423,7 +596,7 @@ export const ACEX_HTML_SHELL_CSS = `
  * Excludes snapshot and runtime `<script>` tags — those are appended by {@link packHtml}.
  *
  * @param loadingBg - CSS color for the initial loading screen (matches drawing background).
- * @param viewerMode - `'view'` shows pan/zoom/layers only; `'measure'` adds measurement tools.
+ * @param viewerMode - `'view'` shows pan/zoom/layers only; `'measure'` adds measurement and markup tools.
  * @returns HTML fragment inserted inside `<body>`.
  */
 export function buildAcExHtmlShellBody(
@@ -431,11 +604,18 @@ export function buildAcExHtmlShellBody(
   viewerMode: AcExViewerMode = 'measure'
 ): string {
   const measureToolbar =
-    viewerMode === 'measure' ? buildAcExMeasureToolbarSection() : ''
+    viewerMode === 'measure' ? buildAcExMeasureMenuButton() : ''
+  const markupToolbar =
+    viewerMode === 'measure' ? buildAcExMarkupMenuButton() : ''
   const settingsToolbar =
     viewerMode === 'measure' ? buildAcExMeasureSettingsToolbarButton() : ''
   const languageToolbar =
     viewerMode === 'view' ? buildAcExLanguageToolbarButton() : ''
+  const submenuTemplates = ''
+  const toolStrips =
+    viewerMode === 'measure'
+      ? `${buildAcExMeasureToolStrip()}${buildAcExMarkupToolStrip()}`
+      : ''
 
   return `
   <div id="mlcad-loading" aria-hidden="true" style="background:${loadingBg}">
@@ -451,6 +631,7 @@ export function buildAcExHtmlShellBody(
         })}
         ${viewerMode === 'measure' ? buildAcExToolbarSeparator() : ''}
         ${measureToolbar}
+        ${markupToolbar}
         ${viewerMode === 'measure' ? buildAcExToolbarSeparator() : ''}
         ${acExToolbarButton(acExHtmlIcons.layer, 'Layers', {
           id: 'mlcad-layers-btn',
@@ -468,6 +649,7 @@ export function buildAcExHtmlShellBody(
           'data-i18n-attr': 'title aria-label'
         })}
       </nav>
+      ${toolStrips}
       ${viewerMode === 'measure' ? buildAcExHtmlSettingsStrip() : ''}
       <div id="mlcad-layer-drawer" role="dialog" data-i18n-attr="aria-label" data-i18n-key="layers.title" aria-label="Layers" hidden>
         <div class="mlcad-drawer-header">
@@ -486,66 +668,178 @@ export function buildAcExHtmlShellBody(
       </div>
     </aside>
     ${viewerMode === 'measure' ? '<footer id="mlcad-status-bar" aria-live="polite"></footer>' : ''}
-  </div>`
+  </div>
+  ${submenuTemplates}`
 }
 
 function buildAcExToolbarSeparator(): string {
   return '<div class="mlcad-tool-separator" aria-hidden="true"></div>'
 }
 
-function buildAcExMeasureToolbarSection(): string {
-  return `
-        ${acExToolbarButton(acExHtmlIcons.measureDistance, 'Measure distance', {
+function buildAcExMeasureMenuButton(): string {
+  return acExToolbarButton(acExHtmlIcons.measure, 'Measurement', {
+    id: 'mlcad-measure-menu-btn',
+    'aria-haspopup': 'true',
+    'aria-expanded': 'false',
+    'data-action': 'measure-menu',
+    'data-i18n-key': 'toolbar.measure',
+    'data-i18n-attr': 'title aria-label'
+  }).replace('class="mlcad-tool-btn"', 'class="mlcad-tool-btn has-children"')
+}
+
+function buildAcExMarkupMenuButton(): string {
+  return acExToolbarButton(acExHtmlIcons.annotation, 'Review', {
+    id: 'mlcad-markup-menu-btn',
+    'aria-haspopup': 'true',
+    'aria-expanded': 'false',
+    'data-action': 'markup-menu',
+    'data-i18n-key': 'toolbar.annotation',
+    'data-i18n-attr': 'title aria-label'
+  }).replace('class="mlcad-tool-btn"', 'class="mlcad-tool-btn has-children"')
+}
+
+function buildAcExMeasureToolStrip(): string {
+  return `<div id="mlcad-measure-strip-wrap" hidden>
+    <div id="mlcad-measure-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="toolbar.measure" aria-label="Measurement">
+      ${acExToolbarButton(acExHtmlIcons.measureDistance, 'Measure distance', {
+        'data-action': 'measure',
+        'data-measure-mode': 'distance',
+        'data-i18n-key': 'toolbar.measureDistance',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.measureAngle, 'Measure angle', {
+        'data-action': 'measure',
+        'data-measure-mode': 'angle',
+        'data-i18n-key': 'toolbar.measureAngle',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.measureArc, 'Measure arc length', {
+        'data-action': 'measure',
+        'data-measure-mode': 'arc',
+        'data-i18n-key': 'toolbar.measureArc',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.measureArea, 'Measure area', {
+        'data-action': 'measure',
+        'data-measure-mode': 'area',
+        'data-i18n-key': 'toolbar.measureArea',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(
+        acExHtmlIcons.measureCoordinate,
+        'Measure coordinates',
+        {
           'data-action': 'measure',
-          'data-measure-mode': 'distance',
-          'data-i18n-key': 'toolbar.measureDistance',
+          'data-measure-mode': 'coordinate',
+          'data-i18n-key': 'toolbar.measureCoordinate',
           'data-i18n-attr': 'title aria-label'
-        })}
-        ${acExToolbarButton(acExHtmlIcons.measureAngle, 'Measure angle', {
-          'data-action': 'measure',
-          'data-measure-mode': 'angle',
-          'data-i18n-key': 'toolbar.measureAngle',
+        }
+      )}
+      ${acExToolbarButton(acExHtmlIcons.markupHide, 'Hide measurements', {
+        'data-action': 'measure-visibility',
+        'data-i18n-key': 'toolbar.measureHide',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(
+        acExHtmlIcons.clearMeasurements,
+        'Clear measurements',
+        {
+          'data-action': 'clear-measurements',
+          'data-i18n-key': 'toolbar.clearMeasurements',
           'data-i18n-attr': 'title aria-label'
-        })}
-        ${acExToolbarButton(acExHtmlIcons.measureArc, 'Measure arc length', {
-          'data-action': 'measure',
-          'data-measure-mode': 'arc',
-          'data-i18n-key': 'toolbar.measureArc',
-          'data-i18n-attr': 'title aria-label'
-        })}
-        ${acExToolbarButton(acExHtmlIcons.measureArea, 'Measure area', {
-          'data-action': 'measure',
-          'data-measure-mode': 'area',
-          'data-i18n-key': 'toolbar.measureArea',
-          'data-i18n-attr': 'title aria-label'
-        })}
-        ${acExToolbarButton(
-          acExHtmlIcons.measureCoordinate,
-          'Measure coordinates',
-          {
-            'data-action': 'measure',
-            'data-measure-mode': 'coordinate',
-            'data-i18n-key': 'toolbar.measureCoordinate',
-            'data-i18n-attr': 'title aria-label'
-          }
-        )}
-        ${acExToolbarButton(
-          acExHtmlIcons.clearMeasurements,
-          'Clear measurements',
-          {
-            'data-action': 'clear-measurements',
-            'data-i18n-key': 'toolbar.clearMeasurements',
-            'data-i18n-attr': 'title aria-label'
-          }
-        )}`
+        }
+      )}
+      ${buildAcExToolbarSeparator()}
+      ${acExToolbarButton(acExHtmlIcons.markupImport, 'Import measurements', {
+        'data-action': 'measure-import',
+        'data-i18n-key': 'toolbar.measureImport',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupExport, 'Export measurements', {
+        'data-action': 'measure-export',
+        'data-i18n-key': 'toolbar.measureExport',
+        'data-i18n-attr': 'title aria-label'
+      })}
+    </div>
+  </div>`
+}
+
+function buildAcExMarkupToolStrip(): string {
+  return `<div id="mlcad-markup-strip-wrap" hidden>
+    <div id="mlcad-markup-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="toolbar.annotation" aria-label="Review">
+      ${acExToolbarButton(acExHtmlIcons.markupCloud, 'Cloud', {
+        'data-action': 'markup',
+        'data-markup-mode': 'cloud',
+        'data-i18n-key': 'toolbar.markupCloud',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupCallout, 'Callout', {
+        'data-action': 'markup',
+        'data-markup-mode': 'callout',
+        'data-i18n-key': 'toolbar.markupCallout',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupText, 'Text', {
+        'data-action': 'markup',
+        'data-markup-mode': 'text',
+        'data-i18n-key': 'toolbar.markupText',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupRect, 'Rectangle', {
+        'data-action': 'markup',
+        'data-markup-mode': 'rect',
+        'data-i18n-key': 'toolbar.markupRect',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupCircle, 'Circle', {
+        'data-action': 'markup',
+        'data-markup-mode': 'circle',
+        'data-i18n-key': 'toolbar.markupCircle',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupArrow, 'Arrow', {
+        'data-action': 'markup',
+        'data-markup-mode': 'arrow',
+        'data-i18n-key': 'toolbar.markupArrow',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupStamp, 'Stamp', {
+        'data-action': 'markup',
+        'data-markup-mode': 'stamp',
+        'data-i18n-key': 'toolbar.markupStamp',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupHide, 'Hide markups', {
+        'data-action': 'markup-visibility',
+        'data-i18n-key': 'toolbar.markupHide',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.clearMarkups, 'Clear markups', {
+        'data-action': 'clear-markups',
+        'data-i18n-key': 'toolbar.clearMarkups',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${buildAcExToolbarSeparator()}
+      ${acExToolbarButton(acExHtmlIcons.markupImport, 'Import markups', {
+        'data-action': 'markup-import',
+        'data-i18n-key': 'toolbar.markupImport',
+        'data-i18n-attr': 'title aria-label'
+      })}
+      ${acExToolbarButton(acExHtmlIcons.markupExport, 'Export markups', {
+        'data-action': 'markup-export',
+        'data-i18n-key': 'toolbar.markupExport',
+        'data-i18n-attr': 'title aria-label'
+      })}
+    </div>
+  </div>`
 }
 
 function buildAcExMeasureSettingsToolbarButton(): string {
-  return acExToolbarButton(acExHtmlIcons.setting, 'Measure settings', {
+  return acExToolbarButton(acExHtmlIcons.setting, 'Settings', {
     id: 'mlcad-settings-btn',
     'aria-haspopup': 'true',
     'aria-expanded': 'false',
     'data-i18n-key': 'toolbar.settings',
     'data-i18n-attr': 'title aria-label'
-  })
+  }).replace('class="mlcad-tool-btn"', 'class="mlcad-tool-btn has-children"')
 }

--- a/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
@@ -1,0 +1,117 @@
+/**
+ * Sidebar tool strips for Measurement / Review in the offline HTML viewer.
+ * Same interaction model as the Settings strip (icon toolbar beside the main nav).
+ *
+ * @module AcExHtmlToolbarFlyout
+ * @packageDocumentation
+ */
+
+/** Handles returned by {@link setupAcExHtmlToolbarFlyouts}. */
+export interface AcExHtmlToolbarFlyoutController {
+  /** Closes any open Measurement / Review strip. */
+  close: () => void
+  /** No-op kept for callers that refresh open-panel labels. */
+  refreshLabels: () => void
+}
+
+/**
+ * Options for wiring Measurement / Review parent buttons to their tool strips.
+ */
+export interface AcExHtmlToolbarFlyoutOptions {
+  /**
+   * Invoked when a strip item is clicked (same contract as top-level
+   * `data-action` toolbar buttons).
+   */
+  onItemClick: (button: HTMLButtonElement) => void
+  /** Close other sidebar panels (settings / layers) before opening a strip. */
+  closeOtherPanels?: () => void
+  /**
+   * Called after a strip opens so callers can sync active/toggle states.
+   */
+  onOpen?: (menuId: 'measure' | 'review', menuRoot: HTMLElement) => void
+}
+
+type AcExToolStripId = 'measure' | 'review'
+
+/**
+ * Wires `#mlcad-measure-menu-btn` / `#mlcad-markup-menu-btn` to toggle
+ * `#mlcad-measure-strip-wrap` / `#mlcad-markup-strip-wrap` like Settings.
+ */
+export function setupAcExHtmlToolbarFlyouts(
+  options: AcExHtmlToolbarFlyoutOptions
+): AcExHtmlToolbarFlyoutController {
+  const measureBtn = document.getElementById(
+    'mlcad-measure-menu-btn'
+  ) as HTMLButtonElement | null
+  const reviewBtn = document.getElementById(
+    'mlcad-markup-menu-btn'
+  ) as HTMLButtonElement | null
+  const measureWrap = document.getElementById('mlcad-measure-strip-wrap')
+  const reviewWrap = document.getElementById('mlcad-markup-strip-wrap')
+  const measureStrip = document.getElementById('mlcad-measure-strip')
+  const reviewStrip = document.getElementById('mlcad-markup-strip')
+
+  let openId: AcExToolStripId | null = null
+
+  const setStripOpen = (id: AcExToolStripId | null) => {
+    const measureOpen = id === 'measure'
+    const reviewOpen = id === 'review'
+    if (measureWrap) measureWrap.hidden = !measureOpen
+    if (reviewWrap) reviewWrap.hidden = !reviewOpen
+    measureBtn?.classList.toggle('active', measureOpen)
+    measureBtn?.classList.toggle('is-menu-open', measureOpen)
+    measureBtn?.setAttribute('aria-expanded', String(measureOpen))
+    reviewBtn?.classList.toggle('active', reviewOpen)
+    reviewBtn?.classList.toggle('is-menu-open', reviewOpen)
+    reviewBtn?.setAttribute('aria-expanded', String(reviewOpen))
+    openId = id
+    if (id === 'measure' && measureStrip) {
+      options.onOpen?.('measure', measureStrip)
+    } else if (id === 'review' && reviewStrip) {
+      options.onOpen?.('review', reviewStrip)
+    }
+  }
+
+  const close = () => setStripOpen(null)
+
+  const toggle = (id: AcExToolStripId) => {
+    if (openId === id) {
+      close()
+      return
+    }
+    options.closeOtherPanels?.()
+    setStripOpen(id)
+  }
+
+  measureBtn?.addEventListener('click', event => {
+    event.stopPropagation()
+    toggle('measure')
+  })
+  reviewBtn?.addEventListener('click', event => {
+    event.stopPropagation()
+    toggle('review')
+  })
+
+  const bindStripClicks = (strip: HTMLElement | null) => {
+    strip
+      ?.querySelectorAll<HTMLButtonElement>('button[data-action]')
+      .forEach(btn => {
+        btn.addEventListener('click', event => {
+          event.stopPropagation()
+          options.onItemClick(btn)
+        })
+      })
+  }
+  bindStripClicks(measureStrip)
+  bindStripClicks(reviewStrip)
+
+  // Strips stay open until the parent button is clicked again (or another
+  // parent strip replaces this one). Canvas clicks must not dismiss them.
+
+  return {
+    close,
+    refreshLabels: () => {
+      // Strip buttons use data-i18n-key; global i18n refresh covers them.
+    }
+  }
+}

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -5,13 +5,16 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
+import { setupAcExDrawStyleToolbar } from './AcExDrawStyleToolbar'
 import { AcExHtmlI18n, detectAcExHtmlLocale } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import { setupAcExHtmlMeasureSettings } from './AcExHtmlMeasureSettings'
+import { setupAcExHtmlToolbarFlyouts } from './AcExHtmlToolbarFlyout'
 import {
   computeLayerExtentsMap,
   resolveLayoutViewExtents
 } from './AcExLayerExtents'
+import { AcExMarkupController, type AcExMarkupMode } from './AcExMarkup'
 import { AcExMeasureController, type AcExMeasureMode } from './AcExMeasurement'
 import { AcExOsnapIndex } from './AcExOsnap'
 import { AcExOsnapMarker } from './AcExOsnapMarker'
@@ -304,12 +307,28 @@ function startViewer(): void {
   }
 
   let measure: AcExMeasureController | null = null
+  let markup: AcExMarkupController | null = null
   const measureSettingsRef: {
     current: ReturnType<typeof setupAcExHtmlMeasureSettings> | null
   } = { current: null }
+  const toolbarFlyoutsRef: {
+    current: ReturnType<typeof setupAcExHtmlToolbarFlyouts> | null
+  } = { current: null }
+  const drawStyleToolbarRef: {
+    current: ReturnType<typeof setupAcExDrawStyleToolbar> | null
+  } = { current: null }
+
+  const isToolActive = () =>
+    measure?.isActive === true || markup?.isActive === true
+
+  const setLeftPanForTools = () => {
+    setOrbitLeftButtonPan(controls, !isToolActive())
+    drawStyleToolbarRef.current?.refresh()
+  }
 
   const render = () => {
     measure?.syncOverlays()
+    markup?.syncOverlays()
     renderer.render(scene, camera)
   }
 
@@ -320,6 +339,7 @@ function startViewer(): void {
       i18n,
       statusEl,
       getReadyStatus: () => readyStatus,
+      drawingName: snapshot.meta.title,
       onOsnapMarker: (snap, screen) => {
         if (snap && screen) {
           osnapMarker?.show(screen.x, screen.y, snap.mode)
@@ -329,8 +349,11 @@ function startViewer(): void {
       },
       getTrackingOptions: () =>
         measureSettingsRef.current?.getTrackingOptions() ?? null,
-      onActiveChange: active => {
-        setOrbitLeftButtonPan(controls, !active)
+      onActiveChange: () => {
+        setLeftPanForTools()
+      },
+      onStyleChange: () => {
+        drawStyleToolbarRef.current?.refresh()
       },
       view: {
         screenToWcs,
@@ -343,11 +366,66 @@ function startViewer(): void {
       }
     })
 
+    markup = new AcExMarkupController({
+      root,
+      i18n,
+      statusEl,
+      getReadyStatus: () => readyStatus,
+      drawingName: snapshot.meta.title,
+      onOsnapMarker: (snap, screen) => {
+        if (snap && screen) {
+          osnapMarker?.show(screen.x, screen.y, snap.mode)
+        } else {
+          osnapMarker?.hide()
+        }
+      },
+      onBeforeActivate: () => {
+        measure?.cancelMode()
+      },
+      onActiveChange: () => {
+        setLeftPanForTools()
+      },
+      onStyleChange: () => {
+        drawStyleToolbarRef.current?.refresh()
+      },
+      getTrackingOptions: () =>
+        measureSettingsRef.current?.getTrackingOptions() ?? null,
+      view: {
+        screenToWcs,
+        wcsToScreen,
+        render,
+        getSnapCacheKey: () => snapCacheKey,
+        resolvePoint: resolveMeasurePoint
+      }
+    })
+
     measureSettingsRef.current = setupAcExHtmlMeasureSettings({
       i18n,
       measure,
       angbase: snapshot.meta.units.angbase,
-      angdir: snapshot.meta.units.angdir
+      angdir: snapshot.meta.units.angdir,
+      onOpen: () => toolbarFlyoutsRef.current?.close()
+    })
+
+    drawStyleToolbarRef.current = setupAcExDrawStyleToolbar({
+      root,
+      i18n,
+      getKind: () => {
+        if (measure?.isActive) return 'measure'
+        if (markup?.isActive) return 'markup'
+        if (markup?.hasSelection) return 'markup'
+        if (measure?.hasSelection) return 'measure'
+        return undefined
+      },
+      getStyle: kind =>
+        kind === 'measure' ? measure!.getDrawStyle() : markup!.getDrawStyle(),
+      applyStyle: (kind, patch) => {
+        if (kind === 'measure') {
+          measure!.setDrawStyle(patch)
+        } else {
+          markup!.setDrawStyle(patch)
+        }
+      }
     })
   }
 
@@ -371,16 +449,6 @@ function startViewer(): void {
     ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
   })
 
-  i18n.setOnChange(() => {
-    readyStatus = snapshot.meta.title ?? i18n.t('status.ready')
-    if (!measure?.isActive) {
-      measure?.refreshIdleStatus()
-    }
-    layerPanel?.refreshLayerLabels()
-    measureSettingsRef.current?.refreshLabels()
-    toolbarCollapse.refreshLabels()
-  })
-
   document
     .getElementById('mlcad-lang-btn')
     ?.addEventListener('click', event => {
@@ -395,43 +463,143 @@ function startViewer(): void {
     render()
   })
 
-  if (measureEnabled && measure) {
-    setupMeasurePointerInput(renderer.domElement, () => measure!, render)
+  if (measureEnabled && measure && markup) {
+    setupToolPointerInput(
+      renderer.domElement,
+      () => measure!,
+      () => markup!,
+      render
+    )
   }
 
-  setupPanCursorFeedback(renderer.domElement, () => measure?.isActive === true)
+  setupPanCursorFeedback(renderer.domElement, () => isToolActive())
 
   renderer.domElement.addEventListener('contextmenu', event => {
     event.preventDefault()
   })
+
+  const handleToolbarAction = (button: HTMLElement) => {
+    const action = button.getAttribute('data-action')
+    if (action === 'fit') {
+      fit()
+    } else if (action === 'clear-measurements') {
+      measure?.clearAll()
+    } else if (action === 'measure-visibility') {
+      measure?.toggleVisible()
+    } else if (action === 'measure-import') {
+      measure?.importSidecar()
+    } else if (action === 'measure-export') {
+      measure?.exportSidecar()
+    } else if (action === 'clear-markups') {
+      markup?.clearAll()
+    } else if (action === 'markup-visibility') {
+      markup?.toggleVisible()
+    } else if (action === 'markup-import') {
+      markup?.importSidecar()
+    } else if (action === 'markup-export') {
+      markup?.exportSidecar()
+    } else if (action === 'measure') {
+      markup?.cancelMode()
+      const mode = button.getAttribute(
+        'data-measure-mode'
+      ) as AcExMeasureMode | null
+      if (mode) {
+        measure?.setMode(mode)
+      }
+    } else if (action === 'markup') {
+      measure?.cancelMode()
+      const mode = button.getAttribute(
+        'data-markup-mode'
+      ) as AcExMarkupMode | null
+      if (mode) {
+        markup?.setMode(mode)
+      }
+    }
+  }
 
   document
     .querySelectorAll('#mlcad-toolbar button[data-action]')
     .forEach(button => {
       button.addEventListener('click', () => {
         const action = button.getAttribute('data-action')
-        if (action === 'fit') {
-          fit()
-        } else if (action === 'clear-measurements') {
-          measure?.clearAll()
-        } else if (action === 'measure') {
-          const mode = button.getAttribute(
-            'data-measure-mode'
-          ) as AcExMeasureMode | null
-          if (mode) {
-            measure?.setMode(mode)
-          }
-        }
+        // Parent menu buttons are handled by the flyout controller.
+        if (action === 'measure-menu' || action === 'markup-menu') return
+        handleToolbarAction(button as HTMLElement)
       })
     })
 
-  if (measureEnabled && measure) {
+  const toolbarFlyouts =
+    measureEnabled && measure && markup
+      ? setupAcExHtmlToolbarFlyouts({
+          onItemClick: handleToolbarAction,
+          closeOtherPanels: () => {
+            measureSettingsRef.current?.close()
+          },
+          onOpen: (menuId, menuRoot) => {
+            if (menuId === 'measure') {
+              measure!.setVisible(measure!.visible)
+              menuRoot
+                .querySelectorAll('[data-measure-mode]')
+                .forEach(btn => {
+                  const mode = btn.getAttribute('data-measure-mode')
+                  btn.classList.toggle('active', mode === measure!.mode)
+                })
+            } else {
+              markup!.setVisible(markup!.visible)
+              menuRoot
+                .querySelectorAll('[data-markup-mode]')
+                .forEach(btn => {
+                  const mode = btn.getAttribute('data-markup-mode')
+                  btn.classList.toggle('active', mode === markup!.mode)
+                })
+            }
+          }
+        })
+      : null
+  toolbarFlyoutsRef.current = toolbarFlyouts
+
+  i18n.setOnChange(() => {
+    readyStatus = snapshot.meta.title ?? i18n.t('status.ready')
+    if (!measure?.isActive && !markup?.isActive) {
+      measure?.refreshIdleStatus()
+      markup?.refreshIdleStatus()
+    }
+    layerPanel?.refreshLayerLabels()
+    measureSettingsRef.current?.refreshLabels()
+    drawStyleToolbarRef.current?.refreshLabels()
+    toolbarCollapse.refreshLabels()
+    toolbarFlyouts?.refreshLabels()
+    // Re-apply visibility button label after i18n DOM refresh.
+    if (markup) {
+      markup.setVisible(markup.visible)
+    }
+    if (measure) {
+      measure.setVisible(measure.visible)
+    }
+    drawStyleToolbarRef.current?.refresh()
+  })
+
+  if (measureEnabled && measure && markup) {
     window.addEventListener('keydown', event => {
-      if (measure!.handleKeyDown(event.key)) {
+      // Don't steal keys from real text fields; markup inline edit uses
+      // stopPropagation on its own keydown handler.
+      const target = event.target as HTMLElement | null
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target?.isContentEditable &&
+          target.closest('.mlcad-markup-text-editing'))
+      ) {
+        return
+      }
+      if (measure!.handleKeyDown(event.key) || markup!.handleKeyDown(event.key)) {
         event.preventDefault()
         return
       }
-      if (measure!.handleSelectionKeyDown(event.key, event)) {
+      if (
+        measure!.handleSelectionKeyDown(event.key, event) ||
+        markup!.handleSelectionKeyDown(event.key, event)
+      ) {
         event.preventDefault()
       }
     })
@@ -494,11 +662,22 @@ function setupToolbarCollapse(
     layersBtn?.setAttribute('aria-expanded', 'false')
 
     if (settingsWrap) settingsWrap.hidden = true
-    settingsBtn?.classList.remove('active')
+    settingsBtn?.classList.remove('active', 'is-menu-open')
     settingsBtn?.setAttribute('aria-expanded', 'false')
 
     if (polarPanel) polarPanel.hidden = true
     polarBtn?.setAttribute('aria-expanded', 'false')
+
+    const measureStrip = document.getElementById('mlcad-measure-strip-wrap')
+    const markupStrip = document.getElementById('mlcad-markup-strip-wrap')
+    const measureMenuBtn = document.getElementById('mlcad-measure-menu-btn')
+    const markupMenuBtn = document.getElementById('mlcad-markup-menu-btn')
+    if (measureStrip) measureStrip.hidden = true
+    if (markupStrip) markupStrip.hidden = true
+    measureMenuBtn?.classList.remove('active', 'is-menu-open')
+    measureMenuBtn?.setAttribute('aria-expanded', 'false')
+    markupMenuBtn?.classList.remove('active', 'is-menu-open')
+    markupMenuBtn?.setAttribute('aria-expanded', 'false')
   }
 
   const syncToggle = () => {
@@ -811,12 +990,13 @@ function setupPanCursorFeedback(
 }
 
 /**
- * Left-button measure picking / selection on capture so selection can block
+ * Left-button tool picking / selection on capture so selection can block
  * OrbitControls pan; while a tool is active left pan is already toggled off.
  */
-function setupMeasurePointerInput(
+function setupToolPointerInput(
   domElement: HTMLElement,
   getMeasure: () => AcExMeasureController,
+  getMarkup: () => AcExMarkupController,
   render: () => void
 ): void {
   let pendingMove: { clientX: number; clientY: number } | null = null
@@ -828,9 +1008,16 @@ function setupMeasurePointerInput(
     pendingMove = null
     if (!sample) return
     const measure = getMeasure()
-    if (!measure.isActive) return
-    measure.handlePointerMove(sample.clientX, sample.clientY)
-    render()
+    const markup = getMarkup()
+    if (measure.isActive) {
+      measure.handlePointerMove(sample.clientX, sample.clientY)
+      render()
+      return
+    }
+    if (markup.isActive) {
+      markup.handlePointerMove(sample.clientX, sample.clientY)
+      render()
+    }
   }
 
   domElement.addEventListener(
@@ -838,15 +1025,31 @@ function setupMeasurePointerInput(
     event => {
       if (event.button !== 0) return
       const measure = getMeasure()
+      const markup = getMarkup()
       if (measure.isActive) {
         if (measure.handlePointerDown(event.clientX, event.clientY)) {
+          if (measure.hasSelection) markup.clearSelection()
+          render()
+        }
+        return
+      }
+      if (markup.isActive) {
+        if (markup.handlePointerDown(event.clientX, event.clientY)) {
+          if (markup.hasSelection) measure.clearSelection()
           render()
         }
         return
       }
       // Capture phase: stop before OrbitControls starts left-button pan.
+      if (markup.handleSelectionPointerDown(event.clientX, event.clientY)) {
+        event.stopImmediatePropagation()
+        if (markup.hasSelection) measure.clearSelection()
+        render()
+        return
+      }
       if (measure.handleSelectionPointerDown(event.clientX, event.clientY)) {
         event.stopImmediatePropagation()
+        if (measure.hasSelection) markup.clearSelection()
         render()
       }
     },
@@ -854,7 +1057,8 @@ function setupMeasurePointerInput(
   )
   domElement.addEventListener('pointermove', event => {
     const measure = getMeasure()
-    if (!measure.isActive) return
+    const markup = getMarkup()
+    if (!measure.isActive && !markup.isActive) return
     pendingMove = { clientX: event.clientX, clientY: event.clientY }
     if (moveRaf === 0) {
       moveRaf = requestAnimationFrame(flushPointerMove)

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -1,0 +1,2046 @@
+/**
+ * Markup annotation tools for the offline HTML viewer.
+ *
+ * Creates Design Review–style overlays (cloud, callout, text, rect, circle,
+ * arrow, stamp) with sidecar JSON import/export compatible with cad-simple-viewer.
+ *
+ * @module AcExMarkup
+ * @packageDocumentation
+ */
+
+import * as THREE from 'three'
+
+import type { AcExHtmlI18n } from './AcExHtmlI18n'
+import { acExHtmlIcons } from './AcExHtmlIcons'
+import {
+  acExComputeLeaderTipOnShape,
+  acExDrawMarkupArrowHead,
+  acExDrawMarkupLeader,
+  acExFitMarkupCanvas,
+  acExHitTestMarkup,
+  acExMarkupCanvasLineWidth,
+  acExMarkupCenter,
+  type AcExMarkupShapeOutline,
+  acExStrokeMarkupCloud,
+  acExTranslateMarkupGeometry} from './AcExMarkupGeometry'
+import { acExBindMarkupPointerDrag } from './AcExMarkupGripDrag'
+import {
+  acExMarkupSidecarFileName,
+  parseAcExMarkupSidecar,
+  stringifyAcExMarkupSidecar
+} from './AcExMarkupSidecar'
+import {
+  editAcExMarkupHtmlText,
+  isAcExMarkupDoublePointer,
+  isAcExMarkupHtmlTextEditing
+} from './AcExMarkupTextEdit'
+import type {
+  AcExMarkupAttachedCallout,
+  AcExMarkupGeometry,
+  AcExMarkupMode,
+  AcExMarkupPoint2d,
+  AcExMarkupRecord,
+  AcExMarkupSidecarFile,
+  AcExMarkupStyle
+} from './AcExMarkupTypes'
+import type { AcExTrackingOptions } from './AcExMeasureTracking'
+import { constrainToAcExTracking } from './AcExMeasureTracking'
+import type { AcExOsnapPoint } from './AcExOsnap'
+
+export type { AcExMarkupMode } from './AcExMarkupTypes'
+
+/** Default markup stroke color (ACI red). */
+export const ACEX_MARKUP_COLOR = '#e53935'
+
+/** @deprecated Selection uses CSS glow; original stroke color is preserved. */
+export const ACEX_MARKUP_SELECT_COLOR = '#ffd54f'
+
+/** Default CAD line weight (≈ 0.70 mm → ~2.5 px). */
+const ACEX_MARKUP_LINE_WEIGHT = 70
+
+/** Default font size for text / callout badges (CSS px). */
+const ACEX_MARKUP_FONT_SIZE = 12
+
+/** Screen-pixel tolerance for picking a committed markup. */
+const MARKUP_HIT_THRESHOLD_PX = 10
+
+/** Built-in stamp ids (caption defaults). */
+const BUILTIN_STAMPS = [
+  'approved',
+  'rejected',
+  'revised',
+  'for-review'
+] as const
+
+type AcExBuiltinStampId = (typeof BUILTIN_STAMPS)[number]
+
+const STAMP_LABELS: Record<AcExBuiltinStampId, string> = {
+  approved: 'APPROVED',
+  rejected: 'REJECTED',
+  revised: 'REVISED',
+  'for-review': 'FOR REVIEW'
+}
+
+interface AcExResolvedPoint {
+  point: THREE.Vector2
+  snap: AcExOsnapPoint | null
+}
+
+/**
+ * View/camera callbacks supplied by {@link AcExHtmlViewerRuntime}.
+ */
+export interface AcExMarkupViewApi {
+  screenToWcs: (clientX: number, clientY: number) => THREE.Vector2
+  wcsToScreen: (wcs: THREE.Vector2) => { x: number; y: number }
+  render: () => void
+  getSnapCacheKey: () => number
+  resolvePoint: (clientX: number, clientY: number) => AcExResolvedPoint
+}
+
+export interface AcExMarkupControllerOptions {
+  root: HTMLElement
+  i18n: AcExHtmlI18n
+  view: AcExMarkupViewApi
+  statusEl: HTMLElement
+  getReadyStatus: () => string
+  drawingName?: string
+  onOsnapMarker: (
+    snap: AcExOsnapPoint | null,
+    screen: { x: number; y: number } | null
+  ) => void
+  onActiveChange?: (active: boolean) => void
+  /** Called when selection or session draw style changes (draw-style toolbar). */
+  onStyleChange?: () => void
+  /** Called when a markup tool starts so the runtime can cancel measure mode. */
+  onBeforeActivate?: () => void
+  /** Ortho/polar tracking from the shared settings panel. */
+  getTrackingOptions?: () => AcExTrackingOptions | null
+}
+
+type AcExMarkupCleanup = () => void
+
+interface AcExMarkupParts {
+  id: string
+  dom: HTMLElement[]
+  canvases: HTMLCanvasElement[]
+  cleanups: AcExMarkupCleanup[]
+}
+
+interface AcExCommittedMarkup {
+  record: AcExMarkupRecord
+  parts: AcExMarkupParts
+}
+
+/** After cloud/rect/circle is drawn: place leader tip + text bubble. */
+interface AcExPlacingShapeCallout {
+  outline: AcExMarkupShapeOutline
+  tip: AcExMarkupPoint2d
+  anchor: AcExMarkupPoint2d
+  badge: HTMLElement
+  tipDot: HTMLElement
+}
+
+function createMarkupId(prefix = 'markup'): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return `${prefix}-${crypto.randomUUID()}`
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function markupNow(): string {
+  return new Date().toISOString()
+}
+
+function defaultStyle(
+  color = ACEX_MARKUP_COLOR,
+  lineWeight = ACEX_MARKUP_LINE_WEIGHT,
+  fontSize = ACEX_MARKUP_FONT_SIZE
+): AcExMarkupStyle {
+  return {
+    color,
+    lineWeight,
+    fontSize
+  }
+}
+
+function point2(v: THREE.Vector2): AcExMarkupPoint2d {
+  return { x: v.x, y: v.y }
+}
+
+function toVector2(p: AcExMarkupPoint2d): THREE.Vector2 {
+  return new THREE.Vector2(p.x, p.y)
+}
+
+/**
+ * Manages markup annotation tools for the offline HTML viewer.
+ */
+export class AcExMarkupController {
+  private readonly _root: HTMLElement
+  private readonly _i18n: AcExHtmlI18n
+  private readonly _view: AcExMarkupViewApi
+  private readonly _statusEl: HTMLElement
+  private readonly _getReadyStatus: () => string
+  private readonly _drawingName: string | undefined
+  private readonly _onOsnapMarker: AcExMarkupControllerOptions['onOsnapMarker']
+  private readonly _onActiveChange: ((active: boolean) => void) | null
+  private readonly _onStyleChange: (() => void) | null
+  private readonly _onBeforeActivate: (() => void) | null
+  private readonly _getTrackingOptions:
+    | (() => AcExTrackingOptions | null)
+    | null
+
+  private readonly _overlayLayer: HTMLDivElement
+  private readonly _previewCanvas: HTMLCanvasElement
+  private readonly _fileInput: HTMLInputElement
+
+  private readonly _committed: AcExCommittedMarkup[] = []
+  private readonly _redrawListeners: AcExMarkupCleanup[] = []
+  private readonly _selectedIds = new Set<string>()
+
+  private _mode: AcExMarkupMode | null = null
+  private _points: THREE.Vector2[] = []
+  private _lastPointer: { x: number; y: number } | null = null
+  private _visible = true
+  private _stampIndex = 0
+  private _inOverlaySync = false
+  private _lastOverlaySyncKey = -1
+  private _overlayRootRect: DOMRect | null = null
+  private _osnapCache: {
+    clientX: number
+    clientY: number
+    cacheKey: number
+    point: THREE.Vector2
+    snap: AcExOsnapPoint | null
+  } | null = null
+  private _drawColor = ACEX_MARKUP_COLOR
+  private _drawLineWeight = ACEX_MARKUP_LINE_WEIGHT
+  private _drawFontSize = ACEX_MARKUP_FONT_SIZE
+  private _placingShapeCallout: AcExPlacingShapeCallout | null = null
+  /** Blocks canvas placement while an inline text session is open. */
+  private _awaitingInlineText = false
+  private _inlineAbort: AbortController | null = null
+  private _lastSelectPointer:
+    | { t: number; x: number; y: number; id: string }
+    | undefined
+
+  constructor(options: AcExMarkupControllerOptions) {
+    this._root = options.root
+    this._i18n = options.i18n
+    this._view = options.view
+    this._statusEl = options.statusEl
+    this._getReadyStatus = options.getReadyStatus
+    this._drawingName = options.drawingName
+    this._onOsnapMarker = options.onOsnapMarker
+    this._onActiveChange = options.onActiveChange ?? null
+    this._onStyleChange = options.onStyleChange ?? null
+    this._onBeforeActivate = options.onBeforeActivate ?? null
+    this._getTrackingOptions = options.getTrackingOptions ?? null
+
+    this._overlayLayer = document.createElement('div')
+    this._overlayLayer.id = 'mlcad-markup-overlays'
+    this._root.appendChild(this._overlayLayer)
+
+    this._previewCanvas = document.createElement('canvas')
+    this._previewCanvas.className =
+      'mlcad-markup-canvas mlcad-markup-canvas--preview'
+    this._overlayLayer.appendChild(this._previewCanvas)
+
+    this._fileInput = document.createElement('input')
+    this._fileInput.type = 'file'
+    this._fileInput.accept = '.json,application/json'
+    this._fileInput.style.display = 'none'
+    this._fileInput.addEventListener('change', () => {
+      void this._handleImportFile()
+    })
+    this._root.appendChild(this._fileInput)
+    this._updateVisibilityToolbar()
+  }
+
+  get isActive(): boolean {
+    return this._mode !== null
+  }
+
+  /** Whether one or more committed markups are selected. */
+  get hasSelection(): boolean {
+    return this._selectedIds.size > 0
+  }
+
+  /** Clears the current markup selection (if any). */
+  clearSelection(): void {
+    this._deselect(true)
+  }
+
+  get mode(): AcExMarkupMode | null {
+    return this._mode
+  }
+
+  get visible(): boolean {
+    return this._visible
+  }
+
+  /** Updates the default stroke/fill color for newly created markups. */
+  setMarkupColor(css: string): void {
+    this.setDrawStyle({ color: css })
+  }
+
+  /** Current session draw style (and selected markup style when applicable). */
+  getDrawStyle(): {
+    color: string
+    lineWeight: number
+    fontSize: number
+  } {
+    const selectedId =
+      this._selectedIds.size === 1
+        ? [...this._selectedIds][0]
+        : undefined
+    if (selectedId) {
+      const record = this._findRecord(selectedId)
+      if (record) {
+        return {
+          color: record.style.color || this._drawColor,
+          lineWeight: record.style.lineWeight ?? this._drawLineWeight,
+          fontSize: record.style.fontSize ?? this._drawFontSize
+        }
+      }
+    }
+    return {
+      color: this._drawColor,
+      lineWeight: this._drawLineWeight,
+      fontSize: this._drawFontSize
+    }
+  }
+
+  /**
+   * Updates session defaults and applies the same patch to the current selection.
+   */
+  setDrawStyle(patch: {
+    color?: string
+    lineWeight?: number
+    fontSize?: number
+  }): void {
+    if (patch.color) this._drawColor = patch.color
+    if (patch.lineWeight != null && patch.lineWeight > 0) {
+      this._drawLineWeight = patch.lineWeight
+    }
+    if (patch.fontSize != null && patch.fontSize > 0) {
+      this._drawFontSize = patch.fontSize
+    }
+    this._applyStyleToSelection(patch)
+    this._refreshActivePreview()
+    this._syncPlacingStyle()
+    this._onStyleChange?.()
+    this._view.render()
+  }
+
+  private _sessionStyle(): AcExMarkupStyle {
+    return defaultStyle(
+      this._drawColor,
+      this._drawLineWeight,
+      this._drawFontSize
+    )
+  }
+
+  private _applyStyleToSelection(patch: {
+    color?: string
+    lineWeight?: number
+    fontSize?: number
+  }): void {
+    if (this._selectedIds.size === 0) return
+    for (const id of this._selectedIds) {
+      const item = this._committed.find(c => c.record.id === id)
+      if (!item) continue
+      const style = item.record.style
+      if (patch.color) style.color = patch.color
+      if (patch.lineWeight != null && patch.lineWeight > 0) {
+        style.lineWeight = patch.lineWeight
+      }
+      if (patch.fontSize != null && patch.fontSize > 0) {
+        style.fontSize = patch.fontSize
+      }
+      item.record.updatedAt = markupNow()
+      const color = style.color || ACEX_MARKUP_COLOR
+      for (const el of item.parts.dom) {
+        if (
+          el.classList.contains('mlcad-markup-badge') ||
+          el.classList.contains('mlcad-markup-stamp')
+        ) {
+          el.style.color = color
+          el.style.borderColor = color
+          if (style.fontSize) {
+            el.style.fontSize = `${style.fontSize}px`
+          }
+        } else if (el.classList.contains('mlcad-markup-dot')) {
+          el.style.background = color
+        }
+      }
+    }
+    this._applySelectionStyles()
+  }
+
+  private _syncPlacingStyle(): void {
+    const placing = this._placingShapeCallout
+    if (!placing) return
+    placing.badge.style.color = this._drawColor
+    placing.badge.style.borderColor = this._drawColor
+    placing.badge.style.fontSize = `${this._drawFontSize}px`
+    placing.tipDot.style.background = this._drawColor
+  }
+
+  setMode(mode: AcExMarkupMode | null, toggleOff = true): void {
+    if (mode === this._mode && toggleOff) {
+      this.cancelMode()
+      return
+    }
+    this.cancelMode()
+    this._deselect(false)
+    if (mode === null) return
+    this._onBeforeActivate?.()
+    this._mode = mode
+    this._points = []
+    this._updateToolbarActive()
+    this._syncGripPointerEvents()
+    this._statusEl.textContent = this._hintForMode(mode)
+    this._onActiveChange?.(true)
+  }
+
+  cancelMode(): void {
+    const wasActive = this._mode !== null || this._placingShapeCallout !== null
+    this._abortInlineText()
+    this._finishPlacingShapeCallout(false)
+    this._mode = null
+    this._points = []
+    this._lastPointer = null
+    this._osnapCache = null
+    this._awaitingInlineText = false
+    this._clearPreview()
+    this._onOsnapMarker(null, null)
+    this._updateToolbarActive()
+    this._syncGripPointerEvents()
+    this._updateIdleStatus()
+    this._view.render()
+    if (wasActive) this._onActiveChange?.(false)
+  }
+
+  private _abortInlineText(): void {
+    this._inlineAbort?.abort()
+    this._inlineAbort = null
+    this._awaitingInlineText = false
+  }
+
+  private _beginInlineText(
+    options: Parameters<typeof editAcExMarkupHtmlText>[0]
+  ): Promise<string | undefined> {
+    this._abortInlineText()
+    const abort = new AbortController()
+    this._inlineAbort = abort
+    this._awaitingInlineText = true
+    this._syncGripPointerEvents()
+    return editAcExMarkupHtmlText({ ...options, signal: abort.signal }).finally(
+      () => {
+        if (this._inlineAbort === abort) {
+          this._inlineAbort = null
+          this._awaitingInlineText = false
+          this._syncGripPointerEvents()
+        }
+      }
+    )
+  }
+
+  refreshIdleStatus(): void {
+    this._updateIdleStatus()
+  }
+
+  clearAll(): void {
+    this.cancelMode()
+    this._deselect(false)
+    for (const item of [...this._committed]) {
+      this._removeCommitted(item.record.id, false)
+    }
+    this._updateIdleStatus()
+    this._view.render()
+  }
+
+  setVisible(visible: boolean): void {
+    this._visible = visible
+    this._overlayLayer.style.display = visible ? '' : 'none'
+    this._updateVisibilityToolbar()
+    this._view.render()
+  }
+
+  toggleVisible(): void {
+    this.setVisible(!this._visible)
+  }
+
+  syncOverlays(): void {
+    if (!this._visible) return
+    this._inOverlaySync = true
+    try {
+      this._overlayRootRect = this._root.getBoundingClientRect()
+      const overlayKey = this._view.getSnapCacheKey()
+      const cameraChanged = overlayKey !== this._lastOverlaySyncKey
+      if (cameraChanged) {
+        for (const fn of this._redrawListeners) fn()
+        this._positionDomOverlays()
+        this._lastOverlaySyncKey = overlayKey
+      }
+      this._refreshActivePreview()
+    } finally {
+      this._inOverlaySync = false
+      this._overlayRootRect = null
+    }
+  }
+
+  handlePointerDown(clientX: number, clientY: number): boolean {
+    if (this._awaitingInlineText || isAcExMarkupHtmlTextEditing()) {
+      return true
+    }
+    if (this._placingShapeCallout) {
+      this._lastPointer = { x: clientX, y: clientY }
+      const point = this._resolvePointerWithOsnap(clientX, clientY)
+      this._completeShapeCalloutAnchor(point)
+      return true
+    }
+    if (this._trySelectCommittedAt(clientX, clientY)) {
+      return true
+    }
+    if (!this._mode) return false
+    this._lastPointer = { x: clientX, y: clientY }
+    const point = this._resolvePointerWithOsnap(clientX, clientY)
+
+    switch (this._mode) {
+      case 'arrow':
+        return this._pointerTwoPoint(point, 'arrow')
+      case 'rect':
+        return this._pointerTwoPoint(point, 'rect')
+      case 'cloud':
+        return this._pointerTwoPoint(point, 'cloud')
+      case 'circle':
+        return this._pointerCircle(point)
+      case 'callout':
+        return this._pointerTwoPoint(point, 'callout')
+      case 'text':
+        return this._pointerText(point)
+      case 'stamp':
+        return this._pointerStamp(point)
+      default:
+        return false
+    }
+  }
+
+  handlePointerMove(clientX: number, clientY: number): void {
+    if (this._awaitingInlineText || isAcExMarkupHtmlTextEditing()) return
+    if (!this._mode && !this._placingShapeCallout) return
+    this._lastPointer = { x: clientX, y: clientY }
+    this._resolvePointerWithOsnap(clientX, clientY)
+    this._refreshActivePreview()
+  }
+
+  handleKeyDown(key: string): boolean {
+    if (isAcExMarkupHtmlTextEditing() || this._awaitingInlineText) {
+      return key === 'Escape'
+    }
+    if (this._placingShapeCallout) {
+      if (key === 'Escape') {
+        // Cancel leader + text box; keep the shape.
+        this._commitPlacingShapeWithoutCallout()
+        return true
+      }
+      return false
+    }
+    if (!this._mode) return false
+    if (key === 'Escape') {
+      this.cancelMode()
+      return true
+    }
+    return false
+  }
+
+  handleSelectionKeyDown(key: string, event: KeyboardEvent): boolean {
+    // Allow delete while a create tool is still armed; only block during
+    // in-progress placement / inline text editing.
+    if (
+      this._placingShapeCallout ||
+      isAcExMarkupHtmlTextEditing() ||
+      this._awaitingInlineText
+    ) {
+      return false
+    }
+    const isDelete =
+      key === 'Delete' ||
+      key === 'Backspace' ||
+      event.code === 'Delete' ||
+      event.code === 'Backspace'
+    if (isDelete && this._selectedIds.size > 0) {
+      event.preventDefault()
+      this.deleteSelected()
+      return true
+    }
+    return false
+  }
+
+  handleSelectionPointerDown(clientX: number, clientY: number): boolean {
+    if (this._mode) return false
+    return this._trySelectCommittedAt(clientX, clientY)
+  }
+
+  deleteSelected(): void {
+    for (const id of [...this._selectedIds]) {
+      this._removeCommitted(id, false)
+    }
+    this._selectedIds.clear()
+    this._updateIdleStatus()
+    this._view.render()
+  }
+
+  exportSidecar(): void {
+    const file: AcExMarkupSidecarFile = {
+      version: 1,
+      drawingName: this._drawingName,
+      markups: this._committed.map(c => c.record)
+    }
+    const text = stringifyAcExMarkupSidecar(file)
+    const blob = new Blob([text], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = acExMarkupSidecarFileName(this._drawingName)
+    a.click()
+    URL.revokeObjectURL(url)
+    this._statusEl.textContent = this._i18n.t('status.markupExported', {
+      count: String(file.markups.length)
+    })
+  }
+
+  importSidecar(): void {
+    this._fileInput.value = ''
+    this._fileInput.click()
+  }
+
+  /** Replace all markups from a parsed sidecar (used by tests / import). */
+  loadSidecar(file: AcExMarkupSidecarFile): void {
+    this.clearAll()
+    for (const record of file.markups) {
+      this._publishRecord(record)
+    }
+    this._updateIdleStatus()
+    this._view.render()
+  }
+
+  private async _handleImportFile(): Promise<void> {
+    const file = this._fileInput.files?.[0]
+    if (!file) return
+    try {
+      const text = await file.text()
+      const sidecar = parseAcExMarkupSidecar(text)
+      this.loadSidecar(sidecar)
+      this._statusEl.textContent = this._i18n.t('status.markupImported', {
+        count: String(sidecar.markups.length)
+      })
+    } catch (error) {
+      this._statusEl.textContent = this._i18n.t('status.markupImportFailed', {
+        error: String(error)
+      })
+    }
+  }
+
+  private _pointerTwoPoint(
+    point: THREE.Vector2,
+    kind: 'arrow' | 'rect' | 'cloud' | 'callout'
+  ): boolean {
+    this._points.push(point.clone())
+    this._syncGripPointerEvents()
+    if (this._points.length < 2) {
+      this._statusEl.textContent = this._hintForSecondPoint(kind)
+      return true
+    }
+    const a = this._points[0]!
+    const b = this._points[1]!
+    this._points = []
+    this._syncGripPointerEvents()
+    this._clearPreview()
+
+    if (kind === 'arrow') {
+      this._commitGeometry('arrow', {
+        type: 'arrow',
+        start: point2(a),
+        end: point2(b)
+      })
+      this._statusEl.textContent = this._hintForMode(kind)
+    } else if (kind === 'rect') {
+      this._beginPlacingShapeCallout({
+        kind: 'rect',
+        corner1: point2(a),
+        corner2: point2(b)
+      })
+    } else if (kind === 'cloud') {
+      this._beginPlacingShapeCallout({
+        kind: 'cloud',
+        corner1: point2(a),
+        corner2: point2(b)
+      })
+    } else {
+      this._beginStandaloneCalloutText(point2(a), point2(b))
+    }
+    return true
+  }
+
+  private _pointerCircle(point: THREE.Vector2): boolean {
+    this._points.push(point.clone())
+    this._syncGripPointerEvents()
+    if (this._points.length < 2) {
+      this._statusEl.textContent = this._i18n.t('status.markupCircleRadiusHint')
+      return true
+    }
+    const center = this._points[0]!
+    const rim = this._points[1]!
+    const radius = center.distanceTo(rim)
+    this._points = []
+    this._syncGripPointerEvents()
+    this._clearPreview()
+    if (radius > 1e-9) {
+      this._beginPlacingShapeCallout({
+        kind: 'circle',
+        center: point2(center),
+        radius
+      })
+    } else {
+      this._statusEl.textContent = this._hintForMode('circle')
+    }
+    return true
+  }
+
+  private _pointerText(point: THREE.Vector2): boolean {
+    if (this._awaitingInlineText) return true
+    const defaultLabel = this._i18n.t('status.markupDefaultLabel')
+    const badge = this._makeTempBadge(point2(point), '', this._drawColor)
+    this._statusEl.textContent = this._i18n.t('status.markupTextEditHint')
+    void this._beginInlineText({
+      el: badge,
+      listenOn: badge,
+      multiline: false,
+      initialText: ''
+    }).then(text => {
+      badge.remove()
+      if (this._mode !== 'text') return
+      // Escape → still commit with default label (matches simple-viewer TEXT cmd).
+      const final = (text ?? defaultLabel).trim() || defaultLabel
+      this._commitGeometry(
+        'text',
+        { type: 'text', position: point2(point) },
+        final
+      )
+      this._statusEl.textContent = this._hintForMode('text')
+      this._view.render()
+    })
+    return true
+  }
+
+  private _pointerStamp(point: THREE.Vector2): boolean {
+    const stampId = BUILTIN_STAMPS[this._stampIndex % BUILTIN_STAMPS.length]!
+    this._stampIndex = (this._stampIndex + 1) % BUILTIN_STAMPS.length
+    this._commitGeometry(
+      'stamp',
+      {
+        type: 'stamp',
+        position: point2(point),
+        stampId
+      },
+      STAMP_LABELS[stampId]
+    )
+    this._statusEl.textContent = this._hintForMode('stamp')
+    return true
+  }
+
+  private _beginStandaloneCalloutText(
+    tip: AcExMarkupPoint2d,
+    anchor: AcExMarkupPoint2d
+  ): void {
+    if (this._awaitingInlineText) return
+    const defaultLabel = this._i18n.t('status.markupDefaultLabel')
+    const badge = this._makeTempBadge(anchor, '', this._drawColor)
+    const tipDot = this._makeTempDot(tip, this._drawColor)
+    this._statusEl.textContent = this._i18n.t('status.markupTextEditHint')
+    const paintLeader = () => {
+      const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
+      if (!ctx) return
+      const tipS = this._worldToOverlay(tip)
+      const anchorS = this._worldToOverlay(anchor)
+      acExDrawMarkupLeader(
+        ctx,
+        tipS,
+        anchorS,
+        this._drawColor,
+        true,
+        acExMarkupCanvasLineWidth(this._drawLineWeight)
+      )
+    }
+    paintLeader()
+    void this._beginInlineText({
+      el: badge,
+      listenOn: badge,
+      multiline: true,
+      initialText: ''
+    }).then(text => {
+      badge.remove()
+      tipDot.remove()
+      this._clearPreview()
+      if (this._mode !== 'callout') return
+      const final = (text ?? '').trim() || defaultLabel
+      this._commitGeometry(
+        'callout',
+        { type: 'callout', tip, anchor },
+        final
+      )
+      this._statusEl.textContent = this._hintForMode('callout')
+      this._view.render()
+    })
+  }
+
+  private _beginPlacingShapeCallout(outline: AcExMarkupShapeOutline): void {
+    const toward =
+      outline.kind === 'circle'
+        ? {
+            x: outline.center.x + Math.max(outline.radius, 1),
+            y: outline.center.y
+          }
+        : {
+            x: Math.max(outline.corner1.x, outline.corner2.x) + 1,
+            y: (outline.corner1.y + outline.corner2.y) / 2
+          }
+    const tip = acExComputeLeaderTipOnShape(outline, toward)
+    const anchor = { ...toward }
+    const badge = this._makeTempBadge(anchor, '', this._drawColor)
+    const tipDot = this._makeTempDot(tip, this._drawColor)
+    this._placingShapeCallout = { outline, tip, anchor, badge, tipDot }
+    this._statusEl.textContent = this._i18n.t('status.markupShapeCalloutHint')
+    this._syncGripPointerEvents()
+    this._refreshActivePreview()
+    this._onActiveChange?.(true)
+  }
+
+  private _completeShapeCalloutAnchor(anchorPoint: THREE.Vector2): void {
+    const placing = this._placingShapeCallout
+    if (!placing || this._awaitingInlineText) return
+    const anchor = point2(anchorPoint)
+    const tip = acExComputeLeaderTipOnShape(placing.outline, anchor)
+    placing.tip = tip
+    placing.anchor = anchor
+    placing.badge.dataset.wcsX = String(anchor.x)
+    placing.badge.dataset.wcsY = String(anchor.y)
+    placing.tipDot.dataset.wcsX = String(tip.x)
+    placing.tipDot.dataset.wcsY = String(tip.y)
+    this._positionTempDom(placing.badge)
+    this._positionTempDom(placing.tipDot)
+    this._refreshActivePreview()
+
+    this._statusEl.textContent = this._i18n.t('status.markupTextEditHint')
+    void this._beginInlineText({
+      el: placing.badge,
+      listenOn: placing.badge,
+      multiline: true,
+      initialText: ''
+    }).then(text => {
+      // Cancelled via tool switch / abort — do not commit.
+      if (this._placingShapeCallout !== placing) return
+      // Escape during text entry → keep tip/anchor; empty text (simple-viewer).
+      // Escape before typing is handled by handleKeyDown (shape only, no callout).
+      const callout: AcExMarkupAttachedCallout = {
+        tip,
+        anchor,
+        text: text || undefined
+      }
+      this._commitShapeWithCallout(placing.outline, callout, text || undefined)
+      this._finishPlacingShapeCallout(true)
+      if (this._mode) {
+        this._statusEl.textContent = this._hintForMode(this._mode)
+      }
+      this._view.render()
+    })
+  }
+
+  private _commitPlacingShapeWithoutCallout(): void {
+    const placing = this._placingShapeCallout
+    if (!placing) return
+    this._commitShapeWithCallout(placing.outline, undefined, undefined)
+    this._finishPlacingShapeCallout(true)
+    if (this._mode) {
+      this._statusEl.textContent = this._hintForMode(this._mode)
+    }
+    this._view.render()
+  }
+
+  private _commitShapeWithCallout(
+    outline: AcExMarkupShapeOutline,
+    callout: AcExMarkupAttachedCallout | undefined,
+    text: string | undefined
+  ): void {
+    if (outline.kind === 'circle') {
+      this._commitGeometry(
+        'circle',
+        {
+          type: 'circle',
+          center: outline.center,
+          radius: outline.radius,
+          callout
+        },
+        text
+      )
+      return
+    }
+    this._commitGeometry(
+      outline.kind,
+      {
+        type: outline.kind,
+        corner1: outline.corner1,
+        corner2: outline.corner2,
+        callout
+      },
+      text
+    )
+  }
+
+  /**
+   * @param keepMode - When true, stay in the current markup tool after cleanup.
+   */
+  private _finishPlacingShapeCallout(keepMode: boolean): void {
+    const placing = this._placingShapeCallout
+    if (!placing) return
+    this._placingShapeCallout = null
+    placing.badge.remove()
+    placing.tipDot.remove()
+    this._clearPreview()
+    this._syncGripPointerEvents()
+    void keepMode
+  }
+
+  private _makeTempBadge(
+    wcs: AcExMarkupPoint2d,
+    text: string,
+    color: string
+  ): HTMLElement {
+    const badge = document.createElement('div')
+    badge.className = 'mlcad-markup-badge'
+    badge.dataset.wcsX = String(wcs.x)
+    badge.dataset.wcsY = String(wcs.y)
+    badge.textContent = text
+    badge.style.color = color
+    badge.style.borderColor = color
+    badge.style.fontSize = `${this._drawFontSize}px`
+    // Must not intercept canvas clicks while placing the leader anchor.
+    badge.style.pointerEvents = 'none'
+    this._overlayLayer.appendChild(badge)
+    this._positionTempDom(badge)
+    return badge
+  }
+
+  private _makeTempDot(wcs: AcExMarkupPoint2d, color: string): HTMLElement {
+    const dot = document.createElement('div')
+    dot.className = 'mlcad-markup-dot'
+    dot.dataset.wcsX = String(wcs.x)
+    dot.dataset.wcsY = String(wcs.y)
+    dot.style.background = color
+    dot.style.pointerEvents = 'none'
+    this._overlayLayer.appendChild(dot)
+    this._positionTempDom(dot)
+    return dot
+  }
+
+  private _positionTempDom(el: HTMLElement): void {
+    const x = Number(el.dataset.wcsX)
+    const y = Number(el.dataset.wcsY)
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return
+    const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
+    const screen = this._view.wcsToScreen(new THREE.Vector2(x, y))
+    el.style.left = `${screen.x - rootRect.left}px`
+    el.style.top = `${screen.y - rootRect.top}px`
+  }
+
+  private _commitGeometry(
+    type: AcExMarkupRecord['type'],
+    geometry: AcExMarkupGeometry,
+    text?: string
+  ): void {
+    const now = markupNow()
+    const record: AcExMarkupRecord = {
+      id: createMarkupId(),
+      type,
+      style: this._sessionStyle(),
+      text,
+      comment: '',
+      status: 'open',
+      author: '',
+      createdAt: now,
+      updatedAt: now,
+      geometry
+    }
+    this._publishRecord(record)
+    this._view.render()
+  }
+
+  private _publishRecord(record: AcExMarkupRecord): void {
+    const parts: AcExMarkupParts = {
+      id: record.id,
+      dom: [],
+      canvases: [],
+      cleanups: []
+    }
+    // Push before building visuals so the initial redraw can resolve the record.
+    this._committed.push({ record, parts })
+    this._buildVisuals(record, parts)
+    this._positionDomOverlays()
+  }
+
+  private _buildVisuals(record: AcExMarkupRecord, parts: AcExMarkupParts): void {
+    const color = record.style.color || ACEX_MARKUP_COLOR
+    const markupId = record.id
+
+    const canvas = document.createElement('canvas')
+    canvas.className = 'mlcad-markup-canvas'
+    canvas.dataset.markupId = markupId
+    this._overlayLayer.appendChild(canvas)
+    parts.canvases.push(canvas)
+
+    const redraw = () => {
+      const live = this._findRecord(markupId) ?? record
+      const ctx = acExFitMarkupCanvas(canvas, this._root)
+      if (!ctx) return
+      this._strokeGeometry(
+        ctx,
+        live.geometry,
+        live.style.color || ACEX_MARKUP_COLOR,
+        acExMarkupCanvasLineWidth(live.style.lineWeight)
+      )
+    }
+    this._redrawListeners.push(redraw)
+    parts.cleanups.push(() => {
+      const idx = this._redrawListeners.indexOf(redraw)
+      if (idx >= 0) this._redrawListeners.splice(idx, 1)
+    })
+    redraw()
+
+    const g = record.geometry
+    const attached =
+      (g.type === 'cloud' || g.type === 'rect' || g.type === 'circle') &&
+      g.callout
+        ? g.callout
+        : null
+
+    let badge: HTMLElement | null = null
+    if (
+      g.type === 'text' ||
+      g.type === 'callout' ||
+      g.type === 'stamp' ||
+      attached
+    ) {
+      badge = document.createElement('div')
+      badge.className =
+        g.type === 'stamp' ? 'mlcad-markup-stamp' : 'mlcad-markup-badge'
+      badge.dataset.markupId = markupId
+      const anchorPos =
+        g.type === 'text' || g.type === 'stamp'
+          ? g.position
+          : g.type === 'callout'
+            ? g.anchor
+            : attached!.anchor
+      badge.dataset.wcsX = String(anchorPos.x)
+      badge.dataset.wcsY = String(anchorPos.y)
+      const label =
+        (attached ? attached.text : undefined) ||
+        record.text?.trim() ||
+        (g.type === 'stamp' && 'stampId' in g
+          ? STAMP_LABELS[g.stampId as AcExBuiltinStampId] ?? g.stampId
+          : this._i18n.t('status.markupDefaultLabel'))
+      badge.textContent = label
+      badge.style.color = color
+      badge.style.borderColor = color
+      if (record.style.fontSize) {
+        badge.style.fontSize = `${record.style.fontSize}px`
+      }
+      this._overlayLayer.appendChild(badge)
+      parts.dom.push(badge)
+
+      if (g.type !== 'stamp') {
+        badge.addEventListener('dblclick', event => {
+          event.stopPropagation()
+          event.preventDefault()
+          this._editText(markupId, badge!)
+        })
+      }
+    }
+
+    let tipDot: HTMLElement | null = null
+    let startDot: HTMLElement | null = null
+    let endDot: HTMLElement | null = null
+    let centerDot: HTMLElement | null = null
+
+    if (g.type === 'arrow' || g.type === 'line') {
+      startDot = this._makeDot(g.start, color, markupId)
+      endDot = this._makeDot(g.end, color, markupId)
+      parts.dom.push(startDot, endDot)
+    } else if (g.type === 'callout') {
+      tipDot = this._makeDot(g.tip, color, markupId)
+      parts.dom.push(tipDot)
+    } else if (attached) {
+      tipDot = this._makeDot(attached.tip, color, markupId)
+      parts.dom.push(tipDot)
+    }
+
+    if (
+      g.type === 'callout' ||
+      g.type === 'cloud' ||
+      g.type === 'rect' ||
+      g.type === 'circle'
+    ) {
+      const center = acExMarkupCenter(record)
+      if (center) {
+        centerDot = this._makeDot(center, color, markupId)
+        parts.dom.push(centerDot)
+      }
+    }
+
+    parts.cleanups.push(
+      this._bindGrips({
+        id: markupId,
+        geometryType: g.type,
+        hasAttachedCallout: !!attached,
+        badge,
+        tipDot,
+        startDot,
+        endDot,
+        centerDot,
+        redraw
+      })
+    )
+    this._syncGripPointerEvents()
+  }
+
+  private _findRecord(id: string): AcExMarkupRecord | undefined {
+    return this._committed.find(c => c.record.id === id)?.record
+  }
+
+  private _gripsEnabled(): boolean {
+    // Allow editing grips even while a create tool is armed; only block during
+    // an in-progress draw / callout placement / inline text session.
+    return (
+      !this._placingShapeCallout &&
+      !this._awaitingInlineText &&
+      !isAcExMarkupHtmlTextEditing() &&
+      this._points.length === 0
+    )
+  }
+
+  private _syncGripPointerEvents(): void {
+    const enable = this._gripsEnabled()
+    for (const item of this._committed) {
+      for (const el of item.parts.dom) {
+        el.style.pointerEvents = enable ? 'auto' : 'none'
+      }
+    }
+  }
+
+  private _clientToWorld(clientX: number, clientY: number): AcExMarkupPoint2d {
+    return point2(this._view.screenToWcs(clientX, clientY))
+  }
+
+  private _placeDomAt(el: HTMLElement, wcs: AcExMarkupPoint2d): void {
+    el.dataset.wcsX = String(wcs.x)
+    el.dataset.wcsY = String(wcs.y)
+    this._positionTempDom(el)
+  }
+
+  private _selectOnly(id: string): void {
+    if (this._selectedIds.size === 1 && this._selectedIds.has(id)) {
+      this._applySelectionStyles()
+      return
+    }
+    this._selectedIds.clear()
+    this._selectedIds.add(id)
+    this._applySelectionStyles()
+    this._onStyleChange?.()
+    const record = this._findRecord(id)
+    this._statusEl.textContent = this._i18n.t('status.markupSelected', {
+      type: record?.type ?? 'markup'
+    })
+    this._view.render()
+  }
+
+  private _touchRecord(id: string): void {
+    const record = this._findRecord(id)
+    if (!record) return
+    record.updatedAt = markupNow()
+  }
+
+  private _bindGrips(options: {
+    id: string
+    geometryType: AcExMarkupRecord['type']
+    hasAttachedCallout: boolean
+    badge: HTMLElement | null
+    tipDot: HTMLElement | null
+    startDot: HTMLElement | null
+    endDot: HTMLElement | null
+    centerDot: HTMLElement | null
+    redraw: () => void
+  }): () => void {
+    const {
+      id,
+      geometryType,
+      hasAttachedCallout,
+      badge,
+      tipDot,
+      startDot,
+      endDot,
+      centerDot,
+      redraw
+    } = options
+    const cleanups: Array<() => void> = []
+    const isEnabled = () => this._gripsEnabled()
+    const clientToWorld = (x: number, y: number) => this._clientToWorld(x, y)
+    const onSelect = () => this._selectOnly(id)
+
+    const shapeOutline = (): AcExMarkupShapeOutline | null => {
+      const record = this._findRecord(id)
+      if (!record) return null
+      const g = record.geometry
+      if (g.type === 'cloud' || g.type === 'rect') {
+        return { kind: g.type, corner1: g.corner1, corner2: g.corner2 }
+      }
+      if (g.type === 'circle') {
+        return { kind: 'circle', center: g.center, radius: g.radius }
+      }
+      return null
+    }
+
+    const syncCenterDot = () => {
+      if (!centerDot) return
+      const record = this._findRecord(id)
+      if (!record) return
+      const center = acExMarkupCenter(record)
+      if (center) this._placeDomAt(centerDot, center)
+    }
+
+    const syncAttachedDom = (g: AcExMarkupGeometry) => {
+      if (g.type === 'callout') {
+        if (tipDot) this._placeDomAt(tipDot, g.tip)
+        if (badge) this._placeDomAt(badge, g.anchor)
+      } else if (
+        (g.type === 'cloud' || g.type === 'rect' || g.type === 'circle') &&
+        g.callout
+      ) {
+        if (tipDot) this._placeDomAt(tipDot, g.callout.tip)
+        if (badge) this._placeDomAt(badge, g.callout.anchor)
+      }
+      syncCenterDot()
+    }
+
+    // Text / stamp: drag badge to move position.
+    if (
+      badge &&
+      (geometryType === 'text' || geometryType === 'stamp')
+    ) {
+      cleanups.push(
+        acExBindMarkupPointerDrag({
+          el: badge,
+          clientToWorld,
+          isEnabled,
+          cursor: 'move',
+          onPointerDown: onSelect,
+          onMove: world => {
+            const record = this._findRecord(id)
+            if (!record) return
+            if (
+              record.geometry.type !== 'text' &&
+              record.geometry.type !== 'stamp'
+            ) {
+              return
+            }
+            record.geometry.position.x = world.x
+            record.geometry.position.y = world.y
+            this._placeDomAt(badge, world)
+          },
+          onCommit: () => this._touchRecord(id)
+        })
+      )
+    }
+
+    // Standalone callout or shape-attached callout: tip + bubble.
+    if (
+      badge &&
+      tipDot &&
+      (geometryType === 'callout' || hasAttachedCallout)
+    ) {
+      cleanups.push(
+        acExBindMarkupPointerDrag({
+          el: tipDot,
+          clientToWorld,
+          isEnabled,
+          onPointerDown: onSelect,
+          onMove: world => {
+            const record = this._findRecord(id)
+            if (!record) return
+            const g = record.geometry
+            let tip = world
+            if (g.type === 'cloud' || g.type === 'rect' || g.type === 'circle') {
+              const outline = shapeOutline()
+              if (!outline || !g.callout) return
+              tip = acExComputeLeaderTipOnShape(outline, world)
+              g.callout.tip.x = tip.x
+              g.callout.tip.y = tip.y
+            } else if (g.type === 'callout') {
+              g.tip.x = tip.x
+              g.tip.y = tip.y
+            } else {
+              return
+            }
+            this._placeDomAt(tipDot, tip)
+            if (geometryType === 'callout') syncCenterDot()
+            redraw()
+          },
+          onCommit: () => this._touchRecord(id)
+        })
+      )
+      cleanups.push(
+        acExBindMarkupPointerDrag({
+          el: badge,
+          clientToWorld,
+          isEnabled,
+          cursor: 'move',
+          onPointerDown: onSelect,
+          onMove: world => {
+            const record = this._findRecord(id)
+            if (!record) return
+            const g = record.geometry
+            if (g.type === 'callout') {
+              g.anchor.x = world.x
+              g.anchor.y = world.y
+            } else if (
+              (g.type === 'cloud' ||
+                g.type === 'rect' ||
+                g.type === 'circle') &&
+              g.callout
+            ) {
+              g.callout.anchor.x = world.x
+              g.callout.anchor.y = world.y
+            } else {
+              return
+            }
+            this._placeDomAt(badge, world)
+            if (geometryType === 'callout') syncCenterDot()
+            redraw()
+          },
+          onCommit: () => this._touchRecord(id)
+        })
+      )
+    }
+
+    // Arrow / line endpoints.
+    if (
+      startDot &&
+      endDot &&
+      (geometryType === 'arrow' || geometryType === 'line')
+    ) {
+      cleanups.push(
+        acExBindMarkupPointerDrag({
+          el: startDot,
+          clientToWorld,
+          isEnabled,
+          onPointerDown: onSelect,
+          onMove: world => {
+            const record = this._findRecord(id)
+            if (!record) return
+            const g = record.geometry
+            if (g.type !== 'arrow' && g.type !== 'line') return
+            g.start.x = world.x
+            g.start.y = world.y
+            this._placeDomAt(startDot, world)
+            redraw()
+          },
+          onCommit: () => this._touchRecord(id)
+        })
+      )
+      cleanups.push(
+        acExBindMarkupPointerDrag({
+          el: endDot,
+          clientToWorld,
+          isEnabled,
+          onPointerDown: onSelect,
+          onMove: world => {
+            const record = this._findRecord(id)
+            if (!record) return
+            const g = record.geometry
+            if (g.type !== 'arrow' && g.type !== 'line') return
+            g.end.x = world.x
+            g.end.y = world.y
+            this._placeDomAt(endDot, world)
+            redraw()
+          },
+          onCommit: () => this._touchRecord(id)
+        })
+      )
+    }
+
+    // Center grip: move whole callout / cloud / rect / circle (+ attached callout).
+    if (
+      centerDot &&
+      (geometryType === 'callout' ||
+        geometryType === 'cloud' ||
+        geometryType === 'rect' ||
+        geometryType === 'circle')
+    ) {
+      let originGeom: AcExMarkupGeometry | null = null
+      let originCenter: AcExMarkupPoint2d | null = null
+      cleanups.push(
+        acExBindMarkupPointerDrag({
+          el: centerDot,
+          clientToWorld,
+          isEnabled,
+          cursor: 'move',
+          onPointerDown: onSelect,
+          onDragStart: () => {
+            const record = this._findRecord(id)
+            if (!record) return
+            originGeom = structuredClone(record.geometry)
+            originCenter = acExMarkupCenter(record)
+          },
+          onMove: world => {
+            const record = this._findRecord(id)
+            if (!record || !originGeom || !originCenter) return
+            const dx = world.x - originCenter.x
+            const dy = world.y - originCenter.y
+            record.geometry = acExTranslateMarkupGeometry(originGeom, dx, dy)
+            syncAttachedDom(record.geometry)
+            this._placeDomAt(centerDot, world)
+            redraw()
+          },
+          onCommit: () => {
+            originGeom = null
+            originCenter = null
+            this._touchRecord(id)
+          }
+        })
+      )
+    }
+
+    return () => {
+      for (const fn of cleanups) fn()
+    }
+  }
+
+  private _makeDot(
+    wcs: AcExMarkupPoint2d,
+    color: string,
+    id: string
+  ): HTMLElement {
+    const dot = document.createElement('div')
+    dot.className = 'mlcad-markup-dot'
+    dot.dataset.markupId = id
+    dot.dataset.wcsX = String(wcs.x)
+    dot.dataset.wcsY = String(wcs.y)
+    dot.style.background = color
+    this._overlayLayer.appendChild(dot)
+    return dot
+  }
+
+  private _worldToOverlay(p: AcExMarkupPoint2d): { x: number; y: number } {
+    const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
+    const screen = this._view.wcsToScreen(toVector2(p))
+    return { x: screen.x - rootRect.left, y: screen.y - rootRect.top }
+  }
+
+  private _overlayToWorld(s: { x: number; y: number }): AcExMarkupPoint2d {
+    const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
+    return point2(
+      this._view.screenToWcs(rootRect.left + s.x, rootRect.top + s.y)
+    )
+  }
+
+  private _strokeGeometry(
+    ctx: CanvasRenderingContext2D,
+    g: AcExMarkupGeometry,
+    color: string,
+    lineWidth: number
+  ): void {
+    const worldToScreen = (p: AcExMarkupPoint2d) => this._worldToOverlay(p)
+    const screenToWorld = (s: { x: number; y: number }) =>
+      this._overlayToWorld(s)
+
+    switch (g.type) {
+      case 'arrow':
+      case 'line': {
+        const a = worldToScreen(g.start)
+        const b = worldToScreen(g.end)
+        ctx.strokeStyle = color
+        ctx.lineWidth = lineWidth
+        ctx.beginPath()
+        ctx.moveTo(a.x, a.y)
+        ctx.lineTo(b.x, b.y)
+        ctx.stroke()
+        if (g.type === 'arrow') {
+          acExDrawMarkupArrowHead(ctx, a, b, color)
+        }
+        break
+      }
+      case 'rect': {
+        const a = worldToScreen(g.corner1)
+        const b = worldToScreen(g.corner2)
+        ctx.strokeStyle = color
+        ctx.lineWidth = lineWidth
+        ctx.strokeRect(
+          Math.min(a.x, b.x),
+          Math.min(a.y, b.y),
+          Math.abs(b.x - a.x),
+          Math.abs(b.y - a.y)
+        )
+        this._strokeAttachedCallout(ctx, g.callout, color, lineWidth)
+        break
+      }
+      case 'highlight': {
+        const a = worldToScreen(g.corner1)
+        const b = worldToScreen(g.corner2)
+        const x = Math.min(a.x, b.x)
+        const y = Math.min(a.y, b.y)
+        const w = Math.abs(b.x - a.x)
+        const h = Math.abs(b.y - a.y)
+        ctx.fillStyle = color
+        ctx.globalAlpha = 0.28
+        ctx.fillRect(x, y, w, h)
+        ctx.globalAlpha = 1
+        ctx.strokeStyle = color
+        ctx.lineWidth = lineWidth
+        ctx.strokeRect(x, y, w, h)
+        break
+      }
+      case 'circle': {
+        const c = worldToScreen(g.center)
+        const rim = worldToScreen({
+          x: g.center.x + g.radius,
+          y: g.center.y
+        })
+        const r = Math.hypot(rim.x - c.x, rim.y - c.y)
+        ctx.strokeStyle = color
+        ctx.lineWidth = lineWidth
+        ctx.beginPath()
+        ctx.arc(c.x, c.y, r, 0, Math.PI * 2)
+        ctx.stroke()
+        this._strokeAttachedCallout(ctx, g.callout, color, lineWidth)
+        break
+      }
+      case 'cloud': {
+        acExStrokeMarkupCloud(
+          ctx,
+          g.corner1,
+          g.corner2,
+          worldToScreen,
+          screenToWorld,
+          color,
+          lineWidth
+        )
+        this._strokeAttachedCallout(ctx, g.callout, color, lineWidth)
+        break
+      }
+      case 'callout': {
+        const tip = worldToScreen(g.tip)
+        const anchor = worldToScreen(g.anchor)
+        acExDrawMarkupLeader(ctx, tip, anchor, color, true, lineWidth)
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  private _strokeAttachedCallout(
+    ctx: CanvasRenderingContext2D,
+    callout: AcExMarkupAttachedCallout | undefined,
+    color: string,
+    lineWidth: number
+  ): void {
+    if (!callout) return
+    const tip = this._worldToOverlay(callout.tip)
+    const anchor = this._worldToOverlay(callout.anchor)
+    // Shape-attached leaders have no arrowhead (Design Review).
+    acExDrawMarkupLeader(ctx, tip, anchor, color, false, lineWidth)
+  }
+
+  private _editText(id: string, badge: HTMLElement): void {
+    if (this._awaitingInlineText || isAcExMarkupHtmlTextEditing()) return
+    const item = this._committed.find(c => c.record.id === id)
+    if (!item) return
+    const g = item.record.geometry
+    const attached =
+      (g.type === 'cloud' || g.type === 'rect' || g.type === 'circle') &&
+      g.callout
+        ? g.callout
+        : null
+    const current =
+      (attached?.text ?? item.record.text ?? badge.textContent ?? '').trim()
+    const multiline = item.record.type !== 'text'
+    this._syncGripPointerEvents()
+    void this._beginInlineText({
+      el: badge,
+      listenOn: badge,
+      multiline,
+      initialText: current
+    }).then(next => {
+      this._syncGripPointerEvents()
+      if (next === undefined || next === current) return
+      item.record.updatedAt = markupNow()
+      if (attached) {
+        attached.text = next || undefined
+        item.record.text = next || undefined
+      } else {
+        item.record.text = next
+      }
+      badge.textContent =
+        next.trim() || this._i18n.t('status.markupDefaultLabel')
+      this._view.render()
+    })
+  }
+
+  private _removeCommitted(id: string, updateStatus: boolean): void {
+    const index = this._committed.findIndex(c => c.record.id === id)
+    if (index < 0) return
+    const item = this._committed[index]!
+    for (const cleanup of item.parts.cleanups) cleanup()
+    for (const el of item.parts.dom) el.remove()
+    for (const canvas of item.parts.canvases) canvas.remove()
+    this._committed.splice(index, 1)
+    this._selectedIds.delete(id)
+    if (updateStatus) this._updateIdleStatus()
+  }
+
+  private _trySelectCommittedAt(clientX: number, clientY: number): boolean {
+    if (!this._visible) return false
+    const hit = this._pickCommitted(clientX, clientY)
+    if (!hit) {
+      this._lastSelectPointer = undefined
+      if (this._selectedIds.size > 0) {
+        this._deselect(true)
+        return true
+      }
+      return false
+    }
+    const next = {
+      t: performance.now(),
+      x: clientX,
+      y: clientY,
+      id: hit.record.id
+    }
+    const isDouble =
+      this._lastSelectPointer?.id === hit.record.id &&
+      isAcExMarkupDoublePointer(this._lastSelectPointer, next)
+    this._lastSelectPointer = next
+
+    this._selectedIds.clear()
+    this._selectedIds.add(hit.record.id)
+    this._applySelectionStyles()
+    this._onStyleChange?.()
+    this._statusEl.textContent = this._i18n.t('status.markupSelected', {
+      type: hit.record.type
+    })
+
+    if (isDouble && hit.record.type !== 'stamp') {
+      const badge = hit.parts.dom.find(el =>
+        el.classList.contains('mlcad-markup-badge')
+      )
+      if (badge) {
+        this._editText(hit.record.id, badge)
+      }
+    }
+
+    this._view.render()
+    return true
+  }
+
+  private _pickCommitted(
+    clientX: number,
+    clientY: number
+  ): AcExCommittedMarkup | null {
+    const worldToScreen = (p: AcExMarkupPoint2d) => {
+      const s = this._view.wcsToScreen(toVector2(p))
+      return s
+    }
+    for (let i = this._committed.length - 1; i >= 0; i--) {
+      const item = this._committed[i]!
+      // Prefer text-box / stamp hit so labels are easy to select.
+      for (const el of item.parts.dom) {
+        if (
+          !el.classList.contains('mlcad-markup-badge') &&
+          !el.classList.contains('mlcad-markup-stamp')
+        ) {
+          continue
+        }
+        const rect = el.getBoundingClientRect()
+        if (
+          clientX >= rect.left &&
+          clientX <= rect.right &&
+          clientY >= rect.top &&
+          clientY <= rect.bottom
+        ) {
+          return item
+        }
+      }
+      // Endpoint dots
+      for (const el of item.parts.dom) {
+        if (!el.classList.contains('mlcad-markup-dot')) continue
+        const rect = el.getBoundingClientRect()
+        if (
+          clientX >= rect.left &&
+          clientX <= rect.right &&
+          clientY >= rect.top &&
+          clientY <= rect.bottom
+        ) {
+          return item
+        }
+      }
+      if (
+        acExHitTestMarkup(
+          item.record,
+          clientX,
+          clientY,
+          MARKUP_HIT_THRESHOLD_PX,
+          worldToScreen
+        )
+      ) {
+        return item
+      }
+    }
+    return null
+  }
+
+  private _deselect(render: boolean): void {
+    if (this._selectedIds.size === 0) return
+    this._selectedIds.clear()
+    this._applySelectionStyles()
+    this._onStyleChange?.()
+    if (render) {
+      this._updateIdleStatus()
+      this._view.render()
+    }
+  }
+
+  private _applySelectionStyles(): void {
+    for (const item of this._committed) {
+      const selected = this._selectedIds.has(item.record.id)
+      const baseColor = item.record.style.color || ACEX_MARKUP_COLOR
+      for (const el of item.parts.dom) {
+        el.classList.toggle('mlcad-markup-selected', selected)
+        // Keep original colors; selection is shown via CSS glow only.
+        if (
+          el.classList.contains('mlcad-markup-badge') ||
+          el.classList.contains('mlcad-markup-stamp')
+        ) {
+          el.style.color = baseColor
+          el.style.borderColor = baseColor
+        } else if (el.classList.contains('mlcad-markup-dot')) {
+          el.style.background = baseColor
+        }
+      }
+      for (const canvas of item.parts.canvases) {
+        canvas.classList.toggle('mlcad-markup-selected', selected)
+      }
+    }
+    for (const fn of this._redrawListeners) fn()
+  }
+
+  private _positionDomOverlays(): void {
+    const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
+    for (const item of this._committed) {
+      for (const el of item.parts.dom) {
+        const x = Number(el.dataset.wcsX)
+        const y = Number(el.dataset.wcsY)
+        if (!Number.isFinite(x) || !Number.isFinite(y)) continue
+        const screen = this._view.wcsToScreen(new THREE.Vector2(x, y))
+        el.style.left = `${screen.x - rootRect.left}px`
+        el.style.top = `${screen.y - rootRect.top}px`
+      }
+    }
+    const placing = this._placingShapeCallout
+    if (placing) {
+      this._positionTempDom(placing.badge)
+      this._positionTempDom(placing.tipDot)
+    }
+  }
+
+  private _resolvePointerWithOsnap(
+    clientX: number,
+    clientY: number
+  ): THREE.Vector2 {
+    const cacheKey = this._view.getSnapCacheKey()
+    if (
+      this._osnapCache &&
+      this._osnapCache.clientX === clientX &&
+      this._osnapCache.clientY === clientY &&
+      this._osnapCache.cacheKey === cacheKey
+    ) {
+      const snap = this._osnapCache.snap
+      if (snap) {
+        this._onOsnapMarker(snap, this._view.wcsToScreen(this._osnapCache.point))
+      } else {
+        this._onOsnapMarker(null, null)
+      }
+      return this._osnapCache.point
+    }
+    const resolved = this._view.resolvePoint(clientX, clientY)
+    let point = resolved.point
+    const tracking = this._getTrackingOptions?.()
+    const reference =
+      this._mode && this._points.length > 0
+        ? this._points[this._points.length - 1]!
+        : null
+    if (tracking && reference && (tracking.ortho || tracking.polar)) {
+      const constrained = constrainToAcExTracking(point, reference, tracking)
+      point = new THREE.Vector2(constrained.x, constrained.y)
+    }
+    this._osnapCache = {
+      clientX,
+      clientY,
+      cacheKey,
+      point: point.clone(),
+      snap: resolved.snap
+    }
+    if (resolved.snap) {
+      this._onOsnapMarker(resolved.snap, this._view.wcsToScreen(point))
+    } else {
+      this._onOsnapMarker(null, null)
+    }
+    return point
+  }
+
+  private _refreshActivePreview(): void {
+    if (this._awaitingInlineText || isAcExMarkupHtmlTextEditing()) {
+      // Keep frozen shape+leader visible while typing after anchor is placed.
+      if (this._placingShapeCallout) {
+        this._paintPlacingShapeCalloutPreview(this._placingShapeCallout)
+      }
+      return
+    }
+    if (
+      (!this._mode && !this._placingShapeCallout) ||
+      !this._lastPointer ||
+      this._inOverlaySync
+    ) {
+      if (!this._mode && !this._placingShapeCallout) this._clearPreview()
+      return
+    }
+
+    if (this._placingShapeCallout) {
+      const cursor = this._resolvePointerWithOsnap(
+        this._lastPointer.x,
+        this._lastPointer.y
+      )
+      const placing = this._placingShapeCallout
+      const anchor = point2(cursor)
+      const tip = acExComputeLeaderTipOnShape(placing.outline, anchor)
+      placing.tip = tip
+      placing.anchor = anchor
+      placing.badge.dataset.wcsX = String(anchor.x)
+      placing.badge.dataset.wcsY = String(anchor.y)
+      placing.tipDot.dataset.wcsX = String(tip.x)
+      placing.tipDot.dataset.wcsY = String(tip.y)
+      this._positionTempDom(placing.badge)
+      this._positionTempDom(placing.tipDot)
+      this._paintPlacingShapeCalloutPreview(placing)
+      return
+    }
+
+    const cursor = this._resolvePointerWithOsnap(
+      this._lastPointer.x,
+      this._lastPointer.y
+    )
+    const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
+    if (!ctx) return
+    const color = this._drawColor
+    const lineWidth = acExMarkupCanvasLineWidth(this._drawLineWeight)
+
+    if (this._points.length === 0) return
+    const a = this._points[0]!
+    const b = cursor
+
+    if (this._mode === 'arrow') {
+      this._strokeGeometry(
+        ctx,
+        { type: 'arrow', start: point2(a), end: point2(b) },
+        color,
+        lineWidth
+      )
+    } else if (this._mode === 'rect') {
+      this._strokeGeometry(
+        ctx,
+        { type: 'rect', corner1: point2(a), corner2: point2(b) },
+        color,
+        lineWidth
+      )
+    } else if (this._mode === 'cloud') {
+      acExStrokeMarkupCloud(
+        ctx,
+        point2(a),
+        point2(b),
+        p => this._worldToOverlay(p),
+        s => this._overlayToWorld(s),
+        color,
+        lineWidth
+      )
+    } else if (this._mode === 'circle') {
+      const radius = a.distanceTo(b)
+      this._strokeGeometry(
+        ctx,
+        { type: 'circle', center: point2(a), radius },
+        color,
+        lineWidth
+      )
+    } else if (this._mode === 'callout') {
+      const tip = this._worldToOverlay(point2(a))
+      const anchor = this._worldToOverlay(point2(b))
+      acExDrawMarkupLeader(ctx, tip, anchor, color, true, lineWidth)
+    }
+  }
+
+  private _paintPlacingShapeCalloutPreview(
+    placing: AcExPlacingShapeCallout
+  ): void {
+    const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
+    if (!ctx) return
+    const color = this._drawColor
+    const lineWidth = acExMarkupCanvasLineWidth(this._drawLineWeight)
+    const outline = placing.outline
+    if (outline.kind === 'circle') {
+      this._strokeGeometry(
+        ctx,
+        {
+          type: 'circle',
+          center: outline.center,
+          radius: outline.radius
+        },
+        color,
+        lineWidth
+      )
+    } else if (outline.kind === 'cloud') {
+      acExStrokeMarkupCloud(
+        ctx,
+        outline.corner1,
+        outline.corner2,
+        p => this._worldToOverlay(p),
+        s => this._overlayToWorld(s),
+        color,
+        lineWidth
+      )
+    } else {
+      this._strokeGeometry(
+        ctx,
+        {
+          type: 'rect',
+          corner1: outline.corner1,
+          corner2: outline.corner2
+        },
+        color,
+        lineWidth
+      )
+    }
+    const tip = this._worldToOverlay(placing.tip)
+    const anchor = this._worldToOverlay(placing.anchor)
+    acExDrawMarkupLeader(ctx, tip, anchor, color, false, lineWidth)
+  }
+
+  private _clearPreview(): void {
+    const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
+    if (ctx) {
+      // already cleared by fit
+    }
+  }
+
+  private _hintForMode(mode: AcExMarkupMode): string {
+    switch (mode) {
+      case 'cloud':
+        return this._i18n.t('status.markupCloudHint')
+      case 'callout':
+        return this._i18n.t('status.markupCalloutHint')
+      case 'text':
+        return this._i18n.t('status.markupTextHint')
+      case 'rect':
+        return this._i18n.t('status.markupRectHint')
+      case 'circle':
+        return this._i18n.t('status.markupCircleHint')
+      case 'arrow':
+        return this._i18n.t('status.markupArrowHint')
+      case 'stamp':
+        return this._i18n.t('status.markupStampHint')
+      default:
+        return this._getReadyStatus()
+    }
+  }
+
+  private _hintForSecondPoint(
+    kind: 'arrow' | 'rect' | 'cloud' | 'callout'
+  ): string {
+    switch (kind) {
+      case 'arrow':
+        return this._i18n.t('status.markupArrowEndHint')
+      case 'rect':
+        return this._i18n.t('status.markupRectCornerHint')
+      case 'cloud':
+        return this._i18n.t('status.markupCloudCornerHint')
+      case 'callout':
+        return this._i18n.t('status.markupCalloutAnchorHint')
+    }
+  }
+
+  private _updateToolbarActive(): void {
+    document.querySelectorAll('[data-markup-mode]').forEach(btn => {
+      const mode = btn.getAttribute('data-markup-mode')
+      btn.classList.toggle('active', mode === this._mode)
+    })
+    document
+      .getElementById('mlcad-markup-menu-btn')
+      ?.classList.toggle('active', this._mode !== null)
+  }
+
+  private _updateVisibilityToolbar(): void {
+    const buttons = document.querySelectorAll(
+      '[data-action="markup-visibility"]'
+    )
+    if (buttons.length === 0) return
+    // Action-oriented: when markups are visible, offer Hide (slashed eye).
+    const titleKey = this._visible
+      ? 'toolbar.markupHide'
+      : 'toolbar.markupShow'
+    const icon = this._visible
+      ? acExHtmlIcons.markupHide
+      : acExHtmlIcons.markupShow
+    const label = this._i18n.t(titleKey)
+    buttons.forEach(btn => {
+      btn.classList.toggle('active', this._visible)
+      btn.classList.toggle('is-toggled', this._visible)
+      btn.setAttribute('data-i18n-key', titleKey)
+      btn.setAttribute('title', label)
+      btn.setAttribute('aria-label', label)
+      const labelEl = btn.querySelector('.mlcad-dropdown-label')
+      if (labelEl) {
+        labelEl.setAttribute('data-i18n-key', titleKey)
+        labelEl.textContent = label
+      }
+      const iconHost = btn.querySelector('.mlcad-dropdown-icon')
+      if (iconHost) {
+        iconHost.innerHTML = icon
+      } else {
+        btn.innerHTML = icon
+      }
+    })
+  }
+
+  private _updateIdleStatus(): void {
+    if (this._mode) return
+    if (this._selectedIds.size > 0) {
+      this._statusEl.textContent = this._i18n.t('status.markupSelected', {
+        type: String(this._selectedIds.size)
+      })
+      return
+    }
+    if (this._committed.length > 0) {
+      this._statusEl.textContent = this._i18n.t('status.markupCount', {
+        count: String(this._committed.length)
+      })
+      return
+    }
+    this._statusEl.textContent = this._getReadyStatus()
+  }
+}

--- a/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
@@ -1,0 +1,582 @@
+/**
+ * Markup geometry helpers (revision cloud, hit tests, canvas strokes).
+ *
+ * @module AcExMarkupGeometry
+ * @packageDocumentation
+ */
+
+import type {
+  AcExMarkupAttachedCallout,
+  AcExMarkupGeometry,
+  AcExMarkupPoint2d,
+  AcExMarkupRecord
+} from './AcExMarkupTypes'
+
+/** Shape outline used to auto-place the leader tip on the perimeter. */
+export type AcExMarkupShapeOutline =
+  | {
+      kind: 'rect' | 'cloud'
+      corner1: AcExMarkupPoint2d
+      corner2: AcExMarkupPoint2d
+    }
+  | {
+      kind: 'circle'
+      center: AcExMarkupPoint2d
+      radius: number
+    }
+
+/**
+ * Design Review–style leader tip: intersection of the ray from the shape
+ * center toward the cursor with the shape outer frame (AABB for rect/cloud,
+ * circle perimeter for circle).
+ */
+export function acExComputeLeaderTipOnShape(
+  outline: AcExMarkupShapeOutline,
+  toward: AcExMarkupPoint2d
+): AcExMarkupPoint2d {
+  if (outline.kind === 'circle') {
+    const { center, radius } = outline
+    const dx = toward.x - center.x
+    const dy = toward.y - center.y
+    const len = Math.hypot(dx, dy)
+    if (len < 1e-9 || radius <= 0) {
+      return { x: center.x + radius, y: center.y }
+    }
+    const s = radius / len
+    return { x: center.x + dx * s, y: center.y + dy * s }
+  }
+
+  const minX = Math.min(outline.corner1.x, outline.corner2.x)
+  const maxX = Math.max(outline.corner1.x, outline.corner2.x)
+  const minY = Math.min(outline.corner1.y, outline.corner2.y)
+  const maxY = Math.max(outline.corner1.y, outline.corner2.y)
+  const cx = (minX + maxX) / 2
+  const cy = (minY + maxY) / 2
+  const hx = (maxX - minX) / 2
+  const hy = (maxY - minY) / 2
+  const dx = toward.x - cx
+  const dy = toward.y - cy
+
+  if (Math.abs(dx) < 1e-9 && Math.abs(dy) < 1e-9) {
+    return { x: maxX, y: cy }
+  }
+
+  const sx = Math.abs(dx) > 1e-9 ? hx / Math.abs(dx) : Number.POSITIVE_INFINITY
+  const sy = Math.abs(dy) > 1e-9 ? hy / Math.abs(dy) : Number.POSITIVE_INFINITY
+  const s = Math.min(sx, sy)
+  return { x: cx + dx * s, y: cy + dy * s }
+}
+
+/** Target screen diameter in CSS pixels for each revision-cloud lobe. */
+const CLOUD_DIAMETER_PIXELS = 8
+
+/** World-space vertex with AutoCAD-style bulge to the next vertex. */
+interface AcExMarkupCloudVertex {
+  x: number
+  y: number
+  bulge: number
+}
+
+/**
+ * Fit a canvas to its container and return a 2D context cleared for this frame.
+ */
+export function acExFitMarkupCanvas(
+  canvas: HTMLCanvasElement,
+  container: HTMLElement
+): CanvasRenderingContext2D | null {
+  const rect = container.getBoundingClientRect()
+  const dpr = window.devicePixelRatio || 1
+  const cssWidth = `${rect.width}px`
+  const cssHeight = `${rect.height}px`
+  const bufferWidth = Math.max(1, Math.floor(rect.width * dpr))
+  const bufferHeight = Math.max(1, Math.floor(rect.height * dpr))
+  canvas.style.left = '0'
+  canvas.style.top = '0'
+  if (canvas.style.width !== cssWidth) canvas.style.width = cssWidth
+  if (canvas.style.height !== cssHeight) canvas.style.height = cssHeight
+  if (canvas.width !== bufferWidth) canvas.width = bufferWidth
+  if (canvas.height !== bufferHeight) canvas.height = bufferHeight
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.clearRect(0, 0, rect.width, rect.height)
+  return ctx
+}
+
+/** Draw a filled arrow head at `to`, pointing along `from` → `to`. */
+export function acExDrawMarkupArrowHead(
+  ctx: CanvasRenderingContext2D,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  color: string
+): void {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const len = Math.hypot(dx, dy) || 1
+  const ux = dx / len
+  const uy = dy / len
+  const size = 12
+  const left = {
+    x: to.x - ux * size - uy * size * 0.45,
+    y: to.y - uy * size + ux * size * 0.45
+  }
+  const right = {
+    x: to.x - ux * size + uy * size * 0.45,
+    y: to.y - uy * size - ux * size * 0.45
+  }
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.moveTo(to.x, to.y)
+  ctx.lineTo(left.x, left.y)
+  ctx.lineTo(right.x, right.y)
+  ctx.closePath()
+  ctx.fill()
+}
+
+/** Draw a leader segment, optionally with an arrow head at the tip. */
+export function acExDrawMarkupLeader(
+  ctx: CanvasRenderingContext2D,
+  tip: { x: number; y: number },
+  anchor: { x: number; y: number },
+  color: string,
+  withArrow = true,
+  lineWidth = 2
+): void {
+  ctx.strokeStyle = color
+  ctx.lineWidth = lineWidth
+  ctx.beginPath()
+  ctx.moveTo(tip.x, tip.y)
+  ctx.lineTo(anchor.x, anchor.y)
+  ctx.stroke()
+  if (withArrow) {
+    acExDrawMarkupArrowHead(ctx, anchor, tip, color)
+  }
+}
+
+/** Map CAD line weight to canvas stroke width in CSS pixels. */
+export function acExMarkupCanvasLineWidth(weight?: number): number {
+  if (weight == null || !Number.isFinite(weight) || weight <= 0) return 2
+  return Math.max(1, weight / 28)
+}
+
+function pixelToWorldDistance(
+  worldToScreen: (p: AcExMarkupPoint2d) => { x: number; y: number },
+  screenToWorld: (p: { x: number; y: number }) => AcExMarkupPoint2d,
+  pixelDistance: number,
+  referencePoint: AcExMarkupPoint2d
+): number {
+  const screenPoint1 = worldToScreen(referencePoint)
+  const screenPoint2 = { x: screenPoint1.x + pixelDistance, y: screenPoint1.y }
+  const worldPoint2 = screenToWorld(screenPoint2)
+  return Math.abs(worldPoint2.x - referencePoint.x)
+}
+
+function markupCloudVertices(
+  firstPoint: AcExMarkupPoint2d,
+  secondPoint: AcExMarkupPoint2d,
+  worldToScreen: (p: AcExMarkupPoint2d) => { x: number; y: number },
+  screenToWorld: (p: { x: number; y: number }) => AcExMarkupPoint2d
+): AcExMarkupCloudVertex[] {
+  const minX = Math.min(firstPoint.x, secondPoint.x)
+  const maxX = Math.max(firstPoint.x, secondPoint.x)
+  const minY = Math.min(firstPoint.y, secondPoint.y)
+  const maxY = Math.max(firstPoint.y, secondPoint.y)
+  const width = maxX - minX
+  const height = maxY - minY
+  const centerPoint = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
+  const cloudDiameter = pixelToWorldDistance(
+    worldToScreen,
+    screenToWorld,
+    CLOUD_DIAMETER_PIXELS,
+    centerPoint
+  )
+  const chordLength = Math.max(cloudDiameter, 1e-6)
+  const numSegmentsX = Math.max(4, Math.ceil(width / chordLength) * 2)
+  const numSegmentsY = Math.max(4, Math.ceil(height / chordLength) * 2)
+
+  const vertices: AcExMarkupCloudVertex[] = []
+  let segmentIndex = 0
+  const calculateBulge = (outward: boolean): number => (outward ? 0.4 : -0.4)
+
+  for (let i = 0; i <= numSegmentsX; i++) {
+    const t = i / numSegmentsX
+    vertices.push({
+      x: minX + width * t,
+      y: minY,
+      bulge: i < numSegmentsX ? calculateBulge(segmentIndex++ % 2 === 0) : 0
+    })
+  }
+  for (let i = 1; i <= numSegmentsY; i++) {
+    const t = i / numSegmentsY
+    vertices.push({
+      x: maxX,
+      y: minY + height * t,
+      bulge: i < numSegmentsY ? calculateBulge(segmentIndex++ % 2 === 0) : 0
+    })
+  }
+  for (let i = 1; i <= numSegmentsX; i++) {
+    const t = 1 - i / numSegmentsX
+    vertices.push({
+      x: minX + width * t,
+      y: maxY,
+      bulge: i < numSegmentsX ? calculateBulge(segmentIndex++ % 2 === 0) : 0
+    })
+  }
+  for (let i = 1; i < numSegmentsY; i++) {
+    const t = 1 - i / numSegmentsY
+    vertices.push({
+      x: minX,
+      y: minY + height * t,
+      bulge:
+        i < numSegmentsY - 1 ? calculateBulge(segmentIndex++ % 2 === 0) : 0
+    })
+  }
+  return vertices
+}
+
+function tessellateBulgeSegment(
+  p1: AcExMarkupPoint2d,
+  p2: AcExMarkupPoint2d,
+  bulge: number,
+  samples = 6
+): AcExMarkupPoint2d[] {
+  if (Math.abs(bulge) < 1e-8) {
+    return [{ x: p2.x, y: p2.y }]
+  }
+  const dx = p2.x - p1.x
+  const dy = p2.y - p1.y
+  const d = Math.hypot(dx, dy)
+  if (d < 1e-12) {
+    return [{ x: p2.x, y: p2.y }]
+  }
+  const cx = (p1.x + p2.x) / 2 - (dy * (1 - bulge * bulge)) / (4 * bulge)
+  const cy = (p1.y + p2.y) / 2 + (dx * (1 - bulge * bulge)) / (4 * bulge)
+  const r = Math.hypot(p1.x - cx, p1.y - cy)
+  const a0 = Math.atan2(p1.y - cy, p1.x - cx)
+  const a1 = Math.atan2(p2.y - cy, p2.x - cx)
+  let delta = a1 - a0
+  if (bulge > 0) {
+    if (delta <= 0) delta += Math.PI * 2
+  } else {
+    if (delta >= 0) delta -= Math.PI * 2
+  }
+  const out: AcExMarkupPoint2d[] = []
+  const steps = Math.max(2, samples)
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps
+    const a = a0 + delta * t
+    out.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
+  }
+  return out
+}
+
+function tessellateMarkupCloud(
+  vertices: AcExMarkupCloudVertex[]
+): AcExMarkupPoint2d[] {
+  if (vertices.length < 2) return vertices.map(v => ({ x: v.x, y: v.y }))
+  const points: AcExMarkupPoint2d[] = [
+    { x: vertices[0].x, y: vertices[0].y }
+  ]
+  for (let i = 0; i < vertices.length; i++) {
+    const a = vertices[i]!
+    const b = vertices[(i + 1) % vertices.length]!
+    const seg = tessellateBulgeSegment(
+      { x: a.x, y: a.y },
+      { x: b.x, y: b.y },
+      a.bulge
+    )
+    for (const p of seg) points.push(p)
+  }
+  return points
+}
+
+/** Stroke a revision cloud on a canvas context (screen projection). */
+export function acExStrokeMarkupCloud(
+  ctx: CanvasRenderingContext2D,
+  first: AcExMarkupPoint2d,
+  second: AcExMarkupPoint2d,
+  worldToScreen: (p: AcExMarkupPoint2d) => { x: number; y: number },
+  screenToWorld: (p: { x: number; y: number }) => AcExMarkupPoint2d,
+  color: string,
+  lineWidth: number
+): void {
+  const vertices = markupCloudVertices(
+    first,
+    second,
+    worldToScreen,
+    screenToWorld
+  )
+  const world = tessellateMarkupCloud(vertices)
+  if (world.length < 2) return
+  const screen = world.map(p => worldToScreen(p))
+  ctx.strokeStyle = color
+  ctx.lineWidth = lineWidth
+  ctx.beginPath()
+  ctx.moveTo(screen[0]!.x, screen[0]!.y)
+  for (let i = 1; i < screen.length; i++) {
+    ctx.lineTo(screen[i]!.x, screen[i]!.y)
+  }
+  ctx.closePath()
+  ctx.stroke()
+}
+
+/** Shortest distance from a screen point to a line segment (pixels). */
+export function acExDistToSegmentPx(
+  px: number,
+  py: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number
+): number {
+  const dx = bx - ax
+  const dy = by - ay
+  const len2 = dx * dx + dy * dy
+  if (len2 < 1e-12) return Math.hypot(px - ax, py - ay)
+  let t = ((px - ax) * dx + (py - ay) * dy) / len2
+  t = Math.max(0, Math.min(1, t))
+  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy))
+}
+
+/** Approximate center of a markup for badge placement / focus. */
+export function acExMarkupCenter(
+  record: AcExMarkupRecord
+): AcExMarkupPoint2d | null {
+  const g = record.geometry
+  switch (g.type) {
+    case 'text':
+    case 'stamp':
+    case 'symbol':
+      return { ...g.position }
+    case 'line':
+    case 'arrow':
+      return {
+        x: (g.start.x + g.end.x) / 2,
+        y: (g.start.y + g.end.y) / 2
+      }
+    case 'cloud':
+    case 'rect':
+    case 'highlight':
+      return {
+        x: (g.corner1.x + g.corner2.x) / 2,
+        y: (g.corner1.y + g.corner2.y) / 2
+      }
+    case 'circle':
+      return { ...g.center }
+    case 'callout':
+      return {
+        x: (g.tip.x + g.anchor.x) / 2,
+        y: (g.tip.y + g.anchor.y) / 2
+      }
+    default:
+      return null
+  }
+}
+
+function acExTranslatePoint(
+  p: AcExMarkupPoint2d,
+  dx: number,
+  dy: number
+): AcExMarkupPoint2d {
+  return { x: p.x + dx, y: p.y + dy }
+}
+
+function acExTranslateAttachedCallout(
+  callout: AcExMarkupAttachedCallout,
+  dx: number,
+  dy: number
+): AcExMarkupAttachedCallout {
+  return {
+    ...callout,
+    tip: acExTranslatePoint(callout.tip, dx, dy),
+    anchor: acExTranslatePoint(callout.anchor, dx, dy)
+  }
+}
+
+/**
+ * Translate markup geometry by a world-space offset (including attached callout).
+ */
+export function acExTranslateMarkupGeometry(
+  geometry: AcExMarkupGeometry,
+  dx: number,
+  dy: number
+): AcExMarkupGeometry {
+  switch (geometry.type) {
+    case 'cloud':
+      return {
+        ...geometry,
+        corner1: acExTranslatePoint(geometry.corner1, dx, dy),
+        corner2: acExTranslatePoint(geometry.corner2, dx, dy),
+        callout: geometry.callout
+          ? acExTranslateAttachedCallout(geometry.callout, dx, dy)
+          : undefined
+      }
+    case 'rect':
+      return {
+        ...geometry,
+        corner1: acExTranslatePoint(geometry.corner1, dx, dy),
+        corner2: acExTranslatePoint(geometry.corner2, dx, dy),
+        callout: geometry.callout
+          ? acExTranslateAttachedCallout(geometry.callout, dx, dy)
+          : undefined
+      }
+    case 'highlight':
+      return {
+        ...geometry,
+        corner1: acExTranslatePoint(geometry.corner1, dx, dy),
+        corner2: acExTranslatePoint(geometry.corner2, dx, dy)
+      }
+    case 'circle':
+      return {
+        ...geometry,
+        center: acExTranslatePoint(geometry.center, dx, dy),
+        callout: geometry.callout
+          ? acExTranslateAttachedCallout(geometry.callout, dx, dy)
+          : undefined
+      }
+    case 'callout':
+      return {
+        ...geometry,
+        tip: acExTranslatePoint(geometry.tip, dx, dy),
+        anchor: acExTranslatePoint(geometry.anchor, dx, dy)
+      }
+    case 'arrow':
+    case 'line':
+      return {
+        ...geometry,
+        start: acExTranslatePoint(geometry.start, dx, dy),
+        end: acExTranslatePoint(geometry.end, dx, dy)
+      }
+    case 'text':
+    case 'stamp':
+    case 'symbol':
+      return {
+        ...geometry,
+        position: acExTranslatePoint(geometry.position, dx, dy)
+      }
+  }
+}
+
+/**
+ * Hit-test markup geometry in screen space.
+ * @returns true when the pointer is within `thresholdPx` of the stroke / shape.
+ */
+export function acExHitTestMarkup(
+  record: AcExMarkupRecord,
+  clientX: number,
+  clientY: number,
+  thresholdPx: number,
+  worldToScreen: (p: AcExMarkupPoint2d) => { x: number; y: number }
+): boolean {
+  const g = record.geometry
+  switch (g.type) {
+    case 'text':
+    case 'stamp':
+    case 'symbol': {
+      const s = worldToScreen(g.position)
+      return Math.hypot(clientX - s.x, clientY - s.y) <= thresholdPx * 2.5
+    }
+    case 'line':
+    case 'arrow': {
+      const a = worldToScreen(g.start)
+      const b = worldToScreen(g.end)
+      return (
+        acExDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <=
+        thresholdPx
+      )
+    }
+    case 'callout': {
+      const a = worldToScreen(g.tip)
+      const b = worldToScreen(g.anchor)
+      return (
+        acExDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <=
+        thresholdPx
+      )
+    }
+    case 'rect':
+    case 'highlight':
+    case 'cloud': {
+      const a = worldToScreen(g.corner1)
+      const b = worldToScreen(g.corner2)
+      const minX = Math.min(a.x, b.x) - thresholdPx
+      const maxX = Math.max(a.x, b.x) + thresholdPx
+      const minY = Math.min(a.y, b.y) - thresholdPx
+      const maxY = Math.max(a.y, b.y) + thresholdPx
+      // Prefer stroke near edges for cloud/rect; fill for highlight.
+      if (g.type === 'highlight') {
+        return (
+          clientX >= minX &&
+          clientX <= maxX &&
+          clientY >= minY &&
+          clientY <= maxY
+        )
+      }
+      const inside =
+        clientX >= Math.min(a.x, b.x) &&
+        clientX <= Math.max(a.x, b.x) &&
+        clientY >= Math.min(a.y, b.y) &&
+        clientY <= Math.max(a.y, b.y)
+      let shapeHit = false
+      if (!inside) {
+        shapeHit =
+          clientX >= minX &&
+          clientX <= maxX &&
+          clientY >= minY &&
+          clientY <= maxY
+      } else {
+        const distEdge = Math.min(
+          Math.abs(clientX - Math.min(a.x, b.x)),
+          Math.abs(clientX - Math.max(a.x, b.x)),
+          Math.abs(clientY - Math.min(a.y, b.y)),
+          Math.abs(clientY - Math.max(a.y, b.y))
+        )
+        shapeHit = distEdge <= thresholdPx * 2 || g.type === 'cloud'
+      }
+      if (shapeHit) return true
+      if (g.type === 'rect' || g.type === 'cloud') {
+        return hitAttachedCallout(
+          g.callout,
+          clientX,
+          clientY,
+          thresholdPx,
+          worldToScreen
+        )
+      }
+      return false
+    }
+    case 'circle': {
+      const c = worldToScreen(g.center)
+      const rim = worldToScreen({
+        x: g.center.x + g.radius,
+        y: g.center.y
+      })
+      const rPx = Math.hypot(rim.x - c.x, rim.y - c.y)
+      const d = Math.hypot(clientX - c.x, clientY - c.y)
+      if (Math.abs(d - rPx) <= thresholdPx * 2) return true
+      return hitAttachedCallout(
+        g.callout,
+        clientX,
+        clientY,
+        thresholdPx,
+        worldToScreen
+      )
+    }
+    default:
+      return false
+  }
+}
+
+function hitAttachedCallout(
+  callout: AcExMarkupAttachedCallout | undefined,
+  clientX: number,
+  clientY: number,
+  thresholdPx: number,
+  worldToScreen: (p: AcExMarkupPoint2d) => { x: number; y: number }
+): boolean {
+  if (!callout) return false
+  const a = worldToScreen(callout.tip)
+  const b = worldToScreen(callout.anchor)
+  return (
+    acExDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <= thresholdPx
+  )
+}

--- a/packages/cad-html-plugin/src/AcExMarkupGripDrag.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupGripDrag.ts
@@ -1,0 +1,142 @@
+/**
+ * Pointer-drag grip host for offline HTML markup overlays.
+ *
+ * Mirrors `@mlightcad/cad-simple-viewer` {@link acapBindOverlayPointerDrag}:
+ * drag starts after a small move so double-click / contenteditable still work.
+ *
+ * @module AcExMarkupGripDrag
+ * @packageDocumentation
+ */
+
+import type { AcExMarkupPoint2d } from './AcExMarkupTypes'
+
+/** Pointer movement (CSS px, squared) before a drag starts. */
+const DRAG_THRESHOLD_PX = 4
+
+const windowListenerOptions: AddEventListenerOptions = {
+  capture: true,
+  passive: false
+}
+
+/** Options for {@link acExBindMarkupPointerDrag}. */
+export interface AcExMarkupPointerDragOptions {
+  /** DOM handle that receives pointerdown. */
+  el: HTMLElement
+  /** Convert client coordinates to world XY. */
+  clientToWorld: (clientX: number, clientY: number) => AcExMarkupPoint2d
+  /** Idle cursor CSS value (default `grab`). */
+  cursor?: string
+  /** Called on pointerdown before any move (e.g. select the markup). */
+  onPointerDown?: (ev: PointerEvent) => void
+  /** Invoked once when the drag threshold is first exceeded. */
+  onDragStart?: () => void
+  /** Invoked on each pointer move after the drag has started. */
+  onMove: (world: AcExMarkupPoint2d, ev: PointerEvent) => void
+  /** Invoked on pointerup / cancel after a drag occurred. */
+  onCommit: () => void
+  /** When true, the binding is inactive (e.g. a create tool is active). */
+  isEnabled?: () => boolean
+}
+
+/**
+ * Bind pointer-drag on one HTML overlay handle.
+ *
+ * @returns Cleanup that removes listeners and cancels an in-progress drag.
+ */
+export function acExBindMarkupPointerDrag(
+  options: AcExMarkupPointerDragOptions
+): () => void {
+  const { el, clientToWorld, onDragStart, onMove, onCommit } = options
+  const idleCursor = options.cursor ?? 'grab'
+
+  el.style.pointerEvents = 'auto'
+  el.style.cursor = idleCursor
+  el.style.touchAction = 'none'
+  el.style.userSelect = 'none'
+
+  let detachActiveDrag: (() => void) | undefined
+
+  const onPointerDown = (e: PointerEvent) => {
+    if (e.button !== 0) return
+    if (options.isEnabled && !options.isEnabled()) return
+    const target = e.target as HTMLElement | null
+    if (
+      e.detail >= 2 ||
+      target?.isContentEditable ||
+      target?.closest('[contenteditable="true"]') ||
+      el.querySelector('[contenteditable="true"]')
+    ) {
+      return
+    }
+
+    options.onPointerDown?.(e)
+    e.stopPropagation()
+    e.preventDefault()
+    // Capture so OrbitControls / canvas handlers cannot steal the gesture.
+    try {
+      el.setPointerCapture(e.pointerId)
+    } catch {
+      // Some browsers reject capture on non-primary targets.
+    }
+
+    const pointerId = e.pointerId
+    const startX = e.clientX
+    const startY = e.clientY
+    let dragging = false
+
+    const detach = () => {
+      window.removeEventListener(
+        'pointermove',
+        onPointerMove,
+        windowListenerOptions
+      )
+      window.removeEventListener(
+        'pointerup',
+        onPointerUp,
+        windowListenerOptions
+      )
+      window.removeEventListener(
+        'pointercancel',
+        onPointerUp,
+        windowListenerOptions
+      )
+      if (detachActiveDrag === detach) detachActiveDrag = undefined
+    }
+
+    const onPointerMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return
+      if (!dragging) {
+        const dx = ev.clientX - startX
+        const dy = ev.clientY - startY
+        if (dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) {
+          return
+        }
+        dragging = true
+        ev.preventDefault()
+        el.style.cursor = 'grabbing'
+        onDragStart?.()
+      }
+      onMove(clientToWorld(ev.clientX, ev.clientY), ev)
+    }
+
+    const onPointerUp = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return
+      detach()
+      if (!dragging) return
+      el.style.cursor = idleCursor
+      onCommit()
+    }
+
+    detachActiveDrag?.()
+    detachActiveDrag = detach
+    window.addEventListener('pointermove', onPointerMove, windowListenerOptions)
+    window.addEventListener('pointerup', onPointerUp, windowListenerOptions)
+    window.addEventListener('pointercancel', onPointerUp, windowListenerOptions)
+  }
+
+  el.addEventListener('pointerdown', onPointerDown)
+  return () => {
+    el.removeEventListener('pointerdown', onPointerDown)
+    detachActiveDrag?.()
+  }
+}

--- a/packages/cad-html-plugin/src/AcExMarkupSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupSidecar.ts
@@ -1,0 +1,220 @@
+/**
+ * Markup sidecar JSON parse / stringify for the offline HTML viewer.
+ * Compatible with cad-simple-viewer `AcApMarkupSidecar` v1.
+ *
+ * @module AcExMarkupSidecar
+ * @packageDocumentation
+ */
+
+import type {
+  AcExMarkupRecord,
+  AcExMarkupSidecarFile,
+  AcExMarkupStatus,
+  AcExMarkupType
+} from './AcExMarkupTypes'
+
+const MARKUP_STATUSES: readonly AcExMarkupStatus[] = [
+  'open',
+  'question',
+  'answered',
+  'closed'
+]
+
+const MARKUP_TYPES: readonly AcExMarkupType[] = [
+  'text',
+  'line',
+  'arrow',
+  'cloud',
+  'rect',
+  'circle',
+  'highlight',
+  'callout',
+  'stamp',
+  'symbol'
+]
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isPoint(value: unknown): value is { x: number; y: number } {
+  return (
+    isPlainObject(value) &&
+    typeof value.x === 'number' &&
+    typeof value.y === 'number'
+  )
+}
+
+function isAttachedCallout(
+  value: unknown
+): value is {
+  tip: { x: number; y: number }
+  anchor: { x: number; y: number }
+  text?: string
+} {
+  if (!isPlainObject(value)) return false
+  if (!isPoint(value.tip) || !isPoint(value.anchor)) return false
+  if (value.text !== undefined && typeof value.text !== 'string') return false
+  return true
+}
+
+function isStatus(value: unknown): value is AcExMarkupStatus {
+  return (
+    typeof value === 'string' &&
+    (MARKUP_STATUSES as readonly string[]).includes(value)
+  )
+}
+
+function isType(value: unknown): value is AcExMarkupType {
+  return (
+    typeof value === 'string' &&
+    (MARKUP_TYPES as readonly string[]).includes(value)
+  )
+}
+
+function parseRecord(raw: unknown): AcExMarkupRecord | undefined {
+  if (!isPlainObject(raw)) return undefined
+  if (typeof raw.id !== 'string' || !isType(raw.type)) return undefined
+  if (!isPlainObject(raw.style) || typeof raw.style.color !== 'string') {
+    return undefined
+  }
+  if (!isPlainObject(raw.geometry) || raw.geometry.type !== raw.type) {
+    return undefined
+  }
+  if (!isStatus(raw.status)) return undefined
+
+  const geometry = raw.geometry as Record<string, unknown>
+  switch (raw.type) {
+    case 'text':
+      if (!isPoint(geometry.position)) return undefined
+      break
+    case 'line':
+    case 'arrow':
+      if (!isPoint(geometry.start) || !isPoint(geometry.end)) return undefined
+      break
+    case 'cloud':
+    case 'rect':
+    case 'highlight':
+      if (!isPoint(geometry.corner1) || !isPoint(geometry.corner2)) {
+        return undefined
+      }
+      if (
+        (raw.type === 'cloud' || raw.type === 'rect') &&
+        geometry.callout !== undefined &&
+        !isAttachedCallout(geometry.callout)
+      ) {
+        return undefined
+      }
+      break
+    case 'circle':
+      if (
+        !isPoint(geometry.center) ||
+        typeof geometry.radius !== 'number' ||
+        !(geometry.radius > 0)
+      ) {
+        return undefined
+      }
+      if (
+        geometry.callout !== undefined &&
+        !isAttachedCallout(geometry.callout)
+      ) {
+        return undefined
+      }
+      break
+    case 'callout':
+      if (!isPoint(geometry.tip) || !isPoint(geometry.anchor)) return undefined
+      break
+    case 'stamp':
+      if (!isPoint(geometry.position) || typeof geometry.stampId !== 'string') {
+        return undefined
+      }
+      break
+    case 'symbol':
+      if (
+        !isPoint(geometry.position) ||
+        typeof geometry.symbolId !== 'string'
+      ) {
+        return undefined
+      }
+      break
+    default:
+      return undefined
+  }
+
+  return {
+    id: raw.id,
+    type: raw.type,
+    layoutId: typeof raw.layoutId === 'string' ? raw.layoutId : undefined,
+    style: {
+      color: raw.style.color,
+      lineWeight:
+        typeof raw.style.lineWeight === 'number'
+          ? raw.style.lineWeight
+          : undefined,
+      fontSize:
+        typeof raw.style.fontSize === 'number' && raw.style.fontSize > 0
+          ? raw.style.fontSize
+          : undefined
+    },
+    text: typeof raw.text === 'string' ? raw.text : undefined,
+    comment: typeof raw.comment === 'string' ? raw.comment : '',
+    status: raw.status,
+    author: typeof raw.author === 'string' ? raw.author : '',
+    createdAt:
+      typeof raw.createdAt === 'string'
+        ? raw.createdAt
+        : new Date().toISOString(),
+    updatedAt:
+      typeof raw.updatedAt === 'string'
+        ? raw.updatedAt
+        : new Date().toISOString(),
+    geometry: raw.geometry as unknown as AcExMarkupRecord['geometry']
+  }
+}
+
+/**
+ * Parse sidecar JSON text into a typed file object.
+ * @throws Error when the payload is not valid markup sidecar v1.
+ */
+export function parseAcExMarkupSidecar(text: string): AcExMarkupSidecarFile {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new Error('Invalid markup sidecar: not JSON')
+  }
+  if (!isPlainObject(parsed) || parsed.version !== 1) {
+    throw new Error('Invalid markup sidecar: expected version 1')
+  }
+  if (!Array.isArray(parsed.markups)) {
+    throw new Error('Invalid markup sidecar: markups must be an array')
+  }
+  const markups: AcExMarkupRecord[] = []
+  for (const item of parsed.markups) {
+    const record = parseRecord(item)
+    if (record) markups.push(record)
+  }
+  return {
+    version: 1,
+    drawingName:
+      typeof parsed.drawingName === 'string' ? parsed.drawingName : undefined,
+    markups
+  }
+}
+
+/** Serialize a sidecar file to pretty-printed JSON. */
+export function stringifyAcExMarkupSidecar(
+  file: AcExMarkupSidecarFile
+): string {
+  return `${JSON.stringify(file, null, 2)}\n`
+}
+
+/**
+ * Suggested sidecar file name for a drawing.
+ * @example acExMarkupSidecarFileName('plan.dwg') → 'plan.markup.json'
+ */
+export function acExMarkupSidecarFileName(drawingName?: string): string {
+  if (!drawingName) return 'drawing.markup.json'
+  const base = drawingName.replace(/\.(dwg|dxf|html)$/i, '')
+  return `${base}.markup.json`
+}

--- a/packages/cad-html-plugin/src/AcExMarkupTextEdit.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupTextEdit.ts
@@ -1,0 +1,211 @@
+/**
+ * In-place contenteditable text editing for markup capsules in the offline HTML viewer.
+ *
+ * Mirrors `@mlightcad/cad-simple-viewer` {@link editMarkupHtmlText} semantics:
+ * Enter / blur commits; Escape cancels; Shift+Enter inserts a newline when multiline.
+ *
+ * @module AcExMarkupTextEdit
+ * @packageDocumentation
+ */
+
+/** Options for {@link editAcExMarkupHtmlText}. */
+export interface AcExMarkupHtmlTextEditOptions {
+  /** Label element that becomes content-editable. */
+  el: HTMLElement
+  /**
+   * Element that receives pointer events while editing.
+   * Defaults to {@link el}. Use the outer capsule so padding clicks stay in the editor.
+   */
+  listenOn?: HTMLElement
+  /**
+   * When `true`, Shift+Enter inserts a newline; Enter still commits.
+   * @defaultValue `false`
+   */
+  multiline?: boolean
+  /** Text shown when editing starts. Defaults to the element's current text. */
+  initialText?: string
+  /** When aborted, editing cancels and restores {@link initialText}. */
+  signal?: AbortSignal
+}
+
+/** CSS class applied to the element while inline editing is active. */
+const EDITING_CLASS = 'mlcad-markup-text-editing'
+
+/** DOM id of the injected stylesheet for inline text editing. */
+const STYLE_ID = 'mlcad-markup-inline-text-edit-styles'
+
+const editingElements = new WeakSet<HTMLElement>()
+
+/** Count of in-progress {@link editAcExMarkupHtmlText} sessions. */
+let editingCount = 0
+
+/**
+ * Whether a markup capsule is currently content-editable.
+ * Canvas gestures should ignore Escape / pick while this is true.
+ */
+export function isAcExMarkupHtmlTextEditing(): boolean {
+  return editingCount > 0
+}
+
+/** Max interval between two pointer-downs treated as a double-click. */
+const DOUBLE_CLICK_MS = 400
+
+/** Max pointer travel between those downs. */
+const DOUBLE_CLICK_SLOP_PX = 6
+
+/**
+ * Whether two pointer downs form a double-click (time + distance).
+ * Overlay handlers often preventDefault, so native `dblclick` is unreliable.
+ */
+export function isAcExMarkupDoublePointer(
+  previous: { t: number; x: number; y: number } | undefined,
+  next: { t: number; x: number; y: number }
+): boolean {
+  if (!previous) return false
+  const dt = next.t - previous.t
+  if (dt < 0 || dt > DOUBLE_CLICK_MS) return false
+  const dx = next.x - previous.x
+  const dy = next.y - previous.y
+  return dx * dx + dy * dy <= DOUBLE_CLICK_SLOP_PX * DOUBLE_CLICK_SLOP_PX
+}
+function ensureStyles(): void {
+  if (typeof document === 'undefined') return
+  if (document.getElementById(STYLE_ID)) return
+  const style = document.createElement('style')
+  style.id = STYLE_ID
+  style.textContent = `
+    .mlcad-markup-text-editing {
+      outline: 1px solid #409eff;
+      outline-offset: 1px;
+      cursor: text !important;
+      user-select: text;
+      pointer-events: auto;
+      min-height: 1.2em;
+      white-space: pre-wrap;
+    }
+  `
+  document.head.appendChild(style)
+}
+
+/** Selects the full text content of an element. */
+function selectAll(el: HTMLElement): void {
+  const selection = window.getSelection()
+  if (!selection) return
+  const range = document.createRange()
+  range.selectNodeContents(el)
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+/** Enables plaintext editing, falling back to `contenteditable="true"`. */
+function enablePlaintext(el: HTMLElement): void {
+  el.setAttribute('contenteditable', 'plaintext-only')
+  if (el.contentEditable !== 'plaintext-only') {
+    el.contentEditable = 'true'
+  }
+}
+
+/**
+ * Makes a markup capsule content-editable until the user commits or cancels.
+ *
+ * @returns Trimmed text on commit, or `undefined` when the user presses Escape.
+ */
+export function editAcExMarkupHtmlText(
+  options: AcExMarkupHtmlTextEditOptions
+): Promise<string | undefined> {
+  ensureStyles()
+  const { el, multiline = false } = options
+  const listenOn = options.listenOn ?? el
+  if (editingElements.has(el)) {
+    return Promise.resolve(undefined)
+  }
+  if (options.signal?.aborted) {
+    return Promise.resolve(undefined)
+  }
+
+  const original =
+    options.initialText !== undefined
+      ? options.initialText
+      : (el.textContent ?? '').trim()
+
+  return new Promise(resolve => {
+    editingElements.add(el)
+    editingCount += 1
+    listenOn.style.pointerEvents = 'auto'
+    el.style.pointerEvents = 'auto'
+    el.textContent = original
+    el.classList.add(EDITING_CLASS)
+    el.tabIndex = 0
+    enablePlaintext(el)
+
+    let settled = false
+    let suppressBlurUntil = performance.now() + 300
+
+    const cleanup = () => {
+      options.signal?.removeEventListener('abort', onAbort)
+      el.classList.remove(EDITING_CLASS)
+      el.removeAttribute('contenteditable')
+      el.removeAttribute('tabindex')
+      listenOn.removeEventListener('pointerdown', onPointerDown, true)
+      el.removeEventListener('keydown', onKeyDown)
+      el.removeEventListener('blur', onBlur)
+      editingElements.delete(el)
+      editingCount = Math.max(0, editingCount - 1)
+    }
+
+    const finish = (commit: boolean) => {
+      if (settled) return
+      settled = true
+      const next = (el.textContent ?? '').trim()
+      if (!commit) {
+        el.textContent = original
+        cleanup()
+        resolve(undefined)
+        return
+      }
+      el.textContent = next
+      cleanup()
+      resolve(next)
+    }
+
+    const onPointerDown = (e: PointerEvent) => {
+      e.stopPropagation()
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.isComposing || e.keyCode === 229) return
+      e.stopPropagation()
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        finish(false)
+        return
+      }
+      if (e.key === 'Enter' && (!multiline || !e.shiftKey)) {
+        e.preventDefault()
+        finish(true)
+      }
+    }
+
+    const onBlur = () => {
+      if (performance.now() < suppressBlurUntil) {
+        el.focus()
+        return
+      }
+      finish(true)
+    }
+
+    const onAbort = () => finish(false)
+
+    listenOn.addEventListener('pointerdown', onPointerDown, true)
+    el.addEventListener('keydown', onKeyDown)
+    el.addEventListener('blur', onBlur)
+    options.signal?.addEventListener('abort', onAbort)
+
+    requestAnimationFrame(() => {
+      if (settled) return
+      suppressBlurUntil = performance.now() + 300
+      el.focus()
+      selectAll(el)
+    })
+  })
+}

--- a/packages/cad-html-plugin/src/AcExMarkupTypes.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupTypes.ts
@@ -1,0 +1,167 @@
+/**
+ * Design Review–style markup types for the offline HTML viewer.
+ *
+ * Schema matches `@mlightcad/cad-simple-viewer` sidecar JSON so markups can be
+ * exchanged between the full CAD app and exported HTML files.
+ *
+ * @module AcExMarkupTypes
+ * @packageDocumentation
+ */
+
+/** Review workflow status for a markup. */
+export type AcExMarkupStatus = 'open' | 'question' | 'answered' | 'closed'
+
+/** Visual markup kinds supported by the offline HTML markup system. */
+export type AcExMarkupType =
+  | 'text'
+  | 'line'
+  | 'arrow'
+  | 'cloud'
+  | 'rect'
+  | 'circle'
+  | 'highlight'
+  | 'callout'
+  | 'stamp'
+  | 'symbol'
+
+/** 2D world point used in markup geometry. */
+export interface AcExMarkupPoint2d {
+  x: number
+  y: number
+}
+
+/** Drawing style stored in the sidecar (CSS-friendly). */
+export interface AcExMarkupStyle {
+  /** CSS color string, e.g. `#ff0000` or `rgb(255,0,0)`. */
+  color: string
+  /** Optional AutoCAD-style line weight enum value. */
+  lineWeight?: number
+  /** Screen-space font size in CSS pixels for text / callout bubbles. */
+  fontSize?: number
+}
+
+/** Shared metadata on every markup record. */
+export interface AcExMarkupMeta {
+  id: string
+  type: AcExMarkupType
+  /** Layout block-table-record id; omitted = visible on every layout. */
+  layoutId?: string
+  style: AcExMarkupStyle
+  /** Optional on-drawing label (text / callout / stamp caption). */
+  text?: string
+  comment: string
+  status: AcExMarkupStatus
+  author: string
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Optional leader + text attached to a shape markup (cloud / rect / circle).
+ * Leaders for shape callouts do **not** use an arrowhead (Design Review style).
+ */
+export interface AcExMarkupAttachedCallout {
+  tip: AcExMarkupPoint2d
+  anchor: AcExMarkupPoint2d
+  text?: string
+}
+
+export interface AcExMarkupTextGeometry {
+  type: 'text'
+  position: AcExMarkupPoint2d
+}
+
+export interface AcExMarkupLineGeometry {
+  type: 'line'
+  start: AcExMarkupPoint2d
+  end: AcExMarkupPoint2d
+}
+
+export interface AcExMarkupArrowGeometry {
+  type: 'arrow'
+  start: AcExMarkupPoint2d
+  end: AcExMarkupPoint2d
+}
+
+export interface AcExMarkupCloudGeometry {
+  type: 'cloud'
+  corner1: AcExMarkupPoint2d
+  corner2: AcExMarkupPoint2d
+  callout?: AcExMarkupAttachedCallout
+}
+
+export interface AcExMarkupRectGeometry {
+  type: 'rect'
+  corner1: AcExMarkupPoint2d
+  corner2: AcExMarkupPoint2d
+  callout?: AcExMarkupAttachedCallout
+}
+
+export interface AcExMarkupCircleGeometry {
+  type: 'circle'
+  center: AcExMarkupPoint2d
+  radius: number
+  callout?: AcExMarkupAttachedCallout
+}
+
+export interface AcExMarkupHighlightGeometry {
+  type: 'highlight'
+  corner1: AcExMarkupPoint2d
+  corner2: AcExMarkupPoint2d
+}
+
+export interface AcExMarkupCalloutGeometry {
+  type: 'callout'
+  /** Leader tip (arrow end). */
+  tip: AcExMarkupPoint2d
+  /** Text bubble anchor. */
+  anchor: AcExMarkupPoint2d
+}
+
+export interface AcExMarkupStampGeometry {
+  type: 'stamp'
+  position: AcExMarkupPoint2d
+  stampId: string
+  imageUrl?: string
+}
+
+export interface AcExMarkupSymbolGeometry {
+  type: 'symbol'
+  position: AcExMarkupPoint2d
+  symbolId: string
+  imageUrl?: string
+}
+
+export type AcExMarkupGeometry =
+  | AcExMarkupTextGeometry
+  | AcExMarkupLineGeometry
+  | AcExMarkupArrowGeometry
+  | AcExMarkupCloudGeometry
+  | AcExMarkupRectGeometry
+  | AcExMarkupCircleGeometry
+  | AcExMarkupHighlightGeometry
+  | AcExMarkupCalloutGeometry
+  | AcExMarkupStampGeometry
+  | AcExMarkupSymbolGeometry
+
+/** One persisted markup item. */
+export type AcExMarkupRecord = AcExMarkupMeta & {
+  geometry: AcExMarkupGeometry
+}
+
+/** Sidecar JSON root (versioned). */
+export interface AcExMarkupSidecarFile {
+  version: 1
+  drawingName?: string
+  markups: AcExMarkupRecord[]
+}
+
+/** Toolbar / interactive create modes (subset of {@link AcExMarkupType}). */
+export type AcExMarkupMode =
+  | 'cloud'
+  | 'callout'
+  | 'text'
+  | 'rect'
+  | 'circle'
+  | 'arrow'
+  | 'stamp'

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -8,6 +8,20 @@
 import * as THREE from 'three'
 
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
+import { acExHtmlIcons } from './AcExHtmlIcons'
+import {
+  ACEX_MEASUREMENT_FONT_SIZE,
+  ACEX_MEASUREMENT_LINE_WEIGHT,
+  acExMeasureCanvasLineWidth,
+  acExMeasurementSidecarFileName,
+  parseAcExMeasurementSidecar,
+  stringifyAcExMeasurementSidecar
+} from './AcExMeasurementSidecar'
+import type {
+  AcExMeasurementRecord,
+  AcExMeasurementSidecarFile,
+  AcExMeasurementSidecarStyle
+} from './AcExMeasurementTypes'
 import {
   type AcExMeasureQuantity,
   type AcExMeasureQuantityEntry,
@@ -25,7 +39,7 @@ import type { AcExOsnapPoint } from './AcExOsnap'
  */
 export const ACEX_MEASURE_COLOR = 0x08e8de
 
-/** Highlight color when a committed measurement is selected. */
+/** Highlight color when a committed measurement is selected (CSS glow only). */
 export const ACEX_MEASURE_SELECT_COLOR = 0xffd54f
 
 /** CSS color string used by 2D canvas measurement overlays. */
@@ -146,6 +160,8 @@ export interface AcExMeasureControllerOptions {
   statusEl: HTMLElement
   /** Returns the idle status text when no measurement tool is active. */
   getReadyStatus: () => string
+  /** Optional drawing title used for sidecar download file names. */
+  drawingName?: string
   /**
    * Called when the snap target under the cursor changes during measurement.
    * @param snap - Active snap mode and world position, or `null` when none.
@@ -162,6 +178,8 @@ export interface AcExMeasureControllerOptions {
    * (for example to toggle left-button pan on OrbitControls).
    */
   onActiveChange?: (active: boolean) => void
+  /** Called when selection or session draw style changes (draw-style toolbar). */
+  onStyleChange?: () => void
 }
 
 /** Teardown callback registered when a measurement overlay is created. @internal */
@@ -179,6 +197,8 @@ interface AcExCommitParts {
 /** One finished measurement that can be selected and deleted. @internal */
 interface AcExCommittedMeasure {
   id: string
+  /** Sidecar-compatible record used for import/export. */
+  record: AcExMeasurementRecord
   parts: AcExCommitParts
   quantity: AcExMeasureQuantity | null
   value: number
@@ -471,6 +491,98 @@ function isAngleOnSweep(start: number, mid: number, end: number): boolean {
 }
 
 /**
+ * Arc length of the shorter arc between two points on circle `g`.
+ * @internal
+ */
+function shortArcLength(
+  p1: THREE.Vector2,
+  p2: THREE.Vector2,
+  g: AcExCircleGeom
+): number {
+  const a1 = Math.atan2(p1.y - g.cy, p1.x - g.cx)
+  const a2 = Math.atan2(p2.y - g.cy, p2.x - g.cx)
+  const span = normaliseAngle(a2 - a1)
+  return Math.min(span, 2 * Math.PI - span) * g.r
+}
+
+/**
+ * Midpoint of the shorter arc between two points on circle `g`.
+ * @internal
+ */
+function shortArcMid(
+  p1: THREE.Vector2,
+  p2: THREE.Vector2,
+  g: AcExCircleGeom
+): THREE.Vector2 {
+  const a1 = Math.atan2(p1.y - g.cy, p1.x - g.cx)
+  const a2 = Math.atan2(p2.y - g.cy, p2.x - g.cx)
+  const ccwSpan = normaliseAngle(a2 - a1)
+  const mid =
+    ccwSpan <= Math.PI ? a1 + ccwSpan / 2 : a1 - (2 * Math.PI - ccwSpan) / 2
+  return new THREE.Vector2(
+    g.cx + g.r * Math.cos(mid),
+    g.cy + g.r * Math.sin(mid)
+  )
+}
+
+/**
+ * Whether the shorter arc from `start` to `end` is counter-clockwise.
+ * @internal
+ */
+function shortArcCounterClockwise(
+  start: THREE.Vector2,
+  end: THREE.Vector2,
+  g: AcExCircleGeom
+): boolean {
+  const a1 = Math.atan2(start.y - g.cy, start.x - g.cx)
+  const a2 = Math.atan2(end.y - g.cy, end.x - g.cx)
+  return normaliseAngle(a2 - a1) <= Math.PI
+}
+
+/** Best-effort CSS color → 24-bit RGB for THREE materials. @internal */
+function cssColorToHex(css: string, fallback: number): number {
+  const s = css.trim()
+  const hex6 = s.match(/^#([0-9a-f]{6})$/i)
+  if (hex6) return Number.parseInt(hex6[1]!, 16)
+  const hex3 = s.match(/^#([0-9a-f]{3})$/i)
+  if (hex3) {
+    const h = hex3[1]!
+    return Number.parseInt(
+      `${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}`,
+      16
+    )
+  }
+  const rgb = s.match(
+    /^rgba?\(\s*([0-9.]+)\s*,\s*([0-9.]+)\s*,\s*([0-9.]+)/i
+  )
+  if (rgb) {
+    const r = Math.max(0, Math.min(255, Math.round(Number(rgb[1]))))
+    const g = Math.max(0, Math.min(255, Math.round(Number(rgb[2]))))
+    const b = Math.max(0, Math.min(255, Math.round(Number(rgb[3]))))
+    if ([r, g, b].every(Number.isFinite)) return (r << 16) | (g << 8) | b
+  }
+  return fallback
+}
+
+/** Sync document CSS accent vars used by measure badges / live label. @internal */
+function applyMeasureAccentCss(hex: number): void {
+  const css = measureColorToCss(hex)
+  const r = (hex >> 16) & 0xff
+  const g = (hex >> 8) & 0xff
+  const b = hex & 0xff
+  const root = document.documentElement
+  root.style.setProperty('--mlcad-measure-accent', css)
+  root.style.setProperty(
+    '--mlcad-measure-accent-border',
+    `rgba(${r}, ${g}, ${b}, 0.45)`
+  )
+  root.style.setProperty(
+    '--mlcad-measure-accent-fill',
+    `rgba(${r}, ${g}, ${b}, 0.2)`
+  )
+}
+
+/**
  * Arc sweep from `start` to `end` that passes through `through` (radians).
  * @returns `{ span, counterClockwise }` for canvas `arc()` and length = span * r.
  * @internal
@@ -581,27 +693,6 @@ function segmentsIntersect(
 }
 
 /**
- * Builds a THREE polyline geometry from WCS vertices (Z = 0).
- * @param points - At least two XY points.
- * @returns Buffer geometry, or `null` when `points.length < 2`.
- * @internal
- */
-function makeLineGeometry(
-  points: THREE.Vector2[]
-): THREE.BufferGeometry | null {
-  if (points.length < 2) return null
-  const positions = new Float32Array(points.length * 3)
-  for (let i = 0; i < points.length; i++) {
-    positions[i * 3] = points[i]!.x
-    positions[i * 3 + 1] = points[i]!.y
-    positions[i * 3 + 2] = 0
-  }
-  const geometry = new THREE.BufferGeometry()
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
-  return geometry
-}
-
-/**
  * Creates a persistent endpoint marker (`mlcad-measure-dot`).
  * World position is stored on `dataset.wcsX` / `dataset.wcsY` and updated by
  * {@link AcExMeasureController.syncOverlays}.
@@ -663,6 +754,8 @@ export class AcExMeasureController {
   private readonly _statusEl: HTMLElement
   /** Idle status text provider. */
   private readonly _getReadyStatus: () => string
+  /** Drawing title for sidecar download names. */
+  private readonly _drawingName: string | undefined
   /** Snap marker callback for the runtime. */
   private readonly _onOsnapMarker: AcExMeasureControllerOptions['onOsnapMarker']
   /** Ortho/polar tracking options from the settings panel. */
@@ -673,20 +766,32 @@ export class AcExMeasureController {
   private readonly _onActiveChange:
     | ((active: boolean) => void)
     | null
+  /** Notifies when selection / session draw style changes. */
+  private readonly _onStyleChange: (() => void) | null
   /** Accent color for lines, labels, and canvas overlays. */
   private _measureColor = ACEX_MEASURE_COLOR
+  /** Session line weight for new measurements. */
+  private _drawLineWeight = ACEX_MEASUREMENT_LINE_WEIGHT
+  /** Session badge font size for new measurements. */
+  private _drawFontSize = ACEX_MEASUREMENT_FONT_SIZE
+  /** Style of the measurement currently being committed (import or interactive). */
+  private _commitStyle: AcExMeasurementSidecarStyle | null = null
   /** Parent group for committed THREE line geometry. */
   private readonly _measureGroup: THREE.Group
   /** Host for canvas overlays, dots, badges, and the live label. */
   private readonly _overlayLayer: HTMLDivElement
   /** Cursor-following value shown during interactive preview. */
   private readonly _liveLabel: HTMLDivElement
+  /** Hidden file input for sidecar import. */
+  private readonly _fileInput: HTMLInputElement
   /** Rubber-band line while picking points. */
   private readonly _previewLine: THREE.Line
   /** Canvas redraw callbacks invoked from {@link syncOverlays}. */
   private readonly _redrawListeners: AcExMeasureCleanup[] = []
   /** Finished measurements that survive after the tool is deactivated. */
   private readonly _committed: AcExCommittedMeasure[] = []
+  /** When false, DOM overlays and THREE measure lines are hidden. */
+  private _visible = true
   /** Parts being assembled for the measurement currently being committed. */
   private _commitParts: AcExCommitParts | null = null
   /** Monotonic id source for {@link _committed}. */
@@ -728,9 +833,11 @@ export class AcExMeasureController {
     this._view = options.view
     this._statusEl = options.statusEl
     this._getReadyStatus = options.getReadyStatus
+    this._drawingName = options.drawingName
     this._onOsnapMarker = options.onOsnapMarker
     this._getTrackingOptions = options.getTrackingOptions ?? null
     this._onActiveChange = options.onActiveChange ?? null
+    this._onStyleChange = options.onStyleChange ?? null
 
     this._measureGroup = new THREE.Group()
     this._measureGroup.name = 'measurements'
@@ -745,6 +852,15 @@ export class AcExMeasureController {
     this._liveLabel.className = 'mlcad-measure-live-label'
     this._overlayLayer.appendChild(this._liveLabel)
 
+    this._fileInput = document.createElement('input')
+    this._fileInput.type = 'file'
+    this._fileInput.accept = '.json,application/json'
+    this._fileInput.style.display = 'none'
+    this._fileInput.addEventListener('change', () => {
+      void this._handleImportFile()
+    })
+    this._root.appendChild(this._fileInput)
+
     const previewMaterial = new THREE.LineBasicMaterial({
       color: this._measureColor,
       depthTest: false
@@ -755,6 +871,7 @@ export class AcExMeasureController {
     this._previewLine.frustumCulled = false
     this._previewLine.renderOrder = 15
     this._scene.add(this._previewLine)
+    this._updateVisibilityToolbar()
   }
 
   /**
@@ -764,6 +881,16 @@ export class AcExMeasureController {
     return this._mode !== null
   }
 
+  /** Whether one or more committed measurements are selected. */
+  get hasSelection(): boolean {
+    return this._selectedIds.size > 0
+  }
+
+  /** Clears the current measurement selection (if any). */
+  clearSelection(): void {
+    this._deselect(true)
+  }
+
   /**
    * Currently selected toolbar mode, or `null` when idle.
    */
@@ -771,28 +898,111 @@ export class AcExMeasureController {
     return this._mode
   }
 
+  /** Whether committed measurement overlays are currently shown. */
+  get visible(): boolean {
+    return this._visible
+  }
+
   /**
-   * Updates the accent color used for measurement overlays and redraws canvases.
+   * Updates the session accent color used for new measurement overlays.
    *
    * @param hex - 24-bit RGB color (for example `0x08e8de`).
    */
   setMeasureColor(hex: number): void {
-    if (!Number.isFinite(hex)) return
-    this._measureColor = hex
-    const material = this._previewLine.material
-    if (material instanceof THREE.LineBasicMaterial) {
-      material.color.setHex(hex)
-    }
-    for (const measure of this._committed) {
-      if (this._selectedIds.has(measure.id)) continue
-      for (const line of measure.parts.lines) {
-        const lineMaterial = line.material
-        if (lineMaterial instanceof THREE.LineBasicMaterial) {
-          lineMaterial.color.setHex(hex)
+    this.setDrawStyle({ colorHex: hex })
+  }
+
+  /** Current session draw style (or selected measurement style when applicable). */
+  getDrawStyle(): {
+    color: string
+    lineWeight: number
+    fontSize: number
+  } {
+    const selectedId =
+      this._selectedIds.size === 1 ? [...this._selectedIds][0] : undefined
+    if (selectedId) {
+      const measure = this._committed.find(m => m.id === selectedId)
+      if (measure) {
+        return {
+          color: measure.record.style.color || this._measureCss(),
+          lineWeight: measure.record.style.lineWeight || this._drawLineWeight,
+          fontSize: measure.record.style.fontSize || this._drawFontSize
         }
       }
     }
-    for (const fn of this._redrawListeners) fn()
+    return {
+      color: this._measureCss(),
+      lineWeight: this._drawLineWeight,
+      fontSize: this._drawFontSize
+    }
+  }
+
+  /**
+   * Updates session defaults and applies the same patch to the current selection.
+   */
+  setDrawStyle(patch: {
+    color?: string
+    colorHex?: number
+    lineWeight?: number
+    fontSize?: number
+  }): void {
+    let colorChanged = false
+    if (patch.colorHex != null && Number.isFinite(patch.colorHex)) {
+      this._measureColor = patch.colorHex
+      colorChanged = true
+    } else if (patch.color) {
+      const next = cssColorToHex(patch.color, this._measureColor)
+      if (next !== this._measureColor || patch.color !== this._measureCss()) {
+        this._measureColor = next
+        colorChanged = true
+      }
+    }
+    if (patch.lineWeight != null && patch.lineWeight > 0) {
+      this._drawLineWeight = patch.lineWeight
+    }
+    if (patch.fontSize != null && patch.fontSize > 0) {
+      this._drawFontSize = patch.fontSize
+    }
+
+    if (colorChanged) {
+      applyMeasureAccentCss(this._measureColor)
+      this._liveLabel.style.color = this._measureCss()
+    }
+
+    const material = this._previewLine.material
+    if (material instanceof THREE.LineBasicMaterial) {
+      material.color.setHex(this._measureColor)
+    }
+
+    const selectionPatch: {
+      color?: string
+      lineWeight?: number
+      fontSize?: number
+    } = {}
+    if (colorChanged || patch.colorHex != null || patch.color) {
+      selectionPatch.color = this._measureCss()
+    }
+    if (patch.lineWeight != null && patch.lineWeight > 0) {
+      selectionPatch.lineWeight = patch.lineWeight
+    }
+    if (patch.fontSize != null && patch.fontSize > 0) {
+      selectionPatch.fontSize = patch.fontSize
+    }
+    this._applyStyleToSelection(selectionPatch)
+
+    // Mid-draw: keep in-progress commit style in sync with the session.
+    if (this._commitStyle) {
+      if (selectionPatch.color) this._commitStyle.color = selectionPatch.color
+      if (selectionPatch.lineWeight != null) {
+        this._commitStyle.lineWeight = selectionPatch.lineWeight
+      }
+      if (selectionPatch.fontSize != null) {
+        this._commitStyle.fontSize = selectionPatch.fontSize
+      }
+    }
+
+    this._refreshActivePreview()
+    this._onStyleChange?.()
     this._view.render()
   }
 
@@ -871,10 +1081,80 @@ export class AcExMeasureController {
   }
 
   /**
+   * Shows or hides all committed measurement graphics (DOM + THREE lines).
+   */
+  setVisible(visible: boolean): void {
+    this._visible = visible
+    this._overlayLayer.style.display = visible ? '' : 'none'
+    this._measureGroup.visible = visible
+    this._updateVisibilityToolbar()
+    this._view.render()
+  }
+
+  /** Toggles {@link setVisible}. */
+  toggleVisible(): void {
+    this.setVisible(!this._visible)
+  }
+
+  /** Download current measurements as a `*.measurement.json` sidecar. */
+  exportSidecar(): void {
+    const file: AcExMeasurementSidecarFile = {
+      version: 1,
+      drawingName: this._drawingName,
+      measurements: this._committed.map(c => c.record)
+    }
+    const text = stringifyAcExMeasurementSidecar(file)
+    const blob = new Blob([text], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = acExMeasurementSidecarFileName(this._drawingName)
+    a.click()
+    URL.revokeObjectURL(url)
+    this._statusEl.textContent = this._i18n.t('status.measureExported', {
+      count: String(file.measurements.length)
+    })
+  }
+
+  /** Open a file picker to import a measurement sidecar JSON. */
+  importSidecar(): void {
+    this._fileInput.value = ''
+    this._fileInput.click()
+  }
+
+  /** Replace all measurements from a parsed sidecar (used by tests / import). */
+  loadSidecar(file: AcExMeasurementSidecarFile): void {
+    this.clearAll()
+    for (const record of file.measurements) {
+      this._publishRecord(record)
+    }
+    this._updateIdleStatus()
+    this._view.render()
+  }
+
+  private async _handleImportFile(): Promise<void> {
+    const file = this._fileInput.files?.[0]
+    if (!file) return
+    try {
+      const text = await file.text()
+      const sidecar = parseAcExMeasurementSidecar(text)
+      this.loadSidecar(sidecar)
+      this._statusEl.textContent = this._i18n.t('status.measureImported', {
+        count: String(sidecar.measurements.length)
+      })
+    } catch (error) {
+      this._statusEl.textContent = this._i18n.t('status.measureImportFailed', {
+        error: String(error)
+      })
+    }
+  }
+
+  /**
    * Repositions DOM badges/dots and redraws registered canvas overlays.
    * Invoke from the viewer `render` path and after resize so graphics track pan/zoom.
    */
   syncOverlays(): void {
+    if (!this._visible) return
     this._inOverlaySync = true
     try {
       this._overlayRootRect = this._root.getBoundingClientRect()
@@ -1057,14 +1337,43 @@ export class AcExMeasureController {
     }
   }
 
-  /** Syncs `#mlcad-toolbar [data-measure-mode]` `active` class with `_mode`. @internal */
+  /** Syncs measure-mode `active` class and parent menu highlight. @internal */
   private _updateToolbarActive(): void {
+    document.querySelectorAll('[data-measure-mode]').forEach(btn => {
+      const mode = btn.getAttribute('data-measure-mode')
+      btn.classList.toggle('active', mode === this._mode)
+    })
     document
-      .querySelectorAll('#mlcad-toolbar [data-measure-mode]')
-      .forEach(btn => {
-        const mode = btn.getAttribute('data-measure-mode')
-        btn.classList.toggle('active', mode === this._mode)
-      })
+      .getElementById('mlcad-measure-menu-btn')
+      ?.classList.toggle('active', this._mode !== null)
+  }
+
+  /** Syncs show/hide measurement button label and icon. @internal */
+  private _updateVisibilityToolbar(): void {
+    const buttons = document.querySelectorAll(
+      '[data-action="measure-visibility"]'
+    )
+    if (buttons.length === 0) return
+    const titleKey = this._visible
+      ? 'toolbar.measureHide'
+      : 'toolbar.measureShow'
+    const icon = this._visible
+      ? acExHtmlIcons.markupHide
+      : acExHtmlIcons.markupShow
+    const label = this._i18n.t(titleKey)
+    buttons.forEach(btn => {
+      btn.classList.toggle('active', this._visible)
+      btn.classList.toggle('is-toggled', this._visible)
+      btn.setAttribute('data-i18n-key', titleKey)
+      btn.setAttribute('title', label)
+      btn.setAttribute('aria-label', label)
+      const iconHost = btn.querySelector('.mlcad-dropdown-icon')
+      if (iconHost) {
+        iconHost.innerHTML = icon
+      } else {
+        btn.innerHTML = icon
+      }
+    })
   }
 
   /** Removes transient preview line, label, and preview canvas. @internal */
@@ -1253,16 +1562,30 @@ export class AcExMeasureController {
    * Persists a coordinate measurement: endpoint dot and offset badge.
    * @internal
    */
-  private _commitCoordinate(point: THREE.Vector2): void {
+  private _commitCoordinate(
+    point: THREE.Vector2,
+    existing?: AcExMeasurementRecord
+  ): void {
     const label = this._formatCoordinateLabel(point.x, point.y)
-    this._startCommit()
+    const id = this._startCommit(existing?.id)
     this._addDot(point)
     const badge = this._addBadge(point, label)
     badge.classList.add('mlcad-measure-badge--coordinate')
-    this._finishCommit((clientX, clientY, threshold) => {
-      const s = this._view.wcsToScreen(point)
-      return Math.hypot(clientX - s.x, clientY - s.y) <= threshold
-    }, null)
+    const record =
+      existing ??
+      this._makeRecord(id, 'point', {
+        type: 'point',
+        position: { x: point.x, y: point.y }
+      })
+    this._finishCommit(
+      (clientX, clientY, threshold) => {
+        const s = this._view.wcsToScreen(point)
+        return Math.hypot(clientX - s.x, clientY - s.y) <= threshold
+      },
+      null,
+      0,
+      record
+    )
     this._statusEl.textContent = this._i18n.t('status.coordinates', {
       x: this._view.formatLength(point.x),
       y: this._view.formatLength(point.y)
@@ -1312,14 +1635,25 @@ export class AcExMeasureController {
    * Persists a distance measurement: line, endpoint dots, and midpoint badge.
    * @internal
    */
-  private _commitDistance(a: THREE.Vector2, b: THREE.Vector2): void {
+  private _commitDistance(
+    a: THREE.Vector2,
+    b: THREE.Vector2,
+    existing?: AcExMeasurementRecord
+  ): void {
     const dist = dist2(a, b)
-    this._startCommit()
+    const id = this._startCommit(existing?.id)
     this._addPersistentLine([a, b])
     this._addDot(a)
     this._addDot(b)
     const mid = new THREE.Vector2((a.x + b.x) / 2, (a.y + b.y) / 2)
     this._addBadge(mid, this._view.formatLength(dist))
+    const record =
+      existing ??
+      this._makeRecord(id, 'distance', {
+        type: 'distance',
+        start: { x: a.x, y: a.y },
+        end: { x: b.x, y: b.y }
+      })
     this._finishCommit(
       (clientX, clientY, threshold) => {
         const sa = this._view.wcsToScreen(a)
@@ -1330,7 +1664,8 @@ export class AcExMeasureController {
         )
       },
       'length',
-      dist
+      dist,
+      record
     )
     this._statusEl.textContent = this._i18n.t('status.distance', {
       value: this._view.formatLength(dist)
@@ -1391,15 +1726,27 @@ export class AcExMeasureController {
   private _commitAngle(
     vertex: THREE.Vector2,
     arm1: THREE.Vector2,
-    arm2: THREE.Vector2
+    arm2: THREE.Vector2,
+    existing?: AcExMeasurementRecord
   ): void {
     const deg = calcAngleDeg(vertex, arm1, arm2)
-    this._startCommit()
+    const id = this._startCommit(existing?.id)
     this._addPersistentLine([vertex, arm1])
     this._addPersistentLine([vertex, arm2])
     const canvas = makeOverlayCanvas(this._overlayLayer)
     this._trackCanvas(canvas)
-    const redraw = () => this._drawAngleArc(canvas, vertex, arm1, arm2)
+    const commitId = id
+    const redraw = () => {
+      const style = this._styleForCommit(commitId)
+      this._drawAngleArc(
+        canvas,
+        vertex,
+        arm1,
+        arm2,
+        style.color,
+        acExMeasureCanvasLineWidth(style.lineWeight)
+      )
+    }
     redraw()
     this._registerRedraw(redraw, () => canvas.remove())
 
@@ -1436,6 +1783,14 @@ export class AcExMeasureController {
       vertex.y + by * offset
     )
     this._addBadge(badgePos, this._view.formatAngle(deg))
+    const record =
+      existing ??
+      this._makeRecord(id, 'angle', {
+        type: 'angle',
+        vertex: { x: vertex.x, y: vertex.y },
+        arm1: { x: arm1.x, y: arm1.y },
+        arm2: { x: arm2.x, y: arm2.y }
+      })
     this._finishCommit(
       (clientX, clientY, threshold) =>
         hitTestAngleMeasure(
@@ -1448,7 +1803,9 @@ export class AcExMeasureController {
           badgePos,
           wcs => this._view.wcsToScreen(wcs)
         ),
-      null
+      null,
+      0,
+      record
     )
     this._statusEl.textContent = this._i18n.t('status.angle', {
       value: this._view.formatAngle(deg)
@@ -1527,14 +1884,26 @@ export class AcExMeasureController {
     geom: AcExCircleGeom,
     start: THREE.Vector2,
     through: THREE.Vector2,
-    end: THREE.Vector2
+    end: THREE.Vector2,
+    existing?: AcExMeasurementRecord
   ): void {
     const len = arcLengthThroughMiddle(start, through, end, geom)
     const mid = arcMidThroughMiddle(start, through, end, geom)
-    this._startCommit()
+    const id = this._startCommit(existing?.id)
     const canvas = makeOverlayCanvas(this._overlayLayer)
     this._trackCanvas(canvas)
-    const redraw = () => this._drawArc(canvas, geom, start, through, end)
+    const redraw = () => {
+      const style = this._styleForCommit(id)
+      this._drawArc(
+        canvas,
+        geom,
+        start,
+        through,
+        end,
+        style.color,
+        acExMeasureCanvasLineWidth(style.lineWeight)
+      )
+    }
     redraw()
     this._registerRedraw(redraw, () => canvas.remove())
 
@@ -1542,6 +1911,15 @@ export class AcExMeasureController {
     this._addDot(through)
     this._addDot(end)
     this._addBadge(mid, this._view.formatLength(len))
+    const record =
+      existing ??
+      this._makeRecord(id, 'arc', {
+        type: 'arc',
+        center: { x: geom.cx, y: geom.cy },
+        radius: geom.r,
+        start: { x: start.x, y: start.y },
+        end: { x: end.x, y: end.y }
+      })
     this._finishCommit(
       (clientX, clientY, threshold) => {
         const sc = this._view.wcsToScreen(new THREE.Vector2(geom.cx, geom.cy))
@@ -1572,11 +1950,78 @@ export class AcExMeasureController {
         )
       },
       'length',
-      len
+      len,
+      record
     )
     this._statusEl.textContent = this._i18n.t('status.arcLength', {
       value: this._view.formatLength(len)
     })
+  }
+
+  /**
+   * Commits an arc from sidecar geometry (short arc; no through point).
+   * @internal
+   */
+  private _commitShortArc(record: AcExMeasurementRecord): void {
+    if (record.geometry.type !== 'arc') return
+    const g = record.geometry
+    const geom: AcExCircleGeom = {
+      cx: g.center.x,
+      cy: g.center.y,
+      r: g.radius
+    }
+    const start = new THREE.Vector2(g.start.x, g.start.y)
+    const end = new THREE.Vector2(g.end.x, g.end.y)
+    const len = shortArcLength(start, end, geom)
+    const mid = shortArcMid(start, end, geom)
+    const counterClockwise = shortArcCounterClockwise(start, end, geom)
+    this._startCommit(record.id)
+    const canvas = makeOverlayCanvas(this._overlayLayer)
+    this._trackCanvas(canvas)
+    const commitId = record.id
+    const redraw = () => {
+      const style = this._styleForCommit(commitId)
+      this._drawShortArc(
+        canvas,
+        geom,
+        start,
+        end,
+        style.color,
+        acExMeasureCanvasLineWidth(style.lineWeight)
+      )
+    }
+    redraw()
+    this._registerRedraw(redraw, () => canvas.remove())
+    this._addDot(start)
+    this._addDot(end)
+    this._addBadge(mid, this._view.formatLength(len))
+    this._finishCommit(
+      (clientX, clientY, threshold) => {
+        const sc = this._view.wcsToScreen(new THREE.Vector2(geom.cx, geom.cy))
+        const ss = this._view.wcsToScreen(start)
+        const se = this._view.wcsToScreen(end)
+        const cx = sc.x
+        const cy = sc.y
+        const screenR = Math.hypot(ss.x - cx, ss.y - cy)
+        const sa = Math.atan2(ss.y - cy, ss.x - cx)
+        const ea = Math.atan2(se.y - cy, se.x - cx)
+        return (
+          distPointToArcPx(
+            clientX,
+            clientY,
+            cx,
+            cy,
+            screenR,
+            sa,
+            ea,
+            counterClockwise
+          ) <= threshold
+        )
+      },
+      'length',
+      len,
+      record
+    )
   }
 
   /**
@@ -1655,21 +2100,36 @@ export class AcExMeasureController {
    * Persists an area measurement: boundary line, fill canvas, vertex dots, badge.
    * @internal
    */
-  private _commitArea(points: THREE.Vector2[]): void {
+  private _commitArea(
+    points: THREE.Vector2[],
+    existing?: AcExMeasurementRecord
+  ): void {
     if (points.length < 3) return
     const area = shoelaceArea(points)
-    const closed = [...points, points[0]!]
-    this._startCommit()
-    this._addPersistentLine(closed)
-
+    const id = this._startCommit(existing?.id)
+    // Outline stroke comes from the area canvas (fill + stroke).
     const canvas = makeOverlayCanvas(this._overlayLayer)
     this._trackCanvas(canvas)
-    const redraw = () => this._drawAreaFill(canvas, points)
+    const redraw = () => {
+      const style = this._styleForCommit(id)
+      this._drawAreaFill(
+        canvas,
+        points,
+        style.color,
+        acExMeasureCanvasLineWidth(style.lineWeight)
+      )
+    }
     redraw()
     this._registerRedraw(redraw, () => canvas.remove())
 
     for (const p of points) this._addDot(p)
     this._addBadge(centroid(points), `${this._view.formatLength(area)}²`)
+    const record =
+      existing ??
+      this._makeRecord(id, 'area', {
+        type: 'area',
+        points: points.map(p => ({ x: p.x, y: p.y }))
+      })
     this._finishCommit(
       (clientX, clientY, threshold) => {
         const poly = this._screenPolyline(points)
@@ -1678,33 +2138,68 @@ export class AcExMeasureController {
         return distPointToPolylinePx(clientX, clientY, closedPoly) <= threshold
       },
       'area',
-      area
+      area,
+      record
     )
     this._statusEl.textContent = this._i18n.t('status.area', {
       value: `${this._view.formatLength(area)}²`
     })
   }
 
-  /** Adds a committed THREE line and registers disposal in `_cleanups`. @internal */
+  /**
+   * Adds a committed polyline as a style-aware canvas overlay (color + line weight).
+   * @internal
+   */
   private _addPersistentLine(points: THREE.Vector2[]): void {
-    const geometry = makeLineGeometry(points)
-    if (!geometry) return
-    const material = new THREE.LineBasicMaterial({
-      color: this._measureColor,
-      depthTest: false
-    })
-    const line = new THREE.Line(geometry, material)
-    line.renderOrder = 18
-    this._measureGroup.add(line)
+    if (points.length < 2) return
     const parts = this._commitParts
-    if (parts) {
-      parts.lines.push(line)
-      parts.cleanups.push(() => {
-        this._measureGroup.remove(line)
-        geometry.dispose()
-        material.dispose()
-      })
+    if (!parts) return
+    const canvas = makeOverlayCanvas(this._overlayLayer)
+    this._trackCanvas(canvas)
+    const commitId = parts.id
+    const pts = points.map(p => p.clone())
+    const redraw = () => {
+      const style = this._styleForCommit(commitId)
+      this._drawPolyline(
+        canvas,
+        pts,
+        style.color || this._measureCss(),
+        acExMeasureCanvasLineWidth(style.lineWeight)
+      )
     }
+    redraw()
+    this._registerRedraw(redraw, () => canvas.remove())
+  }
+
+  /** Draws a WCS polyline on a synced overlay canvas. @internal */
+  private _drawPolyline(
+    canvas: HTMLCanvasElement,
+    points: THREE.Vector2[],
+    strokeCss: string,
+    lineWidth: number
+  ): void {
+    if (points.length < 2) return
+    const synced = this._syncCanvas(canvas)
+    if (!synced) return
+    const { ctx, dpr } = synced
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.save()
+    ctx.scale(dpr, dpr)
+    const rootRect = this._overlayRootOffset()
+    ctx.beginPath()
+    for (let i = 0; i < points.length; i++) {
+      const s = this._view.wcsToScreen(points[i]!)
+      const x = s.x - rootRect.left
+      const y = s.y - rootRect.top
+      if (i === 0) ctx.moveTo(x, y)
+      else ctx.lineTo(x, y)
+    }
+    ctx.strokeStyle = strokeCss
+    ctx.lineWidth = lineWidth
+    ctx.lineJoin = 'round'
+    ctx.lineCap = 'round'
+    ctx.stroke()
+    ctx.restore()
   }
 
   /** Adds a DOM endpoint dot tracked in WCS via dataset attributes. @internal */
@@ -1712,6 +2207,8 @@ export class AcExMeasureController {
     const dot = makeDotEl()
     dot.dataset.wcsX = String(wcs.x)
     dot.dataset.wcsY = String(wcs.y)
+    const css = this._commitCss()
+    if (css) dot.style.background = css
     this._overlayLayer.appendChild(dot)
     this._positionDomOverlays()
     this._trackDom(dot)
@@ -1723,6 +2220,12 @@ export class AcExMeasureController {
     const badge = makeBadgeEl(text)
     badge.dataset.wcsX = String(wcs.x)
     badge.dataset.wcsY = String(wcs.y)
+    const css = this._commitCss()
+    if (css) {
+      badge.style.color = css
+      badge.style.borderColor = css
+    }
+    badge.style.fontSize = `${this._commitFontSize()}px`
     this._overlayLayer.appendChild(badge)
     this._positionDomOverlays()
     this._trackDom(badge)
@@ -1746,28 +2249,126 @@ export class AcExMeasureController {
   }
 
   /** @internal */
-  private _startCommit(): string {
-    const id = `m${++this._commitCounter}`
+  private _startCommit(id?: string): string {
+    const commitId = id ?? `m${++this._commitCounter}`
+    if (!this._commitStyle) {
+      this._commitStyle = this._defaultStyle()
+    }
     this._commitParts = {
-      id,
+      id: commitId,
       dom: [],
       lines: [],
       canvases: [],
       cleanups: []
     }
-    return id
+    return commitId
   }
 
   /** @internal */
   private _finishCommit(
     hitTest: (clientX: number, clientY: number, thresholdPx: number) => boolean,
     quantity: AcExMeasureQuantity | null,
-    value = 0
+    value = 0,
+    record?: AcExMeasurementRecord
   ): void {
     const parts = this._commitParts
-    if (!parts) return
-    this._committed.push({ id: parts.id, parts, hitTest, quantity, value })
+    if (!parts || !record) {
+      this._commitParts = null
+      this._commitStyle = null
+      return
+    }
+    this._committed.push({
+      id: parts.id,
+      record: { ...record, id: parts.id },
+      parts,
+      hitTest,
+      quantity,
+      value
+    })
     this._commitParts = null
+    this._commitStyle = null
+  }
+
+  /** Default sidecar style from the current session draw style. @internal */
+  private _defaultStyle(): AcExMeasurementSidecarStyle {
+    return {
+      color: this._measureCss(),
+      lineWeight: this._drawLineWeight,
+      fontSize: this._drawFontSize
+    }
+  }
+
+  /** Build a new sidecar record for an interactive commit. @internal */
+  private _makeRecord(
+    id: string,
+    type: AcExMeasurementRecord['type'],
+    geometry: AcExMeasurementRecord['geometry']
+  ): AcExMeasurementRecord {
+    return {
+      id,
+      type,
+      style: this._defaultStyle(),
+      geometry
+    }
+  }
+
+  /** CSS color for the measurement currently being committed. @internal */
+  private _commitCss(): string | null {
+    return this._commitStyle?.color ?? null
+  }
+
+  /** Badge font size for the measurement currently being committed. @internal */
+  private _commitFontSize(): number {
+    return this._commitStyle?.fontSize ?? this._drawFontSize
+  }
+
+  /** Resolve live style for a committed (or in-progress) measurement id. @internal */
+  private _styleForCommit(commitId: string): AcExMeasurementSidecarStyle {
+    const measure = this._committed.find(m => m.id === commitId)
+    if (measure) return measure.record.style
+    return this._commitStyle ?? this._defaultStyle()
+  }
+
+  /** Rebuild visuals from a sidecar record (import path). @internal */
+  private _publishRecord(record: AcExMeasurementRecord): void {
+    this._commitStyle = { ...record.style }
+    try {
+      const g = record.geometry
+      switch (g.type) {
+        case 'distance':
+          this._commitDistance(
+            new THREE.Vector2(g.start.x, g.start.y),
+            new THREE.Vector2(g.end.x, g.end.y),
+            record
+          )
+          break
+        case 'angle':
+          this._commitAngle(
+            new THREE.Vector2(g.vertex.x, g.vertex.y),
+            new THREE.Vector2(g.arm1.x, g.arm1.y),
+            new THREE.Vector2(g.arm2.x, g.arm2.y),
+            record
+          )
+          break
+        case 'area':
+          this._commitArea(
+            g.points.map(p => new THREE.Vector2(p.x, p.y)),
+            record
+          )
+          break
+        case 'arc':
+          this._commitShortArc(record)
+          break
+        case 'point':
+          this._commitCoordinate(
+            new THREE.Vector2(g.position.x, g.position.y),
+            record
+          )
+          break
+      }
+    } finally {
+      this._commitStyle = null
+    }
   }
 
   /** @internal */
@@ -1825,9 +2426,14 @@ export class AcExMeasureController {
    * @internal
    */
   private _trySelectCommittedAt(clientX: number, clientY: number): boolean {
+    if (!this._visible) return false
     const measure = this._pickCommittedMeasure(clientX, clientY)
     if (measure) {
       this._select(measure.id)
+      return true
+    }
+    if (this._selectedIds.size > 0) {
+      this._deselect(true)
       return true
     }
     return false
@@ -1838,7 +2444,8 @@ export class AcExMeasureController {
     if (this._selectedIds.has(id)) return
     this._selectedIds.add(id)
     const measure = this._committed.find(m => m.id === id)
-    if (measure) this._applyMeasureSelection(measure.parts, true)
+    if (measure) this._applyMeasureSelection(measure, true)
+    this._onStyleChange?.()
     if (!this._mode) this._updateIdleStatus()
     this._view.render()
   }
@@ -1848,32 +2455,74 @@ export class AcExMeasureController {
     if (this._selectedIds.size === 0) return
     for (const id of this._selectedIds) {
       const measure = this._committed.find(m => m.id === id)
-      if (measure) this._applyMeasureSelection(measure.parts, false)
+      if (measure) this._applyMeasureSelection(measure, false)
     }
     this._selectedIds.clear()
+    this._onStyleChange?.()
     if (updateStatus && !this._mode) this._updateIdleStatus()
     this._view.render()
   }
 
   /** @internal */
   private _applyMeasureSelection(
-    parts: AcExCommitParts,
+    measure: AcExCommittedMeasure,
     selected: boolean
   ): void {
-    for (const line of parts.lines) {
+    const baseHex = cssColorToHex(
+      measure.record.style.color,
+      this._measureColor
+    )
+    const baseCss = measure.record.style.color || measureColorToCss(baseHex)
+    for (const line of measure.parts.lines) {
       const material = line.material
       if (material instanceof THREE.LineBasicMaterial) {
-        material.color.setHex(
-          selected ? ACEX_MEASURE_SELECT_COLOR : this._measureColor
-        )
+        // Keep original color; selection is shown via CSS glow on canvases/DOM.
+        material.color.setHex(baseHex)
       }
     }
-    for (const el of parts.dom) {
+    for (const el of measure.parts.dom) {
       el.classList.toggle('mlcad-measure-selected', selected)
+      if (el.classList.contains('mlcad-measure-badge')) {
+        el.style.color = baseCss
+        el.style.borderColor = baseCss
+        if (measure.record.style.fontSize) {
+          el.style.fontSize = `${measure.record.style.fontSize}px`
+        }
+      } else if (el.classList.contains('mlcad-measure-dot')) {
+        el.style.background = baseCss
+      }
     }
-    for (const canvas of parts.canvases) {
+    for (const canvas of measure.parts.canvases) {
       canvas.classList.toggle('mlcad-measure-selected', selected)
     }
+  }
+
+  /** Apply style patch to currently selected measurements. @internal */
+  private _applyStyleToSelection(patch: {
+    color?: string
+    lineWeight?: number
+    fontSize?: number
+  }): void {
+    if (this._selectedIds.size === 0) return
+    for (const id of this._selectedIds) {
+      const measure = this._committed.find(m => m.id === id)
+      if (!measure) continue
+      const style = measure.record.style
+      if (patch.color) style.color = patch.color
+      if (patch.lineWeight != null && patch.lineWeight > 0) {
+        style.lineWeight = patch.lineWeight
+      }
+      if (patch.fontSize != null && patch.fontSize > 0) {
+        style.fontSize = patch.fontSize
+      }
+      // Keep selection highlight on DOM; canvas redraws pick up color/weight.
+      for (const el of measure.parts.dom) {
+        if (el.classList.contains('mlcad-measure-badge') && style.fontSize) {
+          el.style.fontSize = `${style.fontSize}px`
+        }
+      }
+    }
+    for (const fn of this._redrawListeners) fn()
   }
 
   /** @internal */
@@ -1941,7 +2590,9 @@ export class AcExMeasureController {
     canvas: HTMLCanvasElement,
     vertex: THREE.Vector2,
     arm1: THREE.Vector2,
-    arm2: THREE.Vector2
+    arm2: THREE.Vector2,
+    strokeCss?: string,
+    lineWidth = 2
   ): void {
     const synced = this._syncCanvas(canvas)
     if (!synced) return
@@ -1959,8 +2610,8 @@ export class AcExMeasureController {
 
     ctx.beginPath()
     ctx.arc(vx, vy, arc.r, arc.startAngle, arc.endAngle, arc.antiClockwise)
-    ctx.strokeStyle = this._measureCss()
-    ctx.lineWidth = 2
+    ctx.strokeStyle = strokeCss ?? this._measureCss()
+    ctx.lineWidth = lineWidth
     ctx.stroke()
     ctx.restore()
   }
@@ -1978,7 +2629,14 @@ export class AcExMeasureController {
       canvas = makeOverlayCanvas(this._overlayLayer)
       canvas.classList.add('mlcad-measure-canvas--preview')
     }
-    this._drawAngleArc(canvas, vertex, arm1, arm2)
+    this._drawAngleArc(
+      canvas,
+      vertex,
+      arm1,
+      arm2,
+      this._measureCss(),
+      acExMeasureCanvasLineWidth(this._drawLineWeight)
+    )
   }
 
   /** Draws the arc through `through` between `start` and `end` in screen space. @internal */
@@ -1987,7 +2645,9 @@ export class AcExMeasureController {
     g: AcExCircleGeom,
     start: THREE.Vector2,
     through: THREE.Vector2,
-    end: THREE.Vector2
+    end: THREE.Vector2,
+    strokeCss?: string,
+    lineWidth = 3
   ): void {
     const synced = this._syncCanvas(canvas)
     if (!synced) return
@@ -2013,8 +2673,47 @@ export class AcExMeasureController {
 
     ctx.beginPath()
     ctx.arc(cx, cy, screenR, sa, ea, counterClockwise)
-    ctx.strokeStyle = this._measureCss()
-    ctx.lineWidth = 3
+    ctx.strokeStyle = strokeCss ?? this._measureCss()
+    ctx.lineWidth = lineWidth
+    ctx.stroke()
+    ctx.restore()
+  }
+
+  /** Draws the shorter arc between `start` and `end` (sidecar / simple-viewer). @internal */
+  private _drawShortArc(
+    canvas: HTMLCanvasElement,
+    g: AcExCircleGeom,
+    start: THREE.Vector2,
+    end: THREE.Vector2,
+    strokeCss?: string,
+    lineWidth = 3
+  ): void {
+    const synced = this._syncCanvas(canvas)
+    if (!synced) return
+    const { ctx, dpr } = synced
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.save()
+    ctx.scale(dpr, dpr)
+
+    const rootRect = this._overlayRootOffset()
+    const sc = this._view.wcsToScreen(new THREE.Vector2(g.cx, g.cy))
+    const ss = this._view.wcsToScreen(start)
+    const se = this._view.wcsToScreen(end)
+    const cx = sc.x - rootRect.left
+    const cy = sc.y - rootRect.top
+    const sx = ss.x - rootRect.left
+    const sy = ss.y - rootRect.top
+    const ex = se.x - rootRect.left
+    const ey = se.y - rootRect.top
+    const screenR = Math.hypot(sx - cx, sy - cy)
+    const sa = Math.atan2(sy - cy, sx - cx)
+    const ea = Math.atan2(ey - cy, ex - cx)
+    const counterClockwise = shortArcCounterClockwise(start, end, g)
+
+    ctx.beginPath()
+    ctx.arc(cx, cy, screenR, sa, ea, counterClockwise)
+    ctx.strokeStyle = strokeCss ?? this._measureCss()
+    ctx.lineWidth = lineWidth
     ctx.stroke()
     ctx.restore()
   }
@@ -2033,13 +2732,23 @@ export class AcExMeasureController {
       canvas = makeOverlayCanvas(this._overlayLayer)
       canvas.classList.add('mlcad-measure-canvas--preview')
     }
-    this._drawArc(canvas, g, start, through, end)
+    this._drawArc(
+      canvas,
+      g,
+      start,
+      through,
+      end,
+      this._measureCss(),
+      acExMeasureCanvasLineWidth(this._drawLineWeight)
+    )
   }
 
   /** Fills and strokes a polygon on a synced overlay canvas. @internal */
   private _drawAreaFill(
     canvas: HTMLCanvasElement,
-    points: THREE.Vector2[]
+    points: THREE.Vector2[],
+    strokeCss?: string,
+    lineWidth = 2
   ): void {
     if (points.length < 3) return
     const synced = this._syncCanvas(canvas)
@@ -2055,16 +2764,21 @@ export class AcExMeasureController {
       return { x: s.x - rootRect.left, y: s.y - rootRect.top }
     })
 
+    const stroke = strokeCss ?? this._measureCss()
+    const fill = strokeCss
+      ? measureColorToFill(cssColorToHex(strokeCss, this._measureColor))
+      : this._measureFill()
+
     ctx.beginPath()
     ctx.moveTo(spts[0]!.x, spts[0]!.y)
     for (let i = 1; i < spts.length; i++) {
       ctx.lineTo(spts[i]!.x, spts[i]!.y)
     }
     ctx.closePath()
-    ctx.fillStyle = this._measureFill()
+    ctx.fillStyle = fill
     ctx.fill()
-    ctx.strokeStyle = this._measureCss()
-    ctx.lineWidth = 2
+    ctx.strokeStyle = stroke
+    ctx.lineWidth = lineWidth
     ctx.stroke()
     ctx.restore()
   }
@@ -2079,6 +2793,11 @@ export class AcExMeasureController {
       canvas = makeOverlayCanvas(this._overlayLayer)
       canvas.classList.add('mlcad-measure-canvas--preview')
     }
-    this._drawAreaFill(canvas, points)
+    this._drawAreaFill(
+      canvas,
+      points,
+      this._measureCss(),
+      acExMeasureCanvasLineWidth(this._drawLineWeight)
+    )
   }
 }

--- a/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
@@ -1,0 +1,177 @@
+/**
+ * Measurement sidecar JSON parse / stringify for the offline HTML viewer.
+ * Compatible with cad-simple-viewer `AcApMeasurementSidecar` v1.
+ *
+ * @module AcExMeasurementSidecar
+ * @packageDocumentation
+ */
+
+import type {
+  AcExMeasurementGeometry,
+  AcExMeasurementPoint2d,
+  AcExMeasurementRecord,
+  AcExMeasurementSidecarFile,
+  AcExMeasurementSidecarStyle,
+  AcExMeasurementType
+} from './AcExMeasurementTypes'
+
+/** Default CAD line weight (matches simple-viewer `LineWeight070`). */
+export const ACEX_MEASUREMENT_LINE_WEIGHT = 70
+
+/** Default badge font size in CSS pixels (matches simple-viewer). */
+export const ACEX_MEASUREMENT_FONT_SIZE = 13
+
+/** Map CAD line weight to canvas stroke width in CSS pixels. */
+export function acExMeasureCanvasLineWidth(weight?: number): number {
+  if (weight == null || !Number.isFinite(weight) || weight <= 0) return 2
+  return Math.max(1, weight / 28)
+}
+
+const MEASUREMENT_TYPES: readonly AcExMeasurementType[] = [
+  'distance',
+  'angle',
+  'area',
+  'arc',
+  'point'
+]
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isPoint(value: unknown): value is AcExMeasurementPoint2d {
+  return (
+    isPlainObject(value) &&
+    typeof value.x === 'number' &&
+    typeof value.y === 'number' &&
+    Number.isFinite(value.x) &&
+    Number.isFinite(value.y)
+  )
+}
+
+function isType(value: unknown): value is AcExMeasurementType {
+  return (
+    typeof value === 'string' &&
+    (MEASUREMENT_TYPES as readonly string[]).includes(value)
+  )
+}
+
+function parseStyle(raw: unknown): AcExMeasurementSidecarStyle | undefined {
+  if (!isPlainObject(raw) || typeof raw.color !== 'string') return undefined
+  const lineWeight =
+    typeof raw.lineWeight === 'number' && raw.lineWeight > 0
+      ? raw.lineWeight
+      : ACEX_MEASUREMENT_LINE_WEIGHT
+  const fontSize =
+    typeof raw.fontSize === 'number' && raw.fontSize > 0
+      ? raw.fontSize
+      : ACEX_MEASUREMENT_FONT_SIZE
+  return { color: raw.color, lineWeight, fontSize }
+}
+
+function parseGeometry(
+  type: AcExMeasurementType,
+  raw: unknown
+): AcExMeasurementGeometry | undefined {
+  if (!isPlainObject(raw) || raw.type !== type) return undefined
+  switch (type) {
+    case 'distance':
+      if (!isPoint(raw.start) || !isPoint(raw.end)) return undefined
+      return { type, start: raw.start, end: raw.end }
+    case 'angle':
+      if (!isPoint(raw.vertex) || !isPoint(raw.arm1) || !isPoint(raw.arm2)) {
+        return undefined
+      }
+      return { type, vertex: raw.vertex, arm1: raw.arm1, arm2: raw.arm2 }
+    case 'area':
+      if (!Array.isArray(raw.points) || raw.points.length < 3) return undefined
+      if (!raw.points.every(isPoint)) return undefined
+      return { type, points: raw.points }
+    case 'arc':
+      if (
+        !isPoint(raw.center) ||
+        typeof raw.radius !== 'number' ||
+        !(raw.radius > 0) ||
+        !isPoint(raw.start) ||
+        !isPoint(raw.end)
+      ) {
+        return undefined
+      }
+      return {
+        type,
+        center: raw.center,
+        radius: raw.radius,
+        start: raw.start,
+        end: raw.end
+      }
+    case 'point':
+      if (!isPoint(raw.position)) return undefined
+      return { type, position: raw.position }
+  }
+}
+
+function parseRecord(raw: unknown): AcExMeasurementRecord | undefined {
+  if (!isPlainObject(raw)) return undefined
+  if (typeof raw.id !== 'string' || !isType(raw.type)) return undefined
+  const style = parseStyle(raw.style)
+  const geometry = parseGeometry(raw.type, raw.geometry)
+  if (!style || !geometry) return undefined
+  return {
+    id: raw.id,
+    type: raw.type,
+    layoutId: typeof raw.layoutId === 'string' ? raw.layoutId : undefined,
+    style,
+    geometry
+  }
+}
+
+/**
+ * Parse sidecar JSON text into a typed file object.
+ * @throws Error when the payload is not valid measurement sidecar v1.
+ */
+export function parseAcExMeasurementSidecar(
+  text: string
+): AcExMeasurementSidecarFile {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new Error('Invalid measurement sidecar: not JSON')
+  }
+  if (!isPlainObject(parsed) || parsed.version !== 1) {
+    throw new Error('Invalid measurement sidecar: expected version 1')
+  }
+  if (!Array.isArray(parsed.measurements)) {
+    throw new Error(
+      'Invalid measurement sidecar: measurements must be an array'
+    )
+  }
+  const measurements: AcExMeasurementRecord[] = []
+  for (const item of parsed.measurements) {
+    const record = parseRecord(item)
+    if (record) measurements.push(record)
+  }
+  return {
+    version: 1,
+    drawingName:
+      typeof parsed.drawingName === 'string' ? parsed.drawingName : undefined,
+    measurements
+  }
+}
+
+/** Serialize a sidecar file to pretty-printed JSON. */
+export function stringifyAcExMeasurementSidecar(
+  file: AcExMeasurementSidecarFile
+): string {
+  return `${JSON.stringify(file, null, 2)}\n`
+}
+
+/**
+ * Suggested sidecar file name for a drawing.
+ * @example acExMeasurementSidecarFileName('plan.dwg') → 'plan.measurement.json'
+ */
+export function acExMeasurementSidecarFileName(drawingName?: string): string {
+  if (!drawingName) return 'drawing.measurement.json'
+  const base = drawingName.replace(/\.(dwg|dxf|html)$/i, '')
+  return `${base}.measurement.json`
+}

--- a/packages/cad-html-plugin/src/AcExMeasurementTypes.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurementTypes.ts
@@ -1,0 +1,84 @@
+/**
+ * Measurement sidecar types for the offline HTML viewer.
+ *
+ * Schema matches `@mlightcad/cad-simple-viewer` measurement sidecar JSON so
+ * measurements can be exchanged between the full CAD app and exported HTML.
+ *
+ * @module AcExMeasurementTypes
+ * @packageDocumentation
+ */
+
+/** Measurement kinds that can be persisted in a sidecar JSON file. */
+export type AcExMeasurementType =
+  | 'distance'
+  | 'angle'
+  | 'area'
+  | 'arc'
+  | 'point'
+
+/** 2D world point stored in a measurement sidecar. */
+export interface AcExMeasurementPoint2d {
+  x: number
+  y: number
+}
+
+/** Drawing style stored in the sidecar (CSS-friendly). */
+export interface AcExMeasurementSidecarStyle {
+  color: string
+  lineWeight: number
+  fontSize: number
+}
+
+export interface AcExMeasurementDistanceGeometry {
+  type: 'distance'
+  start: AcExMeasurementPoint2d
+  end: AcExMeasurementPoint2d
+}
+
+export interface AcExMeasurementAngleGeometry {
+  type: 'angle'
+  vertex: AcExMeasurementPoint2d
+  arm1: AcExMeasurementPoint2d
+  arm2: AcExMeasurementPoint2d
+}
+
+export interface AcExMeasurementAreaGeometry {
+  type: 'area'
+  points: AcExMeasurementPoint2d[]
+}
+
+export interface AcExMeasurementArcGeometry {
+  type: 'arc'
+  center: AcExMeasurementPoint2d
+  radius: number
+  start: AcExMeasurementPoint2d
+  end: AcExMeasurementPoint2d
+}
+
+export interface AcExMeasurementPointGeometry {
+  type: 'point'
+  position: AcExMeasurementPoint2d
+}
+
+export type AcExMeasurementGeometry =
+  | AcExMeasurementDistanceGeometry
+  | AcExMeasurementAngleGeometry
+  | AcExMeasurementAreaGeometry
+  | AcExMeasurementArcGeometry
+  | AcExMeasurementPointGeometry
+
+/** One committed measurement in a sidecar file. */
+export interface AcExMeasurementRecord {
+  id: string
+  type: AcExMeasurementType
+  layoutId?: string
+  style: AcExMeasurementSidecarStyle
+  geometry: AcExMeasurementGeometry
+}
+
+/** Sidecar JSON document for measurement overlays. */
+export interface AcExMeasurementSidecarFile {
+  version: 1
+  drawingName?: string
+  measurements: AcExMeasurementRecord[]
+}

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -241,8 +241,8 @@ export type AcExInitialViewMode = 'fit' | 'current'
 /**
  * Offline viewer capability profile embedded at export time.
  *
- * - `view` — pan/zoom and layer visibility only (no measurement or OSNAP data).
- * - `measure` — full viewer with measurement tools and analytic OSNAP catalog.
+ * - `view` — pan/zoom and layer visibility only (no measurement, markup, or OSNAP data).
+ * - `measure` — full viewer with measurement tools, markup annotations, and analytic OSNAP catalog.
  */
 export type AcExViewerMode = 'view' | 'measure'
 


### PR DESCRIPTION
## Summary
- Add Design Review markup tools (cloud, callout, text, rect, circle, arrow, stamp) to the offline HTML viewer, with sidecar JSON import/export compatible with cad-simple-viewer.
- Persist measurements as `*.measurement.json` and share a canvas-top draw-style overlay (color / line weight / font size) between measure and markup tools.
- Keep markup session color independent of the measurement accent so new markups stay ACI red by default.

## Test plan
- [ ] Export HTML in measure mode and confirm Review / Measurement / Settings parent strips appear; view mode still omits them.
- [ ] Draw cloud/rect/circle, place an optional leader, edit text in place, then export/import `*.markup.json` in both the HTML viewer and cad-simple-viewer.
- [ ] Import/export `*.measurement.json` and confirm distance/angle/area/arc/point round-trip.
- [ ] Confirm new markups default to red, not the measurement cyan; changing measure color in the draw-style toolbar does not recolor the markup tool.
- [ ] Select, drag grips, Delete/Backspace, hide/show, and clear markups/measurements.
