### PR TITLE
feat: export paper-space viewports and switch layouts in the HTML viewer

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcApHtmlSnapshotBuilder.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcApHtmlSnapshotBuilder.spec.ts
@@ -1,0 +1,111 @@
+jest.mock('@mlightcad/cad-simple-viewer', () => ({
+  AcApI18n: { currentLocale: 'en' }
+}))
+
+jest.mock('../src/AcExOsnapPrimitiveBuilder', () => ({
+  buildOsnapCatalog: jest.fn(() => undefined)
+}))
+
+import type { AcTrScene } from '@mlightcad/cad-simple-viewer'
+import type { AcDbDatabase } from '@mlightcad/data-model'
+
+import {
+  AcApHtmlSnapshotBuilder,
+  listDatabaseLayouts
+} from '../src/AcApHtmlSnapshotBuilder'
+
+function fakeDatabase(
+  layouts: Array<{
+    layoutName: string
+    tabOrder: number
+    blockTableRecordId: string
+  }>
+) {
+  return {
+    objects: {
+      layout: {
+        newIterator: () => layouts[Symbol.iterator]()
+      }
+    },
+    tables: {
+      blockTable: {
+        newIterator: () => [][Symbol.iterator]()
+      }
+    },
+    extmin: { x: 0, y: 0 },
+    extmax: { x: 10, y: 10 },
+    insunits: 0,
+    lunits: 2,
+    luprec: 2,
+    aunits: 0,
+    auprec: 0,
+    measurement: 1,
+    ltscale: 1,
+    angbase: 0,
+    angdir: 0
+  } as unknown as AcDbDatabase
+}
+
+function emptySceneLayout() {
+  return { layers: new Map() }
+}
+
+function fakeScene(
+  layoutIds: string[],
+  activeLayoutBtrId: string,
+  modelSpaceBtrId: string
+) {
+  const layouts = new Map(
+    layoutIds.map(id => [id, emptySceneLayout()] as const)
+  )
+  return {
+    layouts,
+    layers: new Map(),
+    activeLayoutBtrId,
+    modelSpaceBtrId
+  } as unknown as AcTrScene
+}
+
+describe('listDatabaseLayouts', () => {
+  it('sorts layouts by tab order and keeps display names', () => {
+    const database = fakeDatabase([
+      { layoutName: 'Layout1', tabOrder: 2, blockTableRecordId: 'ps1' },
+      { layoutName: 'Model', tabOrder: 1, blockTableRecordId: 'ms' },
+      { layoutName: 'Layout2', tabOrder: 3, blockTableRecordId: 'ps2' }
+    ])
+
+    expect(listDatabaseLayouts(database).map(layout => layout.name)).toEqual([
+      'Model',
+      'Layout1',
+      'Layout2'
+    ])
+  })
+})
+
+describe('AcApHtmlSnapshotBuilder', () => {
+  it('exports every layout-table tab even when the scene is missing one', () => {
+    const database = fakeDatabase([
+      { layoutName: 'Layout1', tabOrder: 2, blockTableRecordId: 'ps1' },
+      { layoutName: 'Model', tabOrder: 1, blockTableRecordId: 'ms' },
+      { layoutName: 'Layout2', tabOrder: 3, blockTableRecordId: 'ps2' }
+    ])
+    const scene = fakeScene(['ms', 'ps1'], 'ms', 'ms')
+    const snapshot = new AcApHtmlSnapshotBuilder().build(scene, database, {
+      viewerMode: 'view'
+    })
+
+    expect(snapshot.layouts.map(layout => layout.btrId)).toEqual([
+      'ms',
+      'ps1',
+      'ps2'
+    ])
+    expect(snapshot.layouts.map(layout => layout.name)).toEqual([
+      'Model',
+      'Layout1',
+      'Layout2'
+    ])
+    expect(snapshot.layouts[0]?.isModelSpace).toBe(true)
+    expect(snapshot.layouts[2]?.lineBatches).toEqual([])
+    expect(snapshot.activeLayoutBtrId).toBe('ms')
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExHtmlLayoutMenu.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlLayoutMenu.spec.ts
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+
+import { setupAcExHtmlLayoutMenu } from '../src/AcExHtmlLayoutMenu'
+
+describe('setupAcExHtmlLayoutMenu', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  function mountButton() {
+    document.body.innerHTML =
+      '<button type="button" id="mlcad-layout-menu-btn" aria-expanded="false"></button>'
+  }
+
+  it('opens a menu of layouts and switches on click', () => {
+    mountButton()
+    const onSelect = jest.fn()
+    let active = 'btr-model'
+    setupAcExHtmlLayoutMenu({
+      layouts: [
+        { btrId: 'btr-model', name: 'Model' },
+        { btrId: 'btr-ps1', name: 'Layout1' }
+      ],
+      getActiveLayoutBtrId: () => active,
+      onSelect: btrId => {
+        active = btrId
+        onSelect(btrId)
+      }
+    })
+
+    document.getElementById('mlcad-layout-menu-btn')?.click()
+    const menu = document.querySelector('.mlcad-dropdown')
+    expect(menu).toBeTruthy()
+    expect(
+      menu
+        ?.querySelector('[data-layout-id="btr-model"]')
+        ?.classList.contains('active')
+    ).toBe(true)
+
+    document
+      .querySelector<HTMLButtonElement>('[data-layout-id="btr-ps1"]')
+      ?.click()
+    expect(onSelect).toHaveBeenCalledWith('btr-ps1')
+    expect(document.querySelector('.mlcad-dropdown')).toBeNull()
+  })
+
+  it('does not notify when the active layout is chosen again', () => {
+    mountButton()
+    const onSelect = jest.fn()
+    setupAcExHtmlLayoutMenu({
+      layouts: [{ btrId: 'btr-model', name: 'Model' }],
+      getActiveLayoutBtrId: () => 'btr-model',
+      onSelect
+    })
+
+    document.getElementById('mlcad-layout-menu-btn')?.click()
+    document
+      .querySelector<HTMLButtonElement>('[data-layout-id="btr-model"]')
+      ?.click()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('closes on outside click', () => {
+    mountButton()
+    setupAcExHtmlLayoutMenu({
+      layouts: [{ btrId: 'btr-model', name: 'Model' }],
+      getActiveLayoutBtrId: () => 'btr-model',
+      onSelect: jest.fn()
+    })
+
+    document.getElementById('mlcad-layout-menu-btn')?.click()
+    expect(document.querySelector('.mlcad-dropdown')).toBeTruthy()
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    expect(document.querySelector('.mlcad-dropdown')).toBeNull()
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
@@ -16,6 +16,7 @@ describe('buildAcExHtmlShellBody', () => {
     expect(html).toContain('data-action="zoom-window"')
     expect(html).toContain('data-action="zoom-original"')
     expect(html).toContain('id="mlcad-layers-btn"')
+    expect(html).toContain('id="mlcad-layout-menu-btn"')
     expect(html).toContain('id="mlcad-lang-btn"')
     expect(html).toContain('id="mlcad-lang-badge"')
     expect(html).toContain('id="mlcad-locale-strip-wrap"')
@@ -40,6 +41,7 @@ describe('buildAcExHtmlShellBody', () => {
     expect(html).toContain('id="mlcad-measure-menu-btn"')
     expect(html).toContain('id="mlcad-markup-menu-btn"')
     expect(html).toContain('id="mlcad-snap-menu-btn"')
+    expect(html).toContain('id="mlcad-layout-menu-btn"')
     expect(html).toContain('id="mlcad-lang-btn"')
     expect(html).toContain('id="mlcad-lang-badge"')
     expect(html).toContain('has-children')
@@ -68,8 +70,10 @@ describe('buildAcExHtmlShellBody', () => {
     expect(toolbarHtml).toContain('title="Zoom"')
     expect(toolbarHtml).toContain('title="Object snap"')
     expect(toolbarHtml).toContain('title="Language"')
+    expect(toolbarHtml).toContain('title="Layout"')
     expect(toolbarHtml).toContain('data-children-ui="sticky-toolbar"')
     expect(toolbarHtml).toContain('data-children-ui="toolbar"')
+    expect(toolbarHtml).toContain('data-children-ui="menu"')
   })
 
   it('omits markup toolbar controls in view mode', () => {

--- a/packages/cad-html-plugin/__tests__/AcExLayerExtents.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExLayerExtents.spec.ts
@@ -1,6 +1,7 @@
 import {
   computeLayerExtentsMap,
   computeLayoutExtents,
+  computeLayoutViewExtents,
   resolveLayoutViewExtents
 } from '../src/AcExLayerExtents'
 
@@ -91,6 +92,50 @@ describe('AcExLayerExtents', () => {
       minY: 0,
       maxX: 5,
       maxY: 5
+    })
+  })
+
+  it('unions viewport paper frames when a paper layout has no batches', () => {
+    expect(
+      computeLayoutViewExtents({
+        lineBatches: [],
+        meshBatches: [],
+        viewports: [
+          {
+            paper: { minX: 0, minY: 0, maxX: 12, maxY: 9 },
+            model: { minX: 100, minY: 200, maxX: 400, maxY: 500 }
+          },
+          {
+            paper: { minX: 20, minY: 4, maxX: 40, maxY: 30 },
+            model: { minX: 0, minY: 0, maxX: 1, maxY: 1 }
+          }
+        ]
+      })
+    ).toEqual({
+      minX: 0,
+      minY: 0,
+      maxX: 40,
+      maxY: 30
+    })
+  })
+
+  it('frames empty paper layouts to viewport paper instead of the unit box', () => {
+    expect(
+      resolveLayoutViewExtents({
+        lineBatches: [],
+        meshBatches: [],
+        viewports: [
+          {
+            paper: { minX: 2, minY: 3, maxX: 14, maxY: 12 },
+            model: { minX: 0, minY: 0, maxX: 1, maxY: 1 }
+          }
+        ]
+      })
+    ).toEqual({
+      minX: 2,
+      minY: 3,
+      maxX: 14,
+      maxY: 12
     })
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExPaperViewport.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPaperViewport.spec.ts
@@ -1,0 +1,76 @@
+import type { AcExViewportSnapshot } from '../src/AcExSnapshotTypes'
+import {
+  computeViewportCamera,
+  findDrillThroughViewport,
+  modelPointToPaper,
+  paperPointToModel,
+  snapshotHasPaperViewports,
+  viewportContainsPaperPoint,
+  viewportIsNearPaperBorder,
+  viewportPaperToModelScale
+} from '../src/AcExPaperViewport'
+
+const viewport: AcExViewportSnapshot = {
+  paper: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+  model: { minX: 100, minY: 200, maxX: 200, maxY: 400 }
+}
+
+describe('AcExPaperViewport', () => {
+  it('maps paper points to model viewBox and back', () => {
+    const model = paperPointToModel(viewport, 5, 5)
+    expect(model).toEqual({ x: 150, y: 300 })
+    expect(modelPointToPaper(viewport, model.x, model.y)).toEqual({
+      x: 5,
+      y: 5
+    })
+  })
+
+  it('maps paper corners onto model corners', () => {
+    expect(paperPointToModel(viewport, 0, 0)).toEqual({ x: 100, y: 200 })
+    expect(paperPointToModel(viewport, 10, 10)).toEqual({ x: 200, y: 400 })
+  })
+
+  it('computes paper-to-model scale from width', () => {
+    expect(viewportPaperToModelScale(viewport)).toBe(10)
+  })
+
+  it('detects interior vs border hits', () => {
+    expect(viewportContainsPaperPoint(viewport, 5, 5)).toBe(true)
+    expect(viewportContainsPaperPoint(viewport, -1, 5)).toBe(false)
+    expect(viewportIsNearPaperBorder(viewport, 5, 5, 0.5)).toBe(false)
+    expect(viewportIsNearPaperBorder(viewport, 0.2, 5, 0.5)).toBe(true)
+  })
+
+  it('picks the top-most interior viewport for drill-through', () => {
+    const bottom: AcExViewportSnapshot = {
+      paper: { minX: 0, minY: 0, maxX: 20, maxY: 20 },
+      model: { minX: 0, minY: 0, maxX: 1, maxY: 1 }
+    }
+    const top: AcExViewportSnapshot = {
+      paper: { minX: 4, minY: 4, maxX: 8, maxY: 8 },
+      model: { minX: 10, minY: 10, maxX: 20, maxY: 20 }
+    }
+    expect(findDrillThroughViewport([bottom, top], 6, 6, 0.1)).toBe(top)
+    expect(findDrillThroughViewport([bottom, top], 4.05, 6, 0.1)).toBe(bottom)
+  })
+
+  it('fits a viewport camera so model extents fill the scissor rectangle', () => {
+    const fitted = computeViewportCamera(
+      { minX: 0, minY: 0, maxX: 100, maxY: 50 },
+      200,
+      100
+    )
+    expect(fitted.centerX).toBe(50)
+    expect(fitted.centerY).toBe(25)
+    expect(fitted.frustum).toBe(50)
+    expect(fitted.aspect).toBe(2)
+    expect(fitted.zoom).toBe(2)
+  })
+
+  it('detects paper layouts that carry viewports', () => {
+    expect(
+      snapshotHasPaperViewports([{ viewports: [viewport] }, { viewports: [] }])
+    ).toBe(true)
+    expect(snapshotHasPaperViewports([{ viewports: undefined }])).toBe(false)
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExPaperViewport.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPaperViewport.spec.ts
@@ -30,6 +30,20 @@ describe('AcExPaperViewport', () => {
     expect(paperPointToModel(viewport, 10, 10)).toEqual({ x: 200, y: 400 })
   })
 
+  it('rotates paper-to-model mapping by view twist', () => {
+    const twisted: AcExViewportSnapshot = {
+      ...viewport,
+      twist: Math.PI / 2
+    }
+    expect(paperPointToModel(twisted, 5, 5)).toEqual({ x: 150, y: 300 })
+    const model = paperPointToModel(twisted, 10, 5)
+    expect(model.x).toBeCloseTo(150)
+    expect(model.y).toBeCloseTo(350)
+    const paper = modelPointToPaper(twisted, model.x, model.y)
+    expect(paper.x).toBeCloseTo(10)
+    expect(paper.y).toBeCloseTo(5)
+  })
+
   it('computes paper-to-model scale from width', () => {
     expect(viewportPaperToModelScale(viewport)).toBe(10)
   })

--- a/packages/cad-html-plugin/__tests__/AcExPaperViewportCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPaperViewportCollector.spec.ts
@@ -1,0 +1,51 @@
+import {
+  AcDbBlockTableRecord,
+  AcDbDatabase,
+  AcDbViewport,
+  AcGePoint3d
+} from '@mlightcad/data-model'
+
+import { collectLayoutViewports } from '../src/AcExPaperViewportCollector'
+
+describe('collectLayoutViewports', () => {
+  it('skips model space and the default paper-space viewport', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const paper = new AcDbBlockTableRecord()
+    paper.name = '*Paper_Space'
+    db.tables.blockTable.add(paper)
+
+    const defaultVp = new AcDbViewport()
+    defaultVp.centerPoint = new AcGePoint3d(6, 4.5, 0)
+    defaultVp.viewCenter = new AcGePoint3d(6, 4.5, 0)
+    defaultVp.width = 12
+    defaultVp.height = 9
+    defaultVp.viewHeight = 9
+    paper.appendEntity(defaultVp)
+
+    const userVp = new AcDbViewport()
+    userVp.centerPoint = new AcGePoint3d(100, 80, 0)
+    userVp.width = 200
+    userVp.height = 160
+    userVp.viewCenter = new AcGePoint3d(0, 0, 0)
+    userVp.viewHeight = 800
+    userVp.viewTarget = new AcGePoint3d(50, 40, 0)
+    paper.appendEntity(userVp)
+
+    expect(
+      collectLayoutViewports(db, modelSpace.objectId, true)
+    ).toBeUndefined()
+
+    const viewports = collectLayoutViewports(db, paper.objectId, false)
+    expect(viewports).toHaveLength(1)
+    expect(viewports![0]!.paper).toEqual({
+      minX: 0,
+      minY: 0,
+      maxX: 200,
+      maxY: 160
+    })
+    expect(viewports![0]!.model.minX).toBeLessThan(viewports![0]!.model.maxX)
+    expect(viewports![0]!.model.minY).toBeLessThan(viewports![0]!.model.maxY)
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExPaperViewportCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPaperViewportCollector.spec.ts
@@ -31,6 +31,7 @@ describe('collectLayoutViewports', () => {
     userVp.viewCenter = new AcGePoint3d(0, 0, 0)
     userVp.viewHeight = 800
     userVp.viewTarget = new AcGePoint3d(50, 40, 0)
+    userVp.viewTwistAngle = Math.PI / 6
     paper.appendEntity(userVp)
 
     expect(
@@ -45,6 +46,7 @@ describe('collectLayoutViewports', () => {
       maxX: 200,
       maxY: 160
     })
+    expect(viewports![0]!.twist).toBeCloseTo(Math.PI / 6)
     expect(viewports![0]!.model.minX).toBeLessThan(viewports![0]!.model.maxX)
     expect(viewports![0]!.model.minY).toBeLessThan(viewports![0]!.model.maxY)
   })

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
@@ -241,7 +241,8 @@ describe('AcExSnapshotCodec', () => {
           viewports: [
             {
               paper: { minX: 0, minY: 0, maxX: 12, maxY: 9 },
-              model: { minX: 100, minY: 200, maxX: 400, maxY: 500 }
+              model: { minX: 100, minY: 200, maxX: 400, maxY: 500 },
+              twist: Math.PI / 4
             }
           ]
         }
@@ -250,11 +251,18 @@ describe('AcExSnapshotCodec', () => {
     }
 
     const decoded = decodeSnapshot(encodeSnapshot(snapshot).payload)
-    expect(decoded.layouts[0]!.viewports).toEqual([
-      {
-        paper: { minX: 0, minY: 0, maxX: 12, maxY: 9 },
-        model: { minX: 100, minY: 200, maxX: 400, maxY: 500 }
-      }
-    ])
+    expect(decoded.layouts[0]!.viewports?.[0]?.paper).toEqual({
+      minX: 0,
+      minY: 0,
+      maxX: 12,
+      maxY: 9
+    })
+    expect(decoded.layouts[0]!.viewports?.[0]?.model).toEqual({
+      minX: 100,
+      minY: 200,
+      maxX: 400,
+      maxY: 500
+    })
+    expect(decoded.layouts[0]!.viewports?.[0]?.twist).toBeCloseTo(Math.PI / 4)
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
@@ -210,4 +210,51 @@ describe('AcExSnapshotCodec', () => {
     expect(Array.from(line.positions)).toEqual([0, 0, 0, 100, 50, 0])
     expect(line.offset).toEqual([100_000, 2_000_000, 0])
   })
+
+  it('round-trips paper-space viewport descriptors', () => {
+    const snapshot = {
+      version: ACEX_SNAPSHOT_VERSION,
+      meta: {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        extents: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        units: {
+          insunits: 4,
+          lunits: 2,
+          luprec: 4,
+          aunits: 0,
+          auprec: 0,
+          measurement: 1,
+          ltscale: 1,
+          angbase: 0,
+          angdir: 0
+        },
+        background: 0
+      },
+      layers: [{ name: '0', color: 0xffffff, visible: true }],
+      layouts: [
+        {
+          btrId: 'ps',
+          name: 'Layout1',
+          isModelSpace: false,
+          lineBatches: [],
+          meshBatches: [],
+          viewports: [
+            {
+              paper: { minX: 0, minY: 0, maxX: 12, maxY: 9 },
+              model: { minX: 100, minY: 200, maxX: 400, maxY: 500 }
+            }
+          ]
+        }
+      ],
+      activeLayoutBtrId: 'ps'
+    }
+
+    const decoded = decodeSnapshot(encodeSnapshot(snapshot).payload)
+    expect(decoded.layouts[0]!.viewports).toEqual([
+      {
+        paper: { minX: 0, minY: 0, maxX: 12, maxY: 9 },
+        model: { minX: 100, minY: 200, maxX: 400, maxY: 500 }
+      }
+    ])
+  })
 })

--- a/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
@@ -1,13 +1,9 @@
-import {
-  AcApI18n,
-  type AcTrScene
-} from '@mlightcad/cad-simple-viewer'
-import {
-  accmYieldForPaint,
-  type AcDbDatabase} from '@mlightcad/data-model'
+import { AcApI18n, type AcTrScene } from '@mlightcad/cad-simple-viewer'
+import { accmYieldForPaint, type AcDbDatabase } from '@mlightcad/data-model'
 
 import { computeLayoutExtents } from './AcExLayerExtents'
 import { buildOsnapCatalog } from './AcExOsnapPrimitiveBuilder'
+import { collectLayoutViewports } from './AcExPaperViewportCollector'
 import { collectBatchesFromObject3D } from './AcExSceneBatchCollector'
 import {
   ACEX_SNAPSHOT_VERSION,
@@ -127,29 +123,22 @@ export class AcApHtmlSnapshotBuilder {
       })
     })
 
+    const tableLayouts = listDatabaseLayouts(database)
+    const layoutNames = new Map(
+      tableLayouts.map(layout => [layout.blockTableRecordId, layout.name])
+    )
     const layouts: AcExLayoutSnapshot[] = []
-    for (const [btrId, layout] of scene.layouts) {
-      const lineBatches: AcExLineBatch[] = []
-      const meshBatches: AcExMeshBatch[] = []
-      for (const [, layer] of layout.layers) {
-        if (!shouldExportLayer(scene, layer.name, exportInvisibleLayers)) {
-          continue
-        }
-        const collected = collectBatchesFromObject3D(layer.internalObject)
-        lineBatches.push(...collected.lineBatches)
-        meshBatches.push(...collected.meshBatches)
-        await accmYieldForPaint()
-      }
-      layouts.push({
-        btrId,
-        name: resolveLayoutName(database, btrId),
-        isModelSpace: btrId === scene.modelSpaceBtrId,
-        lineBatches,
-        meshBatches,
-        osnap: shouldExportOsnap(options)
-          ? buildOsnapCatalog(database, btrId, { includeLayer })
-          : undefined
-      })
+    for (const btrId of listExportLayoutBtrIds(scene, tableLayouts)) {
+      layouts.push(
+        collectLayoutSnapshot(
+          scene,
+          database,
+          btrId,
+          layoutNames,
+          options,
+          includeLayer
+        )
+      )
       await accmYieldForPaint()
     }
 
@@ -202,29 +191,23 @@ export class AcApHtmlSnapshotBuilder {
       })
     })
 
+    const tableLayouts = listDatabaseLayouts(database)
+    const layoutNames = new Map(
+      tableLayouts.map(layout => [layout.blockTableRecordId, layout.name])
+    )
     const layouts: AcExLayoutSnapshot[] = []
-    scene.layouts.forEach((layout, btrId) => {
-      const lineBatches: AcExLineBatch[] = []
-      const meshBatches: AcExMeshBatch[] = []
-      for (const [, layer] of layout.layers) {
-        if (!shouldExportLayer(scene, layer.name, exportInvisibleLayers)) {
-          continue
-        }
-        const collected = collectBatchesFromObject3D(layer.internalObject)
-        lineBatches.push(...collected.lineBatches)
-        meshBatches.push(...collected.meshBatches)
-      }
-      layouts.push({
-        btrId,
-        name: resolveLayoutName(database, btrId),
-        isModelSpace: btrId === scene.modelSpaceBtrId,
-        lineBatches,
-        meshBatches,
-        osnap: shouldExportOsnap(options)
-          ? buildOsnapCatalog(database, btrId, { includeLayer })
-          : undefined
-      })
-    })
+    for (const btrId of listExportLayoutBtrIds(scene, tableLayouts)) {
+      layouts.push(
+        collectLayoutSnapshot(
+          scene,
+          database,
+          btrId,
+          layoutNames,
+          options,
+          includeLayer
+        )
+      )
+    }
 
     return {
       version: ACEX_SNAPSHOT_VERSION,
@@ -298,17 +281,110 @@ function shouldExportLayer(
   return !layer.isOff && !layer.isFrozen
 }
 
+/** One layout-table row used to order and name exported layouts. */
+interface AcExDatabaseLayoutInfo {
+  name: string
+  tabOrder: number
+  blockTableRecordId: string
+}
+
 /**
- * Resolves a block table record object id to its layout/block name.
+ * Lists layouts from the drawing's layout table, including model space,
+ * sorted by tab order. Used so HTML export covers paper-space tabs that
+ * were never visited (and may be missing from {@link AcTrScene.layouts}).
  *
- * @param database - Drawing whose block table is searched.
- * @param btrId - Object id of the layout's owning block table record.
- * @returns The record name, or `btrId` if no matching block is found.
+ * @param database - Open drawing database.
+ * @returns Layouts in tab order; empty when the layout table is unavailable.
  */
-function resolveLayoutName(database: AcDbDatabase, btrId: string): string {
-  for (const block of database.tables.blockTable.newIterator()) {
-    if (block.objectId === btrId) {
-      return block.name
+export function listDatabaseLayouts(
+  database: AcDbDatabase
+): AcExDatabaseLayoutInfo[] {
+  const layoutTable = database.objects?.layout
+  if (!layoutTable?.newIterator) return []
+
+  const layouts: AcExDatabaseLayoutInfo[] = []
+  for (const layout of layoutTable.newIterator()) {
+    const blockTableRecordId = layout.blockTableRecordId
+    if (!blockTableRecordId) continue
+    layouts.push({
+      name: layout.layoutName || blockTableRecordId,
+      tabOrder: layout.tabOrder ?? 0,
+      blockTableRecordId
+    })
+  }
+  layouts.sort((a, b) => a.tabOrder - b.tabOrder)
+  return layouts
+}
+
+/**
+ * Ordered BTR ids to export: layout-table tabs first (tab order), then any
+ * extra scene layouts that are not in the table.
+ */
+function listExportLayoutBtrIds(
+  scene: AcTrScene,
+  tableLayouts: AcExDatabaseLayoutInfo[]
+): string[] {
+  const seen = new Set<string>()
+  const ids: string[] = []
+  for (const layout of tableLayouts) {
+    if (seen.has(layout.blockTableRecordId)) continue
+    seen.add(layout.blockTableRecordId)
+    ids.push(layout.blockTableRecordId)
+  }
+  for (const btrId of scene.layouts.keys()) {
+    if (seen.has(btrId)) continue
+    seen.add(btrId)
+    ids.push(btrId)
+  }
+  return ids
+}
+
+function collectLayoutSnapshot(
+  scene: AcTrScene,
+  database: AcDbDatabase,
+  btrId: string,
+  layoutNames: Map<string, string>,
+  options: AcApHtmlSnapshotBuilderOptions,
+  includeLayer: ((layerName: string) => boolean) | undefined
+): AcExLayoutSnapshot {
+  const lineBatches: AcExLineBatch[] = []
+  const meshBatches: AcExMeshBatch[] = []
+  const layout = scene.layouts.get(btrId)
+  if (layout) {
+    for (const [, layer] of layout.layers) {
+      if (includeLayer && !includeLayer(layer.name)) {
+        continue
+      }
+      const collected = collectBatchesFromObject3D(layer.internalObject)
+      lineBatches.push(...collected.lineBatches)
+      meshBatches.push(...collected.meshBatches)
+    }
+  }
+  const isModelSpace = btrId === scene.modelSpaceBtrId
+  return {
+    btrId,
+    name: layoutNames.get(btrId) ?? resolveBlockName(database, btrId),
+    isModelSpace,
+    lineBatches,
+    meshBatches,
+    osnap: shouldExportOsnap(options)
+      ? buildOsnapCatalog(database, btrId, { includeLayer })
+      : undefined,
+    viewports: collectLayoutViewports(database, btrId, isModelSpace)
+  }
+}
+
+/**
+ * Resolves a layout BTR id to the block-table record name when the layout
+ * table has no matching row.
+ */
+function resolveBlockName(database: AcDbDatabase, btrId: string): string {
+  const blockTable = database.tables?.blockTable
+  if (blockTable?.newIterator) {
+    for (const block of blockTable.newIterator()) {
+      if (block.objectId === btrId) {
+        return block.name
+      }
     }
   }
   return btrId

--- a/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlSnapshotBuilder.ts
@@ -1,7 +1,7 @@
 import { AcApI18n, type AcTrScene } from '@mlightcad/cad-simple-viewer'
 import { accmYieldForPaint, type AcDbDatabase } from '@mlightcad/data-model'
 
-import { computeLayoutExtents } from './AcExLayerExtents'
+import { computeLayoutViewExtents } from './AcExLayerExtents'
 import { buildOsnapCatalog } from './AcExOsnapPrimitiveBuilder'
 import { collectLayoutViewports } from './AcExPaperViewportCollector'
 import { collectBatchesFromObject3D } from './AcExSceneBatchCollector'
@@ -242,7 +242,7 @@ function buildSnapshotMeta(
   const activeLayout =
     layouts.find(layout => layout.btrId === activeLayoutBtrId) ?? layouts[0]
   const viewExtents = activeLayout
-    ? computeLayoutExtents(activeLayout.lineBatches, activeLayout.meshBatches)
+    ? computeLayoutViewExtents(activeLayout)
     : null
   const initialView = options.initialView ?? 'fit'
 

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -60,6 +60,7 @@ export type AcExHtmlMessageKey =
   | 'toolbar.markupExport'
   | 'toolbar.snap'
   | 'toolbar.layers'
+  | 'toolbar.layout'
   | 'toolbar.language'
   | 'toolbar.localeEn'
   | 'toolbar.localeZh'
@@ -165,6 +166,7 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       markupExport: 'Export markups',
       snap: 'Object snap',
       layers: 'Layers',
+      layout: 'Layout',
       language: 'Language',
       localeEn: 'English',
       localeZh: '中文',
@@ -278,6 +280,7 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       markupExport: '导出批注',
       snap: '对象捕捉',
       layers: '图层',
+      layout: '布局',
       language: '语言',
       localeEn: 'English',
       localeZh: '中文',
@@ -385,6 +388,7 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       markupExport: 'Exportovat poznámky',
       snap: 'Uchopení objektů',
       layers: 'Hladiny',
+      layout: 'Rozvržení',
       language: 'Jazyk',
       localeEn: 'English',
       localeZh: '中文',
@@ -498,6 +502,7 @@ const MESSAGES: Record<AcExHtmlLocale, AcExMessageTree> = {
       markupExport: 'İşaretlemeleri dışa aktar',
       snap: 'Nesne Yakalama',
       layers: 'Katmanlar',
+      layout: 'Düzen',
       language: 'Dil',
       localeEn: 'English',
       localeZh: '中文',

--- a/packages/cad-html-plugin/src/AcExHtmlIcons.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlIcons.ts
@@ -26,14 +26,16 @@ const ICON_MEASURE_COORDINATE =
 
 /** Element Plus icon helper (1024 viewBox, same as cad-viewer). */
 function elementPlusIcon(...pathDs: string[]): string {
-  const paths = pathDs
-    .map(d => `<path fill="currentColor" d="${d}"/>`)
-    .join('')
+  const paths = pathDs.map(d => `<path fill="currentColor" d="${d}"/>`).join('')
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" aria-hidden="true">${paths}</svg>`
 }
 
 const ICON_LAYER =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="m434.8 137.65-149.36-68.1c-16.19-7.4-42.69-7.4-58.88 0L77.3 137.65c-17.6 8-17.6 21.09 0 29.09l148 67.5c16.89 7.7 44.69 7.7 61.58 0l148-67.5c17.52-8 17.52-21.1-.08-29.09M160 308.52l-82.7 37.11c-17.6 8-17.6 21.1 0 29.1l148 67.5c16.89 7.69 44.69 7.69 61.58 0l148-67.5c17.6-8 17.6-21.1 0-29.1l-79.94-38.47"/><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="m160 204.48-82.8 37.16c-17.6 8-17.6 21.1 0 29.1l148 67.49c16.89 7.7 44.69 7.7 61.58 0l148-67.49c17.7-8 17.7-21.1.1-29.1L352 204.48"/></svg>'
+
+/** Drawing layout switcher (same glyph as cad-simple-ui-plugin). */
+const ICON_LAYOUT =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><rect x="2" y="2" width="8.2" height="5" rx="1.2" fill="currentColor"/><rect x="2" y="8.5" width="8.2" height="9.5" rx="1.2" fill="currentColor"/><rect x="11.7" y="2" width="6.3" height="10" rx="1.2" fill="currentColor"/><rect x="11.7" y="13.5" width="6.3" height="4.5" rx="1.2" fill="currentColor"/></svg>'
 
 const ICON_ZOOM_BOX =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M15.0833 14.8083c1.2333-1.3 1.9083-3.0333 1.9083-4.825-.0083-3.325-2.35-6.1833-5.6083-6.8417C8.125 2.4833 4.85 4.2 3.55 7.2583c-1.3 3.0583-.275 6.6083 2.4583 8.5 2.725 1.8917 6.4167 1.6 8.8167-.6917.0917-.0833.175-.175.2583-.2583Zm1.2583.5917 2.575 2.575c-.3167.3167-.625.625-.9417.9417-.8583-.8583-1.7167-1.7167-2.575-2.575-3.4083 2.9-8.4917 2.5917-11.525-.6917C.8417 12.3667.9417 7.275 4.1083 4.1083 7.2667.9417 12.3667.8417 15.65 3.875s3.5917 8.1167.6917 11.525Zm-3.55-2.6083V7.2083H7.2083v5.5833h5.5833ZM5.875 5.875h8.25v8.25H5.875V5.875Z"/></svg>'
@@ -155,6 +157,8 @@ export const acExHtmlIcons = {
   clearMeasurements: ICON_CLEAR_MARKUPS,
   /** Open layer drawer toolbar icon. */
   layer: ICON_LAYER,
+  /** Drawing layout switcher toolbar icon. */
+  layout: ICON_LAYOUT,
   /** Per-layer zoom-to-box button icon (same glyph as zoom window). */
   zoomWindow: ICON_ZOOM_BOX,
   /** Restore the viewport captured when the HTML first opened. */

--- a/packages/cad-html-plugin/src/AcExHtmlLayoutMenu.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlLayoutMenu.ts
@@ -1,0 +1,158 @@
+/**
+ * Layout-switcher dropdown for the offline HTML viewer toolbar.
+ *
+ * Matches cad-simple-ui-plugin: a first-level button with `childrenUi: 'menu'`
+ * lists every exported layout; choosing one switches the current layout.
+ *
+ * @module AcExHtmlLayoutMenu
+ * @packageDocumentation
+ */
+
+import type { AcExLayoutSnapshot } from './AcExSnapshotTypes'
+
+/** Handles returned by {@link setupAcExHtmlLayoutMenu}. */
+export interface AcExHtmlLayoutMenuController {
+  /** Closes the dropdown if it is open. */
+  close: () => void
+  /** Rebuilds item `active` state after a layout switch. */
+  refresh: () => void
+}
+
+/** Dependencies for {@link setupAcExHtmlLayoutMenu}. */
+export interface AcExHtmlLayoutMenuOptions {
+  /** Exported layouts in display (tab) order. */
+  layouts: Pick<AcExLayoutSnapshot, 'btrId' | 'name'>[]
+  /** BTR id of the layout currently shown. */
+  getActiveLayoutBtrId: () => string
+  /**
+   * Called when the user chooses a layout. No-op when the id is already active.
+   */
+  onSelect: (btrId: string) => void
+  /** Closes sibling flyout strips before opening this menu. */
+  closeOtherFlyouts?: () => void
+}
+
+/**
+ * Wires the layout toolbar button to a popover listing every snapshot layout.
+ */
+export function setupAcExHtmlLayoutMenu(
+  options: AcExHtmlLayoutMenuOptions
+): AcExHtmlLayoutMenuController {
+  const btn = document.getElementById(
+    'mlcad-layout-menu-btn'
+  ) as HTMLButtonElement | null
+  if (!btn || options.layouts.length === 0) {
+    return { close: () => {}, refresh: () => {} }
+  }
+
+  let menu: HTMLDivElement | null = null
+
+  const isOpen = () => menu != null
+
+  const syncButton = () => {
+    const open = isOpen()
+    btn.classList.toggle('active', open)
+    btn.classList.toggle('is-menu-open', open)
+    btn.setAttribute('aria-expanded', String(open))
+  }
+
+  const close = () => {
+    if (!menu) return
+    document.removeEventListener('mousedown', handleDocumentClick, true)
+    menu.remove()
+    menu = null
+    syncButton()
+  }
+
+  const handleDocumentClick = (event: MouseEvent) => {
+    if (!(event.target instanceof Node)) return
+    if (menu?.contains(event.target)) return
+    if (btn.contains(event.target)) return
+    close()
+  }
+
+  const positionNear = (root: HTMLDivElement) => {
+    const rect = btn.getBoundingClientRect()
+    const menuRect = root.getBoundingClientRect()
+    let top = rect.top
+    let left = rect.right + 8
+
+    if (left + menuRect.width > window.innerWidth - 8) {
+      left = Math.max(8, rect.left - menuRect.width - 8)
+    }
+    if (top + menuRect.height > window.innerHeight - 8) {
+      top = Math.max(8, window.innerHeight - menuRect.height - 8)
+    }
+
+    root.style.top = `${Math.max(8, top)}px`
+    root.style.left = `${Math.max(8, left)}px`
+  }
+
+  const markActive = (root: HTMLElement) => {
+    const activeId = options.getActiveLayoutBtrId()
+    root
+      .querySelectorAll<HTMLButtonElement>('[data-layout-id]')
+      .forEach(item => {
+        const selected = item.getAttribute('data-layout-id') === activeId
+        item.classList.toggle('active', selected)
+        item.classList.toggle('is-toggled', selected)
+        item.setAttribute('aria-pressed', String(selected))
+      })
+  }
+
+  const open = () => {
+    if (menu) return
+    options.closeOtherFlyouts?.()
+
+    const root = document.createElement('div')
+    root.className = 'mlcad-dropdown'
+    root.setAttribute('role', 'menu')
+    root.setAttribute('aria-labelledby', 'mlcad-layout-menu-btn')
+
+    for (const layout of options.layouts) {
+      const item = document.createElement('button')
+      item.type = 'button'
+      item.className = 'mlcad-dropdown-item'
+      item.setAttribute('role', 'menuitem')
+      item.dataset.layoutId = layout.btrId
+      item.title = layout.name
+
+      const label = document.createElement('span')
+      label.className = 'mlcad-dropdown-label'
+      label.textContent = layout.name
+      item.appendChild(label)
+
+      item.addEventListener('click', event => {
+        event.stopPropagation()
+        close()
+        if (layout.btrId === options.getActiveLayoutBtrId()) return
+        options.onSelect(layout.btrId)
+      })
+      root.appendChild(item)
+    }
+
+    document.body.appendChild(root)
+    markActive(root)
+    positionNear(root)
+    menu = root
+    document.addEventListener('mousedown', handleDocumentClick, true)
+    syncButton()
+  }
+
+  const toggle = () => {
+    if (isOpen()) close()
+    else open()
+  }
+
+  btn.addEventListener('click', event => {
+    event.stopPropagation()
+    toggle()
+  })
+
+  return {
+    close,
+    refresh: () => {
+      if (menu) markActive(menu)
+    }
+  }
+}

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -115,6 +115,9 @@ export const ACEX_HTML_SHELL_CSS = `
     position: fixed;
     z-index: 40;
     min-width: 180px;
+    max-width: min(280px, calc(100vw - 24px));
+    max-height: min(360px, calc(100vh - 24px));
+    overflow-y: auto;
     padding: 4px;
     background: var(--mlcad-ui-bg-elevated);
     border: 1px solid var(--mlcad-ui-border);
@@ -625,8 +628,7 @@ export function buildAcExHtmlShellBody(
     viewerMode === 'measure' ? buildAcExMeasureMenuButton() : ''
   const markupToolbar =
     viewerMode === 'measure' ? buildAcExMarkupMenuButton() : ''
-  const snapToolbar =
-    viewerMode === 'measure' ? buildAcExSnapMenuButton() : ''
+  const snapToolbar = viewerMode === 'measure' ? buildAcExSnapMenuButton() : ''
   const languageToolbar = buildAcExLanguageToolbarButton()
   const submenuTemplates = ''
   const toolStrips = `${buildAcExHtmlZoomStrip()}${
@@ -666,6 +668,7 @@ export function buildAcExHtmlShellBody(
           'data-i18n-key': 'toolbar.layers',
           'data-i18n-attr': 'title aria-label'
         })}
+        ${buildAcExLayoutMenuButton()}
         ${snapToolbar}
         ${languageToolbar}
         ${acExToolbarButton(acExHtmlIcons.chevronUp, 'Collapse toolbar', {
@@ -699,6 +702,18 @@ export function buildAcExHtmlShellBody(
 
 function buildAcExToolbarSeparator(): string {
   return '<div class="mlcad-tool-separator" aria-hidden="true"></div>'
+}
+
+function buildAcExLayoutMenuButton(): string {
+  return acExToolbarButton(acExHtmlIcons.layout, 'Layout', {
+    id: 'mlcad-layout-menu-btn',
+    'aria-haspopup': 'menu',
+    'aria-expanded': 'false',
+    'data-action': 'layout-menu',
+    'data-i18n-key': 'toolbar.layout',
+    'data-i18n-attr': 'title aria-label',
+    'data-children-ui': 'menu'
+  }).replace('class="mlcad-tool-btn"', 'class="mlcad-tool-btn has-children"')
 }
 
 function buildAcExZoomMenuButton(): string {

--- a/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
@@ -6,7 +6,7 @@
  *   another first-level button that opens a strip is clicked. Canvas clicks
  *   do not dismiss it. The parent button acts as a toggle.
  * - `'toolbar'`: icon strip that closes on canvas / outside click.
- * - `'menu'`: optional popover (unused by the built-in HTML chrome).
+ * - `'menu'`: popover listing items (drawing layouts).
  *
  * @module AcExHtmlToolbarFlyout
  * @packageDocumentation

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -531,7 +531,9 @@ function startViewer(): void {
         ACEX_CAMERA_DISTANCE
       )
       viewportCamera.lookAt(fitted.centerX, fitted.centerY, 0)
-      viewportCamera.setRotationFromEuler(new THREE.Euler(0, 0, 0))
+      const twist = viewport.twist ?? 0
+      viewportCamera.up.set(-Math.sin(twist), Math.cos(twist), 0)
+      viewportCamera.setRotationFromEuler(new THREE.Euler(0, 0, twist))
       viewportCamera.zoom = fitted.zoom
       viewportCamera.updateProjectionMatrix()
       acexCameraZoomUniform.value = fitted.zoom

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -8,6 +8,7 @@ import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeome
 import { setupAcExDrawStyleToolbar } from './AcExDrawStyleToolbar'
 import { AcExHtmlI18n, detectAcExHtmlLocale } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
+import { setupAcExHtmlLayoutMenu } from './AcExHtmlLayoutMenu'
 import { setupAcExHtmlMeasureSettings } from './AcExHtmlMeasureSettings'
 import { setupAcExHtmlNavTools } from './AcExHtmlNavTools'
 import {
@@ -23,6 +24,14 @@ import { AcExMeasureController, type AcExMeasureMode } from './AcExMeasurement'
 import { AcExOsnapIndex } from './AcExOsnap'
 import { AcExOsnapMarker } from './AcExOsnapMarker'
 import {
+  computeViewportCamera,
+  findDrillThroughViewport,
+  modelPointToPaper,
+  paperPointToModel,
+  snapshotHasPaperViewports,
+  viewportPaperToModelScale
+} from './AcExPaperViewport'
+import {
   acexCameraZoomUniform,
   createViewerLineMaterial,
   createViewerMeshMaterial,
@@ -31,6 +40,7 @@ import {
 import { decodeSnapshot } from './AcExSnapshotCodec'
 import type {
   AcExExtents,
+  AcExLayoutSnapshot,
   AcExLineBatch,
   AcExMeshBatch,
   AcExSnapshot,
@@ -102,13 +112,14 @@ function startViewer(): void {
   const i18n = new AcExHtmlI18n(detectAcExHtmlLocale())
   i18n.applyToDocument()
 
-  const layout =
+  const initialLayout =
     snapshot.layouts.find(l => l.btrId === snapshot.activeLayoutBtrId) ??
     snapshot.layouts[0]
-  if (!layout) {
+  if (!initialLayout) {
     showViewerError(i18n.t('status.noLayout'))
     return
   }
+  let layout = initialLayout
 
   const layerVisible = new Map(
     snapshot.layers.map(layer => [layer.name, layer.visible])
@@ -141,47 +152,92 @@ function startViewer(): void {
 
   const controls = createOrbitControls(camera, renderer.domElement)
 
-  const layerGroups = new Map<string, THREE.Group>()
-  const wideLineMaterials: LineMaterial[] = []
+  const modelLayout = snapshot.layouts.find(item => item.isModelSpace)
+  const hasPaperViewports = snapshotHasPaperViewports(snapshot.layouts)
+
+  const paperLayerGroups = new Map<string, THREE.Group>()
+  const modelLayerGroups = new Map<string, THREE.Group>()
+  const paperWideLineMaterials: LineMaterial[] = []
+  const modelWideLineMaterials: LineMaterial[] = []
   const wideLineResolution = new THREE.Vector2(initialWidth, initialHeight)
 
-  const getLayerGroup = (layerName: string): THREE.Group => {
-    let group = layerGroups.get(layerName)
+  const paperRoot = new THREE.Group()
+  paperRoot.name = 'paper-space'
+  const modelRoot = new THREE.Group()
+  modelRoot.name = 'model-space'
+  const modelScene = new THREE.Scene()
+  const viewportCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 1000)
+  viewportCamera.up.set(0, 1, 0)
+  const savedViewportBox = new THREE.Vector4()
+
+  const getOrCreateLayerGroup = (
+    groups: Map<string, THREE.Group>,
+    parent: THREE.Object3D,
+    layerName: string
+  ): THREE.Group => {
+    let group = groups.get(layerName)
     if (!group) {
       group = new THREE.Group()
       group.name = layerName
       group.visible = layerVisible.get(layerName) !== false
-      layerGroups.set(layerName, group)
-      scene.add(group)
+      groups.set(layerName, group)
+      parent.add(group)
     }
     return group
   }
 
-  for (const batch of layout.lineBatches) {
-    const object = createLineObject(
-      batch,
-      wideLineMaterials,
-      wideLineResolution
-    )
-    if (object) getLayerGroup(batch.layer).add(object)
+  const populateLayoutGeometry = (
+    next: AcExLayoutSnapshot,
+    groups: Map<string, THREE.Group>,
+    parent: THREE.Object3D,
+    materials: LineMaterial[]
+  ) => {
+    for (const batch of next.lineBatches) {
+      const object = createLineObject(batch, materials, wideLineResolution)
+      if (object) getOrCreateLayerGroup(groups, parent, batch.layer).add(object)
+    }
+    for (const batch of next.meshBatches) {
+      const object = batch.points
+        ? createPointObject(batch)
+        : createMeshObject(batch)
+      if (object) getOrCreateLayerGroup(groups, parent, batch.layer).add(object)
+    }
   }
-  for (const batch of layout.meshBatches) {
-    const object = batch.points
-      ? createPointObject(batch)
-      : createMeshObject(batch)
-    if (object) getLayerGroup(batch.layer).add(object)
+
+  if (modelLayout) {
+    populateLayoutGeometry(
+      modelLayout,
+      modelLayerGroups,
+      modelRoot,
+      modelWideLineMaterials
+    )
+  }
+  if (layout.isModelSpace) {
+    scene.add(modelRoot)
+  } else {
+    scene.add(paperRoot)
+    populateLayoutGeometry(
+      layout,
+      paperLayerGroups,
+      paperRoot,
+      paperWideLineMaterials
+    )
+    if (hasPaperViewports) {
+      modelScene.add(modelRoot)
+    }
   }
 
   const layerExtents = computeLayerExtentsMap(
     layout.lineBatches,
     layout.meshBatches
   )
-  const layoutExtents = resolveLayoutViewExtents(
+  let layoutExtents = resolveLayoutViewExtents(
     layout,
     snapshot.meta.viewExtents ?? snapshot.meta.extents
   )
 
   let osnapIndex: AcExOsnapIndex | null = null
+  let modelOsnapIndex: AcExOsnapIndex | null = null
   let osnapMarker: AcExOsnapMarker | null = null
   let osnapThresholdWcs = 0
   let snapCacheKey = 0
@@ -195,16 +251,29 @@ function startViewer(): void {
     snapCacheKey++
   }
 
+  const applyOsnapLayerVisibility = (index: AcExOsnapIndex | null) => {
+    if (!index) return
+    for (const layer of snapshot.layers) {
+      if (!layer.visible) {
+        index.setLayerHidden(layer.name, true)
+      }
+    }
+  }
+
   if (measureEnabled) {
     osnapIndex = new AcExOsnapIndex()
     osnapMarker = new AcExOsnapMarker(root)
     osnapIndex.rebuild(layout)
-    for (const layer of snapshot.layers) {
-      if (!layer.visible) {
-        osnapIndex.setLayerHidden(layer.name, true)
-      }
+    applyOsnapLayerVisibility(osnapIndex)
+    if (hasPaperViewports && modelLayout) {
+      modelOsnapIndex = new AcExOsnapIndex()
+      modelOsnapIndex.rebuild(modelLayout)
+      applyOsnapLayerVisibility(modelOsnapIndex)
     }
-    releaseSnapshotOsnapCatalogs(snapshot)
+    // Keep inactive-layout catalogs so the user can switch back.
+    if (snapshot.layouts.length <= 1 && !hasPaperViewports) {
+      releaseSnapshotOsnapCatalogs(snapshot)
+    }
   }
 
   removeSnapshotElement(snapshotEl)
@@ -241,7 +310,10 @@ function startViewer(): void {
     const { width, height } = getCanvasSize()
     renderer.setSize(width, height)
     wideLineResolution.set(width, height)
-    for (const material of wideLineMaterials) {
+    for (const material of paperWideLineMaterials) {
+      material.resolution.copy(wideLineResolution)
+    }
+    for (const material of modelWideLineMaterials) {
       material.resolution.copy(wideLineResolution)
     }
     updateCameraFrustum(width, height)
@@ -268,9 +340,21 @@ function startViewer(): void {
     centerY: controls.target.y,
     zoom: camera.zoom
   })
-  let originalView = captureViewState()
+  const originalByLayout = new Map<
+    string,
+    { centerX: number; centerY: number; zoom: number }
+  >()
+  const lastViewByLayout = new Map<
+    string,
+    { centerX: number; centerY: number; zoom: number }
+  >()
   const restoreOriginalView = () => {
-    flyTo(originalView.centerX, originalView.centerY, originalView.zoom)
+    const saved = originalByLayout.get(layout.btrId)
+    if (saved) {
+      flyTo(saved.centerX, saved.centerY, saved.zoom)
+    } else {
+      fit()
+    }
     render()
   }
 
@@ -316,6 +400,31 @@ function startViewer(): void {
     if (!osnapIndex) {
       return { point: raw, snap: null }
     }
+    if (!layout.isModelSpace && modelOsnapIndex) {
+      const viewport = findDrillThroughViewport(
+        layout.viewports,
+        raw.x,
+        raw.y,
+        osnapThresholdWcs
+      )
+      if (viewport) {
+        const modelPt = paperPointToModel(viewport, raw.x, raw.y)
+        const modelThresh =
+          osnapThresholdWcs * viewportPaperToModelScale(viewport)
+        const modelSnap = modelOsnapIndex.findSnap(
+          modelPt.x,
+          modelPt.y,
+          modelThresh
+        )
+        if (modelSnap) {
+          const paper = modelPointToPaper(viewport, modelSnap.x, modelSnap.y)
+          return {
+            point: new THREE.Vector2(paper.x, paper.y),
+            snap: { ...modelSnap, x: paper.x, y: paper.y }
+          }
+        }
+      }
+    }
     const snap = osnapIndex.findSnap(raw.x, raw.y, osnapThresholdWcs)
     const point = snap ? new THREE.Vector2(snap.x, snap.y) : raw
     return { point, snap: snap ?? null }
@@ -328,6 +437,9 @@ function startViewer(): void {
   } = { current: null }
   const toolbarFlyoutsRef: {
     current: ReturnType<typeof setupAcExHtmlToolbarFlyouts> | null
+  } = { current: null }
+  const layoutMenuRef: {
+    current: ReturnType<typeof setupAcExHtmlLayoutMenu> | null
   } = { current: null }
   const drawStyleToolbarRef: {
     current: ReturnType<typeof setupAcExDrawStyleToolbar> | null
@@ -351,10 +463,97 @@ function startViewer(): void {
     navToolsRef.current?.syncButtons()
   }
 
+  const paperWorldToScreen = (
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ) => {
+    const ndc = new THREE.Vector3(x, y, 0).project(camera)
+    return {
+      x: ((ndc.x + 1) / 2) * width,
+      y: ((-ndc.y + 1) / 2) * height
+    }
+  }
+
+  const renderPaperViewports = () => {
+    const viewports = layout.viewports
+    if (
+      layout.isModelSpace ||
+      !viewports?.length ||
+      modelRoot.children.length === 0
+    ) {
+      return
+    }
+    const { width, height } = getCanvasSize()
+    if (width <= 0 || height <= 0) return
+
+    const autoClear = renderer.autoClear
+    renderer.autoClear = false
+    renderer.getViewport(savedViewportBox)
+    renderer.clearDepth()
+
+    for (const viewport of viewports) {
+      const pMin = paperWorldToScreen(
+        viewport.paper.minX,
+        viewport.paper.minY,
+        width,
+        height
+      )
+      const pMax = paperWorldToScreen(
+        viewport.paper.maxX,
+        viewport.paper.maxY,
+        width,
+        height
+      )
+      const minX = Math.min(pMin.x, pMax.x)
+      const maxX = Math.max(pMin.x, pMax.x)
+      const minY = Math.min(pMin.y, pMax.y)
+      const maxY = Math.max(pMin.y, pMax.y)
+      const vpW = maxX - minX
+      const vpH = maxY - minY
+      if (vpW < 1 || vpH < 1) continue
+
+      const scissorX = minX
+      const scissorY = height - maxY
+      renderer.setViewport(scissorX, scissorY, vpW, vpH)
+      renderer.setScissor(scissorX, scissorY, vpW, vpH)
+      renderer.setScissorTest(true)
+
+      const fitted = computeViewportCamera(viewport.model, vpW, vpH)
+      viewportCamera.left = -fitted.aspect * fitted.frustum
+      viewportCamera.right = fitted.aspect * fitted.frustum
+      viewportCamera.top = fitted.frustum
+      viewportCamera.bottom = -fitted.frustum
+      viewportCamera.position.set(
+        fitted.centerX,
+        fitted.centerY,
+        ACEX_CAMERA_DISTANCE
+      )
+      viewportCamera.lookAt(fitted.centerX, fitted.centerY, 0)
+      viewportCamera.setRotationFromEuler(new THREE.Euler(0, 0, 0))
+      viewportCamera.zoom = fitted.zoom
+      viewportCamera.updateProjectionMatrix()
+      acexCameraZoomUniform.value = fitted.zoom
+      renderer.render(modelScene, viewportCamera)
+      renderer.setScissorTest(false)
+    }
+
+    renderer.setViewport(
+      savedViewportBox.x,
+      savedViewportBox.y,
+      savedViewportBox.z,
+      savedViewportBox.w
+    )
+    renderer.autoClear = autoClear
+    acexCameraZoomUniform.value = camera.zoom
+  }
+
   const render = () => {
     measure?.syncOverlays()
     markup?.syncOverlays()
     renderer.render(scene, camera)
+    renderPaperViewports()
   }
 
   if (measureEnabled) {
@@ -382,6 +581,7 @@ function startViewer(): void {
       onStyleChange: () => {
         drawStyleToolbarRef.current?.refresh()
       },
+      getActiveLayoutId: () => layout.btrId,
       view: {
         screenToWcs,
         wcsToScreen,
@@ -389,6 +589,34 @@ function startViewer(): void {
         getSnapCacheKey: () => snapCacheKey,
         resolvePoint: resolveMeasurePoint,
         findCircleOrArcNear: (x, y) => {
+          if (!layout.isModelSpace && modelOsnapIndex) {
+            const viewport = findDrillThroughViewport(
+              layout.viewports,
+              x,
+              y,
+              osnapThresholdWcs
+            )
+            if (viewport) {
+              const modelPt = paperPointToModel(viewport, x, y)
+              const modelScale = viewportPaperToModelScale(viewport)
+              const hit = modelOsnapIndex.findCircleOrArcNear(
+                modelPt.x,
+                modelPt.y,
+                osnapThresholdWcs * modelScale
+              )
+              if (hit) {
+                const onCurve = modelPointToPaper(viewport, hit.x, hit.y)
+                const center = modelPointToPaper(viewport, hit.cx, hit.cy)
+                return {
+                  cx: center.x,
+                  cy: center.y,
+                  r: modelScale === 0 ? hit.r : hit.r / modelScale,
+                  x: onCurve.x,
+                  y: onCurve.y
+                }
+              }
+            }
+          }
           if (!osnapIndex) return null
           return osnapIndex.findCircleOrArcNear(x, y, osnapThresholdWcs) ?? null
         },
@@ -424,6 +652,7 @@ function startViewer(): void {
       },
       getTrackingOptions: () =>
         measureSettingsRef.current?.getTrackingOptions() ?? null,
+      getActiveLayoutId: () => layout.btrId,
       view: {
         screenToWcs,
         wcsToScreen,
@@ -465,27 +694,121 @@ function startViewer(): void {
 
   const toolbarCollapse = setupToolbarCollapse(i18n, () => {
     toolbarFlyoutsRef.current?.close()
+    layoutMenuRef.current?.close()
     measureSettingsRef.current?.close()
   })
 
   const layerPanel = setupLayerPanel({
     snapshot,
     layerVisible,
-    layerGroups,
+    layerGroupMaps: [paperLayerGroups, modelLayerGroups],
     layerExtents,
     statusEl,
     i18n,
     render,
     zoomToExtents,
     cancelZoomWindow: () => navToolsRef.current?.cancelZoomWindow(),
-    osnapIndex,
+    osnapIndexes: [osnapIndex, modelOsnapIndex].filter(
+      (index): index is AcExOsnapIndex => index != null
+    ),
     sortedLayerNames: [
       ...new Set([
         ...snapshot.layers.map(layer => layer.name),
-        ...layerGroups.keys()
+        ...paperLayerGroups.keys(),
+        ...modelLayerGroups.keys()
       ])
     ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
   })
+
+  const disposeObject3D = (object: THREE.Object3D) => {
+    object.traverse(child => {
+      const mesh = child as THREE.Mesh
+      if (mesh.geometry) mesh.geometry.dispose()
+      const material = mesh.material
+      if (Array.isArray(material)) {
+        material.forEach(item => item.dispose())
+      } else if (material) {
+        material.dispose()
+      }
+    })
+  }
+
+  const disposePaperGeometry = () => {
+    for (const group of paperLayerGroups.values()) {
+      paperRoot.remove(group)
+      disposeObject3D(group)
+    }
+    paperLayerGroups.clear()
+    paperWideLineMaterials.length = 0
+  }
+
+  const switchLayout = (btrId: string) => {
+    if (btrId === layout.btrId) return
+    const next = snapshot.layouts.find(item => item.btrId === btrId)
+    if (!next) return
+
+    lastViewByLayout.set(layout.btrId, captureViewState())
+    navToolsRef.current?.cancelZoomWindow()
+    measure?.cancelMode()
+    markup?.cancelMode()
+    osnapMarker?.hide()
+
+    if (!layout.isModelSpace) {
+      disposePaperGeometry()
+    }
+    paperRoot.removeFromParent()
+    modelRoot.removeFromParent()
+
+    layout = next
+    if (layout.isModelSpace) {
+      scene.add(modelRoot)
+    } else {
+      scene.add(paperRoot)
+      populateLayoutGeometry(
+        layout,
+        paperLayerGroups,
+        paperRoot,
+        paperWideLineMaterials
+      )
+      if (hasPaperViewports) {
+        modelScene.add(modelRoot)
+      }
+    }
+
+    const nextLayerExtents = computeLayerExtentsMap(
+      layout.lineBatches,
+      layout.meshBatches
+    )
+    layerExtents.clear()
+    for (const [name, extents] of nextLayerExtents) {
+      layerExtents.set(name, extents)
+    }
+    layoutExtents = resolveLayoutViewExtents(layout)
+    layerPanel?.syncLayerZoomButtons()
+
+    if (osnapIndex) {
+      osnapIndex.rebuild(layout)
+      for (const [name, visible] of layerVisible) {
+        osnapIndex.setLayerHidden(name, visible === false)
+      }
+    }
+
+    const saved = lastViewByLayout.get(btrId)
+    if (saved) {
+      flyTo(saved.centerX, saved.centerY, saved.zoom)
+    } else {
+      fit()
+      const framed = captureViewState()
+      originalByLayout.set(btrId, framed)
+    }
+
+    measure?.syncLayoutVisibility()
+    markup?.syncLayoutVisibility()
+    layoutMenuRef.current?.refresh()
+    recomputeOsnapThresholdWcs()
+    bumpSnapCacheKey()
+    render()
+  }
 
   controls.addEventListener('change', () => {
     acexCameraZoomUniform.value = camera.zoom
@@ -594,7 +917,8 @@ function startViewer(): void {
           action === 'measure-menu' ||
           action === 'markup-menu' ||
           action === 'snap-menu' ||
-          action === 'zoom-menu'
+          action === 'zoom-menu' ||
+          action === 'layout-menu'
         ) {
           return
         }
@@ -612,6 +936,7 @@ function startViewer(): void {
       }
     },
     onOpen: (menuId, menuRoot) => {
+      layoutMenuRef.current?.close()
       if (menuId === 'measure' && measure) {
         measure.setVisible(measure.visible)
         menuRoot.querySelectorAll('[data-measure-mode]').forEach(btn => {
@@ -636,6 +961,13 @@ function startViewer(): void {
     }
   })
   toolbarFlyoutsRef.current = toolbarFlyouts
+
+  layoutMenuRef.current = setupAcExHtmlLayoutMenu({
+    layouts: snapshot.layouts,
+    getActiveLayoutBtrId: () => layout.btrId,
+    onSelect: switchLayout,
+    closeOtherFlyouts: () => toolbarFlyouts.close()
+  })
 
   i18n.setOnChange(() => {
     readyStatus = snapshot.meta.title ?? i18n.t('status.ready')
@@ -681,7 +1013,10 @@ function startViewer(): void {
       return
     }
     if (!measure || !markup) return
-    if (measure.handleKeyDown(event.key, event) || markup.handleKeyDown(event.key)) {
+    if (
+      measure.handleKeyDown(event.key, event) ||
+      markup.handleKeyDown(event.key)
+    ) {
       event.preventDefault()
       return
     }
@@ -708,9 +1043,16 @@ function startViewer(): void {
   } else {
     fit()
   }
-  originalView = captureViewState()
-  releaseLayerGroupsGeometryCpuArrays(layerGroups)
-  releaseSnapshotBatchBuffers(snapshot)
+  const initialView = captureViewState()
+  originalByLayout.set(layout.btrId, initialView)
+  lastViewByLayout.set(layout.btrId, initialView)
+  // Shared typed arrays back the snapshot and THREE attributes. Releasing
+  // them would prevent switching to other layouts later in this session.
+  if (snapshot.layouts.length <= 1 && !hasPaperViewports) {
+    releaseLayerGroupsGeometryCpuArrays(paperLayerGroups)
+    releaseLayerGroupsGeometryCpuArrays(modelLayerGroups)
+    releaseSnapshotBatchBuffers(snapshot)
+  }
   measure?.refreshIdleStatus()
   hideLoading()
 }
@@ -784,8 +1126,8 @@ interface AcExLayerPanelContext {
   snapshot: AcExSnapshot
   /** Mutable visibility map shared with the THREE layer groups. */
   layerVisible: Map<string, boolean>
-  /** THREE groups keyed by layer name. */
-  layerGroups: Map<string, THREE.Group>
+  /** THREE groups keyed by layer name (paper and/or model space). */
+  layerGroupMaps: Map<string, THREE.Group>[]
   /** Precomputed XY extents per layer for zoom-to-layer. */
   layerExtents: Map<string, AcExExtents | null>
   /** Footer status bar element. */
@@ -798,8 +1140,8 @@ interface AcExLayerPanelContext {
   zoomToExtents: (extents: AcExExtents) => void
   /** Clears an in-progress zoom-window rubber band / mode before layer zoom. */
   cancelZoomWindow: () => void
-  /** Object-snap index updated when layer visibility changes. */
-  osnapIndex: AcExOsnapIndex | null
+  /** Object-snap indexes updated when layer visibility changes. */
+  osnapIndexes: AcExOsnapIndex[]
   /** Sorted layer names for bulk show/hide actions. */
   sortedLayerNames: string[]
 }
@@ -808,6 +1150,8 @@ interface AcExLayerPanelContext {
 interface AcExLayerPanelController {
   /** Reapplies `layers.zoomTo` labels on every per-layer zoom button. */
   refreshLayerLabels: () => void
+  /** Enables/disables per-layer zoom after the active layout changes. */
+  syncLayerZoomButtons: () => void
 }
 
 function setupLayerPanel(
@@ -816,14 +1160,14 @@ function setupLayerPanel(
   const {
     snapshot,
     layerVisible,
-    layerGroups,
+    layerGroupMaps,
     layerExtents,
     statusEl,
     i18n,
     render,
     zoomToExtents,
     cancelZoomWindow,
-    osnapIndex,
+    osnapIndexes,
     sortedLayerNames
   } = ctx
 
@@ -843,23 +1187,34 @@ function setupLayerPanel(
 
   const checkboxes: HTMLInputElement[] = []
 
+  const setGroupsVisible = (name: string, visible: boolean) => {
+    for (const groups of layerGroupMaps) {
+      const group = groups.get(name)
+      if (group) group.visible = visible
+    }
+  }
+
   const setLayerVisible = (name: string, visible: boolean) => {
     layerVisible.set(name, visible)
-    const group = layerGroups.get(name)
-    if (group) group.visible = visible
-    osnapIndex?.setLayerHidden(name, !visible)
+    setGroupsVisible(name, visible)
+    for (const index of osnapIndexes) {
+      index.setLayerHidden(name, !visible)
+    }
   }
 
   const setAllLayersVisible = (visible: boolean) => {
     for (const name of sortedLayers) {
       layerVisible.set(name, visible)
-      const group = layerGroups.get(name)
-      if (group) group.visible = visible
+      setGroupsVisible(name, visible)
     }
     if (visible) {
-      osnapIndex?.showAllLayers()
+      for (const index of osnapIndexes) {
+        index.showAllLayers()
+      }
     } else {
-      osnapIndex?.hideAllLayers(sortedLayers)
+      for (const index of osnapIndexes) {
+        index.hideAllLayers(sortedLayers)
+      }
     }
     for (const checkbox of checkboxes) {
       checkbox.checked = visible
@@ -902,17 +1257,16 @@ function setupLayerPanel(
     updateZoomLabels()
     zoomBtn.innerHTML = acExHtmlIcons.zoomBox
     const extents = layerExtents.get(name)
-    if (!extents) {
-      zoomBtn.disabled = true
-    } else {
-      zoomBtn.addEventListener('click', event => {
-        event.preventDefault()
-        event.stopPropagation()
-        cancelZoomWindow()
-        zoomToExtents(extents)
-        statusEl.textContent = i18n.t('status.zoomLayer', { name })
-      })
-    }
+    zoomBtn.disabled = !extents
+    zoomBtn.addEventListener('click', event => {
+      event.preventDefault()
+      event.stopPropagation()
+      const liveExtents = layerExtents.get(name)
+      if (!liveExtents) return
+      cancelZoomWindow()
+      zoomToExtents(liveExtents)
+      statusEl.textContent = i18n.t('status.zoomLayer', { name })
+    })
     layerRows.push({ name, zoomBtn })
 
     row.append(checkbox, swatch, nameEl, zoomBtn)
@@ -950,6 +1304,11 @@ function setupLayerPanel(
         const label = i18n.t('layers.zoomTo', { name: row.name })
         row.zoomBtn.title = label
         row.zoomBtn.setAttribute('aria-label', label)
+      }
+    },
+    syncLayerZoomButtons: () => {
+      for (const row of layerRows) {
+        row.zoomBtn.disabled = !layerExtents.get(row.name)
       }
     }
   }

--- a/packages/cad-html-plugin/src/AcExLayerExtents.ts
+++ b/packages/cad-html-plugin/src/AcExLayerExtents.ts
@@ -119,17 +119,63 @@ export function computeLayoutExtents(
 }
 
 /**
+ * Unions two XY extents, ignoring `null` operands.
+ */
+export function unionExtents(
+  a: AcExExtents | null | undefined,
+  b: AcExExtents | null | undefined
+): AcExExtents | null {
+  if (!a) return b ?? null
+  if (!b) return a
+  return {
+    minX: Math.min(a.minX, b.minX),
+    minY: Math.min(a.minY, b.minY),
+    maxX: Math.max(a.maxX, b.maxX),
+    maxY: Math.max(a.maxY, b.maxY)
+  }
+}
+
+/**
+ * Unions paper-space rectangles of exported viewports. Used so an otherwise
+ * empty paper layout still frames its viewport frames instead of `0,0–1,1`.
+ */
+export function computeViewportPaperExtents(
+  viewports: ReadonlyArray<{ paper: AcExExtents }> | undefined
+): AcExExtents | null {
+  if (!viewports || viewports.length === 0) return null
+  let result: AcExExtents | null = null
+  for (const viewport of viewports) {
+    result = unionExtents(result, viewport.paper)
+  }
+  return result
+}
+
+/**
+ * Unions batch geometry with viewport paper frames for one layout.
+ *
+ * Returns `null` when the layout has neither drawable batches nor viewports.
+ */
+export function computeLayoutViewExtents(
+  layout: Pick<AcExLayoutSnapshot, 'lineBatches' | 'meshBatches' | 'viewports'>
+): AcExExtents | null {
+  return unionExtents(
+    computeLayoutExtents(layout.lineBatches, layout.meshBatches),
+    computeViewportPaperExtents(layout.viewports)
+  )
+}
+
+/**
  * Resolves zoom-to-fit extents for one layout snapshot.
  *
- * Prefers live batch geometry, then persisted {@link AcExSnapshot.meta.viewExtents},
- * and only then the database header extents as a last resort.
+ * Prefers live batch geometry unioned with viewport paper frames, then
+ * persisted {@link AcExSnapshot.meta.viewExtents}, and only then a unit box.
  */
 export function resolveLayoutViewExtents(
-  layout: Pick<AcExLayoutSnapshot, 'lineBatches' | 'meshBatches'>,
+  layout: Pick<AcExLayoutSnapshot, 'lineBatches' | 'meshBatches' | 'viewports'>,
   fallbackExtents?: AcExExtents
 ): AcExExtents {
   return (
-    computeLayoutExtents(layout.lineBatches, layout.meshBatches) ??
+    computeLayoutViewExtents(layout) ??
     fallbackExtents ?? {
       minX: 0,
       minY: 0,

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -22,7 +22,8 @@ import {
   acExMarkupCenter,
   type AcExMarkupShapeOutline,
   acExStrokeMarkupCloud,
-  acExTranslateMarkupGeometry} from './AcExMarkupGeometry'
+  acExTranslateMarkupGeometry
+} from './AcExMarkupGeometry'
 import { acExBindMarkupPointerDrag } from './AcExMarkupGripDrag'
 import {
   acExMarkupSidecarFileName,
@@ -115,6 +116,8 @@ export interface AcExMarkupControllerOptions {
   onBeforeActivate?: () => void
   /** Ortho/polar tracking from the shared settings panel. */
   getTrackingOptions?: () => AcExTrackingOptions | null
+  /** Active layout BTR id; used to stamp and filter markup overlays. */
+  getActiveLayoutId?: () => string
 }
 
 type AcExMarkupCleanup = () => void
@@ -171,6 +174,14 @@ function toVector2(p: AcExMarkupPoint2d): THREE.Vector2 {
   return new THREE.Vector2(p.x, p.y)
 }
 
+function isMarkupOnLayout(
+  recordLayoutId: string | undefined,
+  activeLayoutId: string | undefined
+): boolean {
+  if (activeLayoutId == null) return true
+  return recordLayoutId == null || recordLayoutId === activeLayoutId
+}
+
 /**
  * Manages markup annotation tools for the offline HTML viewer.
  */
@@ -188,6 +199,7 @@ export class AcExMarkupController {
   private readonly _getTrackingOptions:
     | (() => AcExTrackingOptions | null)
     | null
+  private readonly _getActiveLayoutId: (() => string) | null
 
   private readonly _overlayLayer: HTMLDivElement
   private readonly _previewCanvas: HTMLCanvasElement
@@ -237,6 +249,7 @@ export class AcExMarkupController {
     this._onStyleChange = options.onStyleChange ?? null
     this._onBeforeActivate = options.onBeforeActivate ?? null
     this._getTrackingOptions = options.getTrackingOptions ?? null
+    this._getActiveLayoutId = options.getActiveLayoutId ?? null
 
     this._overlayLayer = document.createElement('div')
     this._overlayLayer.id = 'mlcad-markup-overlays'
@@ -302,9 +315,7 @@ export class AcExMarkupController {
     fontSize: number
   } {
     const selectedId =
-      this._selectedIds.size === 1
-        ? [...this._selectedIds][0]
-        : undefined
+      this._selectedIds.size === 1 ? [...this._selectedIds][0] : undefined
     if (selectedId) {
       const record = this._findRecord(selectedId)
       if (record) {
@@ -481,6 +492,29 @@ export class AcExMarkupController {
 
   toggleVisible(): void {
     this.setVisible(!this._visible)
+  }
+
+  /**
+   * Shows or hides committed overlays according to the active layout.
+   * Records without `layoutId` remain visible on every layout.
+   */
+  syncLayoutVisibility(): void {
+    const activeId = this._getActiveLayoutId?.()
+    let selectionChanged = false
+    for (const item of this._committed) {
+      const onLayout = isMarkupOnLayout(item.record.layoutId, activeId)
+      const show = this._visible && onLayout
+      for (const el of item.parts.dom) el.hidden = !show
+      for (const canvas of item.parts.canvases) canvas.hidden = !show
+      if (!onLayout && this._selectedIds.has(item.record.id)) {
+        this._selectedIds.delete(item.record.id)
+        selectionChanged = true
+      }
+    }
+    if (selectionChanged) {
+      this._applySelectionStyles()
+      this._onStyleChange?.()
+    }
   }
 
   syncOverlays(): void {
@@ -800,11 +834,7 @@ export class AcExMarkupController {
       this._clearPreview()
       if (this._mode !== 'callout') return
       const final = (text ?? '').trim() || defaultLabel
-      this._commitGeometry(
-        'callout',
-        { type: 'callout', tip, anchor },
-        final
-      )
+      this._commitGeometry('callout', { type: 'callout', tip, anchor }, final)
       this._statusEl.textContent = this._hintForMode('callout')
       this._view.render()
     })
@@ -978,6 +1008,7 @@ export class AcExMarkupController {
     const record: AcExMarkupRecord = {
       id: createMarkupId(),
       type,
+      layoutId: this._getActiveLayoutId?.(),
       style: this._sessionStyle(),
       text,
       comment: '',
@@ -1002,9 +1033,13 @@ export class AcExMarkupController {
     this._committed.push({ record, parts })
     this._buildVisuals(record, parts)
     this._positionDomOverlays()
+    this.syncLayoutVisibility()
   }
 
-  private _buildVisuals(record: AcExMarkupRecord, parts: AcExMarkupParts): void {
+  private _buildVisuals(
+    record: AcExMarkupRecord,
+    parts: AcExMarkupParts
+  ): void {
     const color = record.style.color || ACEX_MARKUP_COLOR
     const markupId = record.id
 
@@ -1062,7 +1097,7 @@ export class AcExMarkupController {
         (attached ? attached.text : undefined) ||
         record.text?.trim() ||
         (g.type === 'stamp' && 'stampId' in g
-          ? STAMP_LABELS[g.stampId as AcExBuiltinStampId] ?? g.stampId
+          ? (STAMP_LABELS[g.stampId as AcExBuiltinStampId] ?? g.stampId)
           : this._i18n.t('status.markupDefaultLabel'))
       badge.textContent = label
       badge.style.color = color
@@ -1264,10 +1299,7 @@ export class AcExMarkupController {
     }
 
     // Text / stamp: drag badge to move position.
-    if (
-      badge &&
-      (geometryType === 'text' || geometryType === 'stamp')
-    ) {
+    if (badge && (geometryType === 'text' || geometryType === 'stamp')) {
       cleanups.push(
         acExBindMarkupPointerDrag({
           el: badge,
@@ -1294,11 +1326,7 @@ export class AcExMarkupController {
     }
 
     // Standalone callout or shape-attached callout: tip + bubble.
-    if (
-      badge &&
-      tipDot &&
-      (geometryType === 'callout' || hasAttachedCallout)
-    ) {
+    if (badge && tipDot && (geometryType === 'callout' || hasAttachedCallout)) {
       cleanups.push(
         acExBindMarkupPointerDrag({
           el: tipDot,
@@ -1310,7 +1338,11 @@ export class AcExMarkupController {
             if (!record) return
             const g = record.geometry
             let tip = world
-            if (g.type === 'cloud' || g.type === 'rect' || g.type === 'circle') {
+            if (
+              g.type === 'cloud' ||
+              g.type === 'rect' ||
+              g.type === 'circle'
+            ) {
               const outline = shapeOutline()
               if (!outline || !g.callout) return
               tip = acExComputeLeaderTipOnShape(outline, world)
@@ -1602,8 +1634,12 @@ export class AcExMarkupController {
       g.callout
         ? g.callout
         : null
-    const current =
-      (attached?.text ?? item.record.text ?? badge.textContent ?? '').trim()
+    const current = (
+      attached?.text ??
+      item.record.text ??
+      badge.textContent ??
+      ''
+    ).trim()
     const multiline = item.record.type !== 'text'
     this._syncGripPointerEvents()
     void this._beginInlineText({
@@ -1685,6 +1721,11 @@ export class AcExMarkupController {
     }
     for (let i = this._committed.length - 1; i >= 0; i--) {
       const item = this._committed[i]!
+      if (
+        !isMarkupOnLayout(item.record.layoutId, this._getActiveLayoutId?.())
+      ) {
+        continue
+      }
       // Prefer text-box / stamp hit so labels are easy to select.
       for (const el of item.parts.dom) {
         if (
@@ -1798,7 +1839,10 @@ export class AcExMarkupController {
     ) {
       const snap = this._osnapCache.snap
       if (snap) {
-        this._onOsnapMarker(snap, this._view.wcsToScreen(this._osnapCache.point))
+        this._onOsnapMarker(
+          snap,
+          this._view.wcsToScreen(this._osnapCache.point)
+        )
       } else {
         this._onOsnapMarker(null, null)
       }
@@ -2025,9 +2069,7 @@ export class AcExMarkupController {
     if (buttons.length === 0) return
     // State-oriented icon: open eye while visible, slashed eye while hidden.
     // Tooltip stays action-oriented (click to hide / show).
-    const titleKey = this._visible
-      ? 'toolbar.markupHide'
-      : 'toolbar.markupShow'
+    const titleKey = this._visible ? 'toolbar.markupHide' : 'toolbar.markupShow'
     const icon = this._visible
       ? acExHtmlIcons.markupShow
       : acExHtmlIcons.markupHide

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -190,6 +190,8 @@ export interface AcExMeasureControllerOptions {
   onActiveChange?: (active: boolean) => void
   /** Called when selection or session draw style changes (draw-style toolbar). */
   onStyleChange?: () => void
+  /** Active layout BTR id; used to stamp and filter measurement overlays. */
+  getActiveLayoutId?: () => string
 }
 
 /** Teardown callback registered when a measurement overlay is created. @internal */
@@ -212,6 +214,14 @@ interface AcExCommittedMeasure {
   quantity: AcExMeasureQuantity | null
   value: number
   hitTest: (clientX: number, clientY: number, thresholdPx: number) => boolean
+}
+
+function isRecordOnLayout(
+  recordLayoutId: string | undefined,
+  activeLayoutId: string | undefined
+): boolean {
+  if (activeLayoutId == null) return true
+  return recordLayoutId == null || recordLayoutId === activeLayoutId
 }
 
 /**
@@ -805,6 +815,8 @@ export class AcExMeasureController {
   private readonly _onActiveChange: ((active: boolean) => void) | null
   /** Notifies when selection / session draw style changes. */
   private readonly _onStyleChange: (() => void) | null
+  /** Active layout BTR id for stamping / filtering overlays. */
+  private readonly _getActiveLayoutId: (() => string) | null
   /** Accent color for lines, labels, and canvas overlays. */
   private _measureColor = ACEX_MEASURE_COLOR
   /** Session line weight for new measurements. */
@@ -887,6 +899,7 @@ export class AcExMeasureController {
     this._getTrackingOptions = options.getTrackingOptions ?? null
     this._onActiveChange = options.onActiveChange ?? null
     this._onStyleChange = options.onStyleChange ?? null
+    this._getActiveLayoutId = options.getActiveLayoutId ?? null
 
     this._overlayLayer = document.createElement('div')
     this._overlayLayer.id = 'mlcad-measure-overlays'
@@ -1125,6 +1138,29 @@ export class AcExMeasureController {
   /** Toggles {@link setVisible}. */
   toggleVisible(): void {
     this.setVisible(!this._visible)
+  }
+
+  /**
+   * Shows or hides committed overlays according to the active layout.
+   * Records without `layoutId` remain visible on every layout.
+   */
+  syncLayoutVisibility(): void {
+    const activeId = this._getActiveLayoutId?.()
+    let selectionChanged = false
+    for (const measure of this._committed) {
+      const onLayout = isRecordOnLayout(measure.record.layoutId, activeId)
+      const show = this._visible && onLayout
+      for (const el of measure.parts.dom) el.hidden = !show
+      for (const canvas of measure.parts.canvases) canvas.hidden = !show
+      if (!onLayout && this._selectedIds.has(measure.id)) {
+        this._applyMeasureSelection(measure, false)
+        this._selectedIds.delete(measure.id)
+        selectionChanged = true
+      }
+    }
+    if (selectionChanged) {
+      this._onStyleChange?.()
+    }
   }
 
   /** Download current measurements as a `*.measurement.json` sidecar. */
@@ -1935,7 +1971,10 @@ export class AcExMeasureController {
         const start = pointLiesOnCircle(point, lock)
           ? point.clone()
           : new THREE.Vector2(lock.x, lock.y)
-        this._arcLockLastAngle = Math.atan2(start.y - lock.cy, start.x - lock.cx)
+        this._arcLockLastAngle = Math.atan2(
+          start.y - lock.cy,
+          start.x - lock.cx
+        )
         this._points.push(start)
         this._previewArc(this._points[0]!, clientX, clientY)
         return true
@@ -1961,12 +2000,7 @@ export class AcExMeasureController {
       }
       const end = snapPointToCircle(raw, geom)
       this._trackArcLockDirection(end)
-      const sweep = lockedSweep(
-        start,
-        end,
-        geom,
-        this._lockedClockwise()
-      )
+      const sweep = lockedSweep(start, end, geom, this._lockedClockwise())
       if (!sweep) {
         this._points = []
         this._arcLock = null
@@ -2027,12 +2061,7 @@ export class AcExMeasureController {
       }
       const end = snapPointToCircle(raw, geom)
       this._trackArcLockDirection(end)
-      const sweep = lockedSweep(
-        start,
-        end,
-        geom,
-        this._lockedClockwise()
-      )
+      const sweep = lockedSweep(start, end, geom, this._lockedClockwise())
       this._overlayLayer
         .querySelectorAll('.mlcad-measure-canvas--preview-line')
         .forEach(el => el.remove())
@@ -2483,6 +2512,7 @@ export class AcExMeasureController {
     })
     this._commitParts = null
     this._commitStyle = null
+    this.syncLayoutVisibility()
   }
 
   /** Default sidecar style from the current session draw style. @internal */
@@ -2503,6 +2533,7 @@ export class AcExMeasureController {
     return {
       id,
       type,
+      layoutId: this._getActiveLayoutId?.(),
       style: this._defaultStyle(),
       geometry
     }
@@ -2619,6 +2650,11 @@ export class AcExMeasureController {
   ): AcExCommittedMeasure | null {
     for (let i = this._committed.length - 1; i >= 0; i--) {
       const measure = this._committed[i]!
+      if (
+        !isRecordOnLayout(measure.record.layoutId, this._getActiveLayoutId?.())
+      ) {
+        continue
+      }
       if (this._measureHitAt(measure, clientX, clientY)) {
         return measure
       }

--- a/packages/cad-html-plugin/src/AcExPaperViewport.ts
+++ b/packages/cad-html-plugin/src/AcExPaperViewport.ts
@@ -35,10 +35,22 @@ export function viewportIsNearPaperBorder(
 }
 
 /**
- * Paper-space WCS → model-space WCS through a viewport (affine, no twist).
+ * View twist in radians, or `0` when omitted / non-finite.
+ */
+export function viewportTwist(viewport: AcExViewportSnapshot): number {
+  const twist = viewport.twist
+  return typeof twist === 'number' && Number.isFinite(twist) ? twist : 0
+}
+
+/**
+ * Paper-space WCS → model-space WCS through a viewport.
  *
- * Inverse of {@link modelPointToPaper}. Degenerate paper boxes return the
- * model view center.
+ * Maps the paper rectangle onto the DCS view (`model` size around its
+ * center), then rotates by {@link AcExViewportSnapshot.twist} so a
+ * non-zero DVIEW twist matches `AcGiViewport.dcsCenterToWcs`. Degenerate
+ * paper boxes return the model view center.
+ *
+ * Inverse of {@link modelPointToPaper}.
  */
 export function paperPointToModel(
   viewport: AcExViewportSnapshot,
@@ -49,22 +61,18 @@ export function paperPointToModel(
   const model = viewport.model
   const paperW = paper.maxX - paper.minX
   const paperH = paper.maxY - paper.minY
+  const centerX = (model.minX + model.maxX) / 2
+  const centerY = (model.minY + model.maxY) / 2
   if (paperW <= EPS || paperH <= EPS) {
-    return {
-      x: (model.minX + model.maxX) / 2,
-      y: (model.minY + model.maxY) / 2
-    }
+    return { x: centerX, y: centerY }
   }
-  const u = (x - paper.minX) / paperW
-  const v = (y - paper.minY) / paperH
-  return {
-    x: model.minX + u * (model.maxX - model.minX),
-    y: model.minY + v * (model.maxY - model.minY)
-  }
+  const localX = ((x - paper.minX) / paperW - 0.5) * (model.maxX - model.minX)
+  const localY = ((y - paper.minY) / paperH - 0.5) * (model.maxY - model.minY)
+  return rotateOffset(centerX, centerY, localX, localY, viewportTwist(viewport))
 }
 
 /**
- * Model-space WCS → paper-space WCS through a viewport (affine, no twist).
+ * Model-space WCS → paper-space WCS through a viewport.
  *
  * Inverse of {@link paperPointToModel}. Degenerate model boxes return the
  * paper rectangle center.
@@ -84,11 +92,52 @@ export function modelPointToPaper(
       y: (paper.minY + paper.maxY) / 2
     }
   }
-  const u = (x - model.minX) / modelW
-  const v = (y - model.minY) / modelH
+  const centerX = (model.minX + model.maxX) / 2
+  const centerY = (model.minY + model.maxY) / 2
+  const local = unrotateOffset(
+    x - centerX,
+    y - centerY,
+    viewportTwist(viewport)
+  )
+  const u = local.x / modelW + 0.5
+  const v = local.y / modelH + 0.5
   return {
     x: paper.minX + u * (paper.maxX - paper.minX),
     y: paper.minY + v * (paper.maxY - paper.minY)
+  }
+}
+
+function rotateOffset(
+  centerX: number,
+  centerY: number,
+  localX: number,
+  localY: number,
+  twist: number
+): { x: number; y: number } {
+  if (Math.abs(twist) <= EPS) {
+    return { x: centerX + localX, y: centerY + localY }
+  }
+  const cos = Math.cos(twist)
+  const sin = Math.sin(twist)
+  return {
+    x: centerX + localX * cos - localY * sin,
+    y: centerY + localX * sin + localY * cos
+  }
+}
+
+function unrotateOffset(
+  dx: number,
+  dy: number,
+  twist: number
+): { x: number; y: number } {
+  if (Math.abs(twist) <= EPS) {
+    return { x: dx, y: dy }
+  }
+  const cos = Math.cos(twist)
+  const sin = Math.sin(twist)
+  return {
+    x: dx * cos + dy * sin,
+    y: -dx * sin + dy * cos
   }
 }
 

--- a/packages/cad-html-plugin/src/AcExPaperViewport.ts
+++ b/packages/cad-html-plugin/src/AcExPaperViewport.ts
@@ -1,0 +1,167 @@
+import type { AcExExtents, AcExViewportSnapshot } from './AcExSnapshotTypes'
+
+const EPS = 1e-12
+
+/**
+ * Returns `true` when `(x, y)` (paper WCS) lies inside the viewport frame.
+ */
+export function viewportContainsPaperPoint(
+  viewport: AcExViewportSnapshot,
+  x: number,
+  y: number
+): boolean {
+  const box = viewport.paper
+  return x >= box.minX && x <= box.maxX && y >= box.minY && y <= box.maxY
+}
+
+/**
+ * Returns `true` when the paper point is within `tolerance` of any of the
+ * four viewport edges. Used to keep frame clicks on the border instead of
+ * drilling through to model space.
+ */
+export function viewportIsNearPaperBorder(
+  viewport: AcExViewportSnapshot,
+  x: number,
+  y: number,
+  tolerance: number
+): boolean {
+  if (!viewportContainsPaperPoint(viewport, x, y)) return false
+  const box = viewport.paper
+  const distLeft = Math.abs(x - box.minX)
+  const distRight = Math.abs(x - box.maxX)
+  const distBottom = Math.abs(y - box.minY)
+  const distTop = Math.abs(y - box.maxY)
+  return Math.min(distLeft, distRight, distBottom, distTop) <= tolerance
+}
+
+/**
+ * Paper-space WCS → model-space WCS through a viewport (affine, no twist).
+ *
+ * Inverse of {@link modelPointToPaper}. Degenerate paper boxes return the
+ * model view center.
+ */
+export function paperPointToModel(
+  viewport: AcExViewportSnapshot,
+  x: number,
+  y: number
+): { x: number; y: number } {
+  const paper = viewport.paper
+  const model = viewport.model
+  const paperW = paper.maxX - paper.minX
+  const paperH = paper.maxY - paper.minY
+  if (paperW <= EPS || paperH <= EPS) {
+    return {
+      x: (model.minX + model.maxX) / 2,
+      y: (model.minY + model.maxY) / 2
+    }
+  }
+  const u = (x - paper.minX) / paperW
+  const v = (y - paper.minY) / paperH
+  return {
+    x: model.minX + u * (model.maxX - model.minX),
+    y: model.minY + v * (model.maxY - model.minY)
+  }
+}
+
+/**
+ * Model-space WCS → paper-space WCS through a viewport (affine, no twist).
+ *
+ * Inverse of {@link paperPointToModel}. Degenerate model boxes return the
+ * paper rectangle center.
+ */
+export function modelPointToPaper(
+  viewport: AcExViewportSnapshot,
+  x: number,
+  y: number
+): { x: number; y: number } {
+  const paper = viewport.paper
+  const model = viewport.model
+  const modelW = model.maxX - model.minX
+  const modelH = model.maxY - model.minY
+  if (modelW <= EPS || modelH <= EPS) {
+    return {
+      x: (paper.minX + paper.maxX) / 2,
+      y: (paper.minY + paper.maxY) / 2
+    }
+  }
+  const u = (x - model.minX) / modelW
+  const v = (y - model.minY) / modelH
+  return {
+    x: paper.minX + u * (paper.maxX - paper.minX),
+    y: paper.minY + v * (paper.maxY - paper.minY)
+  }
+}
+
+/**
+ * Scale from paper WCS to model WCS along X (used to convert a paper-space
+ * snap aperture into model units).
+ */
+export function viewportPaperToModelScale(
+  viewport: AcExViewportSnapshot
+): number {
+  const paperW = viewport.paper.maxX - viewport.paper.minX
+  if (paperW <= EPS) return 1
+  return (viewport.model.maxX - viewport.model.minX) / paperW
+}
+
+/**
+ * Orthographic camera parameters that fill a CSS-pixel viewport rectangle
+ * with `model` extents, matching `AcTrViewportView.zoomTo(viewBox, 1.0)`
+ * where `_frustum = vpH / 2`.
+ */
+export function computeViewportCamera(
+  model: AcExExtents,
+  vpW: number,
+  vpH: number
+): {
+  centerX: number
+  centerY: number
+  zoom: number
+  frustum: number
+  aspect: number
+} {
+  const spanX = Math.max(model.maxX - model.minX, EPS)
+  const spanY = Math.max(model.maxY - model.minY, EPS)
+  const frustum = Math.max(vpH, EPS) / 2
+  const aspect = vpW / Math.max(vpH, EPS)
+  const zoom = Math.min((2 * aspect * frustum) / spanX, (2 * frustum) / spanY)
+  return {
+    centerX: (model.minX + model.maxX) / 2,
+    centerY: (model.minY + model.maxY) / 2,
+    zoom,
+    frustum,
+    aspect
+  }
+}
+
+/**
+ * Top-most viewport whose interior contains `(x, y)`, skipping the border
+ * band used for frame selection. Search is last-to-first so later DXF
+ * viewports (typically drawn on top) win.
+ */
+export function findDrillThroughViewport(
+  viewports: readonly AcExViewportSnapshot[] | undefined,
+  x: number,
+  y: number,
+  borderTolerance: number
+): AcExViewportSnapshot | undefined {
+  if (!viewports || viewports.length === 0) return undefined
+  for (let i = viewports.length - 1; i >= 0; i--) {
+    const viewport = viewports[i]!
+    if (!viewportContainsPaperPoint(viewport, x, y)) continue
+    if (viewportIsNearPaperBorder(viewport, x, y, borderTolerance)) continue
+    return viewport
+  }
+  return undefined
+}
+
+/**
+ * `true` when any exported paper layout has at least one user viewport.
+ */
+export function snapshotHasPaperViewports(
+  layouts: ReadonlyArray<{ viewports?: AcExViewportSnapshot[] }>
+): boolean {
+  return layouts.some(
+    layout => layout.viewports != null && layout.viewports.length > 0
+  )
+}

--- a/packages/cad-html-plugin/src/AcExPaperViewportCollector.ts
+++ b/packages/cad-html-plugin/src/AcExPaperViewportCollector.ts
@@ -1,7 +1,7 @@
 import {
-  AcDbViewport,
   type AcDbBlockTableRecord,
-  type AcDbDatabase
+  type AcDbDatabase,
+  AcDbViewport
 } from '@mlightcad/data-model'
 import { AcTrViewportView } from '@mlightcad/three-renderer'
 

--- a/packages/cad-html-plugin/src/AcExPaperViewportCollector.ts
+++ b/packages/cad-html-plugin/src/AcExPaperViewportCollector.ts
@@ -1,0 +1,98 @@
+import {
+  AcDbViewport,
+  type AcDbBlockTableRecord,
+  type AcDbDatabase
+} from '@mlightcad/data-model'
+import { AcTrViewportView } from '@mlightcad/three-renderer'
+
+import type { AcExExtents, AcExViewportSnapshot } from './AcExSnapshotTypes'
+
+/**
+ * Collects user-created paper-space viewports for HTML export.
+ *
+ * Skips the default `*Paper_Space` viewport via
+ * {@link AcTrViewportView.isDefaultPaperSpaceViewport}. Model-space layouts
+ * return `undefined`.
+ *
+ * @param database - Open drawing database.
+ * @param layoutBtrId - Block-table-record id of the layout.
+ * @param isModelSpace - When `true`, no viewports are collected.
+ */
+export function collectLayoutViewports(
+  database: AcDbDatabase,
+  layoutBtrId: string,
+  isModelSpace: boolean
+): AcExViewportSnapshot[] | undefined {
+  if (isModelSpace) return undefined
+
+  const block = resolveLayoutBlock(database, layoutBtrId)
+  if (!block?.newIterator) return undefined
+
+  const viewports: AcExViewportSnapshot[] = []
+  for (const entity of block.newIterator()) {
+    if (!(entity instanceof AcDbViewport)) continue
+    if (AcTrViewportView.isDefaultPaperSpaceViewport(entity)) continue
+    if (typeof entity.toGiViewport !== 'function') continue
+
+    const gi = entity.toGiViewport()
+    const paperBox = gi.box
+    const modelBox = gi.viewBox
+    const paper = extentsFromBox2d(paperBox)
+    const model = extentsFromBox2d(modelBox)
+    if (!paper || !model) continue
+    viewports.push({ paper, model })
+  }
+
+  return viewports.length > 0 ? viewports : undefined
+}
+
+function extentsFromBox2d(box: {
+  min: { x: number; y: number }
+  max: { x: number; y: number }
+  isEmpty?: () => boolean
+}): AcExExtents | undefined {
+  if (typeof box.isEmpty === 'function' && box.isEmpty()) return undefined
+  const minX = box.min.x
+  const minY = box.min.y
+  const maxX = box.max.x
+  const maxY = box.max.y
+  if (
+    !Number.isFinite(minX) ||
+    !Number.isFinite(minY) ||
+    !Number.isFinite(maxX) ||
+    !Number.isFinite(maxY) ||
+    maxX - minX <= 0 ||
+    maxY - minY <= 0
+  ) {
+    return undefined
+  }
+  return { minX, minY, maxX, maxY }
+}
+
+function resolveLayoutBlock(
+  database: AcDbDatabase,
+  layoutBtrId: string
+): AcDbBlockTableRecord | undefined {
+  const blockTable = database.tables?.blockTable
+  if (!blockTable) return undefined
+
+  const direct =
+    typeof blockTable.getIdAt === 'function'
+      ? blockTable.getIdAt(layoutBtrId)
+      : undefined
+  if (direct) return direct
+
+  if (typeof blockTable.newIterator === 'function') {
+    for (const block of blockTable.newIterator()) {
+      if (block.objectId === layoutBtrId) {
+        return block
+      }
+    }
+  }
+
+  const modelSpace = blockTable.modelSpace
+  if (modelSpace?.objectId === layoutBtrId) {
+    return modelSpace
+  }
+  return undefined
+}

--- a/packages/cad-html-plugin/src/AcExPaperViewportCollector.ts
+++ b/packages/cad-html-plugin/src/AcExPaperViewportCollector.ts
@@ -40,7 +40,14 @@ export function collectLayoutViewports(
     const paper = extentsFromBox2d(paperBox)
     const model = extentsFromBox2d(modelBox)
     if (!paper || !model) continue
-    viewports.push({ paper, model })
+    const twist = Number.isFinite(gi.viewTwistAngle)
+      ? gi.viewTwistAngle
+      : entity.viewTwistAngle
+    viewports.push(
+      Number.isFinite(twist) && Math.abs(twist) > 1e-12
+        ? { paper, model, twist }
+        : { paper, model }
+    )
   }
 
   return viewports.length > 0 ? viewports : undefined

--- a/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
@@ -96,6 +96,7 @@ function writeLayout(writer: BinaryWriter, layout: AcExLayoutSnapshot): void {
   writer.writeString(layout.name)
   writer.writeU8(layout.isModelSpace ? 1 : 0)
   writer.writeJson(layout.osnap ?? null)
+  writer.writeJson(layout.viewports ?? null)
 
   writer.writeU32(layout.lineBatches.length)
   for (const batch of layout.lineBatches) {
@@ -114,6 +115,10 @@ function readLayout(reader: BinaryReader): AcExLayoutSnapshot {
   const isModelSpace = reader.readU8() !== 0
   const osnapValue = reader.readJson<AcExLayoutSnapshot['osnap'] | null>()
   const osnap = osnapValue ?? undefined
+  const viewportsValue = reader.readJson<
+    AcExLayoutSnapshot['viewports'] | null
+  >()
+  const viewports = viewportsValue ?? undefined
 
   const lineBatchCount = reader.readU32()
   const lineBatches: AcExLineBatch[] = []
@@ -127,7 +132,7 @@ function readLayout(reader: BinaryReader): AcExLayoutSnapshot {
     meshBatches.push(readMeshBatch(reader))
   }
 
-  return { btrId, name, isModelSpace, lineBatches, meshBatches, osnap }
+  return { btrId, name, isModelSpace, lineBatches, meshBatches, osnap, viewports }
 }
 
 function writeLineBatch(writer: BinaryWriter, batch: AcExLineBatch): void {

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -3,8 +3,11 @@ import type { AcExOsnapCatalog } from './AcExOsnapPrimitiveTypes'
 /**
  * Current snapshot schema version.
  * Increment when breaking changes are introduced to {@link AcExSnapshot}.
+ *
+ * v3 adds {@link AcExLayoutSnapshot.viewports} so the offline HTML viewer can
+ * scissor-render model space through paper-space viewports.
  */
-export const ACEX_SNAPSHOT_VERSION = 2 as const
+export const ACEX_SNAPSHOT_VERSION = 3 as const
 
 /**
  * Literal type of the supported snapshot schema version.
@@ -194,6 +197,20 @@ export interface AcExMeshBatch {
 }
 
 /**
+ * One paper-space viewport that shows a rectangle of model space.
+ *
+ * Matches the live viewer's `AcGiViewport.box` (paper) and `viewBox` (model)
+ * so the offline HTML viewer can scissor-render model geometry through the
+ * viewport, the same way {@link AcTrLayoutView} draws `AcTrViewportView`s.
+ */
+export interface AcExViewportSnapshot {
+  /** Viewport border in paper-space WCS (`AcGiViewport.box`). */
+  paper: AcExExtents
+  /** Model-space rectangle shown through the viewport (`AcGiViewport.viewBox`). */
+  model: AcExExtents
+}
+
+/**
  * Geometry for one paper space or model space layout.
  * Contains only display batches — no block definitions or entity handles.
  */
@@ -223,6 +240,13 @@ export interface AcExLayoutSnapshot {
    * {@link AcExLineBatch} / {@link AcExMeshBatch} vertices.
    */
   osnap?: AcExOsnapCatalog
+  /**
+   * User-created paper-space viewports (skipped for model space).
+   *
+   * The default `*Paper_Space` viewport is omitted. The offline viewer uses
+   * these descriptors to scissor-render model-space batches inside each frame.
+   */
+  viewports?: AcExViewportSnapshot[]
 }
 
 /** Camera state for restoring the export-time view in the offline HTML viewer. */

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -208,6 +208,12 @@ export interface AcExViewportSnapshot {
   paper: AcExExtents
   /** Model-space rectangle shown through the viewport (`AcGiViewport.viewBox`). */
   model: AcExExtents
+  /**
+   * View twist in radians (`AcGiViewport.viewTwistAngle`, DXF group 51).
+   * Omitted when zero. Paper↔model mapping and the scissor camera rotate by
+   * this angle around the model view center.
+   */
+  twist?: number
 }
 
 /**

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -69,6 +69,7 @@ export {
 } from './AcApHtmlPluginOptions'
 export {
   AcApHtmlSnapshotBuilder,
+  listDatabaseLayouts,
   type AcApHtmlSnapshotBuilderOptions
 } from './AcApHtmlSnapshotBuilder'
 export { createHtmlPlugin } from './createHtmlPlugin'

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -1032,6 +1032,19 @@ export class AcTrView2d extends AcEdBaseView {
     const db = AcApDocManager.instance.curDocument.database
     const pending: AcDbEntity[] = []
 
+    // Paper-space tabs the user never visited exist in the layout table but
+    // may be missing from the scene until first switch. HTML export needs
+    // every layout's geometry, so register those BTRs before collecting.
+    const layoutTable = db.objects?.layout
+    if (layoutTable?.newIterator) {
+      for (const layout of layoutTable.newIterator()) {
+        const btrId = layout.blockTableRecordId
+        if (btrId) {
+          this._scene.addEmptyLayout(btrId)
+        }
+      }
+    }
+
     for (const [layoutBtrId] of this._scene.layouts) {
       const blockTableRecord = db.tables.blockTable.getIdAt(layoutBtrId)
       if (!blockTableRecord) {

--- a/packages/three-renderer/__tests__/AcTrViewportView.isDefaultPaperSpaceViewport.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrViewportView.isDefaultPaperSpaceViewport.spec.ts
@@ -1,4 +1,61 @@
+import { AcGePoint3d, AcGiViewport } from '@mlightcad/data-model'
+
+import { AcTrRenderer } from '../src/renderer'
+import { AcTrBaseView } from '../src/viewport/AcTrBaseView'
 import { AcTrViewportView } from '../src/viewport/AcTrViewportView'
+
+function createMockRenderer(): AcTrRenderer {
+  return {
+    domElement: {} as HTMLCanvasElement,
+    render: jest.fn()
+  } as unknown as AcTrRenderer
+}
+
+function createViewport(twist: number): AcGiViewport {
+  const gi = new AcGiViewport()
+  gi.centerPoint = new AcGePoint3d(5, 5, 0)
+  gi.width = 10
+  gi.height = 10
+  gi.viewCenter = new AcGePoint3d(0, 0, 0)
+  gi.viewTarget = new AcGePoint3d(150, 300, 0)
+  gi.viewHeight = 200
+  gi.viewTwistAngle = twist
+  return gi
+}
+
+describe('AcTrViewportView twist', () => {
+  it('maps paper points through viewTwistAngle and orients the camera', () => {
+    const parent = new AcTrBaseView(createMockRenderer(), 800, 600)
+    const view = new AcTrViewportView(
+      parent,
+      createViewport(Math.PI / 2),
+      createMockRenderer()
+    )
+
+    const center = view.paperPointToModel({ x: 5, y: 5 })
+    expect(center.x).toBeCloseTo(150)
+    expect(center.y).toBeCloseTo(300)
+
+    const right = view.paperPointToModel({ x: 10, y: 5 })
+    expect(right.x).toBeCloseTo(150)
+    expect(right.y).toBeCloseTo(400)
+
+    expect(view.internalCamera.rotation.z).toBeCloseTo(Math.PI / 2)
+  })
+
+  it('keeps axis-aligned mapping when twist is zero', () => {
+    const parent = new AcTrBaseView(createMockRenderer(), 800, 600)
+    const view = new AcTrViewportView(
+      parent,
+      createViewport(0),
+      createMockRenderer()
+    )
+    const corner = view.paperPointToModel({ x: 0, y: 0 })
+    expect(corner.x).toBeCloseTo(50)
+    expect(corner.y).toBeCloseTo(200)
+    expect(view.internalCamera.rotation.z).toBeCloseTo(0)
+  })
+})
 
 describe('AcTrViewportView.isDefaultPaperSpaceViewport', () => {
   it('detects the classic looks-at-itself default', () => {

--- a/packages/three-renderer/src/viewport/AcTrViewportView.ts
+++ b/packages/three-renderer/src/viewport/AcTrViewportView.ts
@@ -141,6 +141,7 @@ export class AcTrViewportView extends AcTrBaseView {
     this._viewport = viewport.clone()
     this._frustum *= viewport.height / parentView.height
     this.zoomTo(this._viewport.viewBox)
+    this.applyViewTwist()
     this.enabled = false
   }
 
@@ -156,6 +157,7 @@ export class AcTrViewportView extends AcTrBaseView {
    */
   update() {
     this.zoomTo(this._viewport.viewBox, 1.0)
+    this.applyViewTwist()
   }
 
   /**
@@ -194,38 +196,52 @@ export class AcTrViewportView extends AcTrBaseView {
   }
 
   /**
-   * Transforms a point from paper-space WCS into the model-space DCS that
-   * is visible through this viewport. The mapping is the affine transform
-   * defined by:
-   *   - `viewport.box`     — the rectangle the viewport occupies in paper
-   *   - `viewport.viewBox` — the rectangle of model the viewport shows
+   * Transforms a point from paper-space WCS into the model-space WCS that
+   * is visible through this viewport.
    *
-   * Note this intentionally ignores the viewport's twist angle (rotation
-   * within the viewport): AutoCAD viewports may be rotated, but the
-   * current renderer does not support that yet, and adding it here would
-   * silently disagree with what the user sees on screen. When twist
-   * support lands (`AcDbViewport.twistAngle`), update this transform and
-   * the corresponding renderer in lockstep.
+   * Maps the paper rectangle onto the DCS view (`viewBox` size around its
+   * center), then rotates by {@link AcGiViewport.viewTwistAngle} so a
+   * non-zero DVIEW twist matches `AcGiViewport.dcsCenterToWcs` and the
+   * camera applied after zoom-to-fit.
    */
   paperPointToModel(paperPt: AcGePoint2dLike): AcGePoint2d {
     const paperBox = this._viewport.box
     const modelBox = this._viewport.viewBox
     const paperW = paperBox.max.x - paperBox.min.x
     const paperH = paperBox.max.y - paperBox.min.y
-    // Degenerate viewport (collapsed to a line/point) — return the model
-    // view center as a safe fallback so callers don't divide by zero.
+    const centerX = (modelBox.min.x + modelBox.max.x) / 2
+    const centerY = (modelBox.min.y + modelBox.max.y) / 2
     if (paperW <= 0 || paperH <= 0) {
-      return new AcGePoint2d(
-        (modelBox.min.x + modelBox.max.x) / 2,
-        (modelBox.min.y + modelBox.max.y) / 2
-      )
+      return new AcGePoint2d(centerX, centerY)
     }
-    const u = (paperPt.x - paperBox.min.x) / paperW
-    const v = (paperPt.y - paperBox.min.y) / paperH
+    const localX =
+      ((paperPt.x - paperBox.min.x) / paperW - 0.5) *
+      (modelBox.max.x - modelBox.min.x)
+    const localY =
+      ((paperPt.y - paperBox.min.y) / paperH - 0.5) *
+      (modelBox.max.y - modelBox.min.y)
+    const twist = this._viewport.viewTwistAngle
+    if (!Number.isFinite(twist) || twist === 0) {
+      return new AcGePoint2d(centerX + localX, centerY + localY)
+    }
+    const cos = Math.cos(twist)
+    const sin = Math.sin(twist)
     return new AcGePoint2d(
-      modelBox.min.x + u * (modelBox.max.x - modelBox.min.x),
-      modelBox.min.y + v * (modelBox.max.y - modelBox.min.y)
+      centerX + localX * cos - localY * sin,
+      centerY + localX * sin + localY * cos
     )
+  }
+
+  /**
+   * Rotates this viewport's camera by {@link AcGiViewport.viewTwistAngle}
+   * after {@link zoomTo}, which otherwise resets rotation to identity.
+   */
+  private applyViewTwist() {
+    const twist = this._viewport.viewTwistAngle
+    const angle = Number.isFinite(twist) ? twist : 0
+    this._camera.internalCamera.up.set(-Math.sin(angle), Math.cos(angle), 0)
+    this._camera.setRotationFromEuler(new THREE.Euler(0, 0, angle))
+    this._camera.updateProjectionMatrix()
   }
 
   /**
@@ -261,6 +277,7 @@ export class AcTrViewportView extends AcTrBaseView {
         this._height = vpH
         this._frustum = vpH / 2
         this.zoomTo(this._viewport.viewBox, 1.0)
+        this.applyViewTwist()
       }
 
       const y = this._parentView.height - viewportWindowBox.min.y - vpH


### PR DESCRIPTION
## Summary
- Export every layout-table tab (including unvisited paper spaces) and serialize user paper-space viewports in snapshot v3 so the offline HTML viewer can scissor-render model geometry through viewport frames.
- Add a toolbar layout menu matching simple-ui, keep per-layout camera/markup/measurement overlays, and drill object snap through viewport interiors.
- Register missing layout BTRs in `AcTrView2d.ensureEntitiesConvertedForExport` so HTML export collects geometry for paper tabs the user never opened.

## Test plan
- [ ] Run `pnpm test -- --testPathPatterns=packages/cad-html-plugin` (already passed locally: 153 tests).
- [ ] Export a drawing with Model + at least two paper layouts, including one never visited, and confirm the HTML toolbar layout menu lists all tabs.
- [ ] On a paper layout with viewports, confirm model-space content is clipped to each viewport frame and zoom/pan of the sheet still looks correct.
- [ ] Switch layouts, confirm zoom-original is per-layout, and that markup/measurement overlays stay on the layout they were created on.
- [ ] In measure mode, click inside a viewport and confirm object snap hits model geometry; click near the viewport border and confirm it stays on the paper frame.
