### PR TITLE
fix: keep hatch fills below linework in HTML export

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts
@@ -92,6 +92,7 @@ describe('patterned hatch HTML export', () => {
     const { meshBatches } = collectBatchesFromObject3D(root)
     expect(meshBatches).toHaveLength(1)
     expect(meshBatches[0]?.hatchPattern?.patternLines.length).toBeGreaterThan(0)
+    expect(meshBatches[0]?.renderOrder).toBe(-1)
 
     const viewerMaterial = createViewerMeshMaterial(meshBatches[0]!)
     expect(viewerMaterial).toBeInstanceOf(THREE.ShaderMaterial)
@@ -152,6 +153,7 @@ describe('patterned hatch HTML export', () => {
     const decoded = decodeSnapshot(encoded.payload)
     const decodedBatch = decoded.layouts[0]!.meshBatches[0]!
     expect(decodedBatch.hatchPattern).toEqual(batch.hatchPattern)
+    expect(decodedBatch.renderOrder).toBe(-1)
 
     const viewerMaterial = createViewerMeshMaterial(decodedBatch)
     expect(viewerMaterial).toBeInstanceOf(THREE.ShaderMaterial)

--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -697,4 +697,40 @@ describe('collectBatchesFromObject3D rebase offsets', () => {
     expect(lineBatches).toHaveLength(1)
     expect(lineBatches[0]!.positions.length).toBe(12)
   })
+
+  it('exports hatch-tier drawOrder as mesh renderOrder when object.renderOrder is 0', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(
+        new Float32Array([0, 0, 0, 10, 0, 0, 0, 10, 0]),
+        3
+      )
+    )
+    geometry.setIndex(new THREE.BufferAttribute(new Uint32Array([0, 1, 2]), 1))
+    const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 })
+    material.userData.drawOrder = -1
+    const mesh = new THREE.Mesh(geometry, material)
+    expect(mesh.renderOrder).toBe(0)
+
+    const { meshBatches } = collectBatchesFromObject3D(mesh)
+    expect(meshBatches).toHaveLength(1)
+    expect(meshBatches[0]!.renderOrder).toBe(-1)
+  })
+
+  it('omits default linework-tier renderOrder from line batches', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(new Float32Array([0, 0, 0, 10, 0, 0]), 3)
+    )
+    const line = new THREE.LineSegments(
+      geometry,
+      new THREE.LineBasicMaterial({ color: 0xff0000 })
+    )
+
+    const { lineBatches } = collectBatchesFromObject3D(line)
+    expect(lineBatches).toHaveLength(1)
+    expect(lineBatches[0]!.renderOrder).toBeUndefined()
+  })
 })

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
@@ -265,4 +265,57 @@ describe('AcExSnapshotCodec', () => {
     })
     expect(decoded.layouts[0]!.viewports?.[0]?.twist).toBeCloseTo(Math.PI / 4)
   })
+
+  it('round-trips signed renderOrder so hatch fills stay below linework', () => {
+    const snapshot = {
+      version: ACEX_SNAPSHOT_VERSION,
+      meta: {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        extents: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        units: {
+          insunits: 4,
+          lunits: 2,
+          luprec: 4,
+          aunits: 0,
+          auprec: 0,
+          measurement: 1,
+          ltscale: 1,
+          angbase: 0,
+          angdir: 0
+        },
+        background: 0
+      },
+      layers: [{ name: '0', color: 0xffffff, visible: true }],
+      layouts: [
+        {
+          btrId: 'ms',
+          name: '*Model_Space',
+          isModelSpace: true,
+          lineBatches: [
+            {
+              layer: '0',
+              color: 0xff0000,
+              offset: [0, 0, 0] as [number, number, number],
+              positions: f32([0, 0, 0, 10, 0, 0])
+            }
+          ],
+          meshBatches: [
+            {
+              layer: '0',
+              color: 0x00ff00,
+              offset: [0, 0, 0] as [number, number, number],
+              positions: f32([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+              indices: Uint32Array.from([0, 1, 2]),
+              renderOrder: -1
+            }
+          ]
+        }
+      ],
+      activeLayoutBtrId: 'ms'
+    }
+
+    const decoded = decodeSnapshot(encodeSnapshot(snapshot).payload)
+    expect(decoded.layouts[0]!.lineBatches[0]!.renderOrder).toBeUndefined()
+    expect(decoded.layouts[0]!.meshBatches[0]!.renderOrder).toBe(-1)
+  })
 })

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -1319,6 +1319,31 @@ function setupLayerPanel(
   }
 }
 
+function applyBatchPose(
+  object: THREE.Object3D,
+  batch: { offset: [number, number, number]; renderOrder?: number }
+): void {
+  object.position.set(batch.offset[0], batch.offset[1], batch.offset[2])
+  if (batch.renderOrder != null) {
+    object.renderOrder = batch.renderOrder
+  }
+}
+
+/**
+ * Hatch-tier fills sit below linework on the shared Z plane.
+ * Prefer the exported `renderOrder` (from `drawOrder`); patterned/gradient
+ * batches without that field still fall back to `-1`.
+ */
+function resolveMeshRenderOrder(batch: AcExMeshBatch): number | undefined {
+  if (batch.renderOrder != null) {
+    return batch.renderOrder
+  }
+  if (batch.hatchPattern || batch.gradientFill) {
+    return -1
+  }
+  return undefined
+}
+
 function createLineObject(
   batch: AcExLineBatch,
   wideLineMaterials: LineMaterial[],
@@ -1335,7 +1360,7 @@ function createLineObject(
     ) as LineMaterial
     wideLineMaterials.push(material)
     const object = new LineSegments2(geometry, material)
-    object.position.set(batch.offset[0], batch.offset[1], batch.offset[2])
+    applyBatchPose(object, batch)
     return object
   }
 
@@ -1359,7 +1384,7 @@ function createLineObject(
   }
   const material = createViewerLineMaterial(batch)
   const object = new THREE.LineSegments(geometry, material)
-  object.position.set(batch.offset[0], batch.offset[1], batch.offset[2])
+  applyBatchPose(object, batch)
   return object
 }
 
@@ -1533,7 +1558,10 @@ function createPointObject(batch: AcExMeshBatch): THREE.Points | null {
   )
   const material = createViewerPointsMaterial(batch)
   const object = new THREE.Points(geometry, material)
-  object.position.set(batch.offset[0], batch.offset[1], batch.offset[2])
+  applyBatchPose(object, {
+    offset: batch.offset,
+    renderOrder: batch.renderOrder
+  })
   return object
 }
 
@@ -1559,7 +1587,10 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
   }
   const material = createViewerMeshMaterial(batch)
   const object = new THREE.Mesh(geometry, material)
-  object.position.set(batch.offset[0], batch.offset[1], batch.offset[2])
+  applyBatchPose(object, {
+    offset: batch.offset,
+    renderOrder: resolveMeshRenderOrder(batch)
+  })
   return object
 }
 

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -400,6 +400,33 @@ function readMaterialStyle(material: THREE.Material): {
   }
 }
 
+/**
+ * Resolves the snapshot `renderOrder` for a drawable.
+ *
+ * Prefer material `drawOrder` (set even on unbatched hatch meshes) and fall
+ * back to `object.renderOrder` (set on batched meshes in `AcTrBatchedGroup`).
+ * `0` is omitted so the default linework tier stays compact.
+ */
+function resolveExportedRenderOrder(
+  object: THREE.Object3D,
+  material: THREE.Material
+): number | undefined {
+  const fromMaterial = getMaterialMetadata(material).drawOrder
+  const value = fromMaterial ?? object.renderOrder
+  return value === 0 ? undefined : value
+}
+
+function assignRenderOrder(
+  batch: { renderOrder?: number },
+  object: THREE.Object3D,
+  material: THREE.Material
+): void {
+  const renderOrder = resolveExportedRenderOrder(object, material)
+  if (renderOrder != null) {
+    batch.renderOrder = renderOrder
+  }
+}
+
 function resolveExportedHatchPattern(
   object: THREE.Object3D,
   hatchPattern: ReturnType<typeof extractHatchPattern> | undefined
@@ -443,7 +470,7 @@ function buildMeshBatch(
   const gradientPositions = style.gradientFill
     ? exportVertexAttributeSlice(geometry, 'gradientPosition')
     : undefined
-  return {
+  const batch: AcExMeshBatch = {
     layer: style.layer,
     color: style.color,
     offset,
@@ -453,6 +480,8 @@ function buildMeshBatch(
     side: style.side,
     ...slice
   }
+  assignRenderOrder(batch, object, material)
+  return batch
 }
 
 function exportBatchedLine2(
@@ -464,13 +493,15 @@ function exportBatchedLine2(
   }
   const { color, layer } = readMaterialStyle(batch.material as THREE.Material)
   const lineWidth = readLineWidth(batch.material as THREE.Material)
-  return {
+  const exported: AcExLineBatch = {
     layer,
     color,
     offset: readWorldOffset(batch),
     lineWidth,
     ...slice
   }
+  assignRenderOrder(exported, batch, batch.material as THREE.Material)
+  return exported
 }
 
 function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
@@ -484,7 +515,7 @@ function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
   const lineDistances = linePattern
     ? computeLineDistancesForSegments(slice.positions)
     : undefined
-  return {
+  const exported: AcExLineBatch = {
     layer,
     color,
     offset: readWorldOffset(batch),
@@ -492,6 +523,8 @@ function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
     lineDistances,
     ...slice
   }
+  assignRenderOrder(exported, batch, batch.material as THREE.Material)
+  return exported
 }
 
 function exportBatchedMesh(batch: AcTrBatchedMesh): AcExMeshBatch | undefined {
@@ -576,13 +609,15 @@ export function collectBatchesFromObject3D(
       const material = readExportMaterial(child)
       const { color, layer } = readMaterialStyle(material)
       const { offset, ...slice } = exportSceneDrawableSlice(child, rawSlice)
-      lineBatches.push({
+      const exported: AcExLineBatch = {
         layer,
         color,
         offset,
         lineWidth: readLineWidth(material),
         ...slice
-      })
+      }
+      assignRenderOrder(exported, child, material)
+      lineBatches.push(exported)
     } else if (
       child instanceof THREE.LineSegments &&
       !(child instanceof AcTrBatchedLine)
@@ -596,14 +631,16 @@ export function collectBatchesFromObject3D(
       const lineDistances = linePattern
         ? computeLineDistancesForSegments(slice.positions)
         : undefined
-      lineBatches.push({
+      const exported: AcExLineBatch = {
         layer,
         color,
         offset,
         linePattern,
         lineDistances,
         ...slice
-      })
+      }
+      assignRenderOrder(exported, child, material)
+      lineBatches.push(exported)
     } else if (
       child instanceof THREE.Mesh &&
       !(child instanceof AcTrBatchedMesh)

--- a/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
@@ -14,6 +14,7 @@ const F_LINE_INDICES = 1
 const F_LINE_PATTERN = 2
 const F_LINE_DISTANCES = 4
 const F_LINE_WIDTH = 8
+const F_LINE_RENDER_ORDER = 16
 
 const F_MESH_INDICES = 1
 const F_MESH_HATCH = 2
@@ -21,6 +22,7 @@ const F_MESH_GRADIENT_FILL = 4
 const F_MESH_GRADIENT_POS = 8
 const F_MESH_SIDE = 16
 const F_MESH_POINTS = 32
+const F_MESH_RENDER_ORDER = 64
 
 /**
  * Serializes a snapshot to a compact binary byte array.
@@ -132,7 +134,15 @@ function readLayout(reader: BinaryReader): AcExLayoutSnapshot {
     meshBatches.push(readMeshBatch(reader))
   }
 
-  return { btrId, name, isModelSpace, lineBatches, meshBatches, osnap, viewports }
+  return {
+    btrId,
+    name,
+    isModelSpace,
+    lineBatches,
+    meshBatches,
+    osnap,
+    viewports
+  }
 }
 
 function writeLineBatch(writer: BinaryWriter, batch: AcExLineBatch): void {
@@ -152,6 +162,9 @@ function writeLineBatch(writer: BinaryWriter, batch: AcExLineBatch): void {
   if (batch.lineWidth != null && batch.lineWidth > 0) {
     flags |= F_LINE_WIDTH
   }
+  if (batch.renderOrder != null && batch.renderOrder !== 0) {
+    flags |= F_LINE_RENDER_ORDER
+  }
   writer.writeU8(flags)
 
   if (flags & F_LINE_INDICES) {
@@ -165,6 +178,9 @@ function writeLineBatch(writer: BinaryWriter, batch: AcExLineBatch): void {
   }
   if (flags & F_LINE_WIDTH) {
     writer.writeF32(batch.lineWidth!)
+  }
+  if (flags & F_LINE_RENDER_ORDER) {
+    writer.writeI32(batch.renderOrder!)
   }
 }
 
@@ -193,6 +209,9 @@ function readLineBatch(reader: BinaryReader): AcExLineBatch {
   if (flags & F_LINE_WIDTH) {
     batch.lineWidth = reader.readF32()
   }
+  if (flags & F_LINE_RENDER_ORDER) {
+    batch.renderOrder = reader.readI32()
+  }
   return batch
 }
 
@@ -213,6 +232,9 @@ function writeMeshBatch(writer: BinaryWriter, batch: AcExMeshBatch): void {
   }
   if (batch.side != null) flags |= F_MESH_SIDE
   if (batch.points) flags |= F_MESH_POINTS
+  if (batch.renderOrder != null && batch.renderOrder !== 0) {
+    flags |= F_MESH_RENDER_ORDER
+  }
   writer.writeU8(flags)
 
   if (flags & F_MESH_INDICES) {
@@ -229,6 +251,9 @@ function writeMeshBatch(writer: BinaryWriter, batch: AcExMeshBatch): void {
   }
   if (flags & F_MESH_SIDE) {
     writer.writeU8(batch.side!)
+  }
+  if (flags & F_MESH_RENDER_ORDER) {
+    writer.writeI32(batch.renderOrder!)
   }
 }
 
@@ -264,6 +289,9 @@ function readMeshBatch(reader: BinaryReader): AcExMeshBatch {
   if (flags & F_MESH_POINTS) {
     batch.points = true
   }
+  if (flags & F_MESH_RENDER_ORDER) {
+    batch.renderOrder = reader.readI32()
+  }
   return batch
 }
 
@@ -281,6 +309,13 @@ class BinaryWriter {
   writeU32(value: number): void {
     const chunk = new Uint8Array(4)
     new DataView(chunk.buffer).setUint32(0, value >>> 0, true)
+    this.chunks.push(chunk)
+    this.length += 4
+  }
+
+  writeI32(value: number): void {
+    const chunk = new Uint8Array(4)
+    new DataView(chunk.buffer).setInt32(0, value | 0, true)
     this.chunks.push(chunk)
     this.length += 4
   }
@@ -374,6 +409,17 @@ class BinaryReader {
       4
     )
     const value = view.getUint32(0, true)
+    this.offset += 4
+    return value
+  }
+
+  readI32(): number {
+    const view = new DataView(
+      this.bytes.buffer,
+      this.bytes.byteOffset + this.offset,
+      4
+    )
+    const value = view.getInt32(0, true)
     this.offset += 4
     return value
   }

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -6,6 +6,11 @@ import type { AcExOsnapCatalog } from './AcExOsnapPrimitiveTypes'
  *
  * v3 adds {@link AcExLayoutSnapshot.viewports} so the offline HTML viewer can
  * scissor-render model space through paper-space viewports.
+ *
+ * Optional {@link AcExLineBatch.renderOrder} / {@link AcExMeshBatch.renderOrder}
+ * is a backward-compatible flag on v3 batches: hatch fills use `-1` so they
+ * sit below linework on the shared Z plane, matching the live viewer's
+ * `AcGiSubEntityTraits.drawOrder` / `Object3D.renderOrder` tiers.
  */
 export const ACEX_SNAPSHOT_VERSION = 3 as const
 
@@ -139,6 +144,11 @@ export interface AcExLineBatch {
    * `LineSegments2` / `LineMaterial`. Omitted for 1px `THREE.LineSegments`.
    */
   lineWidth?: number
+  /**
+   * Three.js `Object3D.renderOrder` for same-plane compositing.
+   * Omitted when `0` (the default linework tier).
+   */
+  renderOrder?: number
 }
 
 /**
@@ -194,6 +204,11 @@ export interface AcExMeshBatch {
   gradientPositions?: Float32Array
   /** Material side when a custom fill shader is used (`0` = front, `1` = back). */
   side?: number
+  /**
+   * Three.js `Object3D.renderOrder` for same-plane compositing.
+   * Hatch fills are `-1` so they sit below linework; omitted when `0`.
+   */
+  renderOrder?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- HTML snapshots dropped Three.js `renderOrder` (from CAD `drawOrder`), so hatch meshes painted over lines on the shared Z plane.
- Export now stores non-zero `renderOrder` on line/mesh batches (hatch fills use `-1`) and the offline viewer applies it when rebuilding the scene.
- Patterned/gradient batches without the field still fall back to `-1`; binary codec keeps the field optional so existing v3 snapshots still decode.

## Test plan
- [ ] Re-export a drawing with solid and patterned hatches overlapping linework and confirm lines stay visible in the HTML viewer.
- [ ] Confirm MText / wide-polyline fills are not pushed behind lines (linework-tier `renderOrder` remains 0).
- [ ] `npx jest packages/cad-html-plugin/__tests__/AcExHatchExport.spec.ts packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts`