### PR TITLE
feat: add HTML review panel and zoom to full markup extents

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHtmlI18n.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlI18n.spec.ts
@@ -120,5 +120,7 @@ describe('AcExHtmlI18n', () => {
     expect(i18n.t('layers.zoomTo', { name: 'Duvarlar' })).toBe(
       'Duvarlar katmanına yakınlaştır'
     )
+    expect(i18n.t('review.zoomTo')).toBe('Yakınlaştır')
+    expect(i18n.t('review.closeDetails')).toBe('Ayrıntıları kapat')
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
@@ -56,6 +56,12 @@ describe('buildAcExHtmlShellBody', () => {
     expect(html).toContain('data-measure-mode="distance"')
     expect(html).toContain('data-action="measure-import"')
     expect(html).toContain('data-markup-mode="cloud"')
+    expect(html).toContain('data-action="markup-panel"')
+    expect(html).toContain('id="mlcad-review-drawer"')
+    expect(html.indexOf('id="mlcad-markup-strip-wrap"')).toBeLessThan(
+      html.indexOf('id="mlcad-review-drawer"')
+    )
+    expect(html).toContain('mlcad-review-detail-close')
     expect(html).toContain('data-action="clear-markups"')
     expect(html).toContain('id="mlcad-status-bar"')
     expect(html.match(/mlcad-tool-separator/g)?.length).toBeGreaterThanOrEqual(2)
@@ -80,6 +86,8 @@ describe('buildAcExHtmlShellBody', () => {
     const html = buildAcExHtmlShellBody('#000000', 'view')
     expect(html).not.toContain('data-markup-mode=')
     expect(html).not.toContain('data-action="clear-markups"')
+    expect(html).not.toContain('data-action="markup-panel"')
+    expect(html).not.toContain('id="mlcad-review-drawer"')
   })
 
   it('omits the layout switcher when layouts are not exported', () => {

--- a/packages/cad-html-plugin/__tests__/AcExMarkupGeometry.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMarkupGeometry.spec.ts
@@ -2,6 +2,8 @@ import {
   acExComputeLeaderTipOnShape,
   acExHitTestMarkupShapeOutline,
   acExIsAttachableShapeMarkup,
+  acExMarkupBounds,
+  acExMarkupFocusExtents,
   acExMarkupShapeOutlineFromGeometry
 } from '../src/AcExMarkupGeometry'
 import type { AcExMarkupGeometry } from '../src/AcExMarkupTypes'
@@ -97,5 +99,44 @@ describe('acExMarkupShapeOutlineFromGeometry', () => {
       corner1: { x: 1, y: 2 },
       corner2: { x: 3, y: 4 }
     })
+  })
+})
+
+describe('acExMarkupBounds', () => {
+  it('unions a cloud AABB with its attached leader and text-box anchor', () => {
+    expect(
+      acExMarkupBounds({
+        type: 'cloud',
+        corner1: { x: 0, y: 0 },
+        corner2: { x: 20, y: 10 },
+        callout: { tip: { x: 20, y: 5 }, anchor: { x: 80, y: 40 } }
+      })
+    ).toEqual({ minX: 0, minY: 0, maxX: 80, maxY: 40 })
+  })
+
+  it('includes both callout leader tip and text-box anchor', () => {
+    expect(
+      acExMarkupBounds({
+        type: 'callout',
+        tip: { x: 0, y: 0 },
+        anchor: { x: 100, y: -30 }
+      })
+    ).toEqual({ minX: 0, minY: -30, maxX: 100, maxY: 0 })
+  })
+})
+
+describe('acExMarkupFocusExtents', () => {
+  it('unions geometry with overlay client rectangles', () => {
+    expect(
+      acExMarkupFocusExtents(
+        {
+          type: 'callout',
+          tip: { x: 0, y: 0 },
+          anchor: { x: 10, y: 0 }
+        },
+        [{ left: 100, top: 20, right: 180, bottom: 60 }],
+        (clientX, clientY) => ({ x: clientX / 10, y: -clientY / 10 })
+      )
+    ).toEqual({ minX: 0, minY: -6, maxX: 18, maxY: 0 })
   })
 })

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -54,6 +54,7 @@ export type AcExHtmlMessageKey =
   | 'toolbar.markupCircle'
   | 'toolbar.markupArrow'
   | 'toolbar.markupStamp'
+  | 'toolbar.markupPanel'
   | 'toolbar.markupHide'
   | 'toolbar.markupShow'
   | 'toolbar.clearMarkups'
@@ -81,6 +82,25 @@ export type AcExHtmlMessageKey =
   | 'layers.showAll'
   | 'layers.hideAll'
   | 'layers.zoomTo'
+  | 'review.title'
+  | 'review.close'
+  | 'review.searchPlaceholder'
+  | 'review.empty'
+  | 'review.type'
+  | 'review.status'
+  | 'review.author'
+  | 'review.summary'
+  | 'review.details'
+  | 'review.closeDetails'
+  | 'review.label'
+  | 'review.comment'
+  | 'review.zoomTo'
+  | 'review.delete'
+  | 'review.clear'
+  | 'review.statusValues.open'
+  | 'review.statusValues.question'
+  | 'review.statusValues.answered'
+  | 'review.statusValues.closed'
   | 'status.ready'
   | 'status.zoomWindowHint'
   | 'status.measureDistanceHint'
@@ -174,6 +194,7 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       markupCircle: 'Circle',
       markupArrow: 'Arrow',
       markupStamp: 'Stamp',
+      markupPanel: 'Review',
       markupHide: 'Hide markups',
       markupShow: 'Show markups',
       clearMarkups: 'Clear markups',
@@ -207,6 +228,29 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       showAll: 'Show all',
       hideAll: 'Hide all',
       zoomTo: 'Zoom to {name}'
+    },
+    review: {
+      title: 'Review',
+      close: 'Close review',
+      searchPlaceholder: 'Search markups',
+      empty: 'No markups yet',
+      type: 'Type',
+      status: 'Status',
+      author: 'Author',
+      summary: 'Summary',
+      details: 'Details',
+      closeDetails: 'Close details',
+      label: 'Label',
+      comment: 'Comment',
+      zoomTo: 'Zoom to',
+      delete: 'Delete',
+      clear: 'Clear all',
+      statusValues: {
+        open: 'Open',
+        question: 'Question',
+        answered: 'Answered',
+        closed: 'Closed'
+      }
     },
     status: {
       ready: 'Ready',
@@ -307,6 +351,7 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       markupCircle: '圆',
       markupArrow: '箭头',
       markupStamp: '图章',
+      markupPanel: '批注面板',
       markupHide: '隐藏批注',
       markupShow: '显示批注',
       clearMarkups: '清除批注',
@@ -339,6 +384,29 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       showAll: '全部显示',
       hideAll: '全部隐藏',
       zoomTo: '缩放到 {name}'
+    },
+    review: {
+      title: '批注',
+      close: '关闭批注面板',
+      searchPlaceholder: '搜索批注',
+      empty: '暂无批注',
+      type: '类型',
+      status: '状态',
+      author: '作者',
+      summary: '摘要',
+      details: '详情',
+      closeDetails: '关闭详情',
+      label: '标签',
+      comment: '评论',
+      zoomTo: '缩放到',
+      delete: '删除',
+      clear: '全部清除',
+      statusValues: {
+        open: '打开',
+        question: '疑问',
+        answered: '已答复',
+        closed: '已关闭'
+      }
     },
     status: {
       ready: '就绪',
@@ -431,6 +499,7 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       markupCircle: 'Kružnice',
       markupArrow: 'Šipka',
       markupStamp: 'Razítko',
+      markupPanel: 'Kontrola',
       markupHide: 'Skrýt poznámky',
       markupShow: 'Zobrazit poznámky',
       clearMarkups: 'Vymazat poznámky',
@@ -463,6 +532,29 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       showAll: 'Zobrazit vše',
       hideAll: 'Skrýt vše',
       zoomTo: 'Přiblížit na {name}'
+    },
+    review: {
+      title: 'Kontrola',
+      close: 'Zavřít kontrolu',
+      searchPlaceholder: 'Hledat poznámky',
+      empty: 'Zatím žádné poznámky',
+      type: 'Typ',
+      status: 'Stav',
+      author: 'Autor',
+      summary: 'Souhrn',
+      details: 'Podrobnosti',
+      closeDetails: 'Zavřít podrobnosti',
+      label: 'Popisek',
+      comment: 'Komentář',
+      zoomTo: 'Přiblížit na',
+      delete: 'Odstranit',
+      clear: 'Vymazat vše',
+      statusValues: {
+        open: 'Otevřeno',
+        question: 'Otázka',
+        answered: 'Zodpovězeno',
+        closed: 'Uzavřeno'
+      }
     },
     status: {
       ready: 'Připraveno',
@@ -563,6 +655,7 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       markupCircle: 'Daire',
       markupArrow: 'Ok',
       markupStamp: 'Damga',
+      markupPanel: 'İnceleme',
       markupHide: 'İşaretlemeleri gizle',
       markupShow: 'İşaretlemeleri göster',
       clearMarkups: 'İşaretlemeleri temizle',
@@ -595,6 +688,29 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       showAll: 'Tümünü göster',
       hideAll: 'Tümünü gizle',
       zoomTo: '{name} katmanına yakınlaştır'
+    },
+    review: {
+      title: 'İnceleme',
+      close: 'İncelemeyi kapat',
+      searchPlaceholder: 'İşaretlerde ara',
+      empty: 'Henüz işaret yok',
+      type: 'Tür',
+      status: 'Durum',
+      author: 'Yazar',
+      summary: 'Özet',
+      details: 'Ayrıntılar',
+      closeDetails: 'Ayrıntıları kapat',
+      label: 'Etiket',
+      comment: 'Yorum',
+      zoomTo: 'Yakınlaştır',
+      delete: 'Sil',
+      clear: 'Tümünü temizle',
+      statusValues: {
+        open: 'Açık',
+        question: 'Soru',
+        answered: 'Yanıtlandı',
+        closed: 'Kapalı'
+      }
     },
     status: {
       ready: 'Hazır',
@@ -698,6 +814,7 @@ const AR_MESSAGES: AcExMessageTree = {
     'markupCircle': 'دائرة',
     'markupArrow': 'سهم',
     'markupStamp': 'ختم',
+    'markupPanel': 'مراجعة',
     'markupHide': 'إخفاء الملاحظات',
     'markupShow': 'إظهار الملاحظات',
     'clearMarkups': 'مسح الملاحظات',
@@ -731,6 +848,29 @@ const AR_MESSAGES: AcExMessageTree = {
     'showAll': 'إظهار الكل',
     'hideAll': 'إخفاء الكل',
     'zoomTo': 'تكبير إلى {name}'
+  },
+  'review': {
+    'title': 'مراجعة',
+    'close': 'إغلاق المراجعة',
+    'searchPlaceholder': 'البحث في الملاحظات',
+    'empty': 'لا توجد ملاحظات بعد',
+    'type': 'النوع',
+    'status': 'الحالة',
+    'author': 'المؤلف',
+    'summary': 'الملخص',
+    'details': 'التفاصيل',
+    'closeDetails': 'إغلاق التفاصيل',
+    'label': 'التسمية',
+    'comment': 'التعليق',
+    'zoomTo': 'تكبير إلى',
+    'delete': 'حذف',
+    'clear': 'مسح الكل',
+    'statusValues': {
+      'open': 'مفتوح',
+      'question': 'سؤال',
+      'answered': 'تمت الإجابة',
+      'closed': 'مغلق'
+    }
   },
   'status': {
     'ready': 'جاهز',

--- a/packages/cad-html-plugin/src/AcExHtmlIcons.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlIcons.ts
@@ -23,6 +23,7 @@ import {
   ICON_MARKUP_EXPORT,
   ICON_MARKUP_HIDE,
   ICON_MARKUP_IMPORT,
+  ICON_MARKUP_PANEL,
   ICON_MARKUP_RECT,
   ICON_MARKUP_SHOW,
   ICON_MARKUP_STAMP,
@@ -113,6 +114,8 @@ export const acExHtmlIcons = {
   markupArrow: ICON_MARKUP_ARROW,
   /** Markup stamp. */
   markupStamp: ICON_MARKUP_STAMP,
+  /** Review list / markup panel. */
+  markupPanel: ICON_MARKUP_PANEL,
   /** Import markup sidecar JSON. */
   markupImport: ICON_MARKUP_IMPORT,
   /** Export markup sidecar JSON. */

--- a/packages/cad-html-plugin/src/AcExHtmlReviewPanel.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlReviewPanel.ts
@@ -166,11 +166,6 @@ export function setupAcExHtmlReviewPanel(options: {
       const tr = document.createElement('tr')
       tr.dataset.markupId = record.id
       if (record.id === selectedId) tr.classList.add('is-selected')
-      tr.addEventListener('click', () => {
-        detailsOpen = true
-        getMarkup()?.selectFromPanel(record.id)
-        updateDetail()
-      })
 
       const typeCell = document.createElement('td')
       typeCell.textContent = typeLabel(record.type)
@@ -203,10 +198,60 @@ export function setupAcExHtmlReviewPanel(options: {
     }
   }
 
+  const recordsKey = (records: readonly AcExMarkupRecord[]) =>
+    records
+      .map(
+        record =>
+          `${record.id}\t${record.type}\t${record.status}\t${record.author}\t${record.text ?? ''}\t${record.comment}`
+      )
+      .join('\n')
+
+  let tableContentKey = ''
+
+  const syncRowSelection = () => {
+    const selectedId = getMarkup()?.selectedId
+    tbody.querySelectorAll('tr[data-markup-id]').forEach(row => {
+      row.classList.toggle('is-selected', row.getAttribute('data-markup-id') === selectedId)
+    })
+  }
+
   const refresh = () => {
-    renderTable()
+    const records = getMarkup()?.list() ?? []
+    const key = recordsKey(records)
+    if (
+      key === tableContentKey &&
+      tbody.querySelector('tr[data-markup-id], .mlcad-review-empty')
+    ) {
+      syncRowSelection()
+    } else {
+      tableContentKey = key
+      renderTable()
+    }
     updateDetail()
   }
+
+  const rowMarkupId = (event: Event): string | undefined => {
+    const target = event.target
+    if (!(target instanceof Element)) return undefined
+    const row = target.closest('tr[data-markup-id]')
+    if (!row || !tbody.contains(row)) return undefined
+    return row instanceof HTMLElement ? row.dataset.markupId : undefined
+  }
+
+  tbody.addEventListener('click', event => {
+    const id = rowMarkupId(event)
+    if (!id) return
+    detailsOpen = true
+    getMarkup()?.selectFromPanel(id)
+    updateDetail()
+  })
+  tbody.addEventListener('dblclick', event => {
+    const id = rowMarkupId(event)
+    if (!id) return
+    detailsOpen = true
+    getMarkup()?.focus(id)
+    updateDetail()
+  })
 
   const setOpen = (open: boolean) => {
     if (open) closeOtherDrawers()
@@ -293,7 +338,8 @@ export function setupAcExHtmlReviewPanel(options: {
     zoomBtn.textContent = i18n.t('review.zoomTo')
     deleteBtn.textContent = i18n.t('review.delete')
     rebuildStatusOptions()
-    refresh()
+    renderTable()
+    updateDetail()
   }
 
   rebuildStatusOptions()

--- a/packages/cad-html-plugin/src/AcExHtmlReviewPanel.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlReviewPanel.ts
@@ -1,0 +1,307 @@
+/**
+ * Review / markup list drawer for the offline HTML viewer.
+ *
+ * Mirrors cad-simple-ui-plugin's review palette: search, table, details,
+ * zoom-to, delete, and clear-all.
+ *
+ * @module AcExHtmlReviewPanel
+ * @packageDocumentation
+ */
+
+import type { AcExHtmlI18n } from './AcExHtmlI18n'
+import type { AcExMarkupController } from './AcExMarkup'
+import type {
+  AcExMarkupRecord,
+  AcExMarkupStatus,
+  AcExMarkupType
+} from './AcExMarkupTypes'
+
+const STATUSES: readonly AcExMarkupStatus[] = [
+  'open',
+  'question',
+  'answered',
+  'closed'
+]
+
+const TYPE_I18N: Partial<Record<AcExMarkupType, string>> = {
+  cloud: 'toolbar.markupCloud',
+  callout: 'toolbar.markupCallout',
+  text: 'toolbar.markupText',
+  rect: 'toolbar.markupRect',
+  circle: 'toolbar.markupCircle',
+  arrow: 'toolbar.markupArrow',
+  stamp: 'toolbar.markupStamp'
+}
+
+/** Handles returned by {@link setupAcExHtmlReviewPanel}. */
+export interface AcExHtmlReviewPanelController {
+  /** Re-render labels after a locale change. */
+  refreshLabels: () => void
+  /** Close the drawer. */
+  close: () => void
+  /** Open or close the drawer. */
+  setOpen: (open: boolean) => void
+}
+
+/**
+ * Wires the review drawer to the markup controller.
+ *
+ * @returns Controller, or `null` when the shell markup is missing.
+ */
+export function setupAcExHtmlReviewPanel(options: {
+  i18n: AcExHtmlI18n
+  getMarkup: () => AcExMarkupController | null
+  closeOtherDrawers: () => void
+}): AcExHtmlReviewPanelController | null {
+  const { i18n, getMarkup, closeOtherDrawers } = options
+  const drawer = document.getElementById('mlcad-review-drawer')
+  const closeBtn = document.getElementById('mlcad-review-close')
+  if (!drawer) return null
+
+  const searchInput = drawer.querySelector(
+    '.mlcad-review-search'
+  ) as HTMLInputElement | null
+  const clearBtn = drawer.querySelector(
+    '.mlcad-review-clear'
+  ) as HTMLButtonElement | null
+  const tbody = drawer.querySelector('tbody')
+  const detail = drawer.querySelector(
+    '.mlcad-review-detail'
+  ) as HTMLDivElement | null
+  const statusSelect = drawer.querySelector(
+    '.mlcad-review-status'
+  ) as HTMLSelectElement | null
+  const authorInput = drawer.querySelector(
+    '.mlcad-review-author'
+  ) as HTMLInputElement | null
+  const textInput = drawer.querySelector(
+    '.mlcad-review-text'
+  ) as HTMLInputElement | null
+  const commentInput = drawer.querySelector(
+    '.mlcad-review-comment'
+  ) as HTMLTextAreaElement | null
+  const zoomBtn = drawer.querySelector(
+    '.mlcad-review-zoom'
+  ) as HTMLButtonElement | null
+  const deleteBtn = drawer.querySelector(
+    '.mlcad-review-delete'
+  ) as HTMLButtonElement | null
+  const closeDetailsBtn = drawer.querySelector(
+    '.mlcad-review-detail-close'
+  ) as HTMLButtonElement | null
+  if (
+    !searchInput ||
+    !clearBtn ||
+    !tbody ||
+    !detail ||
+    !statusSelect ||
+    !authorInput ||
+    !textInput ||
+    !commentInput ||
+    !zoomBtn ||
+    !deleteBtn ||
+    !closeDetailsBtn
+  ) {
+    return null
+  }
+
+  let detailsOpen = true
+  let unsubscribe: (() => void) | undefined
+
+  const typeLabel = (type: AcExMarkupType) => {
+    const key = TYPE_I18N[type]
+    return key ? i18n.t(key as 'toolbar.markupCloud') : type
+  }
+
+  const statusLabel = (status: AcExMarkupStatus) =>
+    i18n.t(`review.statusValues.${status}` as 'review.statusValues.open')
+
+  const rebuildStatusOptions = () => {
+    const current = statusSelect.value
+    statusSelect.replaceChildren()
+    for (const status of STATUSES) {
+      const option = document.createElement('option')
+      option.value = status
+      option.textContent = statusLabel(status)
+      statusSelect.appendChild(option)
+    }
+    if (current) statusSelect.value = current
+  }
+
+  const selectedRecord = (): AcExMarkupRecord | undefined => {
+    const markup = getMarkup()
+    if (!markup) return undefined
+    const id = markup.selectedId
+    if (!id) return undefined
+    return markup.list().find(record => record.id === id)
+  }
+
+  const renderTable = () => {
+    const markup = getMarkup()
+    const records = markup?.list() ?? []
+    const selectedId = markup?.selectedId
+    const query = searchInput.value.trim().toLowerCase()
+    const rows = query
+      ? records.filter(record => {
+          const hay = `${record.type} ${record.status} ${record.author} ${record.text ?? ''} ${record.comment}`
+          return hay.toLowerCase().includes(query)
+        })
+      : records
+
+    tbody.replaceChildren()
+    clearBtn.disabled = records.length === 0
+
+    if (rows.length === 0) {
+      const emptyRow = document.createElement('tr')
+      emptyRow.className = 'mlcad-review-empty'
+      const cell = document.createElement('td')
+      cell.colSpan = 4
+      cell.textContent = i18n.t('review.empty')
+      emptyRow.appendChild(cell)
+      tbody.appendChild(emptyRow)
+      return
+    }
+
+    for (const record of rows) {
+      const tr = document.createElement('tr')
+      tr.dataset.markupId = record.id
+      if (record.id === selectedId) tr.classList.add('is-selected')
+      tr.addEventListener('click', () => {
+        detailsOpen = true
+        getMarkup()?.selectFromPanel(record.id)
+        updateDetail()
+      })
+
+      const typeCell = document.createElement('td')
+      typeCell.textContent = typeLabel(record.type)
+      const statusCell = document.createElement('td')
+      statusCell.textContent = statusLabel(record.status)
+      const authorCell = document.createElement('td')
+      authorCell.textContent = record.author
+      authorCell.title = record.author
+      const summaryCell = document.createElement('td')
+      const summary = record.text || record.comment || '—'
+      summaryCell.textContent = summary
+      summaryCell.title = summary
+      tr.append(typeCell, statusCell, authorCell, summaryCell)
+      tbody.appendChild(tr)
+    }
+  }
+
+  const updateDetail = () => {
+    const selected = selectedRecord()
+    const show = Boolean(selected && detailsOpen)
+    detail.hidden = !show
+    if (!selected || !show) return
+    statusSelect.value = selected.status
+    authorInput.value = selected.author
+    if (document.activeElement !== textInput) {
+      textInput.value = selected.text ?? ''
+    }
+    if (document.activeElement !== commentInput) {
+      commentInput.value = selected.comment ?? ''
+    }
+  }
+
+  const refresh = () => {
+    renderTable()
+    updateDetail()
+  }
+
+  const setOpen = (open: boolean) => {
+    if (open) closeOtherDrawers()
+    drawer.hidden = !open
+    document
+      .querySelectorAll('[data-action="markup-panel"]')
+      .forEach(btn => {
+        btn.classList.toggle('active', open)
+        btn.setAttribute('aria-pressed', String(open))
+      })
+    if (open) {
+      const markup = getMarkup()
+      unsubscribe?.()
+      unsubscribe = markup?.subscribe(refresh)
+      refresh()
+    } else {
+      unsubscribe?.()
+      unsubscribe = undefined
+    }
+  }
+
+  searchInput.addEventListener('input', () => renderTable())
+  clearBtn.addEventListener('click', () => getMarkup()?.clearAll())
+  closeBtn?.addEventListener('click', () => setOpen(false))
+
+  statusSelect.addEventListener('change', () => {
+    const selected = selectedRecord()
+    if (!selected) return
+    getMarkup()?.updateMeta(selected.id, {
+      status: statusSelect.value as AcExMarkupStatus
+    })
+  })
+  textInput.addEventListener('blur', () => {
+    const selected = selectedRecord()
+    if (!selected) return
+    const next = textInput.value
+    if (next === (selected.text ?? '')) return
+    getMarkup()?.updateMeta(selected.id, { text: next })
+  })
+  commentInput.addEventListener('blur', () => {
+    const selected = selectedRecord()
+    if (!selected) return
+    const next = commentInput.value
+    if (next === selected.comment) return
+    getMarkup()?.updateMeta(selected.id, { comment: next })
+  })
+  zoomBtn.addEventListener('click', () => {
+    const selected = selectedRecord()
+    if (selected) getMarkup()?.focus(selected.id)
+  })
+  deleteBtn.addEventListener('click', () => {
+    const selected = selectedRecord()
+    if (selected) getMarkup()?.removeMarkup(selected.id)
+  })
+  closeDetailsBtn.addEventListener('click', () => {
+    detailsOpen = false
+    updateDetail()
+  })
+
+  const refreshLabels = () => {
+    searchInput.placeholder = i18n.t('review.searchPlaceholder')
+    clearBtn.textContent = i18n.t('review.clear')
+    const typeHeader = drawer.querySelector('[data-review-col="type"]')
+    const statusHeader = drawer.querySelector('[data-review-col="status"]')
+    const authorHeader = drawer.querySelector('[data-review-col="author"]')
+    const summaryHeader = drawer.querySelector('[data-review-col="summary"]')
+    if (typeHeader) typeHeader.textContent = i18n.t('review.type')
+    if (statusHeader) statusHeader.textContent = i18n.t('review.status')
+    if (authorHeader) authorHeader.textContent = i18n.t('review.author')
+    if (summaryHeader) summaryHeader.textContent = i18n.t('review.summary')
+    const detailTitle = drawer.querySelector('.mlcad-review-detail-title')
+    if (detailTitle) detailTitle.textContent = i18n.t('review.details')
+    const closeDetailsLabel = i18n.t('review.closeDetails')
+    closeDetailsBtn.title = closeDetailsLabel
+    closeDetailsBtn.setAttribute('aria-label', closeDetailsLabel)
+    const statusField = drawer.querySelector('[data-review-field="status"]')
+    const authorField = drawer.querySelector('[data-review-field="author"]')
+    const labelField = drawer.querySelector('[data-review-field="label"]')
+    const commentField = drawer.querySelector('[data-review-field="comment"]')
+    if (statusField) statusField.textContent = i18n.t('review.status')
+    if (authorField) authorField.textContent = i18n.t('review.author')
+    if (labelField) labelField.textContent = i18n.t('review.label')
+    if (commentField) commentField.textContent = i18n.t('review.comment')
+    zoomBtn.textContent = i18n.t('review.zoomTo')
+    deleteBtn.textContent = i18n.t('review.delete')
+    rebuildStatusOptions()
+    refresh()
+  }
+
+  rebuildStatusOptions()
+  refreshLabels()
+
+  return {
+    refreshLabels,
+    close: () => setOpen(false),
+    setOpen
+  }
+}

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -31,6 +31,7 @@ export const ACEX_HTML_SHELL_CSS = `
     --mlcad-drawer-width: 220px;
     --mlcad-drawer-gap: 8px;
     --mlcad-ui-inset: 12px;
+    --mlcad-review-max-height: calc(100vh - 2 * var(--mlcad-ui-inset) - 48px);
     --mlcad-z-chrome: 7;
     --mlcad-z-measure: 5;
     --mlcad-z-markup: 6;
@@ -206,11 +207,12 @@ export const ACEX_HTML_SHELL_CSS = `
   }
   #mlcad-zoom-window-rect[hidden] { display: none; }
 
-  #mlcad-layer-drawer {
+  #mlcad-layer-drawer,
+  #mlcad-review-drawer {
     flex-shrink: 1;
     min-width: 0;
     width: var(--mlcad-drawer-width);
-    max-height: min(420px, calc(100vh - 48px));
+    max-height: min(420px, var(--mlcad-review-max-height));
     display: flex; flex-direction: column;
     background: var(--mlcad-ui-bg-elevated);
     border: 1px solid var(--mlcad-ui-border);
@@ -218,8 +220,22 @@ export const ACEX_HTML_SHELL_CSS = `
     box-shadow: var(--mlcad-shadow);
     backdrop-filter: blur(12px);
     overflow: hidden;
+    box-sizing: border-box;
   }
-  #mlcad-layer-drawer[hidden] { display: none; }
+  #mlcad-markup-strip-wrap {
+    position: relative;
+  }
+  #mlcad-review-drawer {
+    position: absolute;
+    left: 100%;
+    top: 0;
+    margin-left: var(--mlcad-drawer-gap);
+    width: min(320px, calc(100vw - 2 * var(--mlcad-ui-inset) - var(--mlcad-toolbar-width) - var(--mlcad-drawer-gap)));
+    height: 100%;
+    max-height: var(--mlcad-review-max-height);
+  }
+  #mlcad-layer-drawer[hidden],
+  #mlcad-review-drawer[hidden] { display: none; }
 
   .mlcad-drawer-header {
     display: flex; align-items: center; justify-content: space-between;
@@ -289,6 +305,92 @@ export const ACEX_HTML_SHELL_CSS = `
   }
   .mlcad-layer-zoom:disabled { opacity: 0.35; cursor: not-allowed; }
 
+  .mlcad-review-toolbar {
+    display: flex; gap: 6px; align-items: center;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--mlcad-ui-border);
+  }
+  .mlcad-review-search {
+    flex: 1; min-width: 0;
+    box-sizing: border-box;
+    padding: 4px 8px;
+    border: 1px solid var(--mlcad-ui-border);
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--mlcad-ui-text);
+    font-size: 12px;
+  }
+  .mlcad-review-clear,
+  .mlcad-review-zoom,
+  .mlcad-review-delete {
+    flex: 0 0 auto;
+    padding: 4px 8px;
+    border: 1px solid var(--mlcad-ui-border);
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--mlcad-ui-text);
+    font-size: 12px; cursor: pointer;
+  }
+  .mlcad-review-clear:disabled { opacity: 0.5; cursor: default; }
+  .mlcad-review-delete { color: #f56c6c; border-color: rgba(245, 108, 108, 0.55); }
+  .mlcad-review-table-wrap { flex: 1 1 auto; min-height: 0; overflow: auto; }
+  .mlcad-review-table {
+    width: 100%; border-collapse: collapse; font-size: 12px;
+  }
+  .mlcad-review-table th,
+  .mlcad-review-table td {
+    padding: 4px 8px; text-align: left;
+    border-bottom: 1px solid var(--mlcad-ui-border);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    max-width: 90px;
+  }
+  .mlcad-review-table tr.is-selected td {
+    background: rgba(26, 140, 255, 0.22);
+  }
+  .mlcad-review-table tr { cursor: pointer; }
+  .mlcad-review-empty td { text-align: center; color: var(--mlcad-ui-muted); cursor: default; }
+  .mlcad-review-detail {
+    flex: 0 1 auto;
+    max-height: 52%;
+    overflow: auto;
+    border-top: 1px solid var(--mlcad-ui-border);
+    padding: 8px 10px 14px;
+    display: flex; flex-direction: column; gap: 6px;
+    box-sizing: border-box;
+  }
+  .mlcad-review-detail[hidden] { display: none; }
+  .mlcad-review-detail-header {
+    display: flex; align-items: center; justify-content: space-between; gap: 4px;
+  }
+  .mlcad-review-detail-title { font-weight: 600; font-size: 12px; }
+  .mlcad-review-detail-close {
+    flex-shrink: 0;
+    width: 24px; height: 24px; padding: 0;
+    border: none; border-radius: 4px;
+    background: transparent; color: var(--mlcad-ui-muted);
+    cursor: pointer; font-size: 16px; line-height: 1;
+  }
+  .mlcad-review-detail-close:hover {
+    background: rgba(255, 255, 255, 0.08); color: var(--mlcad-ui-text);
+  }
+  .mlcad-review-field { display: flex; flex-direction: column; gap: 2px; }
+  .mlcad-review-field-label { font-size: 11px; color: var(--mlcad-ui-muted); }
+  .mlcad-review-status,
+  .mlcad-review-author,
+  .mlcad-review-text,
+  .mlcad-review-comment {
+    box-sizing: border-box; width: 100%;
+    padding: 4px 6px;
+    border: 1px solid var(--mlcad-ui-border);
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--mlcad-ui-text);
+    font-size: 12px;
+  }
+  .mlcad-review-author:disabled { opacity: 0.7; }
+  .mlcad-review-comment { min-height: 44px; resize: vertical; }
+  .mlcad-review-detail-actions { display: flex; gap: 6px; margin-top: 2px; }
+
   #mlcad-status-bar {
     position: absolute; left: 12px; right: 12px; bottom: 10px; z-index: var(--mlcad-z-chrome);
     display: flex; align-items: center; min-height: 28px; padding: 0 12px;
@@ -307,7 +409,8 @@ export const ACEX_HTML_SHELL_CSS = `
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-markup-strip-wrap,
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-zoom-strip-wrap,
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-locale-strip-wrap,
-  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-layer-drawer {
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-layer-drawer,
+  #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-review-drawer {
     display: none !important;
   }
   #mlcad-sidebar.mlcad-sidebar--collapsed #mlcad-toolbar .mlcad-tool-btn:not(#mlcad-toolbar-toggle) {
@@ -737,6 +840,9 @@ export const ACEX_HTML_SHELL_CSS = `
       margin-left: auto;
       max-width: calc(100vw - 2 * var(--mlcad-ui-inset) - var(--mlcad-toolbar-width) - var(--mlcad-drawer-gap));
     }
+    #mlcad-review-drawer {
+      max-width: calc(100vw - 2 * var(--mlcad-ui-inset) - var(--mlcad-toolbar-width) - var(--mlcad-drawer-gap));
+    }
     .mlcad-layer-action-btn {
       min-height: 28px;
       padding: 3px 6px;
@@ -867,6 +973,58 @@ export function buildAcExHtmlShellBody(
 
 function buildAcExToolbarSeparator(): string {
   return '<div class="mlcad-tool-separator" aria-hidden="true"></div>'
+}
+
+function buildAcExReviewDrawer(): string {
+  return `<div id="mlcad-review-drawer" role="dialog" data-i18n-attr="aria-label" data-i18n-key="review.title" aria-label="Review" hidden>
+        <div class="mlcad-drawer-header">
+          <span data-i18n-key="review.title" data-i18n-text>Review</span>
+          <button type="button" class="mlcad-drawer-close" id="mlcad-review-close" data-i18n-key="review.close" data-i18n-attr="aria-label" aria-label="Close review">×</button>
+        </div>
+        <div class="mlcad-review-toolbar">
+          <input type="search" class="mlcad-review-search" data-i18n-key="review.searchPlaceholder" data-i18n-attr="placeholder" placeholder="Search markups" />
+          <button type="button" class="mlcad-review-clear" data-i18n-key="review.clear" data-i18n-text>Clear all</button>
+        </div>
+        <div class="mlcad-review-table-wrap">
+          <table class="mlcad-review-table">
+            <thead>
+              <tr>
+                <th data-review-col="type" data-i18n-key="review.type" data-i18n-text>Type</th>
+                <th data-review-col="status" data-i18n-key="review.status" data-i18n-text>Status</th>
+                <th data-review-col="author" data-i18n-key="review.author" data-i18n-text>Author</th>
+                <th data-review-col="summary" data-i18n-key="review.summary" data-i18n-text>Summary</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div class="mlcad-review-detail" hidden>
+          <div class="mlcad-review-detail-header">
+            <div class="mlcad-review-detail-title" data-i18n-key="review.details" data-i18n-text>Details</div>
+            <button type="button" class="mlcad-review-detail-close" data-i18n-key="review.closeDetails" data-i18n-attr="title aria-label" title="Close details" aria-label="Close details">×</button>
+          </div>
+          <div class="mlcad-review-field">
+            <label class="mlcad-review-field-label" data-review-field="status" data-i18n-key="review.status" data-i18n-text>Status</label>
+            <select class="mlcad-review-status"></select>
+          </div>
+          <div class="mlcad-review-field">
+            <label class="mlcad-review-field-label" data-review-field="author" data-i18n-key="review.author" data-i18n-text>Author</label>
+            <input type="text" class="mlcad-review-author" disabled />
+          </div>
+          <div class="mlcad-review-field">
+            <label class="mlcad-review-field-label" data-review-field="label" data-i18n-key="review.label" data-i18n-text>Label</label>
+            <input type="text" class="mlcad-review-text" />
+          </div>
+          <div class="mlcad-review-field">
+            <label class="mlcad-review-field-label" data-review-field="comment" data-i18n-key="review.comment" data-i18n-text>Comment</label>
+            <textarea class="mlcad-review-comment" rows="2"></textarea>
+          </div>
+          <div class="mlcad-review-detail-actions">
+            <button type="button" class="mlcad-review-zoom" data-i18n-key="review.zoomTo" data-i18n-text>Zoom to</button>
+            <button type="button" class="mlcad-review-delete" data-i18n-key="review.delete" data-i18n-text>Delete</button>
+          </div>
+        </div>
+      </div>`
 }
 
 function buildAcExLayoutMenuButton(): string {
@@ -1051,6 +1209,12 @@ function buildAcExMarkupToolStrip(): string {
         'data-i18n-key': 'toolbar.markupStamp',
         'data-i18n-attr': 'title aria-label'
       })}
+      ${acExToolbarButton(acExHtmlIcons.markupPanel, 'Review', {
+        'data-action': 'markup-panel',
+        'aria-pressed': 'false',
+        'data-i18n-key': 'toolbar.markupPanel',
+        'data-i18n-attr': 'title aria-label'
+      })}
       ${acExToolbarButton(acExHtmlIcons.markupShow, 'Hide markups', {
         'data-action': 'markup-visibility',
         'data-i18n-key': 'toolbar.markupHide',
@@ -1073,6 +1237,7 @@ function buildAcExMarkupToolStrip(): string {
         'data-i18n-attr': 'title aria-label'
       })}
     </div>
+    ${buildAcExReviewDrawer()}
   </div>`
 }
 

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -23,6 +23,7 @@ import { acExHtmlIcons } from './AcExHtmlIcons'
 import { setupAcExHtmlLayoutMenu } from './AcExHtmlLayoutMenu'
 import { setupAcExHtmlMeasureSettings } from './AcExHtmlMeasureSettings'
 import { setupAcExHtmlNavTools } from './AcExHtmlNavTools'
+import { setupAcExHtmlReviewPanel } from './AcExHtmlReviewPanel'
 import {
   setAcExHtmlParentChildIcon,
   setupAcExHtmlToolbarFlyouts
@@ -738,7 +739,8 @@ async function startViewer(): Promise<void> {
         wcsToScreen,
         render,
         getSnapCacheKey: () => snapCacheKey,
-        resolvePoint: resolveMeasurePoint
+        resolvePoint: resolveMeasurePoint,
+        zoomToExtents
       }
     })
 
@@ -797,7 +799,20 @@ async function startViewer(): Promise<void> {
         ...paperLayerGroups.keys(),
         ...modelLayerGroups.keys()
       ])
-    ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true })),
+    closeOtherDrawers: () => reviewPanel?.close()
+  })
+
+  const reviewPanel = setupAcExHtmlReviewPanel({
+    i18n,
+    getMarkup: () => markup,
+    closeOtherDrawers: () => {
+      const layerDrawer = document.getElementById('mlcad-layer-drawer')
+      const layersBtn = document.getElementById('mlcad-layers-btn')
+      if (layerDrawer) layerDrawer.hidden = true
+      layersBtn?.classList.remove('active')
+      layersBtn?.setAttribute('aria-expanded', 'false')
+    }
   })
 
   const disposeObject3D = (object: THREE.Object3D) => {
@@ -968,6 +983,11 @@ async function startViewer(): Promise<void> {
       markup?.importSidecar()
     } else if (action === 'markup-export') {
       markup?.exportSidecar()
+    } else if (action === 'markup-panel') {
+      measure?.cancelMode()
+      markup?.cancelMode()
+      const drawer = document.getElementById('mlcad-review-drawer')
+      reviewPanel?.setOpen(Boolean(drawer?.hidden))
     } else if (action === 'measure') {
       markup?.cancelMode()
       const mode = button.getAttribute(
@@ -1056,6 +1076,7 @@ async function startViewer(): Promise<void> {
       markup?.refreshIdleStatus()
     }
     layerPanel?.refreshLayerLabels()
+    reviewPanel?.refreshLabels()
     measureSettingsRef.current?.refreshLabels()
     drawStyleToolbarRef.current?.refreshLabels()
     toolbarCollapse.refreshLabels()
@@ -1180,6 +1201,13 @@ function setupToolbarCollapse(
     layersBtn?.classList.remove('active')
     layersBtn?.setAttribute('aria-expanded', 'false')
 
+    const reviewDrawer = document.getElementById('mlcad-review-drawer')
+    if (reviewDrawer) reviewDrawer.hidden = true
+    document.querySelectorAll('[data-action="markup-panel"]').forEach(btn => {
+      btn.classList.remove('active')
+      btn.setAttribute('aria-pressed', 'false')
+    })
+
     closeStrips?.()
   }
 
@@ -1235,6 +1263,8 @@ interface AcExLayerPanelContext {
   osnapIndexes: AcExOsnapIndex[]
   /** Sorted layer names for bulk show/hide actions. */
   sortedLayerNames: string[]
+  /** Close the review drawer when the layer drawer opens. */
+  closeOtherDrawers?: () => void
 }
 
 /** Handles returned by {@link setupLayerPanel} for locale-driven UI updates. */
@@ -1259,7 +1289,8 @@ function setupLayerPanel(
     zoomToExtents,
     cancelZoomWindow,
     osnapIndexes,
-    sortedLayerNames
+    sortedLayerNames,
+    closeOtherDrawers
   } = ctx
 
   const layersBtn = document.getElementById('mlcad-layers-btn')
@@ -1365,6 +1396,7 @@ function setupLayerPanel(
   }
 
   const setDrawerOpen = (open: boolean) => {
+    if (open) closeOtherDrawers?.()
     layerDrawer.hidden = !open
     layersBtn.classList.toggle('active', open)
     layersBtn.setAttribute('aria-expanded', String(open))

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -22,6 +22,7 @@ import {
   acExIsAttachableShapeMarkup,
   acExMarkupCanvasLineWidth,
   acExMarkupCenter,
+  acExMarkupFocusExtents,
   type AcExMarkupShapeOutline,
   acExMarkupShapeOutlineFromGeometry,
   acExStrokeMarkupCloud,
@@ -45,11 +46,13 @@ import type {
   AcExMarkupPoint2d,
   AcExMarkupRecord,
   AcExMarkupSidecarFile,
+  AcExMarkupStatus,
   AcExMarkupStyle
 } from './AcExMarkupTypes'
 import type { AcExTrackingOptions } from './AcExMeasureTracking'
 import { constrainToAcExTracking } from './AcExMeasureTracking'
 import type { AcExOsnapPoint } from './AcExOsnap'
+import type { AcExExtents } from './AcExSnapshotTypes'
 
 export type { AcExMarkupMode } from './AcExMarkupTypes'
 
@@ -99,6 +102,8 @@ export interface AcExMarkupViewApi {
   render: () => void
   getSnapCacheKey: () => number
   resolvePoint: (clientX: number, clientY: number) => AcExResolvedPoint
+  /** Frames the camera on world XY extents (review-panel zoom-to). */
+  zoomToExtents: (extents: AcExExtents) => void
 }
 
 export interface AcExMarkupControllerOptions {
@@ -213,6 +218,7 @@ export class AcExMarkupController {
   private readonly _committed: AcExCommittedMarkup[] = []
   private readonly _redrawListeners: AcExMarkupCleanup[] = []
   private readonly _selectedIds = new Set<string>()
+  private readonly _recordListeners = new Set<() => void>()
 
   private _mode: AcExMarkupMode | null = null
   private _points: THREE.Vector2[] = []
@@ -486,6 +492,7 @@ export class AcExMarkupController {
     }
     this._updateIdleStatus()
     this._view.render()
+    this._notifyRecordsChanged()
   }
 
   setVisible(visible: boolean): void {
@@ -519,6 +526,7 @@ export class AcExMarkupController {
     if (selectionChanged) {
       this._applySelectionStyles()
       this._onStyleChange?.()
+      this._notifyRecordsChanged()
     }
   }
 
@@ -652,6 +660,98 @@ export class AcExMarkupController {
     this._onStyleChange?.()
     this._updateIdleStatus()
     this._view.render()
+    this._notifyRecordsChanged()
+  }
+
+  /** Committed markup records on the current drawing (all layouts). */
+  list(): AcExMarkupRecord[] {
+    return this._committed.map(item => item.record)
+  }
+
+  /** Currently selected markup id when exactly one item is selected. */
+  get selectedId(): string | undefined {
+    if (this._selectedIds.size !== 1) return undefined
+    return [...this._selectedIds][0]
+  }
+
+  /**
+   * Subscribe to list / selection changes for the review panel.
+   *
+   * @returns Unsubscriber.
+   */
+  subscribe(listener: () => void): () => void {
+    this._recordListeners.add(listener)
+    return () => {
+      this._recordListeners.delete(listener)
+    }
+  }
+
+  /**
+   * Select a markup from the review panel (replaces the current selection).
+   */
+  selectFromPanel(id: string): void {
+    this._selectOnly(id)
+  }
+
+  /**
+   * Zoom to the combined AABB of a markup (shape, leader, and HTML text box).
+   *
+   * @returns `true` when extents were applied.
+   */
+  focus(id: string): boolean {
+    const item = this._committed.find(entry => entry.record.id === id)
+    if (!item) return false
+    const rects = item.parts.dom
+      .filter(
+        el => !el.classList.contains('mlcad-markup-dot') && !el.hidden
+      )
+      .map(el => el.getBoundingClientRect())
+      .filter(rect => rect.width > 0 || rect.height > 0)
+    const extents = acExMarkupFocusExtents(
+      item.record.geometry,
+      rects,
+      (clientX, clientY) => this._clientToWorld(clientX, clientY)
+    )
+    if (!extents) return false
+    this._view.zoomToExtents(extents)
+    this._selectOnly(id)
+    return true
+  }
+
+  /**
+   * Patch review metadata (status / label / comment) for one markup.
+   */
+  updateMeta(
+    id: string,
+    patch: Partial<Pick<AcExMarkupRecord, 'comment' | 'status' | 'text'>>
+  ): void {
+    const item = this._committed.find(entry => entry.record.id === id)
+    if (!item) return
+    const next: AcExMarkupRecord = {
+      ...item.record,
+      ...patch,
+      updatedAt: markupNow()
+    }
+    if (patch.text !== undefined) {
+      this._rebuildRecord(next)
+    } else {
+      item.record.comment = next.comment
+      item.record.status = next.status as AcExMarkupStatus
+      item.record.updatedAt = next.updatedAt
+    }
+    this._notifyRecordsChanged()
+  }
+
+  /** Remove one committed markup. */
+  removeMarkup(id: string): void {
+    this._removeCommitted(id, true)
+    this._onStyleChange?.()
+    this._view.render()
+    this._notifyRecordsChanged()
+  }
+
+  private _notifyRecordsChanged(): void {
+    for (const listener of this._recordListeners) listener()
   }
 
   exportSidecar(): void {
@@ -686,6 +786,7 @@ export class AcExMarkupController {
     }
     this._updateIdleStatus()
     this._view.render()
+    this._notifyRecordsChanged()
   }
 
   private async _handleImportFile(): Promise<void> {
@@ -1071,6 +1172,7 @@ export class AcExMarkupController {
     this._buildVisuals(record, parts)
     this._positionDomOverlays()
     this.syncLayoutVisibility()
+    this._notifyRecordsChanged()
   }
 
   /**
@@ -1164,6 +1266,7 @@ export class AcExMarkupController {
     this._buildVisuals(record, parts)
     this._positionDomOverlays()
     this.syncLayoutVisibility()
+    this._notifyRecordsChanged()
   }
 
   private _buildVisuals(
@@ -1358,6 +1461,7 @@ export class AcExMarkupController {
             type: this._findRecord(id)?.type ?? 'markup'
           })
     this._view.render()
+    this._notifyRecordsChanged()
   }
 
   private _touchRecord(id: string): void {
@@ -1790,6 +1894,7 @@ export class AcExMarkupController {
       badge.textContent =
         next.trim() || this._i18n.t('status.markupDefaultLabel')
       this._view.render()
+      this._notifyRecordsChanged()
     })
   }
 
@@ -1911,6 +2016,7 @@ export class AcExMarkupController {
       this._updateIdleStatus()
       this._view.render()
     }
+    this._notifyRecordsChanged()
   }
 
   private _applySelectionStyles(): void {

--- a/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
@@ -11,6 +11,7 @@ import type {
   AcExMarkupPoint2d,
   AcExMarkupRecord
 } from './AcExMarkupTypes'
+import type { AcExExtents } from './AcExSnapshotTypes'
 
 /** Shape outline used to auto-place the leader tip on the perimeter. */
 export type AcExMarkupShapeOutline =
@@ -505,6 +506,125 @@ export function acExMarkupCenter(
     default:
       return null
   }
+}
+
+function expandExtents(
+  extents: AcExExtents | null,
+  point: AcExMarkupPoint2d
+): AcExExtents {
+  if (!extents) {
+    return { minX: point.x, minY: point.y, maxX: point.x, maxY: point.y }
+  }
+  return {
+    minX: Math.min(extents.minX, point.x),
+    minY: Math.min(extents.minY, point.y),
+    maxX: Math.max(extents.maxX, point.x),
+    maxY: Math.max(extents.maxY, point.y)
+  }
+}
+
+function expandExtentsByCallout(
+  extents: AcExExtents | null,
+  callout: AcExMarkupAttachedCallout | undefined
+): AcExExtents | null {
+  if (!callout) return extents
+  return expandExtents(expandExtents(extents, callout.tip), callout.anchor)
+}
+
+/**
+ * Axis-aligned world bounds of a markup's control geometry.
+ *
+ * Shapes include an attached callout tip and text-box anchor so zoom-to
+ * frames the leader together with the shape.
+ */
+export function acExMarkupBounds(
+  geometry: AcExMarkupGeometry
+): AcExExtents | null {
+  switch (geometry.type) {
+    case 'line':
+    case 'arrow':
+      return expandExtents(
+        expandExtents(null, geometry.start),
+        geometry.end
+      )
+    case 'rect':
+    case 'cloud':
+      return expandExtentsByCallout(
+        expandExtents(expandExtents(null, geometry.corner1), geometry.corner2),
+        geometry.callout
+      )
+    case 'highlight':
+      return expandExtents(
+        expandExtents(null, geometry.corner1),
+        geometry.corner2
+      )
+    case 'circle':
+      return expandExtentsByCallout(
+        expandExtents(
+          expandExtents(null, {
+            x: geometry.center.x - geometry.radius,
+            y: geometry.center.y - geometry.radius
+          }),
+          {
+            x: geometry.center.x + geometry.radius,
+            y: geometry.center.y + geometry.radius
+          }
+        ),
+        geometry.callout
+      )
+    case 'callout':
+      return expandExtents(expandExtents(null, geometry.tip), geometry.anchor)
+    case 'text':
+    case 'stamp':
+    case 'symbol':
+      return expandExtents(null, geometry.position)
+    default:
+      return null
+  }
+}
+
+/**
+ * Grow extents by overlay client rectangles converted to world space.
+ *
+ * Used so zoom-to includes HTML text boxes / badges / stamps.
+ */
+export function acExExpandExtentsByClientRects(
+  extents: AcExExtents | null,
+  rects: ReadonlyArray<{
+    left: number
+    top: number
+    right: number
+    bottom: number
+  }>,
+  clientToWorld: (clientX: number, clientY: number) => AcExMarkupPoint2d
+): AcExExtents | null {
+  let next = extents
+  for (const rect of rects) {
+    if (rect.right <= rect.left && rect.bottom <= rect.top) continue
+    next = expandExtents(next, clientToWorld(rect.left, rect.top))
+    next = expandExtents(next, clientToWorld(rect.right, rect.bottom))
+  }
+  return next
+}
+
+/**
+ * Combined zoom-to extents: control geometry plus overlay rectangles.
+ */
+export function acExMarkupFocusExtents(
+  geometry: AcExMarkupGeometry,
+  overlayRects: ReadonlyArray<{
+    left: number
+    top: number
+    right: number
+    bottom: number
+  }>,
+  clientToWorld: (clientX: number, clientY: number) => AcExMarkupPoint2d
+): AcExExtents | null {
+  return acExExpandExtentsByClientRects(
+    acExMarkupBounds(geometry),
+    overlayRects,
+    clientToWorld
+  )
 }
 
 function acExTranslatePoint(

--- a/packages/cad-simple-ui-plugin/__tests__/AcExReviewPaletteView.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcExReviewPaletteView.spec.ts
@@ -182,9 +182,12 @@ describe('AcExReviewPaletteView', () => {
     ).toBe(true)
 
     firstRow.click()
-    expect(
-      view.element.querySelector('.ml-ex-ui-review-detail')?.hasAttribute('hidden')
-    ).toBe(false)
+    expect(firstRow.isConnected).toBe(true)
+    firstRow.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+    expect(mockPresenter.focus).toHaveBeenCalledWith(
+      mockView,
+      expect.objectContaining({ id: 'cloud-1' })
+    )
 
     view.destroy()
   })

--- a/packages/cad-simple-ui-plugin/src/ui/AcExReviewPaletteView.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcExReviewPaletteView.ts
@@ -80,6 +80,8 @@ export class AcExReviewPaletteView {
   private selectedId: string | undefined
   /** Previous selected id used to commit drafts when switching rows. */
   private lastSelectedId: string | undefined
+  /** Last markup list signature used to avoid rebuilding rows on selection-only updates. */
+  private tableContentKey = ''
   /** Whether the details pane is visible. */
   private detailsOpen = true
   /** Unsubscribes from markup store changes. */
@@ -174,6 +176,16 @@ export class AcExReviewPaletteView {
     table.appendChild(thead)
 
     this.tbody = document.createElement('tbody')
+    this.tbody.addEventListener('click', event => {
+      const id = this.rowMarkupId(event)
+      if (id) this.handleRowClick(id)
+    })
+    this.tbody.addEventListener('dblclick', event => {
+      const id = this.rowMarkupId(event)
+      if (!id) return
+      const record = this.markups.find(markup => markup.id === id)
+      if (record) this.handleRowDblClick(record)
+    })
     table.appendChild(this.tbody)
     tableWrap.appendChild(table)
     this.element.appendChild(tableWrap)
@@ -313,9 +325,44 @@ export class AcExReviewPaletteView {
 
     this.lastSelectedId = this.selectedId
     this.clearButton.disabled = this.markups.length === 0
-    this.renderTable()
+    this.refreshTable()
     this.updateDetailFields({
       preserveDrafts: this.selectedId === prevId
+    })
+  }
+
+  /** Row markup id from a bubbled table event, if any. */
+  private rowMarkupId(event: Event): string | undefined {
+    const target = event.target
+    if (!(target instanceof Element)) return undefined
+    const row = target.closest('tr[data-markup-id]')
+    if (!row || !this.tbody.contains(row)) return undefined
+    return row instanceof HTMLElement ? row.dataset.markupId : undefined
+  }
+
+  /** Rebuilds rows only when markup list content changes; otherwise updates selection. */
+  private refreshTable() {
+    const key = this.markups
+      .map(
+        record =>
+          `${record.id}\t${record.type}\t${record.status}\t${record.author}\t${record.text ?? ''}\t${record.comment}`
+      )
+      .join('\n')
+    if (
+      key === this.tableContentKey &&
+      this.tbody.querySelector('tr[data-markup-id], .ml-ex-ui-review-empty-row')
+    ) {
+      this.syncRowSelection()
+      return
+    }
+    this.tableContentKey = key
+    this.renderTable()
+  }
+
+  /** Toggles `is-selected` on existing rows without replacing them. */
+  private syncRowSelection() {
+    this.tbody.querySelectorAll<HTMLTableRowElement>('tr[data-markup-id]').forEach(row => {
+      row.classList.toggle('is-selected', row.dataset.markupId === this.selectedId)
     })
   }
 
@@ -342,7 +389,6 @@ export class AcExReviewPaletteView {
       if (record.id === this.selectedId) {
         tr.classList.add('is-selected')
       }
-      tr.addEventListener('click', () => this.handleRowClick(record.id))
 
       const typeCell = document.createElement('td')
       typeCell.textContent = this.typeLabel(record.type)
@@ -417,6 +463,12 @@ export class AcExReviewPaletteView {
     // Re-open details even when the row is already selected: store.select is a
     // no-op for the same id, so syncFromStore will not run.
     this.updateDetailFields({ preserveDrafts: true })
+  }
+
+  /** Selects a markup, opens details, and zooms the view to it. */
+  private handleRowDblClick(record: AcApMarkupRecord) {
+    this.handleRowClick(record.id)
+    this.focusMarkup(record)
   }
 
   /** Commits drafts and hides the details pane. */

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -818,8 +818,16 @@ export function ensureUiStyles() {
 
     .ml-ex-ui-review-detail-actions {
       display: flex;
-      gap: 8px;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: center;
+      gap: 4px;
       margin-top: 4px;
+    }
+
+    .ml-ex-ui-review-detail-actions .ml-ex-ui-review-btn {
+      flex: 0 0 auto;
+      width: auto;
     }
 
     .ml-ex-ui-layer-list .ml-ex-ui-layer-table-wrap {

--- a/packages/cad-simple-viewer/__tests__/AcApMarkupGeometry.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupGeometry.spec.ts
@@ -1,4 +1,5 @@
 import {
+  expandMarkupBoundsByClientRects,
   hitTestMarkupGeometry,
   hitTestMarkupShapeOutline,
   isAttachableShapeMarkup,
@@ -198,5 +199,51 @@ describe('markupGeometryBounds', () => {
     expect(box!.min.y).toBe(-10)
     expect(box!.max.x).toBe(50)
     expect(box!.max.y).toBe(20)
+  })
+
+  it('unions a cloud AABB with its attached leader and text-box anchor', () => {
+    const box = markupGeometryBounds({
+      type: 'cloud',
+      corner1: { x: 0, y: 0 },
+      corner2: { x: 20, y: 10 },
+      callout: { tip: { x: 20, y: 5 }, anchor: { x: 80, y: 40 } }
+    })
+    expect(box).toBeDefined()
+    expect(box!.min.x).toBe(0)
+    expect(box!.min.y).toBe(0)
+    expect(box!.max.x).toBe(80)
+    expect(box!.max.y).toBe(40)
+  })
+
+  it('includes both callout leader tip and text-box anchor', () => {
+    const box = markupGeometryBounds({
+      type: 'callout',
+      tip: { x: 0, y: 0 },
+      anchor: { x: 100, y: -30 }
+    })
+    expect(box).toBeDefined()
+    expect(box!.min.x).toBe(0)
+    expect(box!.min.y).toBe(-30)
+    expect(box!.max.x).toBe(100)
+    expect(box!.max.y).toBe(0)
+  })
+})
+
+describe('expandMarkupBoundsByClientRects', () => {
+  it('unions overlay client rectangles converted to world space', () => {
+    const box = markupGeometryBounds({
+      type: 'callout',
+      tip: { x: 0, y: 0 },
+      anchor: { x: 10, y: 0 }
+    })!
+    expandMarkupBoundsByClientRects(
+      box,
+      [{ left: 100, top: 20, right: 180, bottom: 60 }],
+      (clientX, clientY) => ({ x: clientX / 10, y: -clientY / 10 })
+    )
+    expect(box.min.x).toBe(0)
+    expect(box.min.y).toBe(-6)
+    expect(box.max.x).toBe(18)
+    expect(box.max.y).toBe(0)
   })
 })

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupGeometry.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupGeometry.ts
@@ -192,10 +192,38 @@ function expandAttachedCallout(
 }
 
 /**
+ * Grow `box` by the world-space corners of overlay client rectangles.
+ *
+ * Used so zoom-to includes HTML text boxes / badges / stamps whose size is
+ * screen-space, not just geometry control points.
+ *
+ * @param box - World AABB to expand in place.
+ * @param rects - Overlay `getBoundingClientRect()` results.
+ * @param clientToWorld - Converts viewport/client pixels to world XY.
+ */
+export function expandMarkupBoundsByClientRects(
+  box: AcGeBox2d,
+  rects: ReadonlyArray<{
+    left: number
+    top: number
+    right: number
+    bottom: number
+  }>,
+  clientToWorld: (clientX: number, clientY: number) => AcApMarkupPoint2d
+): void {
+  for (const rect of rects) {
+    if (rect.right <= rect.left && rect.bottom <= rect.top) continue
+    box.expandByPoint(clientToWorld(rect.left, rect.top))
+    box.expandByPoint(clientToWorld(rect.right, rect.bottom))
+  }
+}
+
+/**
  * Axis-aligned world bounds of a markup's control geometry.
  *
- * Used for window / crossing box selection. Point-like markups (text / stamp /
- * symbol) use their anchor; shapes include attached callout tip and anchor.
+ * Used for window / crossing box selection and zoom-to. Point-like markups
+ * (text / stamp / symbol) use their anchor; shapes include attached callout
+ * tip and anchor so leaders are part of the same box as the shape.
  */
 export function markupGeometryBounds(
   geometry: AcApMarkupGeometry

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
@@ -1,9 +1,13 @@
-import { AcGeBox2d, type AcGePoint3dLike } from '@mlightcad/data-model'
+import { AcGeBox2d } from '@mlightcad/data-model'
 
 import type { AcEdBaseView } from '../../editor'
 import { acapNotifyUndoStackChanged } from '../../util/AcApDatabaseEdit'
 import type { AcTrView2d } from '../../view'
-import { isAttachableShapeMarkup } from './AcApMarkupGeometry'
+import {
+  expandMarkupBoundsByClientRects,
+  isAttachableShapeMarkup,
+  markupGeometryBounds
+} from './AcApMarkupGeometry'
 import {
   getMarkupHistory,
   getSessionUndo,
@@ -222,20 +226,51 @@ export class AcApMarkupPresenter {
     getMarkupStore().setSelectedId(id)
   }
 
-  /** Zoom roughly to a markup's primary world point. */
+  /**
+   * Zoom to the combined world AABB of a markup: shape, leader, and published
+   * HTML overlays (text box / badge / stamp).
+   */
   focus(view: AcEdBaseView, record: AcApMarkupRecord): void {
-    const p = createMarkupEntityFromRecord(record).primaryPoint() as
-      | AcGePoint3dLike
-      | undefined
-    if (!p) return
-    const view2d = asView2d(view)
-    const pad = 50
-    const box = new AcGeBox2d()
-      .expandByPoint({ x: p.x - pad, y: p.y - pad })
-      .expandByPoint({ x: p.x + pad, y: p.y + pad })
-    view2d.zoomTo(box, 1.5)
+    const box = markupFocusExtents(view, record)
+    if (!box) return
+    asView2d(view).zoomTo(box, 1.5)
     this.select(view, record.id)
   }
+}
+
+/**
+ * Combined zoom-to box for a markup: control geometry plus HTML text boxes.
+ *
+ * Grip dots are omitted; they sit on geometry already included in the AABB.
+ *
+ * @param view - View used for overlay lookup and client → world conversion.
+ * @param record - Markup whose shape, leader, and overlays are framed.
+ * @returns World AABB, or `undefined` when the markup has no finite bounds.
+ */
+export function markupFocusExtents(
+  view: AcEdBaseView,
+  record: AcApMarkupRecord
+): AcGeBox2d | undefined {
+  const geometryBox = markupGeometryBounds(record.geometry)
+  const box = geometryBox
+    ? new AcGeBox2d(geometryBox.min, geometryBox.max)
+    : new AcGeBox2d()
+  const group = asView2d(view).htmlTransientManager.getGroup(record.id)
+  if (group) {
+    const rects = []
+    for (const child of group.children) {
+      const el = child.element
+      if (el.classList.contains('ml-html-dot')) continue
+      const rect = el.getBoundingClientRect()
+      if (rect.width <= 0 && rect.height <= 0) continue
+      rects.push(rect)
+    }
+    expandMarkupBoundsByClientRects(box, rects, (clientX, clientY) => {
+      const canvas = view.viewportToCanvas({ x: clientX, y: clientY })
+      return view.screenToWorld(canvas)
+    })
+  }
+  return box.isEmpty() ? undefined : box
 }
 
 /** Shared presenter for the active viewer session. */

--- a/packages/cad-viewer-example/package.json
+++ b/packages/cad-viewer-example/package.json
@@ -15,6 +15,7 @@
     "copy:workers": "node ../../tools/copy-workers.mjs dist/assets",
     "dev": "vite",
     "dev:local-data-model": "vite --mode local-data-model",
+    "dev:local-ui-components": "vite --mode local-ui-components",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",

--- a/packages/cad-viewer-example/vite.config.ts
+++ b/packages/cad-viewer-example/vite.config.ts
@@ -30,12 +30,23 @@ const LOCAL_UI_COMPONENTS_ROOT = resolve(
   '../../../ui-components'
 )
 
-function useLocalDataModel(mode: string): boolean {
-  if (mode === 'local-data-model') {
-    return true
-  }
-  const flag = process.env.CAD_VIEWER_USE_LOCAL_DATA_MODEL
+function isEnvFlagEnabled(name: string): boolean {
+  const flag = process.env[name]
   return flag === '1' || flag?.toLowerCase() === 'true'
+}
+
+function useLocalDataModel(mode: string): boolean {
+  return (
+    mode === 'local-data-model' ||
+    isEnvFlagEnabled('CAD_VIEWER_USE_LOCAL_DATA_MODEL')
+  )
+}
+
+function useLocalUiComponents(mode: string): boolean {
+  return (
+    mode === 'local-ui-components' ||
+    isEnvFlagEnabled('CAD_VIEWER_USE_LOCAL_UI_COMPONENTS')
+  )
 }
 
 export default defineConfig(({ command, mode }) => {
@@ -58,7 +69,9 @@ export default defineConfig(({ command, mode }) => {
     useLocalDataModel(mode) &&
     existsSync(LOCAL_DATA_MODEL_ENTRY)
   const linkLocalUiComponents =
-    command === 'serve' && existsSync(LOCAL_UI_COMPONENTS_SRC)
+    command === 'serve' &&
+    useLocalUiComponents(mode) &&
+    existsSync(LOCAL_UI_COMPONENTS_SRC)
   if (command === 'serve') {
     aliases.push({
       find: /^@mlightcad\/(cad-svg-plugin|three-renderer|cad-simple-viewer|cad-viewer)$/,
@@ -84,6 +97,14 @@ export default defineConfig(({ command, mode }) => {
         find: '@mlightcad/ui-components',
         replacement: LOCAL_UI_COMPONENTS_SRC
       })
+    } else if (
+      useLocalUiComponents(mode) &&
+      !existsSync(LOCAL_UI_COMPONENTS_SRC)
+    ) {
+      console.warn(
+        '[cad-viewer-example] Local ui-components alias requested but not found at:',
+        LOCAL_UI_COMPONENTS_SRC
+      )
     }
   }
 

--- a/packages/cad-viewer/src/component/palette/MlDesignReviewPalette.vue
+++ b/packages/cad-viewer/src/component/palette/MlDesignReviewPalette.vue
@@ -27,6 +27,7 @@
       row-key="id"
       :empty-text="t('main.toolPalette.designReview.empty')"
       @row-click="handleRowClick"
+      @row-dblclick="handleRowDblClick"
     >
       <el-table-column
         prop="type"
@@ -119,7 +120,10 @@
 
 <script setup lang="ts">
 import { Close } from '@element-plus/icons-vue'
-import type { AcApMarkupStatus } from '@mlightcad/cad-simple-viewer'
+import type {
+  AcApMarkupRecord,
+  AcApMarkupStatus
+} from '@mlightcad/cad-simple-viewer'
 import {
   ElButton,
   ElForm,
@@ -190,6 +194,11 @@ watch(
 const handleRowClick = (row: { id: string }) => {
   detailsOpen.value = true
   select(row.id)
+}
+
+const handleRowDblClick = (row: AcApMarkupRecord) => {
+  detailsOpen.value = true
+  focus(row)
 }
 
 const closeDetails = () => {
@@ -315,7 +324,14 @@ const statusLabel = (status: AcApMarkupStatus) => {
 
 .ml-design-review-detail-actions {
   display: flex;
-  gap: 8px;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 4px;
   margin-top: 4px;
+}
+
+.ml-design-review-detail-actions :deep(.el-button + .el-button) {
+  margin-left: 0;
 }
 </style>


### PR DESCRIPTION
## Summary
- Add a Review drawer to the offline HTML viewer so markups can be searched, selected, edited, zoomed, and deleted like the in-app review palette.
- Frame zoom-to around the full markup (shape, leader, and HTML text overlays) in both the HTML viewer and cad-simple-viewer.
- Notify the review panel when a layout switch clears selection, so stale row highlight and detail edits cannot linger.
- Opt local `ui-components` linking in cad-viewer-example behind `dev:local-ui-components` / `CAD_VIEWER_USE_LOCAL_UI_COMPONENTS`.

## Test plan
- [ ] Export an HTML viewer in measure mode, open the Review drawer, and confirm the table lists markups with search, detail edit, zoom-to, delete, and clear-all.
- [ ] Select a markup, switch to another layout, and confirm the review row highlight and detail pane clear (and detail edits no longer apply to the old selection).
- [ ] Zoom to a text/callout markup and confirm the camera frames the HTML text box, not just the geometry origin.
- [ ] Confirm Review and Layers drawers are mutually exclusive.
- [ ] Confirm `pnpm exec jest` for AcExHtmlShell, AcExHtmlI18n, AcExMarkupGeometry, and AcApMarkupGeometry still pass.