### PR TITLE
fix: preserve absolute hatch colours when only lineweight is ByLayer

### DIFF
--- a/packages/three-renderer/__tests__/AcTrBatchedGroupLayerStyle.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupLayerStyle.spec.ts
@@ -68,6 +68,66 @@ describe('AcTrBatchedGroup layer style rebind', () => {
     expect(getLayerBoundMaterial).toHaveBeenCalled()
   })
 
+  it('does not clobber absolute hatch colour when only lineweight is ByLayer', () => {
+    // Regression: legend true-color solid hatches on an ACI-7 layer were
+    // painted white during layer sync because followsLayerStyle is true for
+    // ByLayer lineweight alone, and refreshLayerBoundMaterialColor used to
+    // rewrite colour unconditionally.
+    const group = new AcTrBatchedGroup()
+    const absoluteRgb = 0xc8cdd2
+    const sourceMaterial = new THREE.MeshBasicMaterial({ color: absoluteRgb })
+    setMaterialMetadata(sourceMaterial, {
+      layer: '采掘计划',
+      materialKey: 'solid_采掘计划_RGB:200,205,210_draw_-1',
+      isByLayerColor: false,
+      isByLayerLineWeight: true,
+      isForeground: false,
+      drawOrder: -1
+    })
+
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), sourceMaterial)
+    mesh.userData.layerName = '采掘计划'
+    getSceneDrawableUserData(mesh).noBatch = true
+    group.addEntity(createEntity('legend-hatch', mesh))
+
+    let targetMesh: THREE.Mesh | undefined
+    group.traverse(child => {
+      if (
+        targetMesh ||
+        !(child instanceof THREE.Mesh) ||
+        child === mesh
+      ) {
+        return
+      }
+      if (child.geometry instanceof THREE.PlaneGeometry) {
+        targetMesh = child
+      }
+    })
+    expect(targetMesh).toBeDefined()
+
+    const layerColor = {
+      isForeground: true,
+      RGB: 0xffffff
+    }
+
+    // Return the same material instance so rebind takes the in-place colour
+    // refresh path (the path that previously wiped absolute RGB).
+    group.rebindMaterialsForLayer(
+      '采掘计划',
+      { color: layerColor as never },
+      material => material,
+      {
+        currentBackgroundColor: 0x000000,
+        getLineMaterial: jest.fn(),
+        getMTextFillMaterial: jest.fn()
+      } as never
+    )
+
+    const material = targetMesh!.material as THREE.MeshBasicMaterial
+    expect(material.color.getHex()).toBe(absoluteRgb)
+    expect(material.userData.isForeground).toBe(false)
+  })
+
   it('syncAppearanceFromRecord refreshes unbatched drawables in one traversal', () => {
     const group = new AcTrBatchedGroup()
     const sourceMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff })

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -840,6 +840,15 @@ export class AcTrBatchedGroup extends THREE.Group {
     layerTraits: Partial<AcGiSubEntityTraits>,
     styleManager?: AcTrStyleManager
   ) {
+    // Only rewrite colour when the material is actually colour-bound to the
+    // layer. `followsLayerStyle` is also true for ByLayer lineweight / linetype
+    // alone; applying the layer colour in those cases clobbers absolute entity
+    // colours (e.g. true-color solid hatches on an ACI-7 layer become white).
+    const metadata = getMaterialMetadata(material)
+    if (metadata.isByLayerColor !== true) {
+      return
+    }
+
     // An ACI-7 (foreground) layer colour is theme-dependent: applying its raw
     // RGB bakes white onto a light canvas (#464). Resolve it against the
     // current background, and keep the clone's isForeground metadata in sync


### PR DESCRIPTION
## Summary
- `refreshLayerBoundMaterialColor` used to rewrite material colour whenever `followsLayerStyle` was true, including ByLayer lineweight/linetype alone.
- Guard the colour refresh so it only runs when `isByLayerColor` is true, preserving absolute RGB on true-color solid hatches (e.g. legend fills on ACI-7 layers).
- Add a regression test that exercises the in-place rebind path for that case.

## Test plan
- [x] `pnpm test -- AcTrBatchedGroupLayerStyle.spec.ts`
- [ ] Open a drawing with true-color solid hatches on an ACI-7 (foreground) layer and sync/layer-refresh; hatch colours stay absolute (not painted white).
- [ ] Confirm ByLayer-colour entities still update when the layer colour changes.