### PR TITLE
feat: add drawing layout switcher to the simple-ui toolbar

### DIFF
--- a/packages/cad-agent-plugin/src/AcApAgentPlugin.ts
+++ b/packages/cad-agent-plugin/src/AcApAgentPlugin.ts
@@ -7,17 +7,14 @@ import {
 import packageJson from '../package.json'
 import { AcApAgentCmd } from './command/AcApAgentCmd'
 
-/** Registered name of the CAD Agent plugin in the plugin manager. */
-export const AGENT_PLUGIN_NAME = 'AgentPlugin'
-
 /**
  * CAD Agent plugin: natural-language drawing via LLM tool calling.
  *
  * Registers the `agent` command, which opens the agent chat panel in the tool palette.
  */
 export class AcApAgentPlugin implements AcApPlugin {
-  /** Plugin identifier used by {@link AcApPluginManager}. */
-  name = AGENT_PLUGIN_NAME
+  /** Plugin identifier used by {@link AcApPluginManager}. Must match `AGENT_PLUGIN_NAME`. */
+  name = 'AgentPlugin'
   /** Semantic version from `package.json`. */
   version = packageJson.version
   /** Short human-readable description shown in plugin listings. */

--- a/packages/cad-agent-plugin/src/index.ts
+++ b/packages/cad-agent-plugin/src/index.ts
@@ -6,4 +6,5 @@
 
 import './ui/agent-panel.css'
 
+export { createAgentPlugin } from './createAgentPlugin'
 export { default as AgentChatPanel } from './ui/AgentChatPanel.vue'

--- a/packages/cad-agent-plugin/src/register.ts
+++ b/packages/cad-agent-plugin/src/register.ts
@@ -1,7 +1,9 @@
 import type { AcApPluginManager } from '@mlightcad/cad-simple-viewer'
 
-import { AGENT_PLUGIN_NAME } from './AcApAgentPlugin'
 import { registerAgentI18n } from './i18n'
+
+/** Registered name of the CAD Agent plugin in the plugin manager. */
+export const AGENT_PLUGIN_NAME = 'AgentPlugin'
 
 /** Trigger commands handled by {@link AGENT_PLUGIN_NAME}. */
 export const AGENT_PLUGIN_TRIGGERS = ['agent'] as const
@@ -21,13 +23,12 @@ export function registerLazyAgentPlugin(
     name: AGENT_PLUGIN_NAME,
     triggers: [...AGENT_PLUGIN_TRIGGERS],
     loader: async () => {
-      const { createAgentPlugin } = await import('./createAgentPlugin')
+      const { createAgentPlugin } = await import('@mlightcad/cad-agent-plugin')
       return createAgentPlugin()
     }
   })
 }
 
-export { AGENT_PLUGIN_NAME }
 export { mergeAgentI18nIntoVueI18n, registerAgentI18n } from './i18n'
 export {
   openAgentPalette,

--- a/packages/cad-agent-plugin/typings/index.d.ts
+++ b/packages/cad-agent-plugin/typings/index.d.ts
@@ -4,6 +4,9 @@
  * Emitted to `lib/` by `pnpm build:types` (see `scripts/copy-typings.mjs`).
  * Keep in sync with `src/index.ts` exports.
  */
+import type { AcApPlugin } from '@mlightcad/cad-simple-viewer'
 import type { DefineComponent } from 'vue'
+
+export declare function createAgentPlugin(): Promise<AcApPlugin>
 
 export declare const AgentChatPanel: DefineComponent<object, object, unknown>

--- a/packages/cad-agent-plugin/vite.config.ts
+++ b/packages/cad-agent-plugin/vite.config.ts
@@ -1,12 +1,14 @@
-import { resolve } from 'path'
 import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import { defineConfig, PluginOption } from 'vite'
+
 import {
   createLibEntryFileName,
   createLibRollupOutput
 } from '../vite-config/pluginRollupOutput'
 
+const packageName = '@mlightcad/cad-agent-plugin'
 const packageId = 'cad-agent-plugin'
 
 export default defineConfig({
@@ -24,6 +26,7 @@ export default defineConfig({
     },
     minify: true,
     rollupOptions: {
+      external: [packageName],
       output: {
         ...createLibRollupOutput(packageId),
         // Keep `style.css` so `@mlightcad/cad-agent-plugin/style.css` resolves

--- a/packages/cad-simple-ui-plugin/__tests__/AcExToolbar.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcExToolbar.spec.ts
@@ -43,6 +43,14 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
   }
 })
 
+jest.mock('@mlightcad/data-model', () => ({
+  acdbHostApplicationServices: () => ({
+    layoutManager: {
+      setCurrentLayoutBtrId: jest.fn()
+    }
+  })
+}))
+
 import type { AcExToolbarItem } from '../src/config/types'
 import { AcExI18n } from '../src/i18n'
 import { AcExToolbar } from '../src/ui/AcExToolbar'
@@ -154,6 +162,44 @@ describe('AcExToolbar children UI', () => {
       ?.click()
     expect(host.querySelector('.ml-ex-ui-subtoolbar')).toBeNull()
     expect(document.querySelector('.ml-ex-ui-dropdown')).toBeTruthy()
+    toolbar.destroy()
+  })
+
+  it('opens a popover menu for live children getters', () => {
+    const onSelect = jest.fn()
+    const item: AcExToolbarItem = {
+      id: 'layout',
+      label: 'Layout',
+      childrenUi: 'menu',
+      children: []
+    }
+    Object.defineProperty(item, 'children', {
+      configurable: true,
+      enumerable: true,
+      get: () => [
+        { id: 'layout-model', label: 'Model', action: onSelect },
+        { id: 'layout-1', label: 'Layout1', action: onSelect }
+      ]
+    })
+
+    const { host, toolbar } = createToolbar([item])
+    const parent = host.querySelector<HTMLButtonElement>(
+      '[data-toolbar-item-id="layout"]'
+    )
+    expect(parent?.classList.contains('has-children')).toBe(true)
+    parent?.click()
+
+    expect(host.querySelector('.ml-ex-ui-subtoolbar')).toBeNull()
+    const menu = document.querySelector('.ml-ex-ui-dropdown')
+    expect(menu).toBeTruthy()
+    expect(menu?.textContent).toContain('Model')
+    expect(menu?.textContent).toContain('Layout1')
+
+    menu
+      ?.querySelectorAll('button')[1]
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('.ml-ex-ui-dropdown')).toBeNull()
     toolbar.destroy()
   })
 })

--- a/packages/cad-simple-ui-plugin/__tests__/createLayoutToolbarItem.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/createLayoutToolbarItem.spec.ts
@@ -1,0 +1,119 @@
+/** Unit tests for the drawing-layout toolbar button and submenu. */
+
+const mockSetCurrentLayoutBtrId = jest.fn()
+
+const mockLayouts = [
+  {
+    layoutName: 'Model',
+    tabOrder: 0,
+    blockTableRecordId: 'btr-model'
+  },
+  {
+    layoutName: 'Layout1',
+    tabOrder: 2,
+    blockTableRecordId: 'btr-layout1'
+  },
+  {
+    layoutName: 'Layout2',
+    tabOrder: 1,
+    blockTableRecordId: 'btr-layout2'
+  }
+]
+
+let currentSpaceId = 'btr-model'
+
+jest.mock('@mlightcad/cad-simple-viewer', () => ({
+  AcApDocManager: {
+    instance: {
+      get curDocument() {
+        return {
+          database: {
+            currentSpaceId,
+            objects: {
+              layout: {
+                newIterator: () => mockLayouts
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}))
+
+jest.mock('@mlightcad/data-model', () => ({
+  acdbHostApplicationServices: () => ({
+    layoutManager: {
+      setCurrentLayoutBtrId: mockSetCurrentLayoutBtrId
+    }
+  })
+}))
+
+import {
+  createLayoutToolbarChildren,
+  createLayoutToolbarItem,
+  listDocumentLayouts,
+  switchCurrentLayout
+} from '../src/config/createLayoutToolbarItem'
+import { isDynamicToolbarChildren } from '../src/config/toolbarItemUtils'
+
+describe('createLayoutToolbarItem', () => {
+  beforeEach(() => {
+    currentSpaceId = 'btr-model'
+    mockSetCurrentLayoutBtrId.mockReset()
+  })
+
+  it('lists layouts including model space ordered by tabOrder', () => {
+    expect(listDocumentLayouts().map(layout => layout.name)).toEqual([
+      'Model',
+      'Layout2',
+      'Layout1'
+    ])
+  })
+
+  it('marks the current space as active', () => {
+    currentSpaceId = 'btr-layout2'
+    const active = listDocumentLayouts().filter(layout => layout.isActive)
+    expect(active).toEqual([
+      expect.objectContaining({
+        name: 'Layout2',
+        blockTableRecordId: 'btr-layout2'
+      })
+    ])
+  })
+
+  it('creates a menu parent with a live children getter', () => {
+    const item = createLayoutToolbarItem()
+    expect(item.id).toBe('layout')
+    expect(item.childrenUi).toBe('menu')
+    expect(isDynamicToolbarChildren(item)).toBe(true)
+    expect(item.children?.map(child => child.label)).toEqual([
+      'Model',
+      'Layout2',
+      'Layout1'
+    ])
+  })
+
+  it('switches the current layout when a submenu item is chosen', () => {
+    const children = createLayoutToolbarChildren()
+    const layout1 = children.find(child => child.label === 'Layout1')
+    layout1?.action?.()
+    expect(mockSetCurrentLayoutBtrId).toHaveBeenCalledWith('btr-layout1')
+  })
+
+  it('highlights the active layout in the submenu', () => {
+    currentSpaceId = 'btr-layout1'
+    const children = createLayoutToolbarChildren()
+    expect(
+      children.find(child => child.label === 'Layout1')?.toggle?.getValue()
+    ).toBe(true)
+    expect(
+      children.find(child => child.label === 'Model')?.toggle?.getValue()
+    ).toBe(false)
+  })
+
+  it('forwards switchCurrentLayout to the layout manager', () => {
+    switchCurrentLayout('btr-layout2')
+    expect(mockSetCurrentLayoutBtrId).toHaveBeenCalledWith('btr-layout2')
+  })
+})

--- a/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
@@ -15,6 +15,14 @@ jest.mock('@mlightcad/cad-simple-viewer', () => ({
   }
 }))
 
+jest.mock('@mlightcad/data-model', () => ({
+  acdbHostApplicationServices: () => ({
+    layoutManager: {
+      setCurrentLayoutBtrId: jest.fn()
+    }
+  })
+}))
+
 import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
 
 import { createDefaultToolbarItems } from '../src/config/defaultToolbarItems'
@@ -26,7 +34,10 @@ import {
   resolveSelectedChildItem,
   resolveToolbarItems
 } from '../src/config/resolveToolbarItems'
-import { createToolbarSeparator } from '../src/config/toolbarItemUtils'
+import {
+  createToolbarSeparator,
+  isDynamicToolbarChildren
+} from '../src/config/toolbarItemUtils'
 
 describe('resolveToolbarItems', () => {
   it('returns default items when items is default', () => {
@@ -102,6 +113,7 @@ describe('toolbar visibility', () => {
     const visible = filterVisibleToolbarItems(defaults, AcEdOpenMode.Read)
     expect(visible.some(item => item.id === 'annotation')).toBe(false)
     expect(visible.some(item => item.id === 'switch-bg')).toBe(true)
+    expect(visible.some(item => item.id === 'layout')).toBe(true)
     expect(visible.some(item => item.id === 'select')).toBe(true)
   })
 
@@ -181,10 +193,13 @@ describe('default toolbar items', () => {
     expect(items[themeIndex - 1]?.id).toBe('toolbar-placement')
   })
 
-  it('places switch background next to the layer manager', () => {
+  it('places the layout switcher between the layer manager and switch background', () => {
     const items = createDefaultToolbarItems()
     const layerIndex = items.findIndex(item => item.id === 'layer')
-    expect(items[layerIndex + 1]?.id).toBe('switch-bg')
+    expect(items[layerIndex + 1]?.id).toBe('layout')
+    expect(items[layerIndex + 1]?.childrenUi).toBe('menu')
+    expect(items[layerIndex + 1]?.icon).toContain('rect x="2" y="2" width="8.2"')
+    expect(items[layerIndex + 2]?.id).toBe('switch-bg')
   })
 
   it('includes a separator before settings buttons', () => {
@@ -285,6 +300,7 @@ describe('default toolbar items', () => {
       'sticky-toolbar'
     )
     expect(items.find(item => item.id === 'export')?.childrenUi).toBe('toolbar')
+    expect(items.find(item => item.id === 'layout')?.childrenUi).toBe('menu')
     expect(items.find(item => item.id === 'toolbar-placement')?.childrenUi).toBe(
       'toolbar'
     )
@@ -432,6 +448,16 @@ describe('toolbar presets and separators', () => {
       items.map(item => ('preset' in item ? item.preset : item.id))
     ).toEqual(['select', 'pan', 'sep-tools', 'measure'])
     expect(items[3].children?.length).toBeGreaterThan(0)
+  })
+
+  it('preserves live layout children when expanding the layout preset', () => {
+    const items = resolveToolbarItems({
+      items: [{ preset: 'layout' }]
+    })
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe('layout')
+    expect(isDynamicToolbarChildren(items[0])).toBe(true)
+    expect(items[0].childrenUi).toBe('menu')
   })
 
   it('keeps separators when filtering by open mode', () => {

--- a/packages/cad-simple-ui-plugin/src/assets/icons.ts
+++ b/packages/cad-simple-ui-plugin/src/assets/icons.ts
@@ -36,6 +36,10 @@ export const ICON_ZOOM_WINDOW =
 export const ICON_LAYER =
   '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="m434.8 137.65l-149.36-68.1c-16.19-7.4-42.69-7.4-58.88 0L77.3 137.65c-17.6 8-17.6 21.09 0 29.09l148 67.5c16.89 7.7 44.69 7.7 61.58 0l148-67.5c17.52-8 17.52-21.1-.08-29.09M160 308.52l-82.7 37.11c-17.6 8-17.6 21.1 0 29.1l148 67.5c16.89 7.69 44.69 7.69 61.58 0l148-67.5c17.6-8 17.6-21.1 0-29.1l-79.94-38.47"/><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="m160 204.48l-82.8 37.16c-17.6 8-17.6 21.1 0 29.1l148 67.49c16.89 7.7 44.69 7.7 61.58 0l148-67.49c17.7-8 17.7-21.1.1-29.1L352 204.48"/></svg>'
 
+/** Drawing layout switcher icon (staggered bento-box panels). */
+export const ICON_LAYOUT =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><rect x="2" y="2" width="8.2" height="5" rx="1.2" fill="currentColor"/><rect x="2" y="8.5" width="8.2" height="9.5" rx="1.2" fill="currentColor"/><rect x="11.7" y="2" width="6.3" height="10" rx="1.2" fill="currentColor"/><rect x="11.7" y="13.5" width="6.3" height="4.5" rx="1.2" fill="currentColor"/></svg>'
+
 /** Measure tools parent menu icon (copied from cad-viewer `measure.svg`). */
 export const ICON_MEASURE =
   '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20"><path fill="currentColor" fill-rule="evenodd" d="M1.5 7h17v6h-17ZM4.25 7h1v2.5h-1ZM7.5 7h.75v1.5H7.5ZM10.25 7h1v2.5h-1ZM13.5 7h.75v1.5H13.5ZM16.25 7h1v2.5h-1Z"/></svg>'

--- a/packages/cad-simple-ui-plugin/src/config/createLayoutToolbarItem.ts
+++ b/packages/cad-simple-ui-plugin/src/config/createLayoutToolbarItem.ts
@@ -1,0 +1,93 @@
+import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { acdbHostApplicationServices } from '@mlightcad/data-model'
+
+import { ICON_LAYOUT } from '../assets/icons'
+import { copyDynamicToolbarChildren } from './toolbarItemUtils'
+import type { AcExToolbarItem } from './types'
+
+/** One selectable drawing layout (model space or paper space). */
+interface DocumentLayoutInfo {
+  /** Display name from the layout table (e.g. `Model`, `Layout1`). */
+  name: string
+  /** Tab order used to sort the submenu. */
+  tabOrder: number
+  /** Block table record id passed to the layout manager. */
+  blockTableRecordId: string
+  /** Whether this layout is the document's current space. */
+  isActive: boolean
+}
+
+/**
+ * Lists layouts on the active document, including model space, sorted by tab order.
+ *
+ * @returns Layouts when a document is open; otherwise an empty list.
+ */
+export function listDocumentLayouts(): DocumentLayoutInfo[] {
+  const database = AcApDocManager.instance.curDocument?.database
+  const layoutTable = database?.objects?.layout
+  if (!database || !layoutTable?.newIterator) return []
+
+  const layouts: DocumentLayoutInfo[] = []
+  for (const layout of database.objects.layout.newIterator()) {
+    layouts.push({
+      name: layout.layoutName,
+      tabOrder: layout.tabOrder,
+      blockTableRecordId: layout.blockTableRecordId,
+      isActive: layout.blockTableRecordId === database.currentSpaceId
+    })
+  }
+  layouts.sort((a, b) => a.tabOrder - b.tabOrder)
+  return layouts
+}
+
+/**
+ * Switches the current drawing to the layout identified by `blockTableRecordId`.
+ *
+ * @param blockTableRecordId - Layout block table record id.
+ */
+export function switchCurrentLayout(blockTableRecordId: string): void {
+  acdbHostApplicationServices().layoutManager.setCurrentLayoutBtrId(
+    blockTableRecordId
+  )
+}
+
+/**
+ * Builds submenu entries for every layout on the active document.
+ *
+ * @returns Menu items that switch the current layout when clicked.
+ */
+export function createLayoutToolbarChildren(): AcExToolbarItem[] {
+  return listDocumentLayouts().map(layout => ({
+    id: `layout-${layout.blockTableRecordId}`,
+    label: layout.name,
+    action: () => switchCurrentLayout(layout.blockTableRecordId),
+    toggle: {
+      getValue: () => {
+        const database = AcApDocManager.instance.curDocument?.database
+        return database?.currentSpaceId === layout.blockTableRecordId
+      },
+      on: {},
+      off: {}
+    }
+  }))
+}
+
+/**
+ * Creates the default layout-switcher toolbar button.
+ *
+ * Children are resolved from the active document each time they are read, so the
+ * menu stays in sync when a drawing is opened or layouts change.
+ *
+ * @returns Layout parent button with a popover menu (`childrenUi: 'menu'`).
+ */
+export function createLayoutToolbarItem(): AcExToolbarItem {
+  const item: AcExToolbarItem = {
+    id: 'layout',
+    label: 'toolbar.layout',
+    icon: ICON_LAYOUT,
+    requiresDocument: true,
+    childrenUi: 'menu',
+    children: []
+  }
+  return copyDynamicToolbarChildren(item, createLayoutToolbarChildren)
+}

--- a/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
@@ -47,6 +47,7 @@ import {
   ICON_ZOOM_EXTENT,
   ICON_ZOOM_WINDOW
 } from '../assets/icons'
+import { createLayoutToolbarItem } from './createLayoutToolbarItem'
 import type {
   AcExDefaultToolbarContext,
   AcExToolbarItem,
@@ -138,7 +139,7 @@ function createToolbarLocaleItem(
 }
 
 /**
- * Builds the built-in toolbar item list (view, measure, review, export, theme, locale).
+ * Builds the built-in toolbar item list (view, layout, measure, review, export, theme, locale).
  *
  * @param context - Optional callbacks for theme, locale, and placement items.
  * @returns Default {@link AcExToolbarItem} array.
@@ -183,6 +184,7 @@ export function createDefaultToolbarItems(
       icon: ICON_LAYER,
       command: 'layer'
     },
+    createLayoutToolbarItem(),
     {
       id: 'switch-bg',
       label: 'toolbar.switchBg',

--- a/packages/cad-simple-ui-plugin/src/config/resolveToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/resolveToolbarItems.ts
@@ -4,6 +4,7 @@ import { createDefaultToolbarItems } from './defaultToolbarItems'
 import {
   expandToolbarItemConfigs,
   indexToolbarItems,
+  isDynamicToolbarChildren,
   isToolbarSeparatorItem
 } from './toolbarItemUtils'
 import type {
@@ -222,13 +223,20 @@ export function filterVisibleToolbarItems(
         isToolbarSeparatorItem(item) || isToolbarItemVisible(item, openMode)
     )
     .map(item => {
-      if (isToolbarSeparatorItem(item) || !item.children?.length) return item
+      if (
+        isToolbarSeparatorItem(item) ||
+        isDynamicToolbarChildren(item) ||
+        !item.children?.length
+      ) {
+        return item
+      }
       const children = filterVisibleToolbarItems(item.children, openMode)
       return { ...item, children }
     })
     .filter(item => {
       if (isToolbarSeparatorItem(item)) return true
       return (
+        isDynamicToolbarChildren(item) ||
         !item.children ||
         item.children.length > 0 ||
         item.command ||

--- a/packages/cad-simple-ui-plugin/src/config/toolbarItemUtils.ts
+++ b/packages/cad-simple-ui-plugin/src/config/toolbarItemUtils.ts
@@ -39,6 +39,56 @@ export function isToolbarPresetRef(
 }
 
 /**
+ * Returns whether {@link children} is supplied by a getter rather than a static array.
+ *
+ * Dynamic children (for example drawing layouts) must not be snapshotted when
+ * cloning or expanding toolbar items.
+ *
+ * @param item - Toolbar item to inspect.
+ */
+export function isDynamicToolbarChildren(item: AcExToolbarItem): boolean {
+  return (
+    typeof Object.getOwnPropertyDescriptor(item, 'children')?.get === 'function'
+  )
+}
+
+/**
+ * Attaches a getter that rebuilds submenu children each time they are read.
+ *
+ * @param item - Parent toolbar item.
+ * @param getChildren - Factory invoked on each `children` access.
+ * @returns `item` with a live `children` getter.
+ */
+export function copyDynamicToolbarChildren(
+  item: AcExToolbarItem,
+  getChildren: () => AcExToolbarItem[]
+): AcExToolbarItem {
+  Object.defineProperty(item, 'children', {
+    configurable: true,
+    enumerable: true,
+    get: getChildren
+  })
+  return item
+}
+
+/**
+ * Copies a live `children` getter from `source` onto `target` when present.
+ *
+ * @param target - Clone that should keep dynamic children.
+ * @param source - Original item that may define a children getter.
+ * @returns Whether a getter was copied.
+ */
+export function preserveDynamicToolbarChildren(
+  target: AcExToolbarItem,
+  source: AcExToolbarItem
+): boolean {
+  const descriptor = Object.getOwnPropertyDescriptor(source, 'children')
+  if (typeof descriptor?.get !== 'function') return false
+  copyDynamicToolbarChildren(target, descriptor.get)
+  return true
+}
+
+/**
  * Creates a toolbar separator entry.
  *
  * @param id - Optional stable id for debugging.
@@ -78,7 +128,7 @@ export function indexToolbarItems(
   for (const item of items) {
     if (isToolbarSeparatorItem(item)) continue
     map.set(item.id, item)
-    if (item.children?.length) {
+    if (!isDynamicToolbarChildren(item) && item.children?.length) {
       indexToolbarItems(item.children, map)
     }
   }
@@ -123,6 +173,9 @@ function expandToolbarItemConfig(
   }
 
   const buttonItem = item as AcExToolbarItem
+  if (isDynamicToolbarChildren(buttonItem)) {
+    return cloneToolbarItem(buttonItem)
+  }
   if (buttonItem.children?.length) {
     return {
       ...buttonItem,
@@ -137,11 +190,15 @@ function expandToolbarItemConfig(
 }
 
 function cloneToolbarItem(item: AcExToolbarItem): AcExToolbarItem {
+  const clone: AcExToolbarItem = { ...item, children: item.children }
+  if (preserveDynamicToolbarChildren(clone, item)) {
+    return clone
+  }
   if (!item.children?.length) {
-    return { ...item }
+    return clone
   }
   return {
-    ...item,
+    ...clone,
     children: item.children.map(child => cloneToolbarItem(child))
   }
 }

--- a/packages/cad-simple-ui-plugin/src/config/types.ts
+++ b/packages/cad-simple-ui-plugin/src/config/types.ts
@@ -73,7 +73,8 @@ export interface AcExToolbarItem {
   minOpenMode?: AcEdOpenMode
   /** Static or dynamic disabled state evaluated at render time. */
   disabled?: boolean | (() => boolean)
-  /** Nested submenu items shown when the button is clicked. */
+  /** Nested submenu items shown when the button is clicked.
+   * May be a live getter so the list can depend on the active document. */
   children?: AcExToolbarItem[]
   /**
    * Presentation of {@link children}. Defaults to `'menu'` (popover dropdown).

--- a/packages/cad-simple-ui-plugin/src/i18n/cs.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/cs.ts
@@ -10,6 +10,7 @@ export const cs: Record<string, string> = {
   'toolbar.zoomExtent': 'Přiblížit na rozsah',
   'toolbar.zoomWindow': 'Přiblížit oknem',
   'toolbar.layer': 'Správce hladin',
+  'toolbar.layout': 'Rozvržení',
   'toolbar.measure': 'Měření',
   'toolbar.measureDistance': 'Měřit vzdálenost',
   'toolbar.measureAngle': 'Měřit úhel',

--- a/packages/cad-simple-ui-plugin/src/i18n/en.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/en.ts
@@ -10,6 +10,7 @@ export const en: Record<string, string> = {
   'toolbar.zoomExtent': 'Zoom Extents',
   'toolbar.zoomWindow': 'Zoom Window',
   'toolbar.layer': 'Layer Manager',
+  'toolbar.layout': 'Layout',
   'toolbar.measure': 'Measure',
   'toolbar.measureDistance': 'Measure Distance',
   'toolbar.measureAngle': 'Measure Angle',

--- a/packages/cad-simple-ui-plugin/src/i18n/tr.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/tr.ts
@@ -10,6 +10,7 @@ export const tr: Record<string, string> = {
   'toolbar.zoomExtent': 'Kapsama Yakınlaştır',
   'toolbar.zoomWindow': 'Pencere Yakınlaştır',
   'toolbar.layer': 'Katman Yöneticisi',
+  'toolbar.layout': 'Düzen',
   'toolbar.measure': 'Ölçüm',
   'toolbar.measureDistance': 'Mesafe Ölç',
   'toolbar.measureAngle': 'Açı Ölç',

--- a/packages/cad-simple-ui-plugin/src/i18n/zh.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/zh.ts
@@ -10,6 +10,7 @@ export const zh: Record<string, string> = {
   'toolbar.zoomExtent': '缩放至范围',
   'toolbar.zoomWindow': '窗口缩放',
   'toolbar.layer': '图层管理器',
+  'toolbar.layout': '布局',
   'toolbar.measure': '测量',
   'toolbar.measureDistance': '测量距离',
   'toolbar.measureAngle': '测量角度',

--- a/packages/cad-simple-ui-plugin/src/ui/AcExToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExToolbar.ts
@@ -15,6 +15,7 @@ import {
   resolveParentToolbarDisplay
 } from '../config/resolveToolbarItems'
 import {
+  isDynamicToolbarChildren,
   isToolbarChildrenStrip,
   isToolbarSeparatorItem,
   resolveToolbarChildrenUi
@@ -404,7 +405,7 @@ export class AcExToolbar {
       button.setAttribute('aria-label', button.title)
       button.dataset.toolbarItemId = effective.id
 
-      if (effective.children?.length) {
+      if (effective.children?.length || isDynamicToolbarChildren(item)) {
         button.classList.add('has-children')
         button.setAttribute('aria-haspopup', 'true')
         button.setAttribute('aria-expanded', 'false')
@@ -430,9 +431,9 @@ export class AcExToolbar {
         event.stopPropagation()
         if (button.disabled) return
 
-        if (effective.children?.length) {
+        if (effective.children?.length || isDynamicToolbarChildren(item)) {
           const visibleChildren = filterVisibleToolbarItems(
-            effective.children,
+            effective.children ?? [],
             this.openMode
           ).map(resolveEffectiveToolbarItem)
           if (visibleChildren.length === 0) return

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -227,6 +227,8 @@ export function ensureUiStyles() {
       position: fixed;
       z-index: 100;
       min-width: 160px;
+      max-height: min(360px, calc(100vh - 16px));
+      overflow-y: auto;
       padding: 4px;
       background: var(--ml-ui-bg, #ffffff);
       border: 1px solid var(--ml-ui-border, #dcdfe6);

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -840,7 +840,7 @@ class CadViewerApp {
           placement: 'right',
           items: 'default',
           appendItems: [AGENT_TOOLBAR_ITEM],
-          appendItemsAfter: 'layer',
+          appendItemsAfter: 'layout',
           collapsible: true
         }
       })

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
@@ -737,7 +737,7 @@ export class AcApMeasureArcCmd extends AcEdCommand {
     if (!endRaw) return
     const geomNow = jig.geom
     const start2 = toPoint2(start)
-    const end2 = toPoint2(snapToCircle(view.curPos, geomNow))
+    const end2 = toPoint2(snapToCircle(endRaw, geomNow))
     const sweep = lockedSweep(start2, end2, geomNow, jig.clockwise)
     if (!sweep) {
       this.showMessage(AcApI18n.t('jig.measureArc.invalidPoints'), 'warning')


### PR DESCRIPTION
## Summary
- Add a Layout toolbar button that lists model/paper layouts from the active drawing and switches the current space, keeping submenu children live so the list stays in sync.
- Lazy-load the agent plugin through the package entry (same pattern as html/pdf/svg) so the register chunk does not pull in the main bundle.
- Snap locked arc-length endpoints to the accepted prompt point instead of the live cursor.

## Test plan
- [ ] Open a drawing with Model space and at least one paper layout; click the Layout toolbar button and confirm layouts are listed in tab order.
- [ ] Switch layouts from the menu; confirm the viewer switches space and the active layout is highlighted.
- [ ] Open a drawing with many layouts and confirm the menu scrolls instead of overflowing the viewport.
- [ ] With no document open, confirm the Layout button is disabled.
- [ ] Trigger the `agent` command and confirm the agent plugin still lazy-loads.
- [ ] Run locked arc-length measure on a circle and confirm the committed arc uses the accepted end point.