### PR TITLE
feat: sync ui-components locale with the CAD viewer

### DIFF
--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -52,7 +52,7 @@
     "@mlightcad/ribbon": "^0.1.12",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",
-    "@mlightcad/ui-components": "^0.1.10",
+    "@mlightcad/ui-components": "^0.1.11",
     "@element-plus/icons-vue": "^2.3.1",
     "@vueuse/core": "^11.1.0",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -91,6 +91,7 @@ import {
   eventBus
 } from '@mlightcad/cad-simple-viewer'
 import { log } from '@mlightcad/data-model'
+import { provideLocale } from '@mlightcad/ui-components'
 import { ElConfigProvider, ElMessage } from 'element-plus'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -207,7 +208,10 @@ const buildOpenOptions = (): AcApOpenDatabaseOptions => ({
 })
 
 const { t } = useI18n()
-const { effectiveLocale, elementPlusLocale } = useLocale(props.locale)
+const { currentLocale, effectiveLocale, elementPlusLocale } = useLocale(
+  props.locale
+)
+provideLocale(currentLocale)
 const {
   info,
   warning,

--- a/packages/cad-viewer/src/component/palette/MlMemoryProfile.vue
+++ b/packages/cad-viewer/src/component/palette/MlMemoryProfile.vue
@@ -166,7 +166,6 @@
     <ml-overflow-tabs
       v-model="activeTab"
       :tabs="detailTabs"
-      :more-tabs-label="t('main.toolPalette.moreTabs')"
       class="ml-memory-profile-tabs"
     >
       <div

--- a/packages/cad-viewer/src/component/palette/MlPaletteManager.vue
+++ b/packages/cad-viewer/src/component/palette/MlPaletteManager.vue
@@ -13,7 +13,6 @@
       <ml-overflow-tabs
         v-model="store.dialogs.activePaletteTab"
         :tabs="tabs"
-        :more-tabs-label="t('main.toolPalette.moreTabs')"
       >
         <div
           v-if="store.dialogs.activePaletteTab === 'layerManager'"
@@ -85,7 +84,6 @@ import {
 } from '@mlightcad/ui-components'
 import { ElConfigProvider } from 'element-plus'
 import { computed, defineAsyncComponent, nextTick, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import { store } from '../../app'
 import { useSelectionSet, useViewerRect } from '../../composable'
@@ -117,7 +115,6 @@ interface Props {
 }
 
 const props = defineProps<Props>()
-const { t } = useI18n()
 const containerRect = useViewerRect()
 
 const DEFAULT_WIDTH = 520

--- a/packages/cad-viewer/src/locale/ar/main.ts
+++ b/packages/cad-viewer/src/locale/ar/main.ts
@@ -907,16 +907,6 @@ export default {
   toolPalette: {
     ...enMain.toolPalette,
 
-    moreTabs: 'المزيد من اللوحات',
-    dockSide: 'جهة الإرساء',
-    dock: {
-      float: 'إلغاء الإرساء وفتحها كنافذة مستقلة',
-      left: 'إرساء إلى اليسار',
-      top: 'إرساء إلى الأعلى',
-      bottom: 'إرساء إلى الأسفل',
-      right: 'إرساء إلى اليمين'
-    },
-
     entityProperties: {
       ...enMain.toolPalette.entityProperties,
 

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -630,7 +630,6 @@ export default {
     moreLayouts: 'Další rozvržení'
   },
   toolPalette: {
-    moreTabs: 'Další karty',
     entityProperties: {
       tab: 'Vlastnosti',
       title: 'Vlastnosti objektu',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -638,15 +638,6 @@ export default {
     moreLayouts: 'More layouts'
   },
   toolPalette: {
-    moreTabs: 'More tabs',
-    dockSide: 'Dock side',
-    dock: {
-      float: 'Undock into separate window',
-      left: 'Dock to left',
-      top: 'Dock to top',
-      bottom: 'Dock to bottom',
-      right: 'Dock to right'
-    },
     entityProperties: {
       tab: 'Properties',
       title: 'Entity Properties',

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -642,7 +642,6 @@ export default {
     moreLayouts: 'Diğer düzenler'
   },
   toolPalette: {
-    moreTabs: 'Diğer sekmeler',
     entityProperties: {
       tab: 'Özellikler',
       title: 'Varlık Özellikleri',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -597,7 +597,6 @@ export default {
     moreLayouts: '更多布局'
   },
   toolPalette: {
-    moreTabs: '更多标签页',
     entityProperties: {
       tab: '属性',
       title: '图元属性',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   '@mlightcad/mtext-input-box': ^0.2.23
   '@mlightcad/mtext-renderer': ^0.12.4
   '@mlightcad/ribbon': ^0.1.12
-  '@mlightcad/ui-components': ^0.1.10
+  '@mlightcad/ui-components': ^0.1.11
   element-plus: ^2.12.0
   glob: ^13.0.6
   lodash-es: 4.17.21
@@ -413,8 +413,8 @@ importers:
         specifier: 0.0.9
         version: 0.0.9(three@0.172.0)
       '@mlightcad/ui-components':
-        specifier: ^0.1.10
-        version: 0.1.10(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+        specifier: ^0.1.11
+        version: 0.1.11(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(vite@6.4.3(@types/node@24.12.4)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
@@ -1872,8 +1872,8 @@ packages:
     peerDependencies:
       three: ^0.172.0
 
-  '@mlightcad/ui-components@0.1.10':
-    resolution: {integrity: sha512-AhrLhi1ulm2fyf3cdxQq61vnO9gIGAbl6vV43w+FhksDDk9QYfnQ7MLV7/FZ0JJmTha4wcYXx3vW73383daO1w==}
+  '@mlightcad/ui-components@0.1.11':
+    resolution: {integrity: sha512-9za8wiknHdx2XJ50ETK/rElHnZcgSSOFnofea4nGOl1GjGFPRhjl98+8Bmzynv9r1zsNwRw/D1gU6ylTws6Prg==}
     peerDependencies:
       element-plus: ^2.12.0
       vue: ^3.4.21
@@ -7301,7 +7301,7 @@ snapshots:
     dependencies:
       three: 0.172.0
 
-  '@mlightcad/ui-components@0.1.10(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
+  '@mlightcad/ui-components@0.1.11(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ overrides:
   '@mlightcad/mtext-input-box': '^0.2.23'
   '@mlightcad/mtext-renderer': '^0.12.4'
   '@mlightcad/ribbon': '^0.1.12'
-  '@mlightcad/ui-components': '^0.1.10'
+  '@mlightcad/ui-components': '^0.1.11'
   element-plus: '^2.12.0'
   glob: '^13.0.6'
   lodash-es: '4.17.21'


### PR DESCRIPTION
## Summary
- Upgrade `@mlightcad/ui-components` to 0.1.11 so palette overflow/dock chrome strings are owned by the library.
- Call `provideLocale(currentLocale)` from `MlCadViewer` so those strings follow the viewer language.
- Drop the now-unused `more-tabs-label` prop and duplicated `toolPalette.moreTabs` / dock locale keys from cad-viewer.

## Test plan
- [ ] Open the tool palette with several tabs and confirm overflow (`»`) labels match the current language.
- [ ] Switch locale (en / zh / tr / cs / ar) and confirm palette overflow and dock-side menu strings update.
- [ ] Open Memory Profile and confirm its overflow tabs still work without a local `more-tabs-label`.
- [ ] Confirm palette tab titles (Layers, Properties, etc.) still come from cad-viewer i18n.