### PR TITLE
fix(three-renderer): keep compare colors after batch growth

### DIFF
--- a/packages/three-renderer/__tests__/AcTrBatchedGroupHighlight.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrBatchedGroupHighlight.spec.ts
@@ -3,6 +3,7 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
+import { copyArrayContents } from '../src/batch/AcTrBatchedGeometryInfo'
 import { AcTrBatchedGroup } from '../src/batch/AcTrBatchedGroup'
 import { AcTrBatchedLine } from '../src/batch/AcTrBatchedLine'
 import { AcTrBatchedLine2 } from '../src/batch/AcTrBatchedLine2'
@@ -12,6 +13,7 @@ import {
   COMPARE_ROLE_ADDED,
   COMPARE_ROLE_DELETED
 } from '../src/batch/highlight'
+import { buildLineGeometry } from '../src/object/AcTrLineGeometryBuilder'
 import { AcTrEntity } from '../src/object/AcTrEntity'
 import { AcTrLine } from '../src/object/AcTrLine'
 import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
@@ -50,6 +52,32 @@ function findBatchedLine(group: AcTrBatchedGroup): AcTrBatchedLine | undefined {
     }
   })
   return result
+}
+
+function appendIndexedLine(
+  group: AcTrBatchedGroup,
+  material: THREE.LineBasicMaterial,
+  objectId: string,
+  x: number
+) {
+  const built = buildLineGeometry(
+    [
+      { x, y: 0, z: 0 },
+      { x: x + 1, y: 0, z: 0 }
+    ],
+    material
+  )
+  expect(built).not.toBeNull()
+  if (!built) return
+  expect(
+    group.appendLineGeometry(
+      built.geometry as THREE.BufferGeometry,
+      material,
+      built.worldOffset,
+      { objectId }
+    )
+  ).toBe(true)
+  built.geometry.dispose()
 }
 
 describe('AcTrBatchedGroup slot-mask highlight', () => {
@@ -305,5 +333,134 @@ describe('AcTrBatchedGroup slot-mask highlight', () => {
       overrides: [{ objectId: '927', role: 'added' }]
     })
     expect(batched!._highlightState.compareRoleMask[0]).toBe(COMPARE_ROLE_ADDED)
+  })
+
+  it('keeps slotIds and added roles after indexed-line batch growth', () => {
+    const material = new THREE.LineBasicMaterial({ color: 0xffffff })
+    const group = new AcTrBatchedGroup()
+    const ids: string[] = []
+    for (let i = 0; i < 448; i++) {
+      ids.push(`line-${i}`)
+    }
+    ids.push('926', '927')
+
+    for (let i = 0; i < ids.length; i++) {
+      const built = buildLineGeometry(
+        [
+          { x: i, y: 0, z: 0 },
+          { x: i + 1, y: 0, z: 0 }
+        ],
+        material
+      )
+      expect(built).not.toBeNull()
+      if (!built) return
+      expect(
+        group.appendLineGeometry(
+          built.geometry as THREE.BufferGeometry,
+          material,
+          built.worldOffset,
+          { objectId: ids[i] }
+        )
+      ).toBe(true)
+      built.geometry.dispose()
+    }
+
+    const batchedLine = findBatchedLine(group)!
+    const slotId = batchedLine.geometry.getAttribute(BATCH_SLOT_ID_ATTRIBUTE)
+    expect(slotId.getX(100)).toBe(50)
+    expect(slotId.getX(896)).toBe(448)
+    expect(slotId.getX(898)).toBe(449)
+
+    group.setCompareDisplay({
+      enabled: true,
+      overrides: [
+        { objectId: '926', role: 'added' },
+        { objectId: '927', role: 'added' }
+      ]
+    })
+
+    const state = batchedLine._highlightState
+    expect(state.compareRoleMask[448]).toBe(COMPARE_ROLE_ADDED)
+    expect(state.compareRoleMask[449]).toBe(COMPARE_ROLE_ADDED)
+    expect(state.compareRoleMask[50]).toBe(0)
+
+    const texture = state.uploadMaskTexture(true)
+    const data = texture.image.data as Uint8Array
+    expect(data[448 * 4 + 2]).toBe(170)
+    expect(data[449 * 4 + 2]).toBe(170)
+    expect(texture.colorSpace).toBe(THREE.NoColorSpace)
+
+    const overlay = group.getObjectByName('CompareOverlay') as THREE.Group
+    expect(overlay.children).toHaveLength(2)
+    const overlayLine = overlay.children[0] as THREE.LineSegments
+    expect(
+      (overlayLine.material as THREE.LineBasicMaterial).color.getHex()
+    ).toBe(0x22c55e)
+  })
+
+  it('rebinds compare overlay geometry after a later batch growth', () => {
+    const material = new THREE.LineBasicMaterial({ color: 0xffffff })
+    const group = new AcTrBatchedGroup()
+    group.setCompareDisplay({
+      enabled: true,
+      overrides: [{ objectId: 'hit', role: 'added' }]
+    })
+
+    appendIndexedLine(group, material, 'hit', 0)
+    const overlay = group.getObjectByName('CompareOverlay') as THREE.Group
+    expect(overlay.children).toHaveLength(1)
+    const overlayLine = overlay.children[0] as THREE.LineSegments
+    const attributesBefore = overlayLine.geometry.attributes
+    expect(attributesBefore).toBe(findBatchedLine(group)!.geometry.attributes)
+
+    // INITIAL_LINE_VERTEX_CAPACITY is 128 (2 verts/segment → 64 lines).
+    for (let i = 1; i <= 70; i++) {
+      appendIndexedLine(group, material, `filler-${i}`, i)
+    }
+
+    const batchedLine = findBatchedLine(group)!
+    expect(overlay.children).toHaveLength(1)
+    expect(overlay.children[0]).toBe(overlayLine)
+    expect(overlayLine.geometry.attributes).toBe(
+      batchedLine.geometry.attributes
+    )
+    expect(overlayLine.geometry.attributes).not.toBe(attributesBefore)
+    expect(
+      (overlayLine.material as THREE.LineBasicMaterial).color.getHex()
+    ).toBe(0x22c55e)
+  })
+
+  it('drops compare overlay children when the entity is removed', () => {
+    const material = new THREE.LineBasicMaterial({ color: 0xffffff })
+    const group = new AcTrBatchedGroup()
+    appendIndexedLine(group, material, 'drop', 0)
+    appendIndexedLine(group, material, 'keep', 1)
+    group.setCompareDisplay({
+      enabled: true,
+      overrides: [
+        { objectId: 'keep', role: 'added' },
+        { objectId: 'drop', role: 'deleted' }
+      ]
+    })
+
+    const overlay = group.getObjectByName('CompareOverlay') as THREE.Group
+    expect(overlay.children).toHaveLength(2)
+    expect(group.removeEntity('drop')).toBe(true)
+    expect(overlay.children).toHaveLength(1)
+    expect(getObjectUserData(overlay.children[0]).objectId).toBe('keep')
+    const overlayLine = overlay.children[0] as THREE.LineSegments
+    expect(overlayLine.geometry.attributes).toBe(
+      findBatchedLine(group)!.geometry.attributes
+    )
+  })
+
+  it('copies typed-array views with a non-zero byteOffset', () => {
+    const buffer = new ArrayBuffer(16)
+    const src = new Float32Array(buffer, 8, 2)
+    src[0] = 448
+    src[1] = 449
+    const target = new Float32Array(4)
+    copyArrayContents(src, target)
+    expect(Array.from(target)).toEqual([448, 449, 0, 0])
   })
 })

--- a/packages/three-renderer/src/batch/AcTrBatchedGeometryInfo.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGeometryInfo.ts
@@ -166,16 +166,17 @@ export function copyArrayContents(
   src: THREE.TypedArray,
   target: THREE.TypedArray
 ) {
+  const len = Math.min(src.length, target.length)
   if (src.constructor !== target.constructor) {
     // if arrays are of a different type (eg due to index size increasing) then data must be per-element copied
-    const len = Math.min(src.length, target.length)
     for (let i = 0; i < len; i++) {
       target[i] = src[i]
     }
-  } else {
-    // if the arrays use the same data layout we can use a fast block copy
-    const len = Math.min(src.length, target.length)
-    // @ts-expect-error no good way to remove this type error
-    target.set(new src.constructor(src.buffer, 0, len))
+    return
   }
+
+  // Copy the logical view (`src.subarray`), not `src.buffer` from byte 0.
+  // Reconstructing from the backing buffer ignores `byteOffset` and can
+  // drop packed `slotId` values when a batch grows.
+  target.set(src.subarray(0, len))
 }

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -4,6 +4,7 @@ import {
   AcGiSubEntityTraits
 } from '@mlightcad/data-model'
 import * as THREE from 'three'
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
@@ -304,6 +305,21 @@ export class AcTrBatchedGroup extends THREE.Group {
   /** Modified-entity color while compare display is enabled. */
   private _compareModifiedColor = 0xf59e0b
   /**
+   * Origin batches keyed by Three.js `Object3D.id`.
+   *
+   * Compare/highlight lookups use this instead of `getObjectById`, which can
+   * miss containers after buffer growth or when overlay children share the tree.
+   */
+  private _originBatchById: Map<number, AcTrOriginBatch>
+  /**
+   * Top-most overlay of added/deleted/modified slots.
+   *
+   * Role tints in the packed batch shader lose z-fights against coplanar
+   * unchanged TABLE/INSERT linework packed into a later draw. These copies
+   * use unpatched materials and a high renderOrder so hits stay visible.
+   */
+  private _compareOverlay: AcTrHighlightOverlayGroup
+  /**
    * Non-batched objects (for render paths that cannot be merged, e.g. fat lines).
    */
   private _unbatchedObjects: THREE.Group
@@ -329,13 +345,18 @@ export class AcTrBatchedGroup extends THREE.Group {
     this._meshBatches = new Map()
     this._meshWithIndexBatches = new Map()
     this._entitiesMap = new Map()
+    this._originBatchById = new Map()
     this._unbatchedEntities = new Map()
     this._unbatchedObjects = new THREE.Group()
     this._selectedObjects = markHighlightOverlayGroup(new THREE.Group())
     this._hoverObjects = markHighlightOverlayGroup(new THREE.Group())
+    this._compareOverlay = markHighlightOverlayGroup(new THREE.Group())
+    this._compareOverlay.name = 'CompareOverlay'
+    this._compareOverlay.renderOrder = 10000
     this.add(this._unbatchedObjects)
     this.add(this._selectedObjects)
     this.add(this._hoverObjects)
+    this.add(this._compareOverlay)
   }
 
   /**
@@ -512,6 +533,8 @@ export class AcTrBatchedGroup extends THREE.Group {
     })
     this.clearHighlightGroup(this._selectedObjects)
     this.clearHighlightGroup(this._hoverObjects)
+    this.clearHighlightGroup(this._compareOverlay)
+    this._originBatchById.clear()
     this._unbatchedObjects.children.forEach(object => {
       this.disposeObject(object)
     })
@@ -934,9 +957,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     }
 
     entityInfo?.forEach(item => {
-      const batchedObject = this.getObjectById(
-        item.batchedObjectId
-      ) as AcTrBatchedObject
+      const batchedObject = this.getOriginBatch(item.batchedObjectId)
       batchedObject?.setVisibleAt(item.batchId, visible)
     })
 
@@ -1094,6 +1115,10 @@ export class AcTrBatchedGroup extends THREE.Group {
     const role = this._compareRoles.get(objectId) ?? null
     this.applyCompareRoleToEntity(objectId, role)
     this.refreshUnbatchedCompareMaterial(objectId)
+    // Growth replaces packed attributes; overlay wrappers keep the old ones
+    // until rebound. Draw ranges stay valid across capacity increases.
+    this.rebindCompareOverlaySharedBuffers()
+    this.syncCompareOverlayForEntity(objectId)
   }
 
   /**
@@ -1301,14 +1326,13 @@ export class AcTrBatchedGroup extends THREE.Group {
    */
   removeEntity(objectId: string) {
     let result = false
+    let compactedBatches = false
     const entityInfo = this._entitiesMap.get(objectId)
     if (entityInfo) {
-      const batchedObjects = new Map<number, AcTrBatchedObject>()
+      const batchedObjects = new Map<number, AcTrOriginBatch>()
       for (let index = 0, len = entityInfo.length; index < len; index++) {
         const item = entityInfo[index]
-        const batchedObject = this.getObjectById(
-          item.batchedObjectId
-        ) as AcTrBatchedObject
+        const batchedObject = this.getOriginBatch(item.batchedObjectId)
         if (batchedObject) {
           batchedObject.deleteGeometry(item.batchId)
           batchedObjects.set(item.batchedObjectId, batchedObject)
@@ -1316,6 +1340,7 @@ export class AcTrBatchedGroup extends THREE.Group {
         }
       }
       batchedObjects.forEach(batchedObject => batchedObject.optimize())
+      compactedBatches = batchedObjects.size > 0
       this.unselect(objectId)
       this.unhover(objectId)
       this._entitiesMap.delete(objectId)
@@ -1330,6 +1355,15 @@ export class AcTrBatchedGroup extends THREE.Group {
       })
       this._unbatchedEntities.delete(objectId)
       result = true
+    }
+    if (this._compareEnabled) {
+      // Compact moves remaining slot ranges, so shared overlay draw ranges
+      // must be rebuilt. Unbatched-only deletes only drop this entity's copy.
+      if (compactedBatches) {
+        this.refreshCompareOverlay()
+      } else {
+        this.removeCompareOverlayForEntity(objectId)
+      }
     }
     return result
   }
@@ -1346,9 +1380,7 @@ export class AcTrBatchedGroup extends THREE.Group {
       const intersects: THREE.Intersection[] = []
       for (let index = 0, len = entityInfo.length; index < len; index++) {
         const item = entityInfo[index]
-        const batchedObject = this.getObjectById(
-          item.batchedObjectId
-        ) as AcTrBatchedObject
+        const batchedObject = this.getOriginBatch(item.batchedObjectId)
         if (batchedObject) {
           batchedObject.intersectWith(item.batchId, raycaster, intersects)
           if (intersects.length > 0) return true
@@ -1505,6 +1537,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     }
 
     this.applyCompareDisplayToBatches()
+    this.refreshCompareOverlay()
     this.refreshAllUnbatchedCompareMaterials()
   }
 
@@ -1528,6 +1561,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     }
     this.applyCompareRoleToEntity(id, role)
     this.refreshUnbatchedCompareMaterial(id)
+    this.syncCompareOverlayForEntity(id)
   }
 
   /** Pushes compare colors and role masks onto every origin batch in this group. */
@@ -1540,51 +1574,14 @@ export class AcTrBatchedGroup extends THREE.Group {
       modifiedColor: this._compareModifiedColor
     }
 
-    const applyColors = (map: Map<number, AcTrOriginBatch[]>) => {
+    for (const map of this.groups) {
       map.forEach(batches => {
         batches.forEach(batch => {
           batch.setCompareDisplayColors(colorOptions)
-          batch.flushHighlightMask()
+          batch.applyPackedCompareRoles(this._compareRoles)
         })
       })
     }
-
-    const allMaps: Map<number, AcTrOriginBatch[]>[] = [
-      this._pointBatches as Map<number, AcTrOriginBatch[]>,
-      this._pointSymbolBatches as Map<number, AcTrOriginBatch[]>,
-      this._lineBatches as Map<number, AcTrOriginBatch[]>,
-      this._lineWithIndexBatches as Map<number, AcTrOriginBatch[]>,
-      this._line2Batches as Map<number, AcTrOriginBatch[]>,
-      this._meshBatches as Map<number, AcTrOriginBatch[]>,
-      this._meshWithIndexBatches as Map<number, AcTrOriginBatch[]>
-    ]
-
-    for (const map of allMaps) {
-      applyColors(map)
-    }
-
-    // Always clear slot masks first. Applying only the current
-    // `_compareRoles` would leave a previous deleted/added mask on
-    // entities that dropped out of the override set.
-    this._entitiesMap.forEach(items => {
-      items.forEach(item => {
-        const batchedObject = this.getObjectById(
-          item.batchedObjectId
-        ) as AcTrOriginBatch | null
-        batchedObject?.setCompareRoleAt(item.batchId, null)
-      })
-    })
-
-    if (!this._compareEnabled) {
-      for (const map of allMaps) {
-        applyColors(map)
-      }
-      return
-    }
-
-    this._compareRoles.forEach((role, objectId) => {
-      this.applyCompareRoleToEntity(objectId, role)
-    })
   }
 
   /**
@@ -1600,9 +1597,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     const entityInfo = this._entitiesMap.get(objectId)
     const dirtyBatches = new Set<AcTrOriginBatch>()
     entityInfo?.forEach(item => {
-      const batchedObject = this.getObjectById(
-        item.batchedObjectId
-      ) as AcTrOriginBatch | null
+      const batchedObject = this.getOriginBatch(item.batchedObjectId)
       if (batchedObject?.setCompareRoleAt(item.batchId, role)) {
         dirtyBatches.add(batchedObject)
       }
@@ -1753,9 +1748,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     for (const objectId of objectIds) {
       const entityInfo = this._entitiesMap.get(objectId)
       entityInfo?.forEach(item => {
-        const batchedObject = this.getObjectById(
-          item.batchedObjectId
-        ) as AcTrOriginBatch | null
+        const batchedObject = this.getOriginBatch(item.batchedObjectId)
         if (
           batchedObject &&
           batchedObject.setHighlightAt(item.batchId, kind, enabled)
@@ -2007,36 +2000,47 @@ export class AcTrBatchedGroup extends THREE.Group {
     containerGroup: THREE.Group,
     options: {
       maxSlots: number
-      mode: 'highlight' | 'preview'
+      mode: 'highlight' | 'preview' | 'compare'
       previewStyle?: 'normal' | 'dashed'
+      compareColor?: number
     }
   ): number {
     let added = 0
+    const applyOverlayStyle = (object: THREE.Object3D) => {
+      if (options.mode === 'highlight') {
+        this.applyHighlightMaterial(object)
+        return
+      }
+      if (options.mode === 'compare') {
+        this.applyCompareOverlayMaterial(
+          object,
+          options.compareColor ?? 0x22c55e
+        )
+        return
+      }
+      this.applyPreviewMaterial(object, options.previewStyle ?? 'normal')
+    }
     const entityInfo = this._entitiesMap.get(objectId)
     if (entityInfo && added < options.maxSlots) {
       const limit = Math.min(entityInfo.length, options.maxSlots)
       for (let index = 0; index < limit; index++) {
         const item = entityInfo[index]
-        const batchedObject = this.getObjectById(item.batchedObjectId) as
-          | AcTrOriginBatch
-          | undefined
+        const batchedObject = this.getOriginBatch(item.batchedObjectId)
         if (!batchedObject || !this.hasBatchObjectAt(batchedObject)) {
           continue
         }
 
         const object = batchedObject.getObjectAt(item.batchId)
         this.copyHighlightMetadata(batchedObject, object)
-        if (options.mode === 'highlight') {
-          this.applyHighlightMaterial(object)
-        } else {
-          this.applyPreviewMaterial(object, options.previewStyle ?? 'normal')
-        }
+        applyOverlayStyle(object)
 
         const overlayUserData = getHighlightUserData(object)
         overlayUserData.objectId = objectId
+        overlayUserData.batchedObjectId = item.batchedObjectId
         overlayUserData.disposeGeometryOnRemove =
           batchedObject instanceof AcTrBatchedLine2
         overlayUserData.previewDrawable = options.mode === 'preview'
+        object.renderOrder = containerGroup.renderOrder
         containerGroup.add(object)
         added++
       }
@@ -2049,18 +2053,12 @@ export class AcTrBatchedGroup extends THREE.Group {
         const obj = unbatchedObjects[index]
         const overlayObj = obj.clone()
         this.copyHighlightMetadata(obj, overlayObj)
-        if (options.mode === 'highlight') {
-          this.applyHighlightMaterial(overlayObj)
-        } else {
-          this.applyPreviewMaterial(
-            overlayObj,
-            options.previewStyle ?? 'normal'
-          )
-        }
+        applyOverlayStyle(overlayObj)
 
         const overlayUserData = getHighlightUserData(overlayObj)
         overlayUserData.objectId = objectId
         overlayUserData.previewDrawable = options.mode === 'preview'
+        overlayObj.renderOrder = containerGroup.renderOrder
         containerGroup.add(overlayObj)
         added++
       }
@@ -2113,6 +2111,146 @@ export class AcTrBatchedGroup extends THREE.Group {
   }
 
   /**
+   * Assigns a fresh, unpatched material in the compare role color.
+   *
+   * Cloning the batch material would keep the highlight shader, which tints
+   * everything to the unchanged base color when the packed slot mask misses.
+   */
+  private applyCompareOverlayMaterial(object: THREE.Object3D, color: number) {
+    const replace = (node: THREE.Object3D) => {
+      if (node instanceof LineSegments2) {
+        const src = node.material as LineMaterial
+        const material = new LineMaterial({
+          color,
+          linewidth: src.linewidth,
+          worldUnits: src.worldUnits,
+          dashed: false
+        })
+        material.resolution.copy(src.resolution)
+        material.depthTest = true
+        material.polygonOffset = true
+        material.polygonOffsetFactor = -2
+        material.polygonOffsetUnits = -2
+        node.material = material
+      } else if (
+        node instanceof THREE.LineSegments ||
+        node instanceof THREE.Line
+      ) {
+        node.material = new THREE.LineBasicMaterial({
+          color,
+          depthTest: true,
+          polygonOffset: true,
+          polygonOffsetFactor: -2,
+          polygonOffsetUnits: -2
+        })
+      } else if (node instanceof THREE.Mesh) {
+        node.material = new THREE.MeshBasicMaterial({
+          color,
+          side: THREE.DoubleSide,
+          depthTest: true,
+          polygonOffset: true,
+          polygonOffsetFactor: -2,
+          polygonOffsetUnits: -2
+        })
+      } else if (node instanceof THREE.Points) {
+        const src = node.material as THREE.PointsMaterial
+        node.material = new THREE.PointsMaterial({
+          color,
+          size: src.size,
+          sizeAttenuation: src.sizeAttenuation,
+          depthTest: true
+        })
+      }
+
+      node.children.forEach(child => replace(child))
+    }
+    replace(object)
+  }
+
+  /**
+   * Rebinds compare-overlay wrappers onto the live packed attribute arrays.
+   *
+   * {@link AcTrBatchedLine.getObjectAt} shares `attributes`/`index` with the
+   * batch, not the `BufferGeometry` object. `setGeometrySize` disposes those
+   * arrays and allocates new ones; overlay meshes would otherwise keep the
+   * disposed buffers. Line2 overlays own cloned sub-geometry and are skipped.
+   */
+  private rebindCompareOverlaySharedBuffers() {
+    if (this._compareOverlay.children.length === 0) {
+      return
+    }
+    for (const child of this._compareOverlay.children) {
+      const data = getHighlightUserData(child)
+      if (data.batchedObjectId == null || data.disposeGeometryOnRemove) {
+        continue
+      }
+      const batch = this.getOriginBatch(data.batchedObjectId)
+      const childGeometry = this.getDrawableGeometry(child)
+      if (batch == null || childGeometry == null) {
+        continue
+      }
+      if (childGeometry.attributes !== batch.geometry.attributes) {
+        childGeometry.index = batch.geometry.index
+        childGeometry.attributes = batch.geometry.attributes
+      }
+    }
+  }
+
+  /**
+   * Rebuilds the compare overlay for every current role override.
+   */
+  private refreshCompareOverlay() {
+    this.clearHighlightGroup(this._compareOverlay)
+    if (!this._compareEnabled) {
+      return
+    }
+    this._compareRoles.forEach((role, objectId) => {
+      this.appendEntityOverlayDrawables(objectId, this._compareOverlay, {
+        maxSlots: 10000,
+        mode: 'compare',
+        compareColor: this.resolveCompareColor(role)
+      })
+    })
+  }
+
+  /**
+   * Updates the compare overlay for one entity after a late batch append.
+   */
+  private syncCompareOverlayForEntity(objectId: string) {
+    this.removeCompareOverlayForEntity(objectId)
+    if (!this._compareEnabled) {
+      return
+    }
+    const role = this._compareRoles.get(objectId)
+    if (role == null) {
+      return
+    }
+    this.appendEntityOverlayDrawables(objectId, this._compareOverlay, {
+      maxSlots: 10000,
+      mode: 'compare',
+      compareColor: this.resolveCompareColor(role)
+    })
+  }
+
+  /**
+   * Removes compare-overlay drawables owned by `objectId`.
+   */
+  private removeCompareOverlayForEntity(objectId: string) {
+    const stale = this._compareOverlay.children.filter(
+      child => getHighlightUserData(child).objectId === objectId
+    )
+    stale.forEach(child => this.disposeHighlightObject(child))
+    stale.forEach(child => child.removeFromParent())
+  }
+
+  /**
+   * Resolves a packed batch container by its Three.js object id.
+   */
+  private getOriginBatch(batchedObjectId: number) {
+    return this._originBatchById.get(batchedObjectId)
+  }
+
+  /**
    * Copies highlight-related user-data flags from source to target object.
    */
   private copyHighlightMetadata(
@@ -2132,9 +2270,7 @@ export class AcTrBatchedGroup extends THREE.Group {
     item: AcTrEntityInBatchedObject,
     visible: boolean
   ) {
-    const batchedObject = this.getObjectById(item.batchedObjectId) as
-      | AcTrBatchedObject
-      | undefined
+    const batchedObject = this.getOriginBatch(item.batchedObjectId)
     batchedObject?.setVisibleAt(item.batchId, visible)
   }
 
@@ -2142,10 +2278,7 @@ export class AcTrBatchedGroup extends THREE.Group {
    * Returns visibility state for one batched geometry slot.
    */
   private getBatchItemVisible(item: AcTrEntityInBatchedObject): boolean {
-    const batchedObject = this.getObjectById(item.batchedObjectId) as
-      | (AcTrBatchedObject & { getVisibleAt(geometryId: number): boolean })
-      | AcTrBatchedPoint
-      | undefined
+    const batchedObject = this.getOriginBatch(item.batchedObjectId)
     return batchedObject?.getVisibleAt(item.batchId) ?? false
   }
 
@@ -2412,6 +2545,7 @@ export class AcTrBatchedGroup extends THREE.Group {
       })
     }
     list.push(batch)
+    this._originBatchById.set(batch.id, batch)
     this.add(batch)
     return batch
   }

--- a/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedMixin.ts
@@ -970,6 +970,34 @@ export function createAcTrBatchedMixin<
     }
 
     /**
+     * Writes compare roles for every packed slot from `objectId` metadata.
+     *
+     * This is the source of truth for GPU tinting: it does not depend on
+     * `Object3D.getObjectById` or the group-level entity map, so late-appended
+     * handles (and slots whose Three.js container id lookup fails) still
+     * receive added/deleted/modified colors.
+     *
+     * @param roles - Compare roles keyed by entity object id.
+     * @returns This instance for chaining.
+     */
+    applyPackedCompareRoles(roles: ReadonlyMap<string, AcTrBatchCompareRole>) {
+      for (let slotId = 0; slotId < this._geometryInfo.length; slotId++) {
+        const info = this._geometryInfo[slotId]
+        if (!isBatchGeometryActive(info.flags)) {
+          continue
+        }
+        const objectId = info.objectId
+        const role =
+          objectId != null && objectId !== ''
+            ? (roles.get(String(objectId)) ?? null)
+            : null
+        this.setCompareRoleAt(slotId, role)
+      }
+      this.flushHighlightMask()
+      return this
+    }
+
+    /**
      * Applies compare-display colors to the batch highlight state.
      *
      * @param options.enabled - Whether compare coloring is active.

--- a/packages/three-renderer/src/batch/highlight/AcTrBatchHighlightState.ts
+++ b/packages/three-renderer/src/batch/highlight/AcTrBatchHighlightState.ts
@@ -330,6 +330,10 @@ export class AcTrBatchHighlightState {
       this.maskTexture.minFilter = THREE.NearestFilter
       this.maskTexture.magFilter = THREE.NearestFilter
       this.maskTexture.generateMipmaps = false
+      this.maskTexture.unpackAlignment = 1
+      // Role bytes (0/85/170/255) must not be sRGB-decoded; that would map
+      // added (170) into the deleted shader threshold band.
+      this.maskTexture.colorSpace = THREE.NoColorSpace
       this.maskTexture.needsUpdate = true
       this.maskTextureWidth = width
       this.maskTextureHeight = height

--- a/packages/three-renderer/src/util/AcTrObjectUserData.ts
+++ b/packages/three-renderer/src/util/AcTrObjectUserData.ts
@@ -119,6 +119,12 @@ export type AcTrSceneDrawableUserData = AcTrPickableObjectUserData &
 
 export interface AcTrHighlightUserData {
   objectId?: string
+  /**
+   * Three.js id of the origin batch this overlay was extracted from.
+   *
+   * Used to rebind shared packed `attributes`/`index` after batch growth.
+   */
+  batchedObjectId?: number
   disposeGeometryOnRemove?: boolean
   /** Marks geometry extracted for command preview overlays. */
   previewDrawable?: boolean


### PR DESCRIPTION
## Summary
- Keep CAD compare added/deleted/modified tints after packed line batches grow: copy typed-array views by `byteOffset`, look up origin batches by id (not `getObjectById`), and apply packed slot roles without relying on scene-graph lookup.
- Draw compare hits in a high-`renderOrder` overlay with unpatched materials so they stay visible against coplanar unchanged TABLE/INSERT linework.
- Rebind overlay `attributes`/`index` after `setGeometrySize`, and rebuild or drop overlay children on `removeEntity`, so overlays do not keep disposed buffers or deleted entities.

## Test plan
- [ ] `pnpm exec jest packages/three-renderer/__tests__/AcTrBatchedGroupHighlight.spec.ts`
- [ ] Open CAD Diff Viewer, load two drawings that pack enough indexed lines to grow a batch, and confirm added/deleted colors stay correct
- [ ] Enable compare, then keep appending entities (or open a file that streams in after compare is on) and confirm overlay hits still draw
- [ ] In compare mode, erase one highlighted entity and confirm its overlay disappears while remaining hits stay aligned