### PR TITLE
fix: restore undo for deleted drawing entities

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApEntityService.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApEntityService.spec.ts
@@ -1,3 +1,9 @@
+import {
+  AcDbDatabase,
+  AcDbLine,
+  AcGePoint3d
+} from '@mlightcad/data-model'
+
 import { AcApEntityService } from '../src/service/AcApEntityService'
 
 describe('AcApEntityService', () => {
@@ -30,6 +36,7 @@ describe('AcApEntityService', () => {
   test('eraseEntities returns the number of erased entities', () => {
     const erased = new Set<string>()
     const db = {
+      transactionManager: { hasTransaction: () => true },
       openEntityForWrite: jest.fn((objectId: string) => {
         if (objectId === 'missing') return undefined
         return { erase: () => erased.add(objectId) }
@@ -42,5 +49,23 @@ describe('AcApEntityService', () => {
     expect(count).toBe(2)
     expect(erased).toEqual(new Set(['a', 'b']))
     expect(db.openEntityForWrite).toHaveBeenCalledTimes(3)
+  })
+
+  test('eraseEntities records an undoable database change', () => {
+    const db = new AcDbDatabase()
+    const line = new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(10, 0, 0))
+    db.tables.blockTable.modelSpace.appendEntity(line)
+    const objectId = line.objectId
+    const service = new AcApEntityService(db)
+
+    expect(service.eraseEntities([objectId])).toBe(1)
+    expect(db.tables.blockTable.getEntityById(objectId)).toBeUndefined()
+    expect(db.transactionManager.canUndo()).toBe(true)
+
+    expect(db.transactionManager.undo()).toBe(true)
+    expect(db.tables.blockTable.getEntityById(objectId)).toBeDefined()
+
+    expect(db.transactionManager.redo()).toBe(true)
+    expect(db.tables.blockTable.getEntityById(objectId)).toBeUndefined()
   })
 })

--- a/packages/cad-simple-viewer/src/command/modify/AcApEraseCmd.ts
+++ b/packages/cad-simple-viewer/src/command/modify/AcApEraseCmd.ts
@@ -1,11 +1,16 @@
 import { AcApContext } from '../../app'
-import { AcEdCommand } from '../../editor'
+import { AcEdCommand, AcEdOpenMode } from '../../editor'
 import { resolveSelectedIds } from '../../service'
 
 /**
  * Command to delete selected objects from the drawing.
  */
 export class AcApEraseCmd extends AcEdCommand {
+  constructor() {
+    super()
+    this.mode = AcEdOpenMode.Write
+  }
+
   async execute(context: AcApContext) {
     const selectionSet = context.view.selectionSet
     const ids = await resolveSelectedIds(context, 'erase')

--- a/packages/cad-simple-viewer/src/service/AcApEntityService.ts
+++ b/packages/cad-simple-viewer/src/service/AcApEntityService.ts
@@ -149,14 +149,16 @@ export class AcApEntityService {
    * @returns Number of entities successfully erased.
    */
   eraseEntities(objectIds: AcDbObjectId[]): number {
-    let count = 0
-    objectIds.forEach(objectId => {
-      const entity = this.db.openEntityForWrite(objectId)
-      if (!entity) return
-      entity.erase()
-      count++
+    return this.runEntityEdit(() => {
+      let count = 0
+      objectIds.forEach(objectId => {
+        const entity = this.db.openEntityForWrite(objectId)
+        if (!entity) return
+        entity.erase()
+        count++
+      })
+      return count
     })
-    return count
   }
 
   /**
@@ -235,17 +237,19 @@ export class AcApEntityService {
    *
    * @param label - Undo group label.
    * @param fn - Mutation callback.
+   * @returns The value returned by `fn`.
    */
-  runEdit(label: string, fn: () => void): void {
-    acapRunServiceEdit(this.db, label, fn)
+  runEdit<T>(label: string, fn: () => T): T {
+    return acapRunServiceEdit(this.db, label, fn)
   }
 
   /**
    * Runs an entity edit with the default entity undo label.
    *
    * @param fn - Mutation callback.
+   * @returns The value returned by `fn`.
    */
-  runEntityEdit(fn: () => void): void {
-    acapRunServiceEdit(this.db, ENTITY_EDIT_LABEL, fn)
+  runEntityEdit<T>(fn: () => T): T {
+    return acapRunServiceEdit(this.db, ENTITY_EDIT_LABEL, fn)
   }
 }


### PR DESCRIPTION
## Summary
- `ERASE` now runs in Write mode so `trigger()` records an undo transaction, matching MOVE/COPY/ROTATE.
- `eraseEntities` wraps mutations in `runEntityEdit`, so deletes are undoable even when called outside a command.
- Adds a regression test that erase/undo/redo restores the entity in the database.

## Test plan
- [ ] In Write mode, draw a line, select it, press Delete, then Ctrl+Z / Ctrl+Y and confirm the entity reappears and disappears.
- [ ] Confirm Review-mode markup and measurement delete/undo/redo are unchanged.
- [ ] Confirm Delete in Review mode with no overlay selected does not erase CAD entities.
- [ ] `npx jest packages/cad-simple-viewer/__tests__/AcApEntityService.spec.ts`
