### PR TITLE
feat: switch ribbon tabs for overlay selection and keep measure flyouts open

### DIFF
--- a/README.cs.md
+++ b/README.cs.md
@@ -2,6 +2,9 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [Čeština](./README.cs.md)
 
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-simple-viewer.svg?label=cad-simple-viewer)](https://www.npmjs.com/package/@mlightcad/cad-simple-viewer)
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-viewer.svg?label=cad-viewer)](https://www.npmjs.com/package/@mlightcad/cad-viewer)
+
 cad-viewer je `první webový prohlížeč a editor DXF/DWG na světě, který běží zcela v prohlížeči a nevyžaduje žádné backendové služby`.
 Tím, že parsování DWG/DXF, zpracování geometrie a vykreslování probíhá přímo v prohlížeči, cad-viewer umožňuje skutečné bezserverové prohlížení a úpravy CAD — ideální pro cloudové aplikace, offline použití a pracovní postupy citlivé na soukromí.
 

--- a/README.es.md
+++ b/README.es.md
@@ -2,6 +2,9 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [Čeština](./README.cs.md)
 
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-simple-viewer.svg?label=cad-simple-viewer)](https://www.npmjs.com/package/@mlightcad/cad-simple-viewer)
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-viewer.svg?label=cad-viewer)](https://www.npmjs.com/package/@mlightcad/cad-viewer)
+
 cad-viewer es `el primer visor y editor web de DXF/DWG del mundo que funciona completamente en el navegador, sin depender de ningún servicio backend`.
 Al realizar el análisis de DWG/DXF, el procesamiento geométrico y el renderizado directamente en el navegador, cad-viewer permite una visualización y edición CAD verdaderamente sin servidor, ideal para aplicaciones en la nube, uso sin conexión y flujos de trabajo sensibles a la privacidad.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,9 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [Čeština](./README.cs.md)
 
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-simple-viewer.svg?label=cad-simple-viewer)](https://www.npmjs.com/package/@mlightcad/cad-simple-viewer)
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-viewer.svg?label=cad-viewer)](https://www.npmjs.com/package/@mlightcad/cad-viewer)
+
 cad-viewer は、`バックエンドサービスに一切依存せず、完全にブラウザ上で動作する世界初の Web ベース DXF/DWG ビューア兼エディタ` です。
 DWG/DXF の解析、ジオメトリ処理、レンダリングをすべてブラウザ内で行うことで、cad-viewer は真のサーバーレス CAD 閲覧・編集を実現します。クラウドアプリ、オフライン利用、プライバシーに配慮したワークフローに最適です。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,6 +2,9 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [Čeština](./README.cs.md)
 
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-simple-viewer.svg?label=cad-simple-viewer)](https://www.npmjs.com/package/@mlightcad/cad-simple-viewer)
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-viewer.svg?label=cad-viewer)](https://www.npmjs.com/package/@mlightcad/cad-viewer)
+
 cad-viewer는 `백엔드 서비스에 전혀 의존하지 않고 완전히 브라우저에서 동작하는 세계 최초의 웹 기반 DXF/DWG 뷰어 및 에디터`입니다.
 DWG/DXF 파싱, 지오메트리 처리, 렌더링을 브라우저에서 직접 수행함으로써 cad-viewer는 진정한 서버리스 CAD 보기 및 편집을 가능하게 하며, 클라우드 앱, 오프라인 사용, 개인정보에 민감한 워크플로에 이상적입니다.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [Čeština](./README.cs.md)
 
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-simple-viewer.svg?label=cad-simple-viewer)](https://www.npmjs.com/package/@mlightcad/cad-simple-viewer)
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-viewer.svg?label=cad-viewer)](https://www.npmjs.com/package/@mlightcad/cad-viewer)
+
 cad-viewer is `the first web-based DXF/DWG viewer and editor in the world that operates entirely in browser, without relying on any backend services`.
 By performing DWG/DXF parsing, geometry processing, and rendering directly in the browser, cad-viewer enables true serverless CAD viewing and editing, ideal for cloud apps, offline usage, and privacy-sensitive workflows.
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -2,6 +2,9 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [Čeština](./README.cs.md)
 
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-simple-viewer.svg?label=cad-simple-viewer)](https://www.npmjs.com/package/@mlightcad/cad-simple-viewer)
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-viewer.svg?label=cad-viewer)](https://www.npmjs.com/package/@mlightcad/cad-viewer)
+
 O cad-viewer é `o primeiro visualizador e editor web de DXF/DWG do mundo que funciona inteiramente no navegador, sem depender de nenhum serviço de backend`.
 Ao realizar a análise de DWG/DXF, o processamento geométrico e a renderização diretamente no navegador, o cad-viewer possibilita visualização e edição CAD verdadeiramente serverless, ideal para aplicativos em nuvem, uso offline e fluxos de trabalho sensíveis à privacidade.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -2,6 +2,9 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [Čeština](./README.cs.md)
 
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-simple-viewer.svg?label=cad-simple-viewer)](https://www.npmjs.com/package/@mlightcad/cad-simple-viewer)
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-viewer.svg?label=cad-viewer)](https://www.npmjs.com/package/@mlightcad/cad-viewer)
+
 cad-viewer — `первый в мире веб-просмотрщик и редактор DXF/DWG, который полностью работает в браузере без каких-либо серверных сервисов`.
 Благодаря разбору DWG/DXF, обработке геометрии и рендерингу непосредственно в браузере cad-viewer обеспечивает по-настоящему serverless просмотр и редактирование CAD — идеально для облачных приложений, офлайн-работы и сценариев с повышенными требованиями к конфиденциальности.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,9 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Español](./README.es.md) | [Português](./README.pt.md) | [Русский](./README.ru.md) | [Čeština](./README.cs.md)
 
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-simple-viewer.svg?label=cad-simple-viewer)](https://www.npmjs.com/package/@mlightcad/cad-simple-viewer)
+[![npm downloads](https://img.shields.io/npm/dy/@mlightcad/cad-viewer.svg?label=cad-viewer)](https://www.npmjs.com/package/@mlightcad/cad-viewer)
+
 CAD-Viewer 是`全球首个完全运行在浏览器端、无需依赖任何后端服务的 Web 版 DXF/DWG 查看与编辑器`。
 通过在浏览器中直接完成 DWG/DXF 解析、几何处理和渲染，CAD-Viewer 实现了真正的无服务器（serverless）CAD 查看与编辑，非常适合云应用、离线使用以及对隐私敏感的工作场景。
 

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -101,6 +101,11 @@ export function getMeasurementStyle(
   return style ? acapCloneMeasurementStyle(style) : undefined
 }
 
+/** Id of the currently selected measurement group, if any. */
+export function getSelectedMeasurementId(): string | undefined {
+  return selectedMeasurementId
+}
+
 /** Style of the currently selected measurement, if any. */
 export function getActiveMeasurementStyle(): AcApMeasurementStyle | undefined {
   return selectedMeasurementId

--- a/packages/cad-viewer/__tests__/overlaySelectionKind.spec.ts
+++ b/packages/cad-viewer/__tests__/overlaySelectionKind.spec.ts
@@ -1,0 +1,54 @@
+import { classifyOverlaySelection } from '../src/component/ribbon/overlaySelectionKind'
+
+describe('classifyOverlaySelection', () => {
+  it('returns markup when only markups are selected', () => {
+    expect(
+      classifyOverlaySelection({
+        selectedGroups: [{ layer: 'markup' }, { layer: 'markup' }]
+      })
+    ).toBe('markup')
+  })
+
+  it('returns measurement when only measurements are selected', () => {
+    expect(
+      classifyOverlaySelection({
+        selectedGroups: [{ layer: 'measurement' }],
+        measurementSelected: true
+      })
+    ).toBe('measurement')
+  })
+
+  it('returns mixed when markups and measurements are selected together', () => {
+    expect(
+      classifyOverlaySelection({
+        selectedGroups: [{ layer: 'markup' }, { layer: 'measurement' }],
+        markupSelectedId: 'm1',
+        measurementSelected: true
+      })
+    ).toBe('mixed')
+  })
+
+  it('returns mixed when drawing entities and markups are selected together', () => {
+    expect(
+      classifyOverlaySelection({
+        selectedGroups: [{ layer: 'markup' }],
+        cadEntityCount: 2,
+        markupSelectedId: 'm1'
+      })
+    ).toBe('mixed')
+  })
+
+  it('returns mixed when drawing entities and measurements are selected together', () => {
+    expect(
+      classifyOverlaySelection({
+        selectedGroups: [{ layer: 'measurement' }],
+        cadEntityCount: 1,
+        measurementSelected: true
+      })
+    ).toBe('mixed')
+  })
+
+  it('returns none when the selection is empty', () => {
+    expect(classifyOverlaySelection({})).toBe('none')
+  })
+})

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -52,7 +52,7 @@
     "@mlightcad/ribbon": "^0.1.12",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",
-    "@mlightcad/ui-components": "^0.1.9",
+    "@mlightcad/ui-components": "^0.1.10",
     "@element-plus/icons-vue": "^2.3.1",
     "@vueuse/core": "^11.1.0",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/cad-viewer/src/component/layout/MlToolBars.vue
+++ b/packages/cad-viewer/src/component/layout/MlToolBars.vue
@@ -143,6 +143,7 @@ const verticalToolbarData = computed(() => {
       text: t('main.verticalToolbar.measure.text'),
       command: '',
       description: t('main.verticalToolbar.measure.description'),
+      childrenType: 'sticky',
       children: [
         {
           icon: measureDistance,
@@ -216,6 +217,7 @@ const verticalToolbarData = computed(() => {
       text: t('main.verticalToolbar.annotation.text'),
       command: '',
       description: t('main.verticalToolbar.annotation.description'),
+      childrenType: 'sticky',
       children: [
         {
           icon: revCloud,

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -17,8 +17,8 @@ import {
 import {
   AcApConvertToDxfCmd,
   acapCssColor,
-  acapDrawStyleKindForCommand,
   AcApDocManager,
+  acapDrawStyleKindForCommand,
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
   acapGetMeasurementLineWeight,

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -17,6 +17,7 @@ import {
 import {
   AcApConvertToDxfCmd,
   acapCssColor,
+  acapDrawStyleKindForCommand,
   AcApDocManager,
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
@@ -27,6 +28,7 @@ import {
   acapSetMeasurementDrawColor,
   acapSetMeasurementDrawFontSize,
   acapSetMeasurementDrawLineWeight,
+  type AcEdCommandEventArgs,
   AcEdOpenMode,
   type AcTrView2d,
   applyMarkupStyleToSelection,
@@ -38,6 +40,7 @@ import {
   getMarkupFontSize,
   getMarkupLineWeight,
   getMarkupStore,
+  getSelectedMeasurementId,
   isMarkupVisible,
   isMeasurementVisible,
   markupColorToCss,
@@ -158,6 +161,7 @@ import MlRibbonMeasurementUnitsPanel from './MlRibbonMeasurementUnitsPanel.vue'
 import MlRibbonPropertyColorDropdown from './MlRibbonPropertyColorDropdown.vue'
 import MlRibbonPropertyLineTypeSelect from './MlRibbonPropertyLineTypeSelect.vue'
 import MlRibbonPropertyLineWeightSelect from './MlRibbonPropertyLineWeightSelect.vue'
+import { classifyOverlaySelection } from './overlaySelectionKind'
 import { useHatchContextualRibbon } from './useHatchContextualRibbon'
 import { useMTextContextualRibbon } from './useMTextContextualRibbon'
 
@@ -518,6 +522,8 @@ const handleDocumentActivated = () => {
   bindAnnotationVisibilityEvents(AcApDocManager.instance?.curDocument?.database)
   ribbonLayerIsolationSnapshot.value = null
   ribbonLayerPreviousSnapshot.value = null
+  lastActivatedMarkupId = undefined
+  lastActivatedMeasurementId = undefined
   syncMarkupVisibility()
   syncMeasurementVisibility()
   syncMarkupStyleControls()
@@ -546,6 +552,90 @@ const applyToSelectedEntities = (mutator: (entity: AcDbEntity) => void) => {
 
 let unsubscribeMarkupStore: (() => void) | undefined
 let unsubscribeMeasurementSelection: (() => void) | undefined
+let lastActivatedMarkupId: string | undefined
+let lastActivatedMeasurementId: string | undefined
+let overlayTabActivationScheduled = false
+let overlayTabActivationDisposed = false
+
+/**
+ * Reads the live CAD + overlay selection for {@link classifyOverlaySelection}.
+ */
+const overlaySelectionSnapshot = () => {
+  const view = AcApDocManager.instance?.curView
+  return {
+    selectedGroups: view?.htmlTransientManager?.getSelectedGroups(),
+    cadEntityCount: view?.selectionSet?.count ?? 0,
+    markupSelectedId: getMarkupStore().selectedId,
+    measurementSelected: getSelectedMeasurementId() != null
+  }
+}
+
+/**
+ * When the ribbon is showing, selecting only markups switches to the Review
+ * tab and selecting only measurements switches to the Measurement tab.
+ * Mixed selections (markup + measurement, drawing entities + overlay, …)
+ * and deselect do not change the tab; only a newly selected exclusive
+ * overlay does.
+ */
+const activateRibbonTabForOverlaySelection = () => {
+  const kind = classifyOverlaySelection(overlaySelectionSnapshot())
+
+  if (kind === 'mixed') return
+
+  if (kind === 'markup') {
+    const markupId = getMarkupStore().selectedId
+    const markupNewlySelected = markupId !== lastActivatedMarkupId
+    lastActivatedMarkupId = markupId
+    lastActivatedMeasurementId = undefined
+    if (markupNewlySelected && docOpenMode.value >= AcEdOpenMode.Review) {
+      activeRibbonTabId.value = 'review'
+    }
+    return
+  }
+
+  lastActivatedMarkupId = undefined
+
+  if (kind === 'measurement') {
+    const measurementId = getSelectedMeasurementId()
+    const measurementNewlySelected = measurementId !== lastActivatedMeasurementId
+    lastActivatedMeasurementId = measurementId
+    if (measurementNewlySelected) {
+      activeRibbonTabId.value = 'measurement'
+    }
+    return
+  }
+
+  lastActivatedMeasurementId = undefined
+}
+
+/**
+ * Coalesce overlay selection notifications from one box-select into a single
+ * tab decision after every group in that gesture has been selected.
+ */
+const scheduleActivateRibbonTabForOverlaySelection = () => {
+  if (overlayTabActivationScheduled) return
+  overlayTabActivationScheduled = true
+  queueMicrotask(() => {
+    overlayTabActivationScheduled = false
+    if (overlayTabActivationDisposed) return
+    activateRibbonTabForOverlaySelection()
+  })
+}
+
+/**
+ * Switches to Measurement or Review while a drawing command is active so
+ * color / lineweight / font-size can be changed before the overlay is committed.
+ */
+const activateRibbonTabForDrawCommand = (args: AcEdCommandEventArgs) => {
+  const kind = acapDrawStyleKindForCommand(args.command?.globalName)
+  if (kind === 'measure') {
+    activeRibbonTabId.value = 'measurement'
+    return
+  }
+  if (kind === 'markup' && docOpenMode.value >= AcEdOpenMode.Review) {
+    activeRibbonTabId.value = 'review'
+  }
+}
 
 onMounted(() => {
   AcDbSysVarManager.instance().events.sysVarChanged.addEventListener(
@@ -556,6 +646,9 @@ onMounted(() => {
   )
   AcApDocManager.instance.editor.events.commandWillStart.addEventListener(
     handleMTextCommandWillStart
+  )
+  AcApDocManager.instance.editor.events.commandWillStart.addEventListener(
+    activateRibbonTabForDrawCommand
   )
   AcApDocManager.instance.editor.events.commandEnded.addEventListener(
     handleHatchCommandEnded
@@ -582,6 +675,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  overlayTabActivationDisposed = true
   unsubscribeMarkupStore?.()
   unsubscribeMarkupStore = undefined
   unsubscribeMeasurementSelection?.()
@@ -594,6 +688,9 @@ onUnmounted(() => {
   )
   AcApDocManager.instance.editor.events.commandWillStart.removeEventListener(
     handleMTextCommandWillStart
+  )
+  AcApDocManager.instance.editor.events.commandWillStart.removeEventListener(
+    activateRibbonTabForDrawCommand
   )
   AcApDocManager.instance.editor.events.commandEnded.removeEventListener(
     handleHatchCommandEnded
@@ -669,12 +766,13 @@ const syncMarkupStyleControls = () => {
       selected.style.fontSize != null && selected.style.fontSize > 0
         ? selected.style.fontSize
         : getMarkupFontSize()
-    return
+  } else {
+    markupDrawColor.value = defaultMarkupColor()
+    markupDrawColorDisplay.value = markupColorToCss(markupDrawColor.value)
+    markupDrawLineWeight.value = getMarkupLineWeight()
+    markupDrawFontSize.value = getMarkupFontSize()
   }
-  markupDrawColor.value = defaultMarkupColor()
-  markupDrawColorDisplay.value = markupColorToCss(markupDrawColor.value)
-  markupDrawLineWeight.value = getMarkupLineWeight()
-  markupDrawFontSize.value = getMarkupFontSize()
+  scheduleActivateRibbonTabForOverlaySelection()
 }
 
 /**
@@ -726,16 +824,17 @@ const syncMeasurementStyleControls = () => {
     measurementDrawColorDisplay.value = acapCssColor(selected.color)
     measurementDrawLineWeight.value = selected.lineWeight
     measurementDrawFontSize.value = selected.fontSize
-    return
+  } else {
+    const db = getCurrentDatabase()
+    if (db) {
+      const color = acapGetMeasurementColor(db)
+      measurementDrawColor.value = color.clone()
+      measurementDrawColorDisplay.value = acapCssColor(color)
+    }
+    measurementDrawLineWeight.value = acapGetMeasurementLineWeight()
+    measurementDrawFontSize.value = acapGetMeasurementFontSize()
   }
-  const db = getCurrentDatabase()
-  if (db) {
-    const color = acapGetMeasurementColor(db)
-    measurementDrawColor.value = color.clone()
-    measurementDrawColorDisplay.value = acapCssColor(color)
-  }
-  measurementDrawLineWeight.value = acapGetMeasurementLineWeight()
-  measurementDrawFontSize.value = acapGetMeasurementFontSize()
+  scheduleActivateRibbonTabForOverlaySelection()
 }
 
 const handleMeasurementDrawColorChange = (value?: AcCmColor) => {

--- a/packages/cad-viewer/src/component/ribbon/overlaySelectionKind.ts
+++ b/packages/cad-viewer/src/component/ribbon/overlaySelectionKind.ts
@@ -1,0 +1,63 @@
+/** Markup HTML overlay layer name (`MARKUP_LAYER` in cad-simple-viewer). */
+const MARKUP_LAYER = 'markup'
+
+/** Measurement HTML overlay layer name (`MEASUREMENT_LAYER` in cad-simple-viewer). */
+const MEASUREMENT_LAYER = 'measurement'
+
+/**
+ * Homogeneous overlay selection used to decide whether the ribbon should
+ * switch to Review or Measurement.
+ *
+ * `'mixed'` covers markup + measurement, CAD entities + overlay, and any
+ * other combination of distinct kinds.
+ */
+export type OverlaySelectionKind = 'markup' | 'measurement' | 'mixed' | 'none'
+
+/** Minimal selection snapshot so classification does not touch the live view. */
+export interface OverlaySelectionSnapshot {
+  /** HTML overlay groups currently selected (markup, measurement, or other). */
+  selectedGroups?: { layer?: string }[]
+  /** Count of selected drawing entities in the CAD selection set. */
+  cadEntityCount?: number
+  /** Markup store selection id, used when group list is empty. */
+  markupSelectedId?: string
+  /** Whether a measurement is selected in the measurement store. */
+  measurementSelected?: boolean
+}
+
+/**
+ * Classifies the current CAD + overlay selection into one exclusive kind.
+ *
+ * @param snapshot - Selected overlay groups, CAD entity count, and store flags.
+ * @returns Exclusive overlay kind, `'mixed'` when more than one kind is present,
+ *   or `'none'` when nothing relevant is selected.
+ */
+export function classifyOverlaySelection(
+  snapshot: OverlaySelectionSnapshot
+): OverlaySelectionKind {
+  let hasMarkup = false
+  let hasMeasurement = false
+  let hasOtherOverlay = false
+
+  for (const group of snapshot.selectedGroups ?? []) {
+    if (group.layer === MARKUP_LAYER) hasMarkup = true
+    else if (group.layer === MEASUREMENT_LAYER) hasMeasurement = true
+    else hasOtherOverlay = true
+  }
+
+  if (!hasMarkup && snapshot.markupSelectedId) hasMarkup = true
+  if (!hasMeasurement && snapshot.measurementSelected) hasMeasurement = true
+
+  const hasCadEntities = (snapshot.cadEntityCount ?? 0) > 0
+  const kindCount = [
+    hasMarkup,
+    hasMeasurement,
+    hasOtherOverlay,
+    hasCadEntities
+  ].filter(Boolean).length
+
+  if (kindCount > 1) return 'mixed'
+  if (hasMarkup) return 'markup'
+  if (hasMeasurement) return 'measurement'
+  return 'none'
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   '@mlightcad/mtext-input-box': ^0.2.23
   '@mlightcad/mtext-renderer': ^0.12.4
   '@mlightcad/ribbon': ^0.1.12
-  '@mlightcad/ui-components': ^0.1.9
+  '@mlightcad/ui-components': ^0.1.10
   element-plus: ^2.12.0
   glob: ^13.0.6
   lodash-es: 4.17.21
@@ -380,8 +380,8 @@ importers:
         specifier: 0.0.9
         version: 0.0.9(three@0.172.0)
       '@mlightcad/ui-components':
-        specifier: ^0.1.9
-        version: 0.1.9(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+        specifier: ^0.1.10
+        version: 0.1.10(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(vite@6.4.3(@types/node@24.12.4)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
@@ -1836,8 +1836,8 @@ packages:
     peerDependencies:
       three: ^0.172.0
 
-  '@mlightcad/ui-components@0.1.9':
-    resolution: {integrity: sha512-PKR11jNM/LXGWTuXFzwNsod9rEJvNNj9i9c5TtyCo2fu+AkLDJmIG9tBA3tgQlgEYBsKYeI6TArsrk2ChOS8UA==}
+  '@mlightcad/ui-components@0.1.10':
+    resolution: {integrity: sha512-AhrLhi1ulm2fyf3cdxQq61vnO9gIGAbl6vV43w+FhksDDk9QYfnQ7MLV7/FZ0JJmTha4wcYXx3vW73383daO1w==}
     peerDependencies:
       element-plus: ^2.12.0
       vue: ^3.4.21
@@ -7265,7 +7265,7 @@ snapshots:
     dependencies:
       three: 0.172.0
 
-  '@mlightcad/ui-components@0.1.9(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
+  '@mlightcad/ui-components@0.1.10(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ overrides:
   '@mlightcad/mtext-input-box': '^0.2.23'
   '@mlightcad/mtext-renderer': '^0.12.4'
   '@mlightcad/ribbon': '^0.1.12'
-  '@mlightcad/ui-components': '^0.1.9'
+  '@mlightcad/ui-components': '^0.1.10'
   element-plus: '^2.12.0'
   glob: '^13.0.6'
   lodash-es: '4.17.21'


### PR DESCRIPTION
## Summary
- Switch the ribbon to Review or Measurement when only markups or measurements are newly selected, and when those draw commands start, so color / lineweight / font-size controls are available immediately.
- Keep measure and annotation sidebar flyouts open after a tool is chosen (`childrenType: 'sticky'`), using `@mlightcad/ui-components` 0.1.10.
- Mixed selections and deselect do not change the tab; measurement tab activation tracks the selected overlay id, matching markup.

## Test plan
- [ ] Select a markup only: ribbon switches to Review; select a different markup after returning to Home: switches again.
- [ ] Select a measurement only: ribbon switches to Measurement; select a different measurement after returning to Home: switches again.
- [ ] Box-select mixed markup + measurement, or overlay + drawing entities: tab does not change.
- [ ] Start a measure or markup draw command: ribbon switches so style controls can be edited before commit.
- [ ] Measure and annotation sidebar flyouts stay open after picking a child tool.
- [ ] Confirm the app builds against published `@mlightcad/ui-components@0.1.10` (no local path override).