### PR TITLE
refactor: share exact ACI color restore between markup and measurement

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts
@@ -1,6 +1,13 @@
-import { AcCmColor, type AcDbDatabase, AcGiLineWeight } from '@mlightcad/data-model'
+import {
+  AcCmColor,
+  AcCmColorMethod,
+  type AcDbDatabase,
+  AcGiLineWeight
+} from '@mlightcad/data-model'
 
 import {
+  acapCssColor,
+  acapCssToMeasurementColor,
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementFontSize,
   acapGetMeasurementLineWeight,
@@ -64,5 +71,32 @@ describe('AcApMeasurementUtil', () => {
     acapSetMeasurementDrawLineWeight(AcGiLineWeight.ByLayer)
     acapSetMeasurementDrawLineWeight(AcGiLineWeight.ByBlock)
     expect(acapGetMeasurementLineWeight()).toBe(AcGiLineWeight.LineWeight211)
+  })
+})
+
+describe('acapCssToMeasurementColor', () => {
+  it('restores ACI yellow after a CSS round-trip', () => {
+    const yellow = new AcCmColor(AcCmColorMethod.ByACI, 2)
+    const restored = acapCssToMeasurementColor(acapCssColor(yellow))
+    expect(restored.isByACI).toBe(true)
+    expect(restored.colorIndex).toBe(2)
+  })
+
+  it('maps CSS rgb/hex values that match the ACI palette back to ByACI', () => {
+    const rgb = acapCssToMeasurementColor('rgb(255,0,0)')
+    expect(rgb.isByACI).toBe(true)
+    expect(rgb.colorIndex).toBe(1)
+
+    const hex = acapCssToMeasurementColor('#00FF00')
+    expect(hex.isByACI).toBe(true)
+    expect(hex.colorIndex).toBe(3)
+  })
+
+  it('keeps true-color RGB that is not in the ACI palette', () => {
+    const custom = acapCssToMeasurementColor('rgb(12,34,56)')
+    expect(custom.isByColor).toBe(true)
+    expect(custom.red).toBe(12)
+    expect(custom.green).toBe(34)
+    expect(custom.blue).toBe(56)
   })
 })

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
@@ -1,13 +1,13 @@
 import {
   AcCmColor,
   AcCmColorMethod,
-  AcCmColorUtil,
   AcDbDatabase,
   AcDbSystemVariables,
   AcDbSysVarManager,
   AcGiLineWeight
 } from '@mlightcad/data-model'
 
+import { preferExactAciColor } from '../../util/AcApCssColor'
 import type { AcApMarkupStyle } from './AcApMarkupTypes'
 
 /** Factory default markup color (ACI red) used to seed the draw style. */
@@ -89,22 +89,6 @@ export function markupCanvasLineWidth(weight: AcGiLineWeight | number): number {
 /** Convert AcCmColor to a CSS color string for sidecar style. */
 export function markupColorToCss(color: AcCmColor): string {
   return color.cssColor ?? `rgb(${color.red}, ${color.green}, ${color.blue})`
-}
-
-/**
- * If an RGB color matches the AutoCAD palette exactly, restore ByACI so
- * ribbon color dropdowns can show named colors (Red, Yellow, …) instead of
- * Custom after a CSS round-trip.
- */
-function preferExactAciColor(color: AcCmColor): AcCmColor {
-  if (!color.isByColor) return color
-  const rgb = color.RGB
-  if (rgb == null) return color
-  const index = AcCmColorUtil.getIndexByColor(rgb)
-  if (index == null) return color
-  const aci = new AcCmColor()
-  aci.colorIndex = index
-  return aci
 }
 
 /** Parse a CSS color string back into AcCmColor (best-effort). */

--- a/packages/cad-simple-viewer/src/util/AcApCssColor.ts
+++ b/packages/cad-simple-viewer/src/util/AcApCssColor.ts
@@ -1,0 +1,17 @@
+import { AcCmColor, AcCmColorUtil } from '@mlightcad/data-model'
+
+/**
+ * If an RGB color matches the AutoCAD palette exactly, restore ByACI so
+ * ribbon color dropdowns can show named colors (Red, Yellow, …) instead of
+ * Custom after a CSS round-trip.
+ */
+export function preferExactAciColor(color: AcCmColor): AcCmColor {
+  if (!color.isByColor) return color
+  const rgb = color.RGB
+  if (rgb == null) return color
+  const index = AcCmColorUtil.getIndexByColor(rgb)
+  if (index == null) return color
+  const aci = new AcCmColor()
+  aci.colorIndex = index
+  return aci
+}

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
@@ -1,11 +1,12 @@
 import {
   AcCmColor,
-  AcCmColorUtil,
   AcDbDatabase,
   AcDbSystemVariables,
   AcDbSysVarManager,
   AcGiLineWeight
 } from '@mlightcad/data-model'
+
+import { preferExactAciColor } from './AcApCssColor'
 
 /** Factory default CAD line weight for measurement geometry. */
 export const MEASUREMENT_LINE_WEIGHT = AcGiLineWeight.LineWeight070
@@ -113,21 +114,6 @@ export function acapColorToCssAlpha(c: AcCmColor, alpha: number): string {
 /** Returns the CSS color string for a measurement color, with fallback. */
 export function acapCssColor(c: AcCmColor): string {
   return c.cssColor ?? `rgb(${c.red}, ${c.green}, ${c.blue})`
-}
-
-/**
- * If an RGB color matches the AutoCAD palette exactly, restore ByACI so
- * ribbon color dropdowns can show named colors after a CSS round-trip.
- */
-function preferExactAciColor(color: AcCmColor): AcCmColor {
-  if (!color.isByColor) return color
-  const rgb = color.RGB
-  if (rgb == null) return color
-  const index = AcCmColorUtil.getIndexByColor(rgb)
-  if (index == null) return color
-  const aci = new AcCmColor()
-  aci.colorIndex = index
-  return aci
 }
 
 /** Parse a CSS color string back into AcCmColor (best-effort). */

--- a/packages/cad-simple-viewer/src/util/index.ts
+++ b/packages/cad-simple-viewer/src/util/index.ts
@@ -1,3 +1,4 @@
+export * from './AcApCssColor'
 export * from './AcApDatabaseEdit'
 export * from './AcApGeTransform'
 export * from './AcApExportFileNameUtil'


### PR DESCRIPTION
## Summary
- Extract `preferExactAciColor` into a shared helper so markup and measurement no longer duplicate the AutoCAD palette round-trip logic from #511.
- Cover `acapCssToMeasurementColor` with the same ACI restore / true-color cases as markup.

## Test plan
- [ ] `npx jest packages/cad-simple-viewer/__tests__/AcApMarkupUtil.spec.ts packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts`
- [ ] Select a named ACI markup and a measurement overlay; Review ribbon still shows Red / Yellow rather than Custom