### PR TITLE
feat: add AutoCAD-style center osnap ticks

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts
@@ -505,4 +505,51 @@ describe('AcEdOsnapResolver', () => {
       expect(resolver.acquiredCenterMarks[0]?.y).toBeCloseTo(expected.y, 5)
     })
   })
+
+  it('transforms nested insert centers through the parent block transform', () => {
+    withWorkingDatabase(db => {
+      const inner = new AcDbBlockTableRecord()
+      inner.name = 'INNER_CEN_BLK'
+      db.tables.blockTable.add(inner)
+      const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 50)
+      inner.appendEntity(circle)
+
+      const outer = new AcDbBlockTableRecord()
+      outer.name = 'OUTER_CEN_BLK'
+      db.tables.blockTable.add(outer)
+      const nestedInsert = new AcDbBlockReference('INNER_CEN_BLK')
+      nestedInsert.position = new AcGePoint3d(10, 0, 0)
+      outer.appendEntity(nestedInsert)
+
+      const insert = new AcDbBlockReference('OUTER_CEN_BLK')
+      insert.position = new AcGePoint3d(100, 20, 0)
+      insert.scaleFactors = new AcGePoint3d(2, 2, 1)
+      db.tables.blockTable.modelSpace.appendEntity(insert)
+
+      const expected = new AcGePoint3d(0, 0, 0)
+        .applyMatrix4(nestedInsert.blockTransform)
+        .applyMatrix4(insert.blockTransform)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([
+        {
+          id: insert.objectId,
+          children: [{ id: nestedInsert.objectId }]
+        }
+      ])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: expected.x + 50, y: expected.y },
+        hitRadiusPx: 20
+      })
+
+      expect(resolver.acquiredCenterMarks).toHaveLength(1)
+      expect(resolver.acquiredCenterMarks[0]?.x).toBeCloseTo(expected.x, 5)
+      expect(resolver.acquiredCenterMarks[0]?.y).toBeCloseTo(expected.y, 5)
+      expect(resolver.acquiredCenterMarks[0]?.x).not.toBeCloseTo(10, 5)
+    })
+  })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts
@@ -1,5 +1,7 @@
 import {
   AcDbArc,
+  AcDbBlockReference,
+  AcDbBlockTableRecord,
   AcDbCircle,
   AcDbDatabase,
   AcDbEllipse,
@@ -54,7 +56,9 @@ function withWorkingDatabase(run: (db: AcDbDatabase) => void) {
   }
 }
 
-function createMockView(pickResults: Array<{ id: string }>): AcEdBaseView {
+function createMockView(
+  pickResults: Array<{ id: string; children?: Array<{ id: string }> }>
+): AcEdBaseView {
   return {
     pick: jest.fn().mockReturnValue(pickResults),
     // 1 CSS px == 1 WCS unit so threshold equals hitRadiusPx
@@ -228,7 +232,7 @@ describe('AcEdOsnapResolver', () => {
     })
   })
 
-  it('drops the acquired center tick after the cursor leaves the supporting circle', () => {
+  it('keeps the acquired center tick after the cursor leaves the curve until the command ends', () => {
     withWorkingDatabase(db => {
       const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 100)
       db.tables.blockTable.modelSpace.appendEntity(circle)
@@ -250,6 +254,15 @@ describe('AcEdOsnapResolver', () => {
       })
 
       expect(snap).toBeUndefined()
+      expect(resolver.acquiredCenterMarks).toHaveLength(1)
+
+      const nearCenter = resolver.resolve({
+        cursorWcs: { x: 1, y: 0 },
+        hitRadiusPx: 20
+      })
+      expect(nearCenter?.type).toBe(AcDbOsnapMode.Center)
+
+      resolver.clearAcquiredCenters()
       expect(resolver.acquiredCenterMarks).toHaveLength(0)
     })
   })
@@ -384,6 +397,112 @@ describe('AcEdOsnapResolver', () => {
       })
 
       expect(resolver.acquiredCenterMarks).toHaveLength(0)
+    })
+  })
+
+  it('accumulates center ticks from multiple hovered circles in one command', () => {
+    withWorkingDatabase(db => {
+      const a = new AcDbCircle(new AcGePoint3d(0, 0, 0), 40)
+      const b = new AcDbCircle(new AcGePoint3d(100, 0, 0), 40)
+      db.tables.blockTable.modelSpace.appendEntity(a)
+      db.tables.blockTable.modelSpace.appendEntity(b)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([{ id: a.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: 40, y: 0 },
+        hitRadiusPx: 20
+      })
+      ;(view.pick as jest.Mock).mockReturnValue([{ id: b.objectId }])
+      resolver.resolve({
+        cursorWcs: { x: 140, y: 0 },
+        hitRadiusPx: 20
+      })
+
+      expect(resolver.acquiredCenterMarks).toHaveLength(2)
+      expect(resolver.acquiredCenterMarks[0]?.x).toBeCloseTo(0, 5)
+      expect(resolver.acquiredCenterMarks[1]?.x).toBeCloseTo(100, 5)
+    })
+  })
+
+  it('acquires the center of a circle inside a block reference', () => {
+    withWorkingDatabase(db => {
+      const block = new AcDbBlockTableRecord()
+      block.name = 'CEN_BLK'
+      db.tables.blockTable.add(block)
+      const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 80)
+      block.appendEntity(circle)
+
+      const insert = new AcDbBlockReference('CEN_BLK')
+      insert.position = new AcGePoint3d(30, 10, 0)
+      db.tables.blockTable.modelSpace.appendEntity(insert)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([
+        { id: insert.objectId, children: [{ id: circle.objectId }] }
+      ])
+      const resolver = new AcEdOsnapResolver(view)
+      const snap = resolver.resolve({
+        cursorWcs: { x: 110, y: 10 },
+        hitRadiusPx: 20
+      })
+
+      expect(snap).toBeUndefined()
+      expect(resolver.acquiredCenterMarks).toHaveLength(1)
+      expect(resolver.acquiredCenterMarks[0]?.x).toBeCloseTo(30, 5)
+      expect(resolver.acquiredCenterMarks[0]?.y).toBeCloseTo(10, 5)
+    })
+  })
+
+  it('acquires the bulge-arc center of a polyline inside a block reference', () => {
+    withWorkingDatabase(db => {
+      const block = new AcDbBlockTableRecord()
+      block.name = 'PL_BLK'
+      db.tables.blockTable.add(block)
+      const polyline = new AcDbPolyline()
+      polyline.addVertexAt(0, new AcGePoint2d(0, 0), 1)
+      polyline.addVertexAt(1, new AcGePoint2d(10, 0))
+      block.appendEntity(polyline)
+
+      const insert = new AcDbBlockReference('PL_BLK')
+      insert.position = new AcGePoint3d(20, 0, 0)
+      db.tables.blockTable.modelSpace.appendEntity(insert)
+
+      const local = new AcGeCircArc2d({ x: 0, y: 0 }, { x: 10, y: 0 }, 1)
+      const expected = new AcGePoint3d(
+        local.center.x,
+        local.center.y,
+        0
+      ).applyMatrix4(insert.blockTransform)
+      const mid = new AcGePoint3d(
+        local.midPoint.x,
+        local.midPoint.y,
+        0
+      ).applyMatrix4(insert.blockTransform)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([
+        { id: insert.objectId, children: [{ id: polyline.objectId }] }
+      ])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: mid.x, y: mid.y },
+        hitRadiusPx: 20
+      })
+
+      expect(resolver.acquiredCenterMarks).toHaveLength(1)
+      expect(resolver.acquiredCenterMarks[0]?.x).toBeCloseTo(expected.x, 5)
+      expect(resolver.acquiredCenterMarks[0]?.y).toBeCloseTo(expected.y, 5)
     })
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts
@@ -1,10 +1,17 @@
 import {
+  AcDbArc,
+  AcDbCircle,
   AcDbDatabase,
+  AcDbEllipse,
   AcDbLine,
   AcDbOsnapMode,
+  AcDbPolyline,
   acdbHostApplicationServices,
   acdbOsnapModesToMask,
-  AcGePoint3d
+  AcGeCircArc2d,
+  AcGePoint2d,
+  AcGePoint3d,
+  AcGeVector3d
 } from '@mlightcad/data-model'
 
 import { AcApSettingManager } from '../src/app/AcApSettingManager'
@@ -47,9 +54,7 @@ function withWorkingDatabase(run: (db: AcDbDatabase) => void) {
   }
 }
 
-function createMockView(
-  pickResults: Array<{ id: string }>
-): AcEdBaseView {
+function createMockView(pickResults: Array<{ id: string }>): AcEdBaseView {
   return {
     pick: jest.fn().mockReturnValue(pickResults),
     // 1 CSS px == 1 WCS unit so threshold equals hitRadiusPx
@@ -164,6 +169,221 @@ describe('AcEdOsnapResolver', () => {
       expect(snap?.type).toBe(AcDbOsnapMode.EndPoint)
       expect(snap?.x).toBeCloseTo(5, 5)
       expect(snap?.y).toBeCloseTo(0, 5)
+    })
+  })
+
+  it('acquires a center tick when hovering a large circle without snapping to the center', () => {
+    withWorkingDatabase(db => {
+      const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 100)
+      db.tables.blockTable.modelSpace.appendEntity(circle)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([{ id: circle.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      const snap = resolver.resolve({
+        cursorWcs: { x: 100, y: 0 },
+        hitRadiusPx: 20
+      })
+
+      expect(snap).toBeUndefined()
+      expect(resolver.acquiredCenterMarks).toHaveLength(1)
+      expect(resolver.acquiredCenterMarks[0]?.x).toBeCloseTo(0, 5)
+      expect(resolver.acquiredCenterMarks[0]?.y).toBeCloseTo(0, 5)
+      expect(
+        AcEdOsnapResolver.displayCenterMarks(resolver.acquiredCenterMarks, snap)
+      ).toHaveLength(1)
+    })
+  })
+
+  it('snaps to an acquired circle center after the cursor moves onto the tick', () => {
+    withWorkingDatabase(db => {
+      const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 100)
+      db.tables.blockTable.modelSpace.appendEntity(circle)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([{ id: circle.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: 100, y: 0 },
+        hitRadiusPx: 20
+      })
+      ;(view.pick as jest.Mock).mockReturnValue([])
+      const snap = resolver.resolve({
+        cursorWcs: { x: 1, y: 0 },
+        hitRadiusPx: 20
+      })
+
+      expect(snap?.type).toBe(AcDbOsnapMode.Center)
+      expect(snap?.x).toBeCloseTo(0, 5)
+      expect(snap?.y).toBeCloseTo(0, 5)
+      expect(
+        AcEdOsnapResolver.displayCenterMarks(resolver.acquiredCenterMarks, snap)
+      ).toHaveLength(0)
+    })
+  })
+
+  it('drops the acquired center tick after the cursor leaves the supporting circle', () => {
+    withWorkingDatabase(db => {
+      const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 100)
+      db.tables.blockTable.modelSpace.appendEntity(circle)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([{ id: circle.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: 100, y: 0 },
+        hitRadiusPx: 20
+      })
+      ;(view.pick as jest.Mock).mockReturnValue([])
+      const snap = resolver.resolve({
+        cursorWcs: { x: 200, y: 0 },
+        hitRadiusPx: 20
+      })
+
+      expect(snap).toBeUndefined()
+      expect(resolver.acquiredCenterMarks).toHaveLength(0)
+    })
+  })
+
+  it('snaps to circle center immediately when the center is already within the aperture', () => {
+    withWorkingDatabase(db => {
+      const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 10)
+      db.tables.blockTable.modelSpace.appendEntity(circle)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([{ id: circle.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      const snap = resolver.resolve({
+        cursorWcs: { x: 10, y: 0 },
+        hitRadiusPx: 20
+      })
+
+      expect(snap?.type).toBe(AcDbOsnapMode.Center)
+      expect(snap?.x).toBeCloseTo(0, 5)
+      expect(snap?.y).toBeCloseTo(0, 5)
+    })
+  })
+
+  it('acquires the arc center when hovering an arc', () => {
+    withWorkingDatabase(db => {
+      const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 50, 0, Math.PI / 2)
+      db.tables.blockTable.modelSpace.appendEntity(arc)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([{ id: arc.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: 50, y: 0 },
+        hitRadiusPx: 20
+      })
+
+      expect(resolver.acquiredCenterMarks).toHaveLength(1)
+      expect(resolver.acquiredCenterMarks[0]?.x).toBeCloseTo(0, 5)
+      expect(resolver.acquiredCenterMarks[0]?.y).toBeCloseTo(0, 5)
+    })
+  })
+
+  it('acquires the ellipse center when hovering an ellipse', () => {
+    withWorkingDatabase(db => {
+      const ellipse = new AcDbEllipse(
+        new AcGePoint3d(2, 3, 0),
+        AcGeVector3d.Z_AXIS,
+        AcGeVector3d.X_AXIS,
+        40,
+        20,
+        0,
+        Math.PI * 2
+      )
+      db.tables.blockTable.modelSpace.appendEntity(ellipse)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([{ id: ellipse.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: 42, y: 3 },
+        hitRadiusPx: 20
+      })
+
+      expect(resolver.acquiredCenterMarks).toHaveLength(1)
+      expect(resolver.acquiredCenterMarks[0]?.x).toBeCloseTo(2, 5)
+      expect(resolver.acquiredCenterMarks[0]?.y).toBeCloseTo(3, 5)
+    })
+  })
+
+  it('acquires the bulge-arc center when hovering a polyline arc segment', () => {
+    withWorkingDatabase(db => {
+      const polyline = new AcDbPolyline()
+      polyline.addVertexAt(0, new AcGePoint2d(0, 0), 1)
+      polyline.addVertexAt(1, new AcGePoint2d(10, 0))
+      db.tables.blockTable.modelSpace.appendEntity(polyline)
+
+      const expected = new AcGeCircArc2d({ x: 0, y: 0 }, { x: 10, y: 0 }, 1)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center
+      ])
+
+      const view = createMockView([{ id: polyline.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: {
+          x: expected.midPoint.x,
+          y: expected.midPoint.y
+        },
+        hitRadiusPx: 20
+      })
+
+      expect(resolver.acquiredCenterMarks).toHaveLength(1)
+      expect(resolver.acquiredCenterMarks[0]?.x).toBeCloseTo(
+        expected.center.x,
+        5
+      )
+      expect(resolver.acquiredCenterMarks[0]?.y).toBeCloseTo(
+        expected.center.y,
+        5
+      )
+    })
+  })
+
+  it('does not acquire a center tick when hovering a line', () => {
+    withWorkingDatabase(db => {
+      const line = new AcDbLine(
+        new AcGePoint3d(0, 0, 0),
+        new AcGePoint3d(10, 0, 0)
+      )
+      db.tables.blockTable.modelSpace.appendEntity(line)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Center,
+        AcDbOsnapMode.EndPoint
+      ])
+
+      const view = createMockView([{ id: line.objectId }])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: 5, y: 0 },
+        hitRadiusPx: 20
+      })
+
+      expect(resolver.acquiredCenterMarks).toHaveLength(0)
     })
   })
 })

--- a/packages/cad-simple-viewer/src/editor/grip/AcEdGripEditSession.ts
+++ b/packages/cad-simple-viewer/src/editor/grip/AcEdGripEditSession.ts
@@ -86,6 +86,7 @@ export class AcEdGripEditSession {
   private finish() {
     this._jig.end()
     this._osnapMarkerManager.clear()
+    this._view.osnapResolver.clearAcquiredCenters()
     document.removeEventListener('mousemove', this._boundMouseMove)
     document.removeEventListener('mouseup', this._boundMouseUp)
     document.removeEventListener('keydown', this._boundKeyDown)
@@ -105,6 +106,12 @@ export class AcEdGripEditSession {
       cursorWcs,
       lastPoint: this._target.gripBaseWcs
     })
+    this._osnapMarkerManager.setHintMarkers(
+      AcEdOsnapResolver.displayCenterMarks(
+        this._view.osnapResolver.acquiredCenterMarks,
+        snapPoint
+      )
+    )
 
     if (snapPoint) {
       this._osnapMarkerManager.showMarker(

--- a/packages/cad-simple-viewer/src/editor/input/AcEdOsnapCenterMarks.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdOsnapCenterMarks.ts
@@ -210,9 +210,6 @@ function collectBlockCenterMarks(
   if (!found) {
     return collectFromOsnapCenter(blockRef, pickPoint, canonicalGsMark(gsMark))
   }
-  if (found.entity instanceof AcDbBlockReference) {
-    return collectBlockCenterMarks(found.entity, pickPoint)
-  }
 
   const inverse = found.transform.clone().invert()
   const localPick = new AcGePoint3d(pickPoint).applyMatrix4(inverse)

--- a/packages/cad-simple-viewer/src/editor/input/AcEdOsnapCenterMarks.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdOsnapCenterMarks.ts
@@ -1,6 +1,7 @@
 import {
   AcDb2dPolyline,
   AcDbArc,
+  AcDbBlockReference,
   AcDbCircle,
   AcDbEllipse,
   AcDbEntity,
@@ -8,7 +9,9 @@ import {
   AcDbOsnapMode,
   AcDbPolyline,
   AcGeCircArc2d,
+  AcGeMatrix3d,
   AcGePoint2dLike,
+  AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
 
@@ -17,8 +20,6 @@ export interface AcEdOsnapCenterMark {
   x: number
   y: number
   z: number
-  /** Supporting-curve radius used to keep the mark while moving toward the center. */
-  keepRadius: number
 }
 
 const BULGE_EPS = 1e-10
@@ -59,17 +60,29 @@ function tryBulgeArc(
   }
 }
 
-function markFromPoint(
-  point: AcGePoint3dLike,
-  keepRadius: number
-): AcEdOsnapCenterMark | undefined {
-  if (!(keepRadius > 0) || !Number.isFinite(keepRadius)) return undefined
+function markFromPoint(point: AcGePoint3dLike): AcEdOsnapCenterMark {
   return {
     x: point.x,
     y: point.y,
-    z: point.z ?? 0,
-    keepRadius
+    z: point.z ?? 0
   }
+}
+
+function transformMark(
+  mark: AcEdOsnapCenterMark,
+  matrix: AcGeMatrix3d
+): AcEdOsnapCenterMark {
+  const point = new AcGePoint3d(mark.x, mark.y, mark.z).applyMatrix4(matrix)
+  return markFromPoint(point)
+}
+
+/**
+ * Child spatial-index ids may get a `#n` suffix when the same object appears
+ * more than once in a block. Strip that before matching database object ids.
+ */
+export function canonicalGsMark(id: AcDbObjectId): AcDbObjectId {
+  if (typeof id !== 'string') return id
+  return id.replace(/#\d+$/, '')
 }
 
 function polylineVertices(entity: AcDbPolyline | AcDb2dPolyline): Array<{
@@ -135,10 +148,11 @@ function collectPolylineArcCenter(
   }
 
   if (!bestArc) return undefined
-  return markFromPoint(
-    { x: bestArc.center.x, y: bestArc.center.y, z: entity.elevation },
-    bestArc.radius
-  )
+  return markFromPoint({
+    x: bestArc.center.x,
+    y: bestArc.center.y,
+    z: entity.elevation
+  })
 }
 
 function collectFromOsnapCenter(
@@ -154,38 +168,81 @@ function collectFromOsnapCenter(
     points,
     gsMark
   )
-  const marks: AcEdOsnapCenterMark[] = []
-  for (const point of points) {
-    const keepRadius = hypot2(pickPoint.x, pickPoint.y, point.x, point.y)
-    const mark = markFromPoint(point, keepRadius)
-    if (mark) marks.push(mark)
+  return points.map(point => markFromPoint(point))
+}
+
+function findBlockSubEntity(
+  blockRef: AcDbBlockReference,
+  gsMark: AcDbObjectId,
+  parentMat: AcGeMatrix3d
+): { entity: AcDbEntity; transform: AcGeMatrix3d } | undefined {
+  const blockTableRecord = blockRef.blockTableRecord
+  if (!blockTableRecord) return undefined
+
+  const thisMat = new AcGeMatrix3d().multiplyMatrices(
+    parentMat,
+    blockRef.blockTransform
+  )
+  const targetId = canonicalGsMark(gsMark)
+
+  for (const entity of blockTableRecord.newIterator()) {
+    if (entity.objectId === gsMark || entity.objectId === targetId) {
+      return { entity, transform: thisMat }
+    }
+    if (entity instanceof AcDbBlockReference) {
+      const nested = findBlockSubEntity(entity, gsMark, thisMat)
+      if (nested) return nested
+    }
   }
-  return marks
+  return undefined
+}
+
+function collectBlockCenterMarks(
+  blockRef: AcDbBlockReference,
+  pickPoint: AcGePoint3dLike,
+  gsMark?: AcDbObjectId
+): AcEdOsnapCenterMark[] {
+  if (!gsMark) {
+    return collectFromOsnapCenter(blockRef, pickPoint)
+  }
+
+  const found = findBlockSubEntity(blockRef, gsMark, new AcGeMatrix3d())
+  if (!found) {
+    return collectFromOsnapCenter(blockRef, pickPoint, canonicalGsMark(gsMark))
+  }
+  if (found.entity instanceof AcDbBlockReference) {
+    return collectBlockCenterMarks(found.entity, pickPoint)
+  }
+
+  const inverse = found.transform.clone().invert()
+  const localPick = new AcGePoint3d(pickPoint).applyMatrix4(inverse)
+  return collectCenterMarksFromEntity(found.entity, localPick).map(mark =>
+    transformMark(mark, found.transform)
+  )
 }
 
 /**
  * Collects AutoCAD-style center ticks for circular geometry under the cursor.
  *
- * Circle, arc, ellipse, and the closest bulge segment of a polyline each
- * contribute one center. Other entities fall back to `subGetOsnapPoints(Center)`
- * so block references still acquire nested circle/arc/ellipse centers.
+ * Circle, arc, ellipse, polyline bulge segments, and the same geometry nested
+ * in block references each contribute a center.
  */
 export function collectCenterMarksFromEntity(
   entity: AcDbEntity,
   pickPoint: AcGePoint3dLike,
   gsMark?: AcDbObjectId
 ): AcEdOsnapCenterMark[] {
+  if (entity instanceof AcDbBlockReference) {
+    return collectBlockCenterMarks(entity, pickPoint, gsMark)
+  }
   if (entity instanceof AcDbCircle) {
-    const mark = markFromPoint(entity.center, entity.radius)
-    return mark ? [mark] : []
+    return [markFromPoint(entity.center)]
   }
   if (entity instanceof AcDbArc) {
-    const mark = markFromPoint(entity.center, entity.radius)
-    return mark ? [mark] : []
+    return [markFromPoint(entity.center)]
   }
   if (entity instanceof AcDbEllipse) {
-    const mark = markFromPoint(entity.center, entity.majorAxisRadius)
-    return mark ? [mark] : []
+    return [markFromPoint(entity.center)]
   }
   if (entity instanceof AcDbPolyline || entity instanceof AcDb2dPolyline) {
     const mark = collectPolylineArcCenter(entity, pickPoint)
@@ -194,20 +251,18 @@ export function collectCenterMarksFromEntity(
   return collectFromOsnapCenter(entity, pickPoint, gsMark)
 }
 
-/**
- * Keeps acquired centers while the cursor is still inside the supporting
- * curve, so the plus mark remains after leaving the circumference.
- */
-export function retainAcquiredCenterMarks(
-  marks: readonly AcEdOsnapCenterMark[],
-  cursor: AcGePoint2dLike,
-  aperture: number
+/** Appends newly hovered centers without dropping marks acquired earlier. */
+export function mergeAcquiredCenterMarks(
+  existing: readonly AcEdOsnapCenterMark[],
+  incoming: readonly AcEdOsnapCenterMark[]
 ): AcEdOsnapCenterMark[] {
-  const pad = Math.max(0, aperture)
-  return marks.filter(mark => {
-    const dist = hypot2(cursor.x, cursor.y, mark.x, mark.y)
-    return dist <= mark.keepRadius + pad
-  })
+  const merged = [...existing]
+  for (const mark of incoming) {
+    if (!merged.some(item => centerMarksCoincide(item, mark))) {
+      merged.push(mark)
+    }
+  }
+  return merged
 }
 
 export function centerMarksCoincide(

--- a/packages/cad-simple-viewer/src/editor/input/AcEdOsnapCenterMarks.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdOsnapCenterMarks.ts
@@ -1,0 +1,219 @@
+import {
+  AcDb2dPolyline,
+  AcDbArc,
+  AcDbCircle,
+  AcDbEllipse,
+  AcDbEntity,
+  AcDbObjectId,
+  AcDbOsnapMode,
+  AcDbPolyline,
+  AcGeCircArc2d,
+  AcGePoint2dLike,
+  AcGePoint3dLike
+} from '@mlightcad/data-model'
+
+/** Geometric center acquired by hovering circular geometry. */
+export interface AcEdOsnapCenterMark {
+  x: number
+  y: number
+  z: number
+  /** Supporting-curve radius used to keep the mark while moving toward the center. */
+  keepRadius: number
+}
+
+const BULGE_EPS = 1e-10
+
+function hypot2(ax: number, ay: number, bx: number, by: number) {
+  return Math.hypot(ax - bx, ay - by)
+}
+
+function distToSegment(
+  px: number,
+  py: number,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+) {
+  const dx = x1 - x0
+  const dy = y1 - y0
+  const lenSq = dx * dx + dy * dy
+  if (lenSq < 1e-18) return hypot2(px, py, x0, y0)
+  let t = ((px - x0) * dx + (py - y0) * dy) / lenSq
+  t = Math.max(0, Math.min(1, t))
+  return hypot2(px, py, x0 + t * dx, y0 + t * dy)
+}
+
+function tryBulgeArc(
+  start: AcGePoint2dLike,
+  end: AcGePoint2dLike,
+  bulge: number
+): AcGeCircArc2d | undefined {
+  if (!(Math.abs(bulge) > BULGE_EPS)) return undefined
+  try {
+    const arc = new AcGeCircArc2d(start, end, bulge)
+    if (!(arc.radius > 0) || !Number.isFinite(arc.radius)) return undefined
+    return arc
+  } catch {
+    return undefined
+  }
+}
+
+function markFromPoint(
+  point: AcGePoint3dLike,
+  keepRadius: number
+): AcEdOsnapCenterMark | undefined {
+  if (!(keepRadius > 0) || !Number.isFinite(keepRadius)) return undefined
+  return {
+    x: point.x,
+    y: point.y,
+    z: point.z ?? 0,
+    keepRadius
+  }
+}
+
+function polylineVertices(entity: AcDbPolyline | AcDb2dPolyline): Array<{
+  x: number
+  y: number
+  bulge: number
+}> {
+  if (entity instanceof AcDb2dPolyline) {
+    const count = entity.numberOfVertices
+    return Array.from({ length: count }, (_, i) => {
+      const p = entity.getPointAt(i)
+      return { x: p.x, y: p.y, bulge: entity.getBulgeAt(i) }
+    })
+  }
+
+  const runtimeVertices = (
+    entity as unknown as {
+      _geo?: { vertices?: Array<{ x: number; y: number; bulge?: number }> }
+    }
+  )._geo?.vertices
+  if (runtimeVertices && runtimeVertices.length > 0) {
+    return runtimeVertices.map(vertex => ({
+      x: vertex.x,
+      y: vertex.y,
+      bulge: vertex.bulge ?? 0
+    }))
+  }
+
+  const count = entity.numberOfVertices
+  return Array.from({ length: count }, (_, i) => {
+    const p = entity.getPoint2dAt(i)
+    return { x: p.x, y: p.y, bulge: 0 }
+  })
+}
+
+function collectPolylineArcCenter(
+  entity: AcDbPolyline | AcDb2dPolyline,
+  pickPoint: AcGePoint3dLike
+): AcEdOsnapCenterMark | undefined {
+  const vertices = polylineVertices(entity)
+  if (vertices.length < 2) return undefined
+
+  const segmentCount = entity.closed ? vertices.length : vertices.length - 1
+  let bestDist = Number.POSITIVE_INFINITY
+  let bestArc: AcGeCircArc2d | undefined
+
+  for (let i = 0; i < segmentCount; i++) {
+    const start = vertices[i]!
+    const end = vertices[(i + 1) % vertices.length]!
+    const arc = tryBulgeArc(start, end, start.bulge)
+    const dist = arc
+      ? hypot2(
+          pickPoint.x,
+          pickPoint.y,
+          arc.nearestPoint(pickPoint).x,
+          arc.nearestPoint(pickPoint).y
+        )
+      : distToSegment(pickPoint.x, pickPoint.y, start.x, start.y, end.x, end.y)
+    if (dist < bestDist) {
+      bestDist = dist
+      bestArc = arc
+    }
+  }
+
+  if (!bestArc) return undefined
+  return markFromPoint(
+    { x: bestArc.center.x, y: bestArc.center.y, z: entity.elevation },
+    bestArc.radius
+  )
+}
+
+function collectFromOsnapCenter(
+  entity: AcDbEntity,
+  pickPoint: AcGePoint3dLike,
+  gsMark?: AcDbObjectId
+): AcEdOsnapCenterMark[] {
+  const points: AcGePoint3dLike[] = []
+  entity.subGetOsnapPoints(
+    AcDbOsnapMode.Center,
+    pickPoint,
+    pickPoint,
+    points,
+    gsMark
+  )
+  const marks: AcEdOsnapCenterMark[] = []
+  for (const point of points) {
+    const keepRadius = hypot2(pickPoint.x, pickPoint.y, point.x, point.y)
+    const mark = markFromPoint(point, keepRadius)
+    if (mark) marks.push(mark)
+  }
+  return marks
+}
+
+/**
+ * Collects AutoCAD-style center ticks for circular geometry under the cursor.
+ *
+ * Circle, arc, ellipse, and the closest bulge segment of a polyline each
+ * contribute one center. Other entities fall back to `subGetOsnapPoints(Center)`
+ * so block references still acquire nested circle/arc/ellipse centers.
+ */
+export function collectCenterMarksFromEntity(
+  entity: AcDbEntity,
+  pickPoint: AcGePoint3dLike,
+  gsMark?: AcDbObjectId
+): AcEdOsnapCenterMark[] {
+  if (entity instanceof AcDbCircle) {
+    const mark = markFromPoint(entity.center, entity.radius)
+    return mark ? [mark] : []
+  }
+  if (entity instanceof AcDbArc) {
+    const mark = markFromPoint(entity.center, entity.radius)
+    return mark ? [mark] : []
+  }
+  if (entity instanceof AcDbEllipse) {
+    const mark = markFromPoint(entity.center, entity.majorAxisRadius)
+    return mark ? [mark] : []
+  }
+  if (entity instanceof AcDbPolyline || entity instanceof AcDb2dPolyline) {
+    const mark = collectPolylineArcCenter(entity, pickPoint)
+    return mark ? [mark] : []
+  }
+  return collectFromOsnapCenter(entity, pickPoint, gsMark)
+}
+
+/**
+ * Keeps acquired centers while the cursor is still inside the supporting
+ * curve, so the plus mark remains after leaving the circumference.
+ */
+export function retainAcquiredCenterMarks(
+  marks: readonly AcEdOsnapCenterMark[],
+  cursor: AcGePoint2dLike,
+  aperture: number
+): AcEdOsnapCenterMark[] {
+  const pad = Math.max(0, aperture)
+  return marks.filter(mark => {
+    const dist = hypot2(cursor.x, cursor.y, mark.x, mark.y)
+    return dist <= mark.keepRadius + pad
+  })
+}
+
+export function centerMarksCoincide(
+  mark: AcGePoint2dLike,
+  snap: AcGePoint2dLike,
+  tol = 1e-8
+) {
+  return hypot2(mark.x, mark.y, snap.x, snap.y) <= tol
+}

--- a/packages/cad-simple-viewer/src/editor/input/AcEdOsnapResolver.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdOsnapResolver.ts
@@ -12,7 +12,15 @@ import {
 
 import { AcApSettingManager } from '../../app/AcApSettingManager'
 import { AcEdBaseView } from '../view/AcEdBaseView'
+import {
+  type AcEdOsnapCenterMark,
+  centerMarksCoincide,
+  collectCenterMarksFromEntity,
+  retainAcquiredCenterMarks
+} from './AcEdOsnapCenterMarks'
 import { AcEdMarkerType } from './marker/AcEdMarker'
+
+export type { AcEdOsnapCenterMark } from './AcEdOsnapCenterMarks'
 
 export type AcEdOsnapPoint = AcGePoint3dLike & {
   type: AcDbOsnapMode
@@ -37,9 +45,37 @@ const MAX_INTERSECTION_SOURCES = 48
  */
 export class AcEdOsnapResolver {
   private readonly _view: AcEdBaseView
+  private _acquiredCenters: AcEdOsnapCenterMark[] = []
 
   constructor(view: AcEdBaseView) {
     this._view = view
+  }
+
+  /**
+   * Center ticks acquired by hovering circular geometry. Shown as plus marks;
+   * moving the cursor onto a tick snaps to that center.
+   */
+  get acquiredCenterMarks(): readonly AcEdOsnapCenterMark[] {
+    return this._acquiredCenters
+  }
+
+  /** Clears acquired center ticks. Call when an input session ends. */
+  clearAcquiredCenters() {
+    this._acquiredCenters = []
+  }
+
+  /**
+   * Center ticks to draw as plus marks. Hides a tick that is already the
+   * active Center snap so the circle AutoSnap marker replaces it.
+   */
+  static displayCenterMarks(
+    marks: readonly AcEdOsnapCenterMark[],
+    snap?: AcEdOsnapPoint
+  ): AcEdOsnapCenterMark[] {
+    if (!snap || snap.type !== AcDbOsnapMode.Center) {
+      return [...marks]
+    }
+    return marks.filter(mark => !centerMarksCoincide(mark, snap))
   }
 
   /**
@@ -48,16 +84,26 @@ export class AcEdOsnapResolver {
   resolve(options: AcEdOsnapResolveOptions): AcEdOsnapPoint | undefined {
     const hitRadiusPx = options.hitRadiusPx ?? DEFAULT_HIT_RADIUS_PX
     const lastPoint = options.lastPoint ?? options.cursorWcs
-    const snapPoints = this.collectOsnapPoints(
-      options.cursorWcs,
-      lastPoint,
-      hitRadiusPx
-    )
-    if (snapPoints.length === 0) return undefined
-
     const p1 = this._view.screenToWorld({ x: 0, y: 0 })
     const p2 = this._view.screenToWorld({ x: hitRadiusPx, y: 0 })
     const threshold = p2.x - p1.x
+    const snapPoints = this.collectOsnapPoints(
+      options.cursorWcs,
+      lastPoint,
+      hitRadiusPx,
+      threshold
+    )
+
+    for (const mark of this._acquiredCenters) {
+      snapPoints.push({
+        x: mark.x,
+        y: mark.y,
+        z: mark.z,
+        type: AcDbOsnapMode.Center
+      })
+    }
+
+    if (snapPoints.length === 0) return undefined
 
     let bestPriority = Number.MAX_VALUE
     let bestDist = Number.MAX_VALUE
@@ -189,7 +235,8 @@ export class AcEdOsnapResolver {
   private collectOsnapPoints(
     cursorWcs: AcGePoint2dLike,
     lastPoint: AcGePoint2dLike,
-    hitRadiusPx: number
+    hitRadiusPx: number,
+    aperture: number
   ): AcEdOsnapPoint[] {
     const results = this._view.pick(cursorWcs, hitRadiusPx)
     const db = acdbHostApplicationServices().workingDatabase
@@ -239,6 +286,55 @@ export class AcEdOsnapResolver {
       this.collectIntersectionOsnapPoints(uniqueEntities, osnapPoints)
     }
 
+    this.updateAcquiredCenters(
+      cursorWcs,
+      results,
+      modelSpace,
+      pickPoint,
+      aperture
+    )
+
     return osnapPoints
+  }
+
+  private updateAcquiredCenters(
+    cursorWcs: AcGePoint2dLike,
+    results: Array<{
+      id: AcDbObjectId
+      children?: Array<{ id: AcDbObjectId }>
+    }>,
+    modelSpace: { getIdAt: (id: AcDbObjectId) => AcDbEntity | undefined },
+    pickPoint: AcGePoint3dLike,
+    aperture: number
+  ) {
+    if (
+      !acdbHasOsnapMode(
+        AcApSettingManager.instance.osnapModes,
+        AcDbOsnapMode.Center
+      )
+    ) {
+      this._acquiredCenters = []
+      return
+    }
+
+    const hovered: AcEdOsnapCenterMark[] = []
+    results.forEach(item => {
+      const entity = modelSpace.getIdAt(item.id)
+      if (!entity) return
+      if (item.children && item.children.length > 0) {
+        item.children.forEach(child => {
+          hovered.push(
+            ...collectCenterMarksFromEntity(entity, pickPoint, child.id)
+          )
+        })
+      } else {
+        hovered.push(...collectCenterMarksFromEntity(entity, pickPoint))
+      }
+    })
+
+    this._acquiredCenters =
+      hovered.length > 0
+        ? hovered
+        : retainAcquiredCenterMarks(this._acquiredCenters, cursorWcs, aperture)
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/AcEdOsnapResolver.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdOsnapResolver.ts
@@ -14,9 +14,10 @@ import { AcApSettingManager } from '../../app/AcApSettingManager'
 import { AcEdBaseView } from '../view/AcEdBaseView'
 import {
   type AcEdOsnapCenterMark,
+  canonicalGsMark,
   centerMarksCoincide,
   collectCenterMarksFromEntity,
-  retainAcquiredCenterMarks
+  mergeAcquiredCenterMarks
 } from './AcEdOsnapCenterMarks'
 import { AcEdMarkerType } from './marker/AcEdMarker'
 
@@ -52,8 +53,9 @@ export class AcEdOsnapResolver {
   }
 
   /**
-   * Center ticks acquired by hovering circular geometry. Shown as plus marks;
-   * moving the cursor onto a tick snaps to that center.
+   * Center ticks acquired by hovering circular geometry. Shown as plus marks
+   * for the rest of the current point prompt; moving the cursor onto a tick
+   * snaps to that center.
    */
   get acquiredCenterMarks(): readonly AcEdOsnapCenterMark[] {
     return this._acquiredCenters
@@ -90,8 +92,7 @@ export class AcEdOsnapResolver {
     const snapPoints = this.collectOsnapPoints(
       options.cursorWcs,
       lastPoint,
-      hitRadiusPx,
-      threshold
+      hitRadiusPx
     )
 
     for (const mark of this._acquiredCenters) {
@@ -235,8 +236,7 @@ export class AcEdOsnapResolver {
   private collectOsnapPoints(
     cursorWcs: AcGePoint2dLike,
     lastPoint: AcGePoint2dLike,
-    hitRadiusPx: number,
-    aperture: number
+    hitRadiusPx: number
   ): AcEdOsnapPoint[] {
     const results = this._view.pick(cursorWcs, hitRadiusPx)
     const db = acdbHostApplicationServices().workingDatabase
@@ -264,7 +264,7 @@ export class AcEdOsnapResolver {
             osnapPoints,
             pickPoint,
             last,
-            child.id
+            canonicalGsMark(child.id)
           )
         )
       } else {
@@ -286,26 +286,18 @@ export class AcEdOsnapResolver {
       this.collectIntersectionOsnapPoints(uniqueEntities, osnapPoints)
     }
 
-    this.updateAcquiredCenters(
-      cursorWcs,
-      results,
-      modelSpace,
-      pickPoint,
-      aperture
-    )
+    this.updateAcquiredCenters(results, modelSpace, pickPoint)
 
     return osnapPoints
   }
 
   private updateAcquiredCenters(
-    cursorWcs: AcGePoint2dLike,
     results: Array<{
       id: AcDbObjectId
       children?: Array<{ id: AcDbObjectId }>
     }>,
     modelSpace: { getIdAt: (id: AcDbObjectId) => AcDbEntity | undefined },
-    pickPoint: AcGePoint3dLike,
-    aperture: number
+    pickPoint: AcGePoint3dLike
   ) {
     if (
       !acdbHasOsnapMode(
@@ -324,7 +316,11 @@ export class AcEdOsnapResolver {
       if (item.children && item.children.length > 0) {
         item.children.forEach(child => {
           hovered.push(
-            ...collectCenterMarksFromEntity(entity, pickPoint, child.id)
+            ...collectCenterMarksFromEntity(
+              entity,
+              pickPoint,
+              canonicalGsMark(child.id)
+            )
           )
         })
       } else {
@@ -332,9 +328,9 @@ export class AcEdOsnapResolver {
       }
     })
 
-    this._acquiredCenters =
-      hovered.length > 0
-        ? hovered
-        : retainAcquiredCenterMarks(this._acquiredCenters, cursorWcs, aperture)
+    this._acquiredCenters = mergeAcquiredCenterMarks(
+      this._acquiredCenters,
+      hovered
+    )
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/marker/AcEdMarker.ts
+++ b/packages/cad-simple-viewer/src/editor/input/marker/AcEdMarker.ts
@@ -9,6 +9,7 @@ export type AcEdMarkerType =
   | 'rect'
   | 'diamond'
   | 'x'
+  | 'plus'
   | 'intersection'
 
 /**
@@ -169,6 +170,28 @@ export class AcEdMarker {
         transform: translate(-50%, -50%) rotate(-45deg);
       }
 
+      .ml-marker-plus::before,
+      .ml-marker-plus::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        background: currentColor;
+        transform-origin: center;
+      }
+
+      .ml-marker-plus::before {
+        width: 100%;
+        height: 2px;
+        transform: translate(-50%, -50%);
+      }
+
+      .ml-marker-plus::after {
+        width: 2px;
+        height: 100%;
+        transform: translate(-50%, -50%);
+      }
+
       .ml-marker-intersection {
         border: 2px solid currentColor;
         background: transparent;
@@ -237,6 +260,12 @@ export class AcEdMarker {
 
       case 'x':
         this._el.classList.add('ml-marker-x')
+        this._el.style.width = `${this._size}px`
+        this._el.style.height = `${this._size}px`
+        break
+
+      case 'plus':
+        this._el.classList.add('ml-marker-plus')
         this._el.style.width = `${this._size}px`
         this._el.style.height = `${this._size}px`
         break

--- a/packages/cad-simple-viewer/src/editor/input/marker/AcEdOSnapMarkerManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/marker/AcEdOSnapMarkerManager.ts
@@ -18,8 +18,12 @@ export class AcEdMarkerManager {
   /** The view associated with this input operation */
   private view: AcEdBaseView
 
-  /** Internal stack of active markers */
+  /** Internal stack of active snap markers */
   private stack: AcEdMarker[] = []
+
+  /** AutoCAD-style acquired center ticks (plus marks), not part of the snap stack. */
+  private hintMarkers: AcEdMarker[] = []
+  private hintPositions: AcGePoint2dLike[] = []
 
   constructor(view: AcEdBaseView) {
     this.view = view
@@ -40,14 +44,38 @@ export class AcEdMarkerManager {
     size?: number,
     color?: string
   ) {
-    // worldToScreen() returns canvas-local coordinates.
-    const canvasPos = this.view.worldToScreen(pos)
-    // Marker DOM is mounted in view.container, so convert to container-local.
-    const containerPos = this.view.canvasToContainer(canvasPos)
-    const marker = new AcEdMarker(type, size, color, this.view.container)
-    marker.setPosition(containerPos)
+    const marker = this.createMarker(pos, type, size, color)
     this.stack.push(marker)
     return marker
+  }
+
+  /**
+   * Replaces acquired-center plus marks. These stay visible independently of
+   * the snap-marker stack so hovering a circle can show its center tick while
+   * the cursor still snaps to nearest/quadrant on the circumference.
+   */
+  public setHintMarkers(
+    positions: readonly AcGePoint2dLike[],
+    type: AcEdMarkerType = 'plus',
+    size?: number,
+    color?: string
+  ) {
+    this.clearHintMarkers()
+    this.hintPositions = positions.map(pos => ({ x: pos.x, y: pos.y }))
+    for (const pos of this.hintPositions) {
+      this.hintMarkers.push(this.createMarker(pos, type, size, color))
+    }
+  }
+
+  /**
+   * Repositions acquired-center hint markers after pan/zoom.
+   */
+  public repositionHints() {
+    for (let i = 0; i < this.hintMarkers.length; i++) {
+      const pos = this.hintPositions[i]
+      if (!pos) continue
+      this.hintMarkers[i]!.setPosition(this.toContainerPos(pos))
+    }
   }
 
   /**
@@ -76,6 +104,7 @@ export class AcEdMarkerManager {
    * Should be called when OSNAP indicators need to be fully reset.
    */
   public clear() {
+    this.clearHintMarkers()
     for (const marker of this.stack) marker.destroy()
     this.stack = []
   }
@@ -91,5 +120,27 @@ export class AcEdMarkerManager {
    */
   public top(): AcEdMarker | undefined {
     return this.stack[this.stack.length - 1]
+  }
+
+  private createMarker(
+    pos: AcGePoint2dLike,
+    type?: AcEdMarkerType,
+    size?: number,
+    color?: string
+  ) {
+    const marker = new AcEdMarker(type, size, color, this.view.container)
+    marker.setPosition(this.toContainerPos(pos))
+    return marker
+  }
+
+  private toContainerPos(pos: AcGePoint2dLike) {
+    const canvasPos = this.view.worldToScreen(pos)
+    return this.view.canvasToContainer(canvasPos)
+  }
+
+  private clearHintMarkers() {
+    for (const marker of this.hintMarkers) marker.destroy()
+    this.hintMarkers = []
+    this.hintPositions = []
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -253,6 +253,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     this.inputs?.dispose()
     this.rubberBand?.dispose()
     this.osnapMarkerManager?.clear()
+    this.view.osnapResolver.clearAcquiredCenters()
   }
 
   /**
@@ -278,6 +279,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     if (this.osnapMarkerManager && this.lastOsnapPoint) {
       this.osnapMarkerManager.repositionTop(this.lastOsnapPoint)
     }
+    this.osnapMarkerManager?.repositionHints()
 
     if (!this.suppressDisplay && this.view.curMousePos) {
       this.setPosition(this.view.canvasToViewport(this.view.curMousePos))
@@ -360,6 +362,12 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
           ? { x: this.lastPoint.x, y: this.lastPoint.y, z: 0 }
           : undefined
       })
+      this.osnapMarkerManager.setHintMarkers(
+        AcEdOsnapResolver.displayCenterMarks(
+          this.view.osnapResolver.acquiredCenterMarks,
+          this.lastOsnapPoint
+        )
+      )
 
       if (this.lastOsnapPoint) {
         wcsPos.x = this.lastOsnapPoint.x


### PR DESCRIPTION
## Summary
- Hovering a circle, arc, ellipse, elliptical arc, or polyline bulge now shows a plus tick at the geometric center while Center osnap is on.
- Moving the cursor onto that tick snaps to the center; the plus stays visible while traveling inside the supporting curve so zoomed-in circles can still be snapped.
- Point prompts and grip edits both display the ticks, and the plus is replaced by the usual circle AutoSnap marker once Center is active.

## Test plan
- [ ] Enable Center osnap, draw a large circle, zoom in, hover the circumference and confirm a plus appears at the center
- [ ] Move the cursor onto the plus and confirm it snaps to the center (circle marker)
- [ ] Repeat for arc, ellipse, elliptical arc, and a polyline bulge segment
- [ ] Confirm a small/zoomed-out circle still snaps to center immediately when the center is already in the aperture
- [ ] Confirm the plus disappears after leaving the supporting curve, and that lines do not show a center tick
- [ ] Confirm grip-edit snapping also shows and snaps to the plus
