### PR TITLE
fix: restore named ACI colors in overlay style dropdowns after CSS round-trip

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApMarkupUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupUtil.spec.ts
@@ -1,0 +1,41 @@
+import { AcCmColor, AcCmColorMethod } from '@mlightcad/data-model'
+
+import {
+  createDefaultMarkupColor,
+  cssToMarkupColor,
+  markupColorToCss
+} from '../src/command/markup/AcApMarkupUtil'
+
+describe('cssToMarkupColor', () => {
+  it('restores ACI red after a CSS round-trip', () => {
+    const css = markupColorToCss(createDefaultMarkupColor())
+    const restored = cssToMarkupColor(css)
+    expect(restored.isByACI).toBe(true)
+    expect(restored.colorIndex).toBe(1)
+  })
+
+  it('maps CSS rgb/hex values that match the ACI palette back to ByACI', () => {
+    const rgb = cssToMarkupColor('rgb(255,0,0)')
+    expect(rgb.isByACI).toBe(true)
+    expect(rgb.colorIndex).toBe(1)
+
+    const hex = cssToMarkupColor('#00FF00')
+    expect(hex.isByACI).toBe(true)
+    expect(hex.colorIndex).toBe(3)
+  })
+
+  it('keeps true-color RGB that is not in the ACI palette', () => {
+    const custom = cssToMarkupColor('rgb(12,34,56)')
+    expect(custom.isByColor).toBe(true)
+    expect(custom.red).toBe(12)
+    expect(custom.green).toBe(34)
+    expect(custom.blue).toBe(56)
+  })
+
+  it('preserves an already-ByACI color method', () => {
+    const yellow = new AcCmColor(AcCmColorMethod.ByACI, 2)
+    const restored = cssToMarkupColor(markupColorToCss(yellow))
+    expect(restored.isByACI).toBe(true)
+    expect(restored.colorIndex).toBe(2)
+  })
+})

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
@@ -1,6 +1,7 @@
 import {
   AcCmColor,
   AcCmColorMethod,
+  AcCmColorUtil,
   AcDbDatabase,
   AcDbSystemVariables,
   AcDbSysVarManager,
@@ -90,12 +91,28 @@ export function markupColorToCss(color: AcCmColor): string {
   return color.cssColor ?? `rgb(${color.red}, ${color.green}, ${color.blue})`
 }
 
+/**
+ * If an RGB color matches the AutoCAD palette exactly, restore ByACI so
+ * ribbon color dropdowns can show named colors (Red, Yellow, …) instead of
+ * Custom after a CSS round-trip.
+ */
+function preferExactAciColor(color: AcCmColor): AcCmColor {
+  if (!color.isByColor) return color
+  const rgb = color.RGB
+  if (rgb == null) return color
+  const index = AcCmColorUtil.getIndexByColor(rgb)
+  if (index == null) return color
+  const aci = new AcCmColor()
+  aci.colorIndex = index
+  return aci
+}
+
 /** Parse a CSS color string back into AcCmColor (best-effort). */
 export function cssToMarkupColor(css: string): AcCmColor {
   const fromString = AcCmColor.fromString(css)
-  if (fromString) return fromString
+  if (fromString) return preferExactAciColor(fromString)
   try {
-    return new AcCmColor().setRGBFromCss(css)
+    return preferExactAciColor(new AcCmColor().setRGBFromCss(css))
   } catch {
     return createDefaultMarkupColor()
   }

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
@@ -1,5 +1,6 @@
 import {
   AcCmColor,
+  AcCmColorUtil,
   AcDbDatabase,
   AcDbSystemVariables,
   AcDbSysVarManager,
@@ -114,12 +115,27 @@ export function acapCssColor(c: AcCmColor): string {
   return c.cssColor ?? `rgb(${c.red}, ${c.green}, ${c.blue})`
 }
 
+/**
+ * If an RGB color matches the AutoCAD palette exactly, restore ByACI so
+ * ribbon color dropdowns can show named colors after a CSS round-trip.
+ */
+function preferExactAciColor(color: AcCmColor): AcCmColor {
+  if (!color.isByColor) return color
+  const rgb = color.RGB
+  if (rgb == null) return color
+  const index = AcCmColorUtil.getIndexByColor(rgb)
+  if (index == null) return color
+  const aci = new AcCmColor()
+  aci.colorIndex = index
+  return aci
+}
+
 /** Parse a CSS color string back into AcCmColor (best-effort). */
 export function acapCssToMeasurementColor(css: string): AcCmColor {
   const fromString = AcCmColor.fromString(css)
-  if (fromString) return fromString
+  if (fromString) return preferExactAciColor(fromString)
   try {
-    return new AcCmColor().setRGBFromCss(css)
+    return preferExactAciColor(new AcCmColor().setRGBFromCss(css))
   } catch {
     const fallback = new AcCmColor()
     fallback.setRGB(123, 135, 148)

--- a/packages/cad-viewer/src/component/common/MlColorDropdown.vue
+++ b/packages/cad-viewer/src/component/common/MlColorDropdown.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-import { AcCmColor, AcCmColorMethod } from '@mlightcad/data-model'
+import { AcCmColor, AcCmColorMethod, AcCmColorUtil } from '@mlightcad/data-model'
 import { ElOption, ElSelect } from 'element-plus'
 import { type Component, computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -101,15 +101,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const dlgVisible = ref<boolean>(false)
-const selectedKey = ref<string>(colorToKey(props.modelValue))
-const selectedColor = computed<string | undefined>(() =>
-  props.modelValue?.toString()
-)
-const selectedDisplayColor = computed<string>(
-  () => props.displayColor || keyToDisplayColor(selectedKey.value)
-)
-
 const defaultItems = [
   { key: 'bylayer', name: 'ByLayer' },
   { key: 'byblock', name: 'ByBlock' },
@@ -120,6 +111,15 @@ const defaultItems = [
   { key: 'aci-5', name: 'Blue' },
   { key: 'aci-6', name: 'Magenta' }
 ]
+
+const dlgVisible = ref<boolean>(false)
+const selectedKey = ref<string>(colorToKey(props.modelValue))
+const selectedColor = computed<string | undefined>(() =>
+  props.modelValue?.toString()
+)
+const selectedDisplayColor = computed<string>(
+  () => props.displayColor || keyToDisplayColor(selectedKey.value)
+)
 
 const mergedColorItems = computed(() =>
   defaultItems.map(i => ({
@@ -171,10 +171,23 @@ function handleDialogCancel() {
   selectedKey.value = colorToKey(props.modelValue)
 }
 
+function namedRibbonAciKey(c: AcCmColor): string | undefined {
+  let index: number | undefined
+  if (c.isByACI) index = c.colorIndex
+  else if (c.isByColor && c.RGB != null) {
+    index = AcCmColorUtil.getIndexByColor(c.RGB)
+  }
+  if (index == null) return undefined
+  const key = `aci-${index}`
+  return defaultItems.some(item => item.key === key) ? key : undefined
+}
+
 function colorToKey(c?: AcCmColor): string {
   if (!c) return ''
   if (c.isByLayer) return 'bylayer'
   if (c.isByBlock) return 'byblock'
+  const namedAci = namedRibbonAciKey(c)
+  if (namedAci) return namedAci
   if (c.isByACI) return `aci-${c.colorIndex}`
   if (c.isByColor) return `rgb-${c.red}-${c.green}-${c.blue}`
   return ''
@@ -210,7 +223,9 @@ function keyToDisplayColor(key: string) {
 function keyToDisplayName(key: string) {
   const found = mergedColorItems.value.find(i => i.key === key)
   if (found) return found.i18nName
-  if (key.startsWith('rgb-')) return t('main.colorDropdown.custom')
+  if (key.startsWith('rgb-') || key.startsWith('aci-')) {
+    return t('main.colorDropdown.custom')
+  }
   return ''
 }
 </script>

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -165,6 +165,9 @@ import { classifyOverlaySelection } from './overlaySelectionKind'
 import { useHatchContextualRibbon } from './useHatchContextualRibbon'
 import { useMTextContextualRibbon } from './useMTextContextualRibbon'
 
+/** Shared dropdown width for color / line-weight / font-size in overlay Style panels. */
+const OVERLAY_STYLE_CONTROL_WIDTH = '120px'
+
 interface Props {
   currentLocale?: LocaleProp
 }
@@ -1251,6 +1254,7 @@ const buildBaseTabs = (
           modelValue: markupDrawColor.value,
           displayColor: markupDrawColorDisplay.value,
           placeholder: t('main.ribbon.property.color'),
+          controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMarkupDrawColorChange
         }
       }
@@ -1266,6 +1270,7 @@ const buildBaseTabs = (
           modelValue: markupDrawLineWeight.value,
           placeholder: t('main.ribbon.property.lineWeight'),
           numericOnly: true,
+          controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMarkupDrawLineWeightChange
         }
       }
@@ -1281,7 +1286,7 @@ const buildBaseTabs = (
           modelValue: markupDrawFontSize.value,
           options: [10, 12, 14, 16, 18, 20, 24, 28, 32],
           placeholder: t('main.verticalToolbar.markupFontSize.text'),
-          controlWidth: '108px',
+          controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMarkupDrawFontSizeChange
         }
       }
@@ -1434,6 +1439,7 @@ const buildBaseTabs = (
           modelValue: measurementDrawColor.value,
           displayColor: measurementDrawColorDisplay.value,
           placeholder: t('main.ribbon.property.color'),
+          controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMeasurementDrawColorChange
         }
       }
@@ -1449,6 +1455,7 @@ const buildBaseTabs = (
           modelValue: measurementDrawLineWeight.value,
           placeholder: t('main.ribbon.property.lineWeight'),
           numericOnly: true,
+          controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMeasurementDrawLineWeightChange
         }
       }
@@ -1464,7 +1471,7 @@ const buildBaseTabs = (
           modelValue: measurementDrawFontSize.value,
           options: [10, 12, 13, 14, 16, 18, 20, 24, 28, 32],
           placeholder: t('main.verticalToolbar.measurementFontSize.text'),
-          controlWidth: '108px',
+          controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMeasurementDrawFontSizeChange
         }
       }

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonMarkupFontSizeSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonMarkupFontSizeSelect.vue
@@ -49,8 +49,8 @@ const props = withDefaults(defineProps<RibbonMarkupFontSizeSelectProps>(), {
   options: () => [10, 12, 14, 16, 18, 20, 24, 28, 32],
   disabled: false,
   placeholder: '',
-  // Match lineweight control width so the left icon stays visible.
-  controlWidth: undefined
+  // Match overlay line-weight control width so the three style dropdowns align.
+  controlWidth: '120px'
 })
 
 const emit = defineEmits<{


### PR DESCRIPTION
## Summary
- Overlay colors are stored as CSS strings. After a round-trip, exact AutoCAD palette RGB became `ByColor`, so the Review ribbon showed Custom instead of Red / Yellow / Green.
- Restore `ByACI` when the RGB matches the AutoCAD palette exactly, and map those colors onto the named ribbon dropdown keys.
- Align overlay color, line-weight, and font-size controls to a shared 120px width.

## Test plan
- [ ] Select a red markup overlay; the Review ribbon color dropdown shows Red, not Custom
- [ ] Repeat for measurement overlays using Yellow / Green / other named ACI colors
- [ ] A custom RGB that is not in the ACI palette still shows Custom
- [ ] Overlay Style color / line-weight / font-size dropdowns align at 120px
- [ ] `npx jest packages/cad-simple-viewer/__tests__/AcApMarkupUtil.spec.ts`