### PR TITLE
refactor: rename simple UI plugin AcEx types to AcUi

### DIFF
--- a/packages/cad-simple-ui-plugin/README.md
+++ b/packages/cad-simple-ui-plugin/README.md
@@ -33,7 +33,7 @@ Load the plugin after creating the document manager. Apply the initial UI theme 
 
 ```typescript
 import { AcApDocManager, acedApplyUiTheme } from '@mlightcad/cad-simple-viewer'
-import { createSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
+import { acuiCreateSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
 
 const host = document.getElementById('viewer-host')!
 
@@ -42,7 +42,7 @@ acedApplyUiTheme('dark', host)
 AcApDocManager.createInstance({ container: host })
 
 await AcApDocManager.instance.pluginManager.loadPlugin(
-  createSimpleUiPlugin({
+  acuiCreateSimpleUiPlugin({
     host,
     toolbar: {
       placement: 'right',
@@ -57,9 +57,9 @@ await AcApDocManager.instance.pluginManager.loadPlugin(
 Import from `@mlightcad/cad-simple-ui-plugin/register` so the main plugin bundle is loaded only when you register it:
 
 ```typescript
-import { registerSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin/register'
+import { acuiRegisterSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin/register'
 
-await registerSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
+await acuiRegisterSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
   host,
   toolbar: { placement: 'right', items: 'default' }
 })
@@ -70,7 +70,7 @@ await registerSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
 The [vanilla example](../cad-simple-viewer-example) **defers viewer and plugin initialization until the user opens a file** (local upload or predefined sample). That keeps the first paint lightweight:
 
 1. Page load — only file picker UI; no `AcApDocManager` yet.
-2. First open — `acedApplyUiTheme`, `AcApDocManager.createInstance`, lazy export plugins, then `registerSimpleUiPlugin`.
+2. First open — `acedApplyUiTheme`, `AcApDocManager.createInstance`, lazy export plugins, then `acuiRegisterSimpleUiPlugin`.
 3. Subsequent opens — reuse the same viewer instance.
 
 You can adopt the same pattern or load the plugin at startup (see Quick start above). Both are supported.
@@ -114,7 +114,7 @@ The built-in theme toggle button updates `COLORTHEME` when a document is open, o
 The layer list is enabled automatically when the resolved toolbar includes a layer button (`id: 'layer'` or `{ preset: 'layer' }`). Layers always render as a tab in the dock panel.
 
 ```typescript
-createSimpleUiPlugin({
+acuiCreateSimpleUiPlugin({
   host,
   dockPanel: {
     defaultSide: 'left', // 'top' | 'bottom' | 'left' | 'right' (default: 'left')
@@ -155,7 +155,7 @@ plugin.setDockPanelSize(320)
 You can enable an empty dock panel for future tabs without a layer button:
 
 ```typescript
-createSimpleUiPlugin({
+acuiCreateSimpleUiPlugin({
   host,
   dockPanel: { enabled: true }
 })
@@ -168,10 +168,10 @@ The built-in `layerclose` command emits `close-layer-manager`, which the plugin 
 The review palette is enabled automatically when the resolved toolbar includes the Review button (`id: 'markup-panel'`, included in the default `annotation` preset). It lists HTML markups from `getMarkupStore()` and supports the same workflow as cad-viewer's Vue review palette: search, clear all, select a row, edit status/label/comment, zoom to, and delete.
 
 ```typescript
-createSimpleUiPlugin({
+acuiCreateSimpleUiPlugin({
   host,
   toolbar: {
-    items: [toolbarPreset('annotation')]
+    items: [acuiToolbarPreset('annotation')]
   }
 })
 ```
@@ -208,8 +208,8 @@ Use `appendItems` only when you want to keep the built-in default and add a few 
 import {
   SIMPLE_UI_PLUGIN_NAME,
   type AcApSimpleUiPlugin,
-  createToolbarLayoutSwitcher,
-  toolbarPreset
+  acuiCreateToolbarLayoutSwitcher,
+  acuiToolbarPreset
 } from '@mlightcad/cad-simple-ui-plugin'
 
 const plugin = docManager.pluginManager.getPlugin(
@@ -217,18 +217,18 @@ const plugin = docManager.pluginManager.getPlugin(
 ) as AcApSimpleUiPlugin
 
 plugin.setToolbarItems([
-  toolbarPreset('select'),
-  toolbarPreset('pan'),
-  toolbarPreset('layer')
+  acuiToolbarPreset('select'),
+  acuiToolbarPreset('pan'),
+  acuiToolbarPreset('layer')
 ])
 
 // Optional: prepend a submenu button that switches between full layouts
 plugin.setToolbarItems(
   [
-    toolbarPreset('select'),
+    acuiToolbarPreset('select'),
     { id: 'line', label: 'Line', command: 'line', requiresDocument: true }
   ],
-  createToolbarLayoutSwitcher({
+  acuiCreateToolbarLayoutSwitcher({
     presets: [
       { id: 'view', label: 'View tools' },
       { id: 'draw', label: 'Draw tools' }
@@ -239,9 +239,9 @@ plugin.setToolbarItems(
 )
 ```
 
-See `cad-simple-viewer-example` (`demoToolbarPresets.ts`) for a working layout switcher prepended to the **viewer toolbar** (via `createToolbarLayoutSwitcher` + `setToolbarItems`). The example dev toolbar also includes a layout dropdown that calls the same preset helpers.
+See `cad-simple-viewer-example` (`demoToolbarPresets.ts`) for a working layout switcher prepended to the **viewer toolbar** (via `acuiCreateToolbarLayoutSwitcher` + `setToolbarItems`). The example dev toolbar also includes a layout dropdown that calls the same preset helpers.
 
-### `AcExToolbarItem` fields
+### `AcUiToolbarItem` fields
 
 | Field | Description |
 |-------|-------------|
@@ -270,9 +270,9 @@ Keep all predefined buttons and append your own at the end:
 
 ```typescript
 import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
-import { createSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
+import { acuiCreateSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
 
-createSimpleUiPlugin({
+acuiCreateSimpleUiPlugin({
   toolbar: {
     placement: 'right',
     items: 'default',
@@ -294,25 +294,25 @@ Pick built-in buttons by id and group them with separators — no need to duplic
 
 ```typescript
 import {
-  createSimpleUiPlugin,
-  createToolbarSeparator,
-  toolbarPreset
+  acuiCreateSimpleUiPlugin,
+  acuiCreateToolbarSeparator,
+  acuiToolbarPreset
 } from '@mlightcad/cad-simple-ui-plugin'
 
-createSimpleUiPlugin({
+acuiCreateSimpleUiPlugin({
   toolbar: {
     placement: 'right',
     items: [
-      toolbarPreset('select'),
-      toolbarPreset('pan'),
-      toolbarPreset('zoom-extent'),
-      createToolbarSeparator('sep-tools'),
-      toolbarPreset('layer'),
-      toolbarPreset('measure'),
-      createToolbarSeparator('sep-settings'),
-      toolbarPreset('switch-bg'),
-      toolbarPreset('theme'),
-      toolbarPreset('locale')
+      acuiToolbarPreset('select'),
+      acuiToolbarPreset('pan'),
+      acuiToolbarPreset('zoom-extent'),
+      acuiCreateToolbarSeparator('sep-tools'),
+      acuiToolbarPreset('layer'),
+      acuiToolbarPreset('measure'),
+      acuiCreateToolbarSeparator('sep-settings'),
+      acuiToolbarPreset('switch-bg'),
+      acuiToolbarPreset('theme'),
+      acuiToolbarPreset('locale')
     ]
   }
 })
@@ -334,7 +334,7 @@ items: [
 Replace the default set with your own list:
 
 ```typescript
-createSimpleUiPlugin({
+acuiCreateSimpleUiPlugin({
   toolbar: {
     placement: 'top',
     items: [
@@ -466,7 +466,7 @@ Submenu flyout direction follows toolbar placement (e.g. arrow points left when 
 ### 9. Disable toolbar
 
 ```typescript
-createSimpleUiPlugin({
+acuiCreateSimpleUiPlugin({
   toolbar: { enabled: false }
 })
 ```
@@ -477,7 +477,7 @@ Disabling the toolbar also disables the layer dock UI, because the layer list is
 
 ```typescript
 import { AcApDocManager, AcEdOpenMode, acedApplyUiTheme } from '@mlightcad/cad-simple-viewer'
-import { createSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
+import { acuiCreateSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin'
 
 const viewerPane = document.getElementById('viewerPane')!
 
@@ -486,7 +486,7 @@ acedApplyUiTheme('dark', viewerPane)
 AcApDocManager.createInstance({ container: document.getElementById('cad-container')! })
 
 await AcApDocManager.instance.pluginManager.loadPlugin(
-  createSimpleUiPlugin({
+  acuiCreateSimpleUiPlugin({
     host: viewerPane,
     toolbar: {
       placement: 'right',
@@ -531,8 +531,8 @@ To use the layer UI in a custom toolbar, include the built-in preset or a button
 
 ```typescript
 items: [
-  toolbarPreset('select'),
-  toolbarPreset('layer')
+  acuiToolbarPreset('select'),
+  acuiToolbarPreset('layer')
 ]
 ```
 
@@ -542,19 +542,19 @@ Omit the layer button from `items` if you do not want the layer dock UI or `laye
 
 | Export | Description |
 |--------|-------------|
-| `createSimpleUiPlugin(options)` | Returns an `AcApPlugin` instance |
-| `registerSimpleUiPlugin(pluginManager, options)` | Eager-load helper |
+| `acuiCreateSimpleUiPlugin(options)` | Returns an `AcApPlugin` instance |
+| `acuiRegisterSimpleUiPlugin(pluginManager, options)` | Eager-load helper |
 | `AcApLayerStore` | Document-scoped layer observer and UI mutations |
-| `AcExSimpleUiPluginOptions` | Plugin configuration type |
-| `AcExToolbarItem` | Single toolbar button definition |
-| `AcExToolbarChildrenUi` | `'menu' \| 'toolbar' \| 'sticky-toolbar'` |
-| `AcExToolbarItemConfig` | Button, separator, or preset reference in toolbar config |
-| `createToolbarSeparator(id?)` | Helper that creates a separator entry |
-| `toolbarPreset(id)` | Helper that references a built-in button |
-| `createDefaultToolbarPresetMap()` | Built-in items keyed by id (advanced use) |
-| `AcExToolbarPlacement` | `'top' \| 'bottom' \| 'left' \| 'right'` |
+| `AcUiSimpleUiPluginOptions` | Plugin configuration type |
+| `AcUiToolbarItem` | Single toolbar button definition |
+| `AcUiToolbarChildrenUi` | `'menu' \| 'toolbar' \| 'sticky-toolbar'` |
+| `AcUiToolbarItemConfig` | Button, separator, or preset reference in toolbar config |
+| `acuiCreateToolbarSeparator(id?)` | Helper that creates a separator entry |
+| `acuiToolbarPreset(id)` | Helper that references a built-in button |
+| `acuiCreateDefaultToolbarPresetMap()` | Built-in items keyed by id (advanced use) |
+| `AcUiToolbarPlacement` | `'top' \| 'bottom' \| 'left' \| 'right'` |
 
 ## See also
 
-- [cad-simple-viewer-example](../cad-simple-viewer-example) — vanilla TypeScript demo (lazy init on first file open; uses `registerSimpleUiPlugin`)
+- [cad-simple-viewer-example](../cad-simple-viewer-example) — vanilla TypeScript demo (lazy init on first file open; uses `acuiRegisterSimpleUiPlugin`)
 - [cad-viewer](../cad-viewer) — full Vue + Element Plus application shell

--- a/packages/cad-simple-ui-plugin/__tests__/AcUiDockPanel.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcUiDockPanel.spec.ts
@@ -2,8 +2,8 @@
 
 import { ML_UI_MOBILE_MEDIA_QUERY } from '@mlightcad/cad-simple-viewer'
 
-import { AcExI18n, registerSimpleUiI18n } from '../src/i18n'
-import { AcExDockPanel } from '../src/ui/AcExDockPanel'
+import { AcUiI18n, acuiRegisterSimpleUiI18n } from '../src/i18n'
+import { AcUiDockPanel } from '../src/ui/AcUiDockPanel'
 
 class ResizeObserverMock {
   observe() {}
@@ -41,15 +41,15 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
 })
 
 function createPanel(
-  options?: Partial<ConstructorParameters<typeof AcExDockPanel>[0]>
+  options?: Partial<ConstructorParameters<typeof AcUiDockPanel>[0]>
 ) {
-  registerSimpleUiI18n()
+  acuiRegisterSimpleUiI18n()
   const host = document.createElement('div')
   document.body.appendChild(host)
 
-  const panel = new AcExDockPanel({
+  const panel = new AcUiDockPanel({
     host,
-    i18n: new AcExI18n(),
+    i18n: new AcUiI18n(),
     defaultSide: 'left',
     defaultOpen: false,
     defaultHeight: 240,
@@ -66,7 +66,7 @@ function createTabContent(label = 'content') {
   return content
 }
 
-describe('AcExDockPanel', () => {
+describe('AcUiDockPanel', () => {
   afterEach(() => {
     document.body.replaceChildren()
     document.getElementById('ml-ex-ui-styles')?.remove()
@@ -282,10 +282,10 @@ describe('AcExDockPanel', () => {
     host.appendChild(canvasParent)
     document.body.appendChild(host)
 
-    registerSimpleUiI18n()
-    const panel = new AcExDockPanel({
+    acuiRegisterSimpleUiI18n()
+    const panel = new AcUiDockPanel({
       host,
-      i18n: new AcExI18n(),
+      i18n: new AcUiI18n(),
       defaultSide: 'left',
       defaultOpen: false
     })
@@ -307,10 +307,10 @@ describe('AcExDockPanel', () => {
     host.appendChild(canvasParent)
     document.body.appendChild(host)
 
-    registerSimpleUiI18n()
-    const panel = new AcExDockPanel({
+    acuiRegisterSimpleUiI18n()
+    const panel = new AcUiDockPanel({
       host,
-      i18n: new AcExI18n(),
+      i18n: new AcUiI18n(),
       defaultSide: 'left',
       defaultOpen: false
     })
@@ -330,10 +330,10 @@ describe('AcExDockPanel', () => {
     const host = document.createElement('div')
     document.body.appendChild(host)
 
-    registerSimpleUiI18n()
-    const panel = new AcExDockPanel({
+    acuiRegisterSimpleUiI18n()
+    const panel = new AcUiDockPanel({
       host,
-      i18n: new AcExI18n(),
+      i18n: new AcUiI18n(),
       defaultSide: 'left',
       defaultOpen: false
     })
@@ -365,10 +365,10 @@ describe('AcExDockPanel', () => {
     const host = document.createElement('div')
     document.body.appendChild(host)
 
-    registerSimpleUiI18n()
-    const panel = new AcExDockPanel({
+    acuiRegisterSimpleUiI18n()
+    const panel = new AcUiDockPanel({
       host,
-      i18n: new AcExI18n(),
+      i18n: new AcUiI18n(),
       defaultSide: 'left',
       defaultOpen: false
     })

--- a/packages/cad-simple-ui-plugin/__tests__/AcUiLayerListView.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcUiLayerListView.spec.ts
@@ -78,27 +78,27 @@ jest.mock('@mlightcad/data-model', () => ({
   }
 }))
 
-import { AcExI18n, registerSimpleUiI18n } from '../src/i18n'
-import { AcExLayerListView } from '../src/ui/AcExLayerListView'
+import { AcUiI18n, acuiRegisterSimpleUiI18n } from '../src/i18n'
+import { AcUiLayerListView } from '../src/ui/AcUiLayerListView'
 
 function createView() {
-  registerSimpleUiI18n()
+  acuiRegisterSimpleUiI18n()
   const host = document.createElement('div')
   document.body.appendChild(host)
-  return new AcExLayerListView({
+  return new AcUiLayerListView({
     editor: editor as never,
-    i18n: new AcExI18n(),
+    i18n: new AcUiI18n(),
     host
   })
 }
 
-function getLayerNames(view: AcExLayerListView) {
+function getLayerNames(view: AcUiLayerListView) {
   return Array.from(
     view.element.querySelectorAll('.ml-ex-ui-layer-name')
   ).map(el => el.textContent?.replace(/\*$/, '') ?? '')
 }
 
-describe('AcExLayerListView', () => {
+describe('AcUiLayerListView', () => {
   afterEach(() => {
     document.body.replaceChildren()
     document.getElementById('ml-ex-ui-styles')?.remove()

--- a/packages/cad-simple-ui-plugin/__tests__/AcUiReviewPaletteView.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcUiReviewPaletteView.spec.ts
@@ -74,8 +74,8 @@ jest.mock('@mlightcad/cad-simple-viewer', () => ({
 
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 
-import { AcExI18n, registerSimpleUiI18n } from '../src/i18n'
-import { AcExReviewPaletteView } from '../src/ui/AcExReviewPaletteView'
+import { AcUiI18n, acuiRegisterSimpleUiI18n } from '../src/i18n'
+import { AcUiReviewPaletteView } from '../src/ui/AcUiReviewPaletteView'
 
 function createRecord(
   overrides: Partial<AcApMarkupRecord> & Pick<AcApMarkupRecord, 'id' | 'type'>
@@ -93,14 +93,14 @@ function createRecord(
 }
 
 function createView() {
-  registerSimpleUiI18n()
-  return new AcExReviewPaletteView({
+  acuiRegisterSimpleUiI18n()
+  return new AcUiReviewPaletteView({
     editor: AcApDocManager.instance,
-    i18n: new AcExI18n()
+    i18n: new AcUiI18n()
   })
 }
 
-describe('AcExReviewPaletteView', () => {
+describe('AcUiReviewPaletteView', () => {
   beforeEach(() => {
     records.length = 0
     selectedId = undefined

--- a/packages/cad-simple-ui-plugin/__tests__/AcUiToolbar.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcUiToolbar.spec.ts
@@ -51,27 +51,27 @@ jest.mock('@mlightcad/data-model', () => ({
   })
 }))
 
-import type { AcExToolbarItem } from '../src/config/types'
-import { AcExI18n } from '../src/i18n'
-import { AcExToolbar } from '../src/ui/AcExToolbar'
+import type { AcUiToolbarItem } from '../src/config/types'
+import { AcUiI18n } from '../src/i18n'
+import { AcUiToolbar } from '../src/ui/AcUiToolbar'
 
-function createToolbar(items: AcExToolbarItem[]) {
+function createToolbar(items: AcUiToolbarItem[]) {
   const host = document.createElement('div')
   Object.defineProperty(host, 'clientWidth', { value: 800 })
   Object.defineProperty(host, 'clientHeight', { value: 600 })
   document.body.appendChild(host)
   const onCommand = jest.fn()
-  const toolbar = new AcExToolbar({
+  const toolbar = new AcUiToolbar({
     host,
     placement: 'right',
     items,
-    i18n: new AcExI18n(),
+    i18n: new AcUiI18n(),
     onCommand
   })
   return { host, toolbar, onCommand }
 }
 
-describe('AcExToolbar children UI', () => {
+describe('AcUiToolbar children UI', () => {
   afterEach(() => {
     document.body.replaceChildren()
     document.getElementById('ml-ex-ui-styles')?.remove()
@@ -167,7 +167,7 @@ describe('AcExToolbar children UI', () => {
 
   it('opens a popover menu for live children getters', () => {
     const onSelect = jest.fn()
-    const item: AcExToolbarItem = {
+    const item: AcUiToolbarItem = {
       id: 'layout',
       label: 'Layout',
       childrenUi: 'menu',

--- a/packages/cad-simple-ui-plugin/__tests__/createLayoutToolbarItem.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/createLayoutToolbarItem.spec.ts
@@ -50,21 +50,21 @@ jest.mock('@mlightcad/data-model', () => ({
 }))
 
 import {
-  createLayoutToolbarChildren,
-  createLayoutToolbarItem,
-  listDocumentLayouts,
-  switchCurrentLayout
+  acuiCreateLayoutToolbarChildren,
+  acuiCreateLayoutToolbarItem,
+  acuiListDocumentLayouts,
+  acuiSwitchCurrentLayout
 } from '../src/config/createLayoutToolbarItem'
-import { isDynamicToolbarChildren } from '../src/config/toolbarItemUtils'
+import { acuiIsDynamicToolbarChildren } from '../src/config/toolbarItemUtils'
 
-describe('createLayoutToolbarItem', () => {
+describe('acuiCreateLayoutToolbarItem', () => {
   beforeEach(() => {
     currentSpaceId = 'btr-model'
     mockSetCurrentLayoutBtrId.mockReset()
   })
 
   it('lists layouts including model space ordered by tabOrder', () => {
-    expect(listDocumentLayouts().map(layout => layout.name)).toEqual([
+    expect(acuiListDocumentLayouts().map(layout => layout.name)).toEqual([
       'Model',
       'Layout2',
       'Layout1'
@@ -73,7 +73,7 @@ describe('createLayoutToolbarItem', () => {
 
   it('marks the current space as active', () => {
     currentSpaceId = 'btr-layout2'
-    const active = listDocumentLayouts().filter(layout => layout.isActive)
+    const active = acuiListDocumentLayouts().filter(layout => layout.isActive)
     expect(active).toEqual([
       expect.objectContaining({
         name: 'Layout2',
@@ -83,10 +83,10 @@ describe('createLayoutToolbarItem', () => {
   })
 
   it('creates a menu parent with a live children getter', () => {
-    const item = createLayoutToolbarItem()
+    const item = acuiCreateLayoutToolbarItem()
     expect(item.id).toBe('layout')
     expect(item.childrenUi).toBe('menu')
-    expect(isDynamicToolbarChildren(item)).toBe(true)
+    expect(acuiIsDynamicToolbarChildren(item)).toBe(true)
     expect(item.children?.map(child => child.label)).toEqual([
       'Model',
       'Layout2',
@@ -95,7 +95,7 @@ describe('createLayoutToolbarItem', () => {
   })
 
   it('switches the current layout when a submenu item is chosen', () => {
-    const children = createLayoutToolbarChildren()
+    const children = acuiCreateLayoutToolbarChildren()
     const layout1 = children.find(child => child.label === 'Layout1')
     layout1?.action?.()
     expect(mockSetCurrentLayoutBtrId).toHaveBeenCalledWith('btr-layout1')
@@ -103,7 +103,7 @@ describe('createLayoutToolbarItem', () => {
 
   it('highlights the active layout in the submenu', () => {
     currentSpaceId = 'btr-layout1'
-    const children = createLayoutToolbarChildren()
+    const children = acuiCreateLayoutToolbarChildren()
     expect(
       children.find(child => child.label === 'Layout1')?.toggle?.getValue()
     ).toBe(true)
@@ -112,8 +112,8 @@ describe('createLayoutToolbarItem', () => {
     ).toBe(false)
   })
 
-  it('forwards switchCurrentLayout to the layout manager', () => {
-    switchCurrentLayout('btr-layout2')
+  it('forwards acuiSwitchCurrentLayout to the layout manager', () => {
+    acuiSwitchCurrentLayout('btr-layout2')
     expect(mockSetCurrentLayoutBtrId).toHaveBeenCalledWith('btr-layout2')
   })
 })

--- a/packages/cad-simple-ui-plugin/__tests__/createSimpleUiPlugin.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/createSimpleUiPlugin.spec.ts
@@ -148,8 +148,8 @@ jest.mock('@mlightcad/data-model', () => ({
 import { AcApDocManager, AcEdCommandStack } from '@mlightcad/cad-simple-viewer'
 import { AcDbDatabase } from '@mlightcad/data-model'
 
+import { acuiToolbarPreset } from '../src/config/toolbarItemUtils'
 import { AcApSimpleUiPlugin } from '../src/createSimpleUiPlugin'
-import { toolbarPreset } from '../src/config/toolbarItemUtils'
 
 function createHostTree() {
   const host = document.createElement('div')
@@ -204,7 +204,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('select'), toolbarPreset('layer')]
+        items: [acuiToolbarPreset('select'), acuiToolbarPreset('layer')]
       }
     })
 
@@ -222,7 +222,7 @@ describe('AcApSimpleUiPlugin', () => {
       host,
       dockPanel: { enabled: true },
       toolbar: {
-        items: [toolbarPreset('select')]
+        items: [acuiToolbarPreset('select')]
       }
     })
 
@@ -247,7 +247,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('layer')]
+        items: [acuiToolbarPreset('layer')]
       }
     })
 
@@ -290,7 +290,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('layer')]
+        items: [acuiToolbarPreset('layer')]
       }
     })
 
@@ -329,7 +329,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('layer')]
+        items: [acuiToolbarPreset('layer')]
       }
     })
 
@@ -352,7 +352,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('layer')]
+        items: [acuiToolbarPreset('layer')]
       }
     })
 
@@ -375,7 +375,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('layer')]
+        items: [acuiToolbarPreset('layer')]
       }
     })
 
@@ -410,7 +410,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('layer')]
+        items: [acuiToolbarPreset('layer')]
       }
     })
 
@@ -444,7 +444,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('layer')]
+        items: [acuiToolbarPreset('layer')]
       }
     })
 
@@ -476,7 +476,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('select'), toolbarPreset('layer')],
+        items: [acuiToolbarPreset('select'), acuiToolbarPreset('layer')],
         collapsible: true
       }
     })
@@ -503,17 +503,17 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('select')]
+        items: [acuiToolbarPreset('select')]
       }
     })
 
     expect(mockCommands.has('SYSTEM:layer')).toBe(false)
 
-    plugin.setToolbarItems([toolbarPreset('select'), toolbarPreset('layer')])
+    plugin.setToolbarItems([acuiToolbarPreset('select'), acuiToolbarPreset('layer')])
     expect(mockCommands.has('SYSTEM:layer')).toBe(true)
     expect(host.querySelector('.ml-ex-ui-dock-panel')).not.toBeNull()
 
-    plugin.setToolbarItems([toolbarPreset('select')])
+    plugin.setToolbarItems([acuiToolbarPreset('select')])
     expect(mockCommands.has('SYSTEM:layer')).toBe(false)
     expect(host.querySelector('.ml-ex-ui-dock-panel')).toBeNull()
   })
@@ -523,7 +523,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('annotation')]
+        items: [acuiToolbarPreset('annotation')]
       }
     })
 
@@ -555,20 +555,20 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('select')]
+        items: [acuiToolbarPreset('select')]
       }
     })
 
     expect(mockCommands.has('SYSTEM:markuppanel')).toBe(false)
 
     plugin.setToolbarItems([
-      toolbarPreset('select'),
-      toolbarPreset('annotation')
+      acuiToolbarPreset('select'),
+      acuiToolbarPreset('annotation')
     ])
     expect(mockCommands.has('SYSTEM:markuppanel')).toBe(true)
     expect(host.querySelector('.ml-ex-ui-dock-panel')).not.toBeNull()
 
-    plugin.setToolbarItems([toolbarPreset('select')])
+    plugin.setToolbarItems([acuiToolbarPreset('select')])
     expect(mockCommands.has('SYSTEM:markuppanel')).toBe(false)
     expect(host.querySelector('.ml-ex-ui-dock-panel')).toBeNull()
   })
@@ -581,7 +581,7 @@ describe('AcApSimpleUiPlugin', () => {
     const { plugin } = loadPlugin({
       host,
       toolbar: {
-        items: [toolbarPreset('layer')]
+        items: [acuiToolbarPreset('layer')]
       }
     })
 

--- a/packages/cad-simple-ui-plugin/__tests__/normalizePluginOptions.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/normalizePluginOptions.spec.ts
@@ -1,8 +1,8 @@
-import { normalizePluginOptions } from '../src/config/normalizePluginOptions'
+import { acuiNormalizePluginOptions } from '../src/config/normalizePluginOptions'
 
-describe('normalizePluginOptions', () => {
+describe('acuiNormalizePluginOptions', () => {
   it('does not create dock panel by default', () => {
-    const resolved = normalizePluginOptions({})
+    const resolved = acuiNormalizePluginOptions({})
     expect(resolved.shouldCreateDockPanel).toBe(false)
     expect(resolved.dockPanel.defaultSide).toBe('left')
     expect(resolved.dockPanel.defaultOpen).toBe(false)
@@ -11,14 +11,14 @@ describe('normalizePluginOptions', () => {
   })
 
   it('creates dock panel when explicitly enabled', () => {
-    const resolved = normalizePluginOptions({
+    const resolved = acuiNormalizePluginOptions({
       dockPanel: { enabled: true }
     })
     expect(resolved.shouldCreateDockPanel).toBe(true)
   })
 
   it('applies dock panel option overrides', () => {
-    const resolved = normalizePluginOptions({
+    const resolved = acuiNormalizePluginOptions({
       dockPanel: {
         enabled: true,
         defaultOpen: true,
@@ -34,7 +34,7 @@ describe('normalizePluginOptions', () => {
   })
 
   it('defaults toolbar edge offset', () => {
-    const resolved = normalizePluginOptions({})
+    const resolved = acuiNormalizePluginOptions({})
     expect(resolved.toolbar.edgeOffset).toBe(8)
   })
 })

--- a/packages/cad-simple-ui-plugin/__tests__/resolveDockMountTarget.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveDockMountTarget.spec.ts
@@ -11,9 +11,9 @@ jest.mock('@mlightcad/cad-simple-viewer', () => ({
   }
 }))
 
-import { resolveDockMountTarget } from '../src/config/resolveDockMountTarget'
+import { acuiResolveDockMountTarget } from '../src/config/resolveDockMountTarget'
 
-describe('resolveDockMountTarget', () => {
+describe('acuiResolveDockMountTarget', () => {
   afterEach(() => {
     mockCurView.container = undefined
   })
@@ -22,7 +22,7 @@ describe('resolveDockMountTarget', () => {
     const host = { contains: () => true } as unknown as HTMLElement
     const mountTarget = {} as HTMLElement
 
-    expect(resolveDockMountTarget(host, mountTarget)).toBe(mountTarget)
+    expect(acuiResolveDockMountTarget(host, mountTarget)).toBe(mountTarget)
   })
 
   it('returns canvas parent when it is inside host', () => {
@@ -33,7 +33,7 @@ describe('resolveDockMountTarget', () => {
     } as unknown as HTMLElement
 
     mockCurView.container = canvas
-    expect(resolveDockMountTarget(host)).toBe(canvasParent)
+    expect(acuiResolveDockMountTarget(host)).toBe(canvasParent)
   })
 
   it('falls back to host when canvas parent is outside host', () => {
@@ -44,6 +44,6 @@ describe('resolveDockMountTarget', () => {
     } as unknown as HTMLElement
 
     mockCurView.container = canvas
-    expect(resolveDockMountTarget(host)).toBe(host)
+    expect(acuiResolveDockMountTarget(host)).toBe(host)
   })
 })

--- a/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
@@ -5,7 +5,7 @@ jest.mock('@mlightcad/cad-simple-viewer', () => ({
       curDocument: undefined
     }
   },
-  /** Minimal mock used by {@link createDefaultToolbarItems} markup visibility toggle. */
+  /** Minimal mock used by {@link acuiCreateDefaultToolbarItems} markup visibility toggle. */
   isMarkupVisible: () => true,
   isMeasurementVisible: () => true,
   AcEdOpenMode: {
@@ -25,29 +25,29 @@ jest.mock('@mlightcad/data-model', () => ({
 
 import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
 
-import { createDefaultToolbarItems } from '../src/config/defaultToolbarItems'
+import { acuiCreateDefaultToolbarItems } from '../src/config/defaultToolbarItems'
 import {
-  filterVisibleToolbarItems,
-  isToolbarItemVisible,
-  resolveEffectiveToolbarItem,
-  resolveParentToolbarDisplay,
-  resolveSelectedChildItem,
-  resolveToolbarItems
+  acuiFilterVisibleToolbarItems,
+  acuiIsToolbarItemVisible,
+  acuiResolveEffectiveToolbarItem,
+  acuiResolveParentToolbarDisplay,
+  acuiResolveSelectedChildItem,
+  acuiResolveToolbarItems
 } from '../src/config/resolveToolbarItems'
 import {
-  createToolbarSeparator,
-  isDynamicToolbarChildren
+  acuiCreateToolbarSeparator,
+  acuiIsDynamicToolbarChildren
 } from '../src/config/toolbarItemUtils'
 
-describe('resolveToolbarItems', () => {
+describe('acuiResolveToolbarItems', () => {
   it('returns default items when items is default', () => {
-    const items = resolveToolbarItems({ items: 'default' })
+    const items = acuiResolveToolbarItems({ items: 'default' })
     expect(items.length).toBeGreaterThan(0)
     expect(items[0].id).toBe('select')
   })
 
   it('appends custom items after defaults', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: 'default',
       appendItems: [{ id: 'custom', command: 'test' }]
     })
@@ -56,7 +56,7 @@ describe('resolveToolbarItems', () => {
   })
 
   it('inserts appendItems after a root toolbar item id', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: 'default',
       appendItems: [{ id: 'agent', command: 'agent' }],
       appendItemsAfter: 'layer'
@@ -66,7 +66,7 @@ describe('resolveToolbarItems', () => {
   })
 
   it('inserts appendItems before a root toolbar item id', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: 'default',
       appendItems: [{ id: 'agent', command: 'agent' }],
       appendItemsBefore: 'measure'
@@ -76,7 +76,7 @@ describe('resolveToolbarItems', () => {
   })
 
   it('prefers appendItemsBefore over appendItemsAfter', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: 'default',
       appendItems: [{ id: 'agent', command: 'agent' }],
       appendItemsAfter: 'select',
@@ -90,7 +90,7 @@ describe('resolveToolbarItems', () => {
   })
 
   it('falls back to the end when the append anchor is missing', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: 'default',
       appendItems: [{ id: 'custom', command: 'test' }],
       appendItemsAfter: 'missing-item'
@@ -99,7 +99,7 @@ describe('resolveToolbarItems', () => {
   })
 
   it('uses custom item list when provided', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: [{ id: 'only', command: 'only' }]
     })
     expect(items).toHaveLength(1)
@@ -109,8 +109,8 @@ describe('resolveToolbarItems', () => {
 
 describe('toolbar visibility', () => {
   it('hides review-only items in read mode', () => {
-    const defaults = createDefaultToolbarItems()
-    const visible = filterVisibleToolbarItems(defaults, AcEdOpenMode.Read)
+    const defaults = acuiCreateDefaultToolbarItems()
+    const visible = acuiFilterVisibleToolbarItems(defaults, AcEdOpenMode.Read)
     expect(visible.some(item => item.id === 'annotation')).toBe(false)
     expect(visible.some(item => item.id === 'switch-bg')).toBe(true)
     expect(visible.some(item => item.id === 'layout')).toBe(true)
@@ -118,21 +118,21 @@ describe('toolbar visibility', () => {
   })
 
   it('shows review-only items in review mode', () => {
-    const defaults = createDefaultToolbarItems()
-    const visible = filterVisibleToolbarItems(defaults, AcEdOpenMode.Review)
+    const defaults = acuiCreateDefaultToolbarItems()
+    const visible = acuiFilterVisibleToolbarItems(defaults, AcEdOpenMode.Review)
     expect(visible.some(item => item.id === 'annotation')).toBe(true)
     expect(visible.some(item => item.id === 'switch-bg')).toBe(true)
   })
 
   it('respects minOpenMode on individual items', () => {
     expect(
-      isToolbarItemVisible(
+      acuiIsToolbarItemVisible(
         { id: 'x', minOpenMode: AcEdOpenMode.Review },
         AcEdOpenMode.Read
       )
     ).toBe(false)
     expect(
-      isToolbarItemVisible(
+      acuiIsToolbarItemVisible(
         { id: 'x', minOpenMode: AcEdOpenMode.Review },
         AcEdOpenMode.Write
       )
@@ -153,14 +153,14 @@ describe('toolbar visibility', () => {
         ]
       }
     ]
-    const visible = filterVisibleToolbarItems(items, AcEdOpenMode.Read)
+    const visible = acuiFilterVisibleToolbarItems(items, AcEdOpenMode.Read)
     expect(visible[0].children?.map(child => child.id)).toEqual(['read-child'])
   })
 })
 
-describe('resolveEffectiveToolbarItem', () => {
+describe('acuiResolveEffectiveToolbarItem', () => {
   it('uses off branch when toggle value is false', () => {
-    const item = resolveEffectiveToolbarItem({
+    const item = acuiResolveEffectiveToolbarItem({
       id: 'toggle',
       toggle: {
         getValue: () => false,
@@ -175,7 +175,7 @@ describe('resolveEffectiveToolbarItem', () => {
 
 describe('default toolbar items', () => {
   it('includes export submenu, theme toggle and locale picker', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const exportItem = items.find(item => item.id === 'export')
     expect(exportItem?.children?.map(child => child.command)).toEqual([
       'chtml',
@@ -188,13 +188,13 @@ describe('default toolbar items', () => {
   })
 
   it('places toolbar placement button before theme', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const themeIndex = items.findIndex(item => item.id === 'theme')
     expect(items[themeIndex - 1]?.id).toBe('toolbar-placement')
   })
 
   it('places the layout switcher between the layer manager and switch background', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const layerIndex = items.findIndex(item => item.id === 'layer')
     expect(items[layerIndex + 1]?.id).toBe('layout')
     expect(items[layerIndex + 1]?.childrenUi).toBe('menu')
@@ -203,7 +203,7 @@ describe('default toolbar items', () => {
   })
 
   it('includes a separator before settings buttons', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const placementIndex = items.findIndex(
       item => item.id === 'toolbar-placement'
     )
@@ -215,7 +215,7 @@ describe('default toolbar items', () => {
   })
 
   it('uses selected child icon for toolbar placement and locale', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     expect(items.find(item => item.id === 'export')?.childIcon).toBeUndefined()
     expect(
       items.find(item => item.id === 'annotation')?.childIcon
@@ -228,7 +228,7 @@ describe('default toolbar items', () => {
   })
 
   it('uses markup commands from the review panel in the annotation submenu', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const annotation = items.find(item => item.id === 'annotation')
     expect(
       annotation?.children?.map(child =>
@@ -259,7 +259,7 @@ describe('default toolbar items', () => {
   })
 
   it('places measurement visibility in the measure submenu', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const measure = items.find(item => item.id === 'measure')
     expect(
       measure?.children?.map(child =>
@@ -285,14 +285,14 @@ describe('default toolbar items', () => {
   })
 
   it('places review tools after measure and export after review', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const measureIndex = items.findIndex(item => item.id === 'measure')
     expect(items[measureIndex + 1]?.id).toBe('annotation')
     expect(items[measureIndex + 2]?.id).toBe('export')
   })
 
   it('uses sticky sub-toolbars for measure and review, dismissible for export and placement', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     expect(items.find(item => item.id === 'measure')?.childrenUi).toBe(
       'sticky-toolbar'
     )
@@ -308,7 +308,7 @@ describe('default toolbar items', () => {
   })
 
   it('uses the same export parent icon as cad-viewer toolbar and ribbon', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     expect(items.find(item => item.id === 'export')?.icon).toContain(
       'M15.5 2H9.1L4.5 6.6'
     )
@@ -318,7 +318,7 @@ describe('default toolbar items', () => {
   })
 
   it('uses the same review submenu icons as cad-viewer', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const annotation = items.find(item => item.id === 'annotation')
     const iconOf = (id: string) =>
       annotation?.children?.find(child => child.id === id)?.icon
@@ -344,7 +344,7 @@ describe('default toolbar items', () => {
   })
 
   it('uses the same measurement submenu icons as cad-viewer', () => {
-    const items = createDefaultToolbarItems()
+    const items = acuiCreateDefaultToolbarItems()
     const measure = items.find(item => item.id === 'measure')
     const iconOf = (id: string) =>
       measure?.children?.find(child => child.id === id)?.icon
@@ -365,7 +365,7 @@ describe('default toolbar items', () => {
   })
 
   it('offers all supported locales in a dismissible language sub-toolbar', () => {
-    const items = createDefaultToolbarItems({
+    const items = acuiCreateDefaultToolbarItems({
       getTheme: () => 'light',
       setTheme: () => undefined,
       getLocale: () => 'cs',
@@ -389,7 +389,7 @@ describe('default toolbar items', () => {
 
 describe('parent toolbar display', () => {
   it('keeps parent icon when childIcon is fixed', () => {
-    const parent = resolveParentToolbarDisplay({
+    const parent = acuiResolveParentToolbarDisplay({
       id: 'measure',
       icon: 'parent-icon',
       childIcon: 'fixed',
@@ -399,7 +399,7 @@ describe('parent toolbar display', () => {
   })
 
   it('uses selected child icon when childIcon is selected', () => {
-    const parent = resolveParentToolbarDisplay(
+    const parent = acuiResolveParentToolbarDisplay(
       {
         id: 'export',
         label: 'toolbar.export',
@@ -418,7 +418,7 @@ describe('parent toolbar display', () => {
   })
 
   it('resolves active child by runtime selection first', () => {
-    const child = resolveSelectedChildItem(
+    const child = acuiResolveSelectedChildItem(
       {
         id: 'export',
         selectedChildId: 'export-html',
@@ -435,11 +435,11 @@ describe('parent toolbar display', () => {
 
 describe('toolbar presets and separators', () => {
   it('expands preset references in a custom layout', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: [
         { preset: 'select' },
         { preset: 'pan' },
-        createToolbarSeparator('sep-tools'),
+        acuiCreateToolbarSeparator('sep-tools'),
         { preset: 'measure' }
       ]
     })
@@ -450,24 +450,24 @@ describe('toolbar presets and separators', () => {
   })
 
   it('preserves live layout children when expanding the layout preset', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: [{ preset: 'layout' }]
     })
     expect(items).toHaveLength(1)
     expect(items[0].id).toBe('layout')
-    expect(isDynamicToolbarChildren(items[0])).toBe(true)
+    expect(acuiIsDynamicToolbarChildren(items[0])).toBe(true)
     expect(items[0].childrenUi).toBe('menu')
   })
 
   it('keeps separators when filtering by open mode', () => {
-    const items = resolveToolbarItems({
+    const items = acuiResolveToolbarItems({
       items: [
         { preset: 'select' },
-        createToolbarSeparator(),
+        acuiCreateToolbarSeparator(),
         { preset: 'annotation' }
       ]
     })
-    const visible = filterVisibleToolbarItems(items, AcEdOpenMode.Read)
+    const visible = acuiFilterVisibleToolbarItems(items, AcEdOpenMode.Read)
     expect(visible.some(item => item.type === 'separator')).toBe(true)
     expect(visible.some(item => item.id === 'select')).toBe(true)
     expect(visible.some(item => item.id === 'annotation')).toBe(false)

--- a/packages/cad-simple-ui-plugin/__tests__/resolveToolbarMountTarget.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveToolbarMountTarget.spec.ts
@@ -13,9 +13,9 @@ jest.mock('@mlightcad/cad-simple-viewer', () => ({
   }
 }))
 
-import { resolveToolbarMountTarget } from '../src/config/resolveToolbarMountTarget'
+import { acuiResolveToolbarMountTarget } from '../src/config/resolveToolbarMountTarget'
 
-describe('resolveToolbarMountTarget', () => {
+describe('acuiResolveToolbarMountTarget', () => {
   afterEach(() => {
     mockCurView.container = undefined
   })
@@ -24,7 +24,7 @@ describe('resolveToolbarMountTarget', () => {
     const host = { contains: () => true } as unknown as HTMLElement
     const mountTarget = {} as HTMLElement
 
-    expect(resolveToolbarMountTarget(host, mountTarget)).toBe(mountTarget)
+    expect(acuiResolveToolbarMountTarget(host, mountTarget)).toBe(mountTarget)
   })
 
   it('returns canvas container when it is inside host', () => {
@@ -34,7 +34,7 @@ describe('resolveToolbarMountTarget', () => {
     } as unknown as HTMLElement
 
     mockCurView.container = canvasContainer
-    expect(resolveToolbarMountTarget(host)).toBe(canvasContainer)
+    expect(acuiResolveToolbarMountTarget(host)).toBe(canvasContainer)
   })
 
   it('falls back to host when canvas container is outside host', () => {
@@ -44,6 +44,6 @@ describe('resolveToolbarMountTarget', () => {
     } as unknown as HTMLElement
 
     mockCurView.container = canvasContainer
-    expect(resolveToolbarMountTarget(host)).toBe(host)
+    expect(acuiResolveToolbarMountTarget(host)).toBe(host)
   })
 })

--- a/packages/cad-simple-ui-plugin/src/command/AcApLayerUiCmd.ts
+++ b/packages/cad-simple-ui-plugin/src/command/AcApLayerUiCmd.ts
@@ -4,10 +4,10 @@ import {
   eventBus
 } from '@mlightcad/cad-simple-viewer'
 
-import type { AcExDockPanel } from '../ui/AcExDockPanel'
+import type { AcUiDockPanel } from '../ui/AcUiDockPanel'
 
 /** Shared interface for layer UI controllers. */
-export interface AcExLayerUiController {
+export interface AcUiLayerUiController {
   /** Toggles layer UI from the `layer` CAD command. */
   toggleFromCommand(): void
   /** Hides or closes layer UI (used by `close-layer-manager` event). */
@@ -19,7 +19,7 @@ export interface AcExLayerUiController {
 /**
  * Layer UI controller that opens the layers tab in a dock panel.
  */
-export class AcExLayerDockController implements AcExLayerUiController {
+export class AcUiLayerDockController implements AcUiLayerUiController {
   private readonly handleCloseLayerManager = () => {
     this.hide()
   }
@@ -29,7 +29,7 @@ export class AcExLayerDockController implements AcExLayerUiController {
    * @param layersTabId - Tab id registered for the layer list.
    */
   constructor(
-    private readonly dockPanel: AcExDockPanel,
+    private readonly dockPanel: AcUiDockPanel,
     private readonly layersTabId = 'layers'
   ) {
     eventBus.on('close-layer-manager', this.handleCloseLayerManager)
@@ -60,7 +60,7 @@ export class AcExLayerDockController implements AcExLayerUiController {
 }
 
 /** Actions invoked by the `layer` command to prepare and open layer UI in the dock. */
-export interface AcExLayerCommandActions {
+export interface AcUiLayerCommandActions {
   /** Ensures the dock panel and layers tab exist before toggling. */
   prepare(): void
   /** Activates the layers tab in the dock panel. */
@@ -68,9 +68,9 @@ export interface AcExLayerCommandActions {
 }
 
 /** Mutable holder so the `layer` command stays registered while the UI mode switches. */
-export class AcExLayerUiControllerHolder implements AcExLayerUiController {
+export class AcUiLayerUiControllerHolder implements AcUiLayerUiController {
   /** Active layer UI controller delegate. */
-  current?: AcExLayerUiController
+  current?: AcUiLayerUiController
 
   toggleFromCommand() {
     this.current?.toggleFromCommand()
@@ -92,7 +92,7 @@ export class AcApLayerUiCmd extends AcEdCommand {
   /**
    * @param actions - Prepare and toggle callbacks wired by the plugin.
    */
-  constructor(private readonly actions: AcExLayerCommandActions) {
+  constructor(private readonly actions: AcUiLayerCommandActions) {
     super()
   }
 

--- a/packages/cad-simple-ui-plugin/src/command/AcApMarkupPanelUiCmd.ts
+++ b/packages/cad-simple-ui-plugin/src/command/AcApMarkupPanelUiCmd.ts
@@ -1,7 +1,7 @@
 import { AcApContext, AcEdCommand } from '@mlightcad/cad-simple-viewer'
 
 /** Actions invoked by the `markuppanel` command to prepare and open review UI. */
-export interface AcExMarkupPanelCommandActions {
+export interface AcUiMarkupPanelCommandActions {
   /** Ensures the dock panel and review tab exist before opening. */
   prepare(): void
   /** Activates the review tab in the dock panel. */
@@ -15,7 +15,7 @@ export class AcApMarkupPanelUiCmd extends AcEdCommand {
   /**
    * @param actions - Prepare and open callbacks wired by the plugin.
    */
-  constructor(private readonly actions: AcExMarkupPanelCommandActions) {
+  constructor(private readonly actions: AcUiMarkupPanelCommandActions) {
     super()
   }
 

--- a/packages/cad-simple-ui-plugin/src/config/createLayoutToolbarItem.ts
+++ b/packages/cad-simple-ui-plugin/src/config/createLayoutToolbarItem.ts
@@ -2,8 +2,8 @@ import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { acdbHostApplicationServices } from '@mlightcad/data-model'
 
 import { ICON_LAYOUT } from '../assets/icons'
-import { copyDynamicToolbarChildren } from './toolbarItemUtils'
-import type { AcExToolbarItem } from './types'
+import { acuiCopyDynamicToolbarChildren } from './toolbarItemUtils'
+import type { AcUiToolbarItem } from './types'
 
 /** One selectable drawing layout (model space or paper space). */
 interface DocumentLayoutInfo {
@@ -22,7 +22,7 @@ interface DocumentLayoutInfo {
  *
  * @returns Layouts when a document is open; otherwise an empty list.
  */
-export function listDocumentLayouts(): DocumentLayoutInfo[] {
+export function acuiListDocumentLayouts(): DocumentLayoutInfo[] {
   const database = AcApDocManager.instance.curDocument?.database
   const layoutTable = database?.objects?.layout
   if (!database || !layoutTable?.newIterator) return []
@@ -45,7 +45,7 @@ export function listDocumentLayouts(): DocumentLayoutInfo[] {
  *
  * @param blockTableRecordId - Layout block table record id.
  */
-export function switchCurrentLayout(blockTableRecordId: string): void {
+export function acuiSwitchCurrentLayout(blockTableRecordId: string): void {
   acdbHostApplicationServices().layoutManager.setCurrentLayoutBtrId(
     blockTableRecordId
   )
@@ -56,11 +56,11 @@ export function switchCurrentLayout(blockTableRecordId: string): void {
  *
  * @returns Menu items that switch the current layout when clicked.
  */
-export function createLayoutToolbarChildren(): AcExToolbarItem[] {
-  return listDocumentLayouts().map(layout => ({
+export function acuiCreateLayoutToolbarChildren(): AcUiToolbarItem[] {
+  return acuiListDocumentLayouts().map(layout => ({
     id: `layout-${layout.blockTableRecordId}`,
     label: layout.name,
-    action: () => switchCurrentLayout(layout.blockTableRecordId),
+    action: () => acuiSwitchCurrentLayout(layout.blockTableRecordId),
     toggle: {
       getValue: () => {
         const database = AcApDocManager.instance.curDocument?.database
@@ -80,8 +80,8 @@ export function createLayoutToolbarChildren(): AcExToolbarItem[] {
  *
  * @returns Layout parent button with a popover menu (`childrenUi: 'menu'`).
  */
-export function createLayoutToolbarItem(): AcExToolbarItem {
-  const item: AcExToolbarItem = {
+export function acuiCreateLayoutToolbarItem(): AcUiToolbarItem {
+  const item: AcUiToolbarItem = {
     id: 'layout',
     label: 'toolbar.layout',
     icon: ICON_LAYOUT,
@@ -89,5 +89,5 @@ export function createLayoutToolbarItem(): AcExToolbarItem {
     childrenUi: 'menu',
     children: []
   }
-  return copyDynamicToolbarChildren(item, createLayoutToolbarChildren)
+  return acuiCopyDynamicToolbarChildren(item, acuiCreateLayoutToolbarChildren)
 }

--- a/packages/cad-simple-ui-plugin/src/config/createToolbarLayoutSwitcher.ts
+++ b/packages/cad-simple-ui-plugin/src/config/createToolbarLayoutSwitcher.ts
@@ -1,18 +1,18 @@
 import { ICON_TOOLBAR_PLACEMENT } from '../assets/icons'
-import type { AcExToolbarItem } from './types'
+import type { AcUiToolbarItem } from './types'
 
 /** One selectable entry in a toolbar layout switcher submenu. */
-export interface AcExToolbarLayoutPreset {
+export interface AcUiToolbarLayoutPreset {
   /** Stable preset identifier. */
   id: string
   /** Display label for the submenu entry. */
   label: string
 }
 
-/** Options for {@link createToolbarLayoutSwitcher}. */
-export interface AcExToolbarLayoutSwitcherOptions {
+/** Options for {@link acuiCreateToolbarLayoutSwitcher}. */
+export interface AcUiToolbarLayoutSwitcherOptions {
   /** Presets shown in the submenu. */
-  presets: AcExToolbarLayoutPreset[]
+  presets: AcUiToolbarLayoutPreset[]
   /** Id of the currently active preset. */
   currentId: string
   /** Invoked when the user selects a preset. */
@@ -33,9 +33,9 @@ export interface AcExToolbarLayoutSwitcherOptions {
  *
  * @param options - Presets, current selection, and selection handler.
  */
-export function createToolbarLayoutSwitcher(
-  options: AcExToolbarLayoutSwitcherOptions
-): AcExToolbarItem {
+export function acuiCreateToolbarLayoutSwitcher(
+  options: AcUiToolbarLayoutSwitcherOptions
+): AcUiToolbarItem {
   const id = options.id ?? 'toolbar-layout-switcher'
   const selectedChildId = `layout-${options.currentId}`
 
@@ -58,12 +58,12 @@ export function createToolbarLayoutSwitcher(
  * Prepends a layout switcher and separator before a fully custom toolbar item list.
  *
  * @param items - Toolbar items for the active preset (not including the switcher).
- * @param switcher - Layout switcher button from {@link createToolbarLayoutSwitcher}.
+ * @param switcher - Layout switcher button from {@link acuiCreateToolbarLayoutSwitcher}.
  */
-export function prependToolbarLayoutSwitcher(
-  items: AcExToolbarItem[],
-  switcher: AcExToolbarItem
-): AcExToolbarItem[] {
+export function acuiPrependToolbarLayoutSwitcher(
+  items: AcUiToolbarItem[],
+  switcher: AcUiToolbarItem
+): AcUiToolbarItem[] {
   return [
     switcher,
     { type: 'separator', id: 'toolbar-layout-switcher-separator' },

--- a/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
@@ -47,37 +47,37 @@ import {
   ICON_ZOOM_EXTENT,
   ICON_ZOOM_WINDOW
 } from '../assets/icons'
-import { createLayoutToolbarItem } from './createLayoutToolbarItem'
+import { acuiCreateLayoutToolbarItem } from './createLayoutToolbarItem'
 import type {
-  AcExDefaultToolbarContext,
-  AcExToolbarItem,
-  AcExToolbarPlacement
+  AcUiDefaultToolbarContext,
+  AcUiToolbarItem,
+  AcUiToolbarPlacement
 } from './types'
 
-const TOOLBAR_PLACEMENTS: AcExToolbarPlacement[] = [
+const TOOLBAR_PLACEMENTS: AcUiToolbarPlacement[] = [
   'top',
   'bottom',
   'left',
   'right'
 ]
 
-const PLACEMENT_ICONS: Record<AcExToolbarPlacement, string> = {
+const PLACEMENT_ICONS: Record<AcUiToolbarPlacement, string> = {
   top: ICON_PLACEMENT_TOP,
   bottom: ICON_PLACEMENT_BOTTOM,
   left: ICON_PLACEMENT_LEFT,
   right: ICON_PLACEMENT_RIGHT
 }
 
-const PLACEMENT_LABELS: Record<AcExToolbarPlacement, string> = {
+const PLACEMENT_LABELS: Record<AcUiToolbarPlacement, string> = {
   top: 'toolbar.placementTop',
   bottom: 'toolbar.placementBottom',
   left: 'toolbar.placementLeft',
   right: 'toolbar.placementRight'
 }
 
-function createToolbarPlacementItem(
-  context?: AcExDefaultToolbarContext
-): AcExToolbarItem {
+function acuiCreateToolbarPlacementItem(
+  context?: AcUiDefaultToolbarContext
+): AcUiToolbarItem {
   return {
     id: 'toolbar-placement',
     label: 'toolbar.placement',
@@ -118,9 +118,9 @@ function localeBadgeIcon(badge: string): string {
   return `<span style="font-size:10px;font-weight:700;line-height:1">${badge}</span>`
 }
 
-function createToolbarLocaleItem(
-  context?: AcExDefaultToolbarContext
-): AcExToolbarItem {
+function acuiCreateToolbarLocaleItem(
+  context?: AcUiDefaultToolbarContext
+): AcUiToolbarItem {
   const current = context?.getLocale() ?? 'en'
   return {
     id: 'locale',
@@ -144,18 +144,18 @@ function createToolbarLocaleItem(
  * Builds the built-in toolbar item list (view, layout, measure, review, export, theme, locale).
  *
  * @param context - Optional callbacks for theme, locale, and placement items.
- * @returns Default {@link AcExToolbarItem} array.
+ * @returns Default {@link AcUiToolbarItem} array.
  */
-export function createDefaultToolbarItems(
-  context?: AcExDefaultToolbarContext
-): AcExToolbarItem[] {
+export function acuiCreateDefaultToolbarItems(
+  context?: AcUiDefaultToolbarContext
+): AcUiToolbarItem[] {
   const getTheme = (): AcEdUiTheme => context?.getTheme() ?? 'light'
   const toggleTheme = () => {
     const next: AcEdUiTheme = getTheme() === 'dark' ? 'light' : 'dark'
     context?.setTheme(next)
   }
 
-  const items: AcExToolbarItem[] = [
+  const items: AcUiToolbarItem[] = [
     {
       id: 'select',
       label: 'toolbar.select',
@@ -186,7 +186,7 @@ export function createDefaultToolbarItems(
       icon: ICON_LAYER,
       command: 'layer'
     },
-    createLayoutToolbarItem(),
+    acuiCreateLayoutToolbarItem(),
     {
       id: 'switch-bg',
       label: 'toolbar.switchBg',
@@ -394,7 +394,7 @@ export function createDefaultToolbarItems(
       type: 'separator',
       id: 'sep-settings'
     },
-    createToolbarPlacementItem(context),
+    acuiCreateToolbarPlacementItem(context),
     {
       id: 'theme',
       requiresDocument: false,
@@ -412,7 +412,7 @@ export function createDefaultToolbarItems(
         }
       }
     },
-    createToolbarLocaleItem(context)
+    acuiCreateToolbarLocaleItem(context)
   ]
 
   return items

--- a/packages/cad-simple-ui-plugin/src/config/normalizePluginOptions.ts
+++ b/packages/cad-simple-ui-plugin/src/config/normalizePluginOptions.ts
@@ -1,8 +1,8 @@
-import type { AcExSimpleUiPluginOptions } from './types'
+import type { AcUiSimpleUiPluginOptions } from './types'
 
 /** Resolved plugin options with explicit defaults for nested sections. */
-export type AcExNormalizedPluginOptions = Required<
-  Omit<AcExSimpleUiPluginOptions, 'host' | 'locale'>
+export type AcUiNormalizedPluginOptions = Required<
+  Omit<AcUiSimpleUiPluginOptions, 'host' | 'locale'>
 > & {
   host?: HTMLElement
   shouldCreateDockPanel: boolean
@@ -13,9 +13,9 @@ export type AcExNormalizedPluginOptions = Required<
  *
  * @param options - Raw plugin options from the caller.
  */
-export function normalizePluginOptions(
-  options: AcExSimpleUiPluginOptions = {}
-): AcExNormalizedPluginOptions {
+export function acuiNormalizePluginOptions(
+  options: AcUiSimpleUiPluginOptions = {}
+): AcUiNormalizedPluginOptions {
   const dockPanelEnabled = options.dockPanel?.enabled === true
 
   return {

--- a/packages/cad-simple-ui-plugin/src/config/resolveDockMountTarget.ts
+++ b/packages/cad-simple-ui-plugin/src/config/resolveDockMountTarget.ts
@@ -10,7 +10,7 @@ import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
  * @param host - Plugin host element (toolbar and theme root).
  * @param mountTarget - Optional explicit dock mount element.
  */
-export function resolveDockMountTarget(
+export function acuiResolveDockMountTarget(
   host: HTMLElement,
   mountTarget?: HTMLElement
 ): HTMLElement {

--- a/packages/cad-simple-ui-plugin/src/config/resolveToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/resolveToolbarItems.ts
@@ -1,16 +1,16 @@
 import { AcEdOpenMode } from '@mlightcad/cad-simple-viewer'
 
-import { createDefaultToolbarItems } from './defaultToolbarItems'
+import { acuiCreateDefaultToolbarItems } from './defaultToolbarItems'
 import {
-  expandToolbarItemConfigs,
-  indexToolbarItems,
-  isDynamicToolbarChildren,
-  isToolbarSeparatorItem
+  acuiExpandToolbarItemConfigs,
+  acuiIndexToolbarItems,
+  acuiIsDynamicToolbarChildren,
+  acuiIsToolbarSeparatorItem
 } from './toolbarItemUtils'
 import type {
-  AcExDefaultToolbarContext,
-  AcExSimpleUiPluginOptions,
-  AcExToolbarItem
+  AcUiDefaultToolbarContext,
+  AcUiSimpleUiPluginOptions,
+  AcUiToolbarItem
 } from './types'
 
 /**
@@ -18,11 +18,11 @@ import type {
  *
  * @param context - Context for theme/locale/placement presets.
  */
-export function createDefaultToolbarPresetMap(
-  context?: AcExDefaultToolbarContext
-): Map<string, AcExToolbarItem> {
-  const map = new Map<string, AcExToolbarItem>()
-  indexToolbarItems(createDefaultToolbarItems(context), map)
+export function acuiCreateDefaultToolbarPresetMap(
+  context?: AcUiDefaultToolbarContext
+): Map<string, AcUiToolbarItem> {
+  const map = new Map<string, AcUiToolbarItem>()
+  acuiIndexToolbarItems(acuiCreateDefaultToolbarItems(context), map)
   return map
 }
 
@@ -34,11 +34,11 @@ export function createDefaultToolbarPresetMap(
  * @param position - Optional anchor id (`after` or `before`); omitted means end.
  * @returns New item array with `toInsert` merged in.
  */
-export function insertToolbarItemsAt(
-  items: AcExToolbarItem[],
-  toInsert: AcExToolbarItem[],
+export function acuiInsertToolbarItemsAt(
+  items: AcUiToolbarItem[],
+  toInsert: AcUiToolbarItem[],
   position?: { after?: string; before?: string }
-): AcExToolbarItem[] {
+): AcUiToolbarItem[] {
   if (!toInsert.length) return items
 
   const anchorId = position?.before ?? position?.after
@@ -66,26 +66,26 @@ export function insertToolbarItemsAt(
  *
  * @param options - Toolbar subsection of plugin options.
  * @param context - Context for default theme/locale/placement items.
- * @returns Resolved toolbar items ready for {@link AcExToolbar}.
+ * @returns Resolved toolbar items ready for {@link AcUiToolbar}.
  */
-export function resolveToolbarItems(
-  options: AcExSimpleUiPluginOptions['toolbar'],
-  context?: AcExDefaultToolbarContext
-): AcExToolbarItem[] {
+export function acuiResolveToolbarItems(
+  options: AcUiSimpleUiPluginOptions['toolbar'],
+  context?: AcUiDefaultToolbarContext
+): AcUiToolbarItem[] {
   const toolbar = options ?? {}
-  const presets = createDefaultToolbarPresetMap(context)
-  let items: AcExToolbarItem[]
+  const presets = acuiCreateDefaultToolbarPresetMap(context)
+  let items: AcUiToolbarItem[]
 
   if (toolbar.items === 'default' || toolbar.items == null) {
-    items = createDefaultToolbarItems(context)
+    items = acuiCreateDefaultToolbarItems(context)
   } else {
-    items = expandToolbarItemConfigs(toolbar.items, presets)
+    items = acuiExpandToolbarItemConfigs(toolbar.items, presets)
   }
 
   if (toolbar.appendItems?.length) {
-    items = insertToolbarItemsAt(
+    items = acuiInsertToolbarItemsAt(
       items,
-      expandToolbarItemConfigs(toolbar.appendItems, presets),
+      acuiExpandToolbarItemConfigs(toolbar.appendItems, presets),
       {
         after: toolbar.appendItemsAfter,
         before: toolbar.appendItemsBefore
@@ -102,8 +102,8 @@ export function resolveToolbarItems(
  * @param item - Toolbar item to test.
  * @param openMode - Current document open mode.
  */
-export function isToolbarItemVisible(
-  item: AcExToolbarItem,
+export function acuiIsToolbarItemVisible(
+  item: AcUiToolbarItem,
   openMode: AcEdOpenMode
 ): boolean {
   if (item.minOpenMode == null) return true
@@ -116,10 +116,10 @@ export function isToolbarItemVisible(
  * @param item - Item that may define a `toggle` configuration.
  * @returns Item with effective label, icon, command, and action from the active branch.
  */
-export function resolveEffectiveToolbarItem(
-  item: AcExToolbarItem
-): AcExToolbarItem {
-  if (isToolbarSeparatorItem(item)) return item
+export function acuiResolveEffectiveToolbarItem(
+  item: AcUiToolbarItem
+): AcUiToolbarItem {
+  if (acuiIsToolbarSeparatorItem(item)) return item
   if (!item.toggle) return item
   const active = item.toggle.getValue()
   const branch = active ? item.toggle.on : item.toggle.off
@@ -137,10 +137,10 @@ export function resolveEffectiveToolbarItem(
  * @param item - Parent item with `children`.
  * @param activeChildId - Runtime-selected child id, if any.
  */
-export function resolveSelectedChildItem(
-  item: AcExToolbarItem,
+export function acuiResolveSelectedChildItem(
+  item: AcUiToolbarItem,
   activeChildId?: string
-): AcExToolbarItem | undefined {
+): AcUiToolbarItem | undefined {
   if (!item.children?.length) return undefined
 
   const candidates = [activeChildId, item.selectedChildId].filter(
@@ -157,25 +157,25 @@ export function resolveSelectedChildItem(
 /**
  * Applies parent-button display fields for submenu parents.
  *
- * When {@link AcExToolbarItem.childIcon} is `'selected'`, the parent icon is
+ * When {@link AcUiToolbarItem.childIcon} is `'selected'`, the parent icon is
  * taken from the active submenu child while the parent label is unchanged.
  *
  * @param item - Parent toolbar item (may include `children`).
  * @param activeChildId - Runtime-selected child id, if any.
  */
-export function resolveParentToolbarDisplay(
-  item: AcExToolbarItem,
+export function acuiResolveParentToolbarDisplay(
+  item: AcUiToolbarItem,
   activeChildId?: string
-): AcExToolbarItem {
-  const effective = resolveEffectiveToolbarItem(item)
+): AcUiToolbarItem {
+  const effective = acuiResolveEffectiveToolbarItem(item)
   if (effective.childIcon !== 'selected' || !effective.children?.length) {
     return effective
   }
 
-  const child = resolveSelectedChildItem(effective, activeChildId)
+  const child = acuiResolveSelectedChildItem(effective, activeChildId)
   if (!child) return effective
 
-  const resolvedChild = resolveEffectiveToolbarItem(child)
+  const resolvedChild = acuiResolveEffectiveToolbarItem(child)
   return {
     ...effective,
     icon: resolvedChild.icon ?? effective.icon
@@ -188,8 +188,8 @@ export function resolveParentToolbarDisplay(
  * @param item - Toolbar item to inspect.
  * @returns `requiresDocument` when set, otherwise `true` when `command` is set.
  */
-export function itemRequiresDocument(item: AcExToolbarItem): boolean {
-  if (isToolbarSeparatorItem(item)) return false
+export function acuiItemRequiresDocument(item: AcUiToolbarItem): boolean {
+  if (acuiIsToolbarSeparatorItem(item)) return false
   if (item.requiresDocument != null) return item.requiresDocument
   return Boolean(item.command || item.anchorAction)
 }
@@ -199,7 +199,7 @@ export function itemRequiresDocument(item: AcExToolbarItem): boolean {
  *
  * @param item - Toolbar item with optional static or dynamic `disabled`.
  */
-export function isToolbarItemDisabled(item: AcExToolbarItem): boolean {
+export function acuiIsToolbarItemDisabled(item: AcUiToolbarItem): boolean {
   if (item.disabled == null) return false
   return typeof item.disabled === 'function' ? item.disabled() : item.disabled
 }
@@ -213,30 +213,31 @@ export function isToolbarItemDisabled(item: AcExToolbarItem): boolean {
  * @param items - Root toolbar items.
  * @param openMode - Current document open mode.
  */
-export function filterVisibleToolbarItems(
-  items: AcExToolbarItem[],
+export function acuiFilterVisibleToolbarItems(
+  items: AcUiToolbarItem[],
   openMode: AcEdOpenMode
-): AcExToolbarItem[] {
+): AcUiToolbarItem[] {
   return items
     .filter(
       item =>
-        isToolbarSeparatorItem(item) || isToolbarItemVisible(item, openMode)
+        acuiIsToolbarSeparatorItem(item) ||
+        acuiIsToolbarItemVisible(item, openMode)
     )
     .map(item => {
       if (
-        isToolbarSeparatorItem(item) ||
-        isDynamicToolbarChildren(item) ||
+        acuiIsToolbarSeparatorItem(item) ||
+        acuiIsDynamicToolbarChildren(item) ||
         !item.children?.length
       ) {
         return item
       }
-      const children = filterVisibleToolbarItems(item.children, openMode)
+      const children = acuiFilterVisibleToolbarItems(item.children, openMode)
       return { ...item, children }
     })
     .filter(item => {
-      if (isToolbarSeparatorItem(item)) return true
+      if (acuiIsToolbarSeparatorItem(item)) return true
       return (
-        isDynamicToolbarChildren(item) ||
+        acuiIsDynamicToolbarChildren(item) ||
         !item.children ||
         item.children.length > 0 ||
         item.command ||

--- a/packages/cad-simple-ui-plugin/src/config/resolveToolbarMountTarget.ts
+++ b/packages/cad-simple-ui-plugin/src/config/resolveToolbarMountTarget.ts
@@ -9,7 +9,7 @@ import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
  * @param host - Plugin host element (theme root and outer layout).
  * @param mountTarget - Optional explicit toolbar mount element.
  */
-export function resolveToolbarMountTarget(
+export function acuiResolveToolbarMountTarget(
   host: HTMLElement,
   mountTarget?: HTMLElement
 ): HTMLElement {

--- a/packages/cad-simple-ui-plugin/src/config/toolbarItemUtils.ts
+++ b/packages/cad-simple-ui-plugin/src/config/toolbarItemUtils.ts
@@ -1,9 +1,9 @@
 import type {
-  AcExToolbarChildrenUi,
-  AcExToolbarItem,
-  AcExToolbarItemConfig,
-  AcExToolbarPresetRef,
-  AcExToolbarSeparator
+  AcUiToolbarChildrenUi,
+  AcUiToolbarItem,
+  AcUiToolbarItemConfig,
+  AcUiToolbarPresetRef,
+  AcUiToolbarSeparator
 } from './types'
 
 /**
@@ -11,30 +11,30 @@ import type {
  *
  * @param item - Parent toolbar item.
  */
-export function resolveToolbarChildrenUi(
-  item: AcExToolbarItem
-): AcExToolbarChildrenUi {
+export function acuiResolveToolbarChildrenUi(
+  item: AcUiToolbarItem
+): AcUiToolbarChildrenUi {
   return item.childrenUi ?? 'menu'
 }
 
 /** Returns whether {@link childrenUi} is an icon sub-toolbar (sticky or dismissible). */
-export function isToolbarChildrenStrip(
-  childrenUi: AcExToolbarChildrenUi
+export function acuiIsToolbarChildrenStrip(
+  childrenUi: AcUiToolbarChildrenUi
 ): boolean {
   return childrenUi === 'toolbar' || childrenUi === 'sticky-toolbar'
 }
 
 /** Returns whether a toolbar config entry is a visual separator. */
-export function isToolbarSeparatorItem(
-  item: AcExToolbarItemConfig
-): item is AcExToolbarSeparator {
+export function acuiIsToolbarSeparatorItem(
+  item: AcUiToolbarItemConfig
+): item is AcUiToolbarSeparator {
   return 'type' in item && item.type === 'separator'
 }
 
 /** Returns whether a toolbar config entry references a built-in preset button. */
-export function isToolbarPresetRef(
-  item: AcExToolbarItemConfig
-): item is AcExToolbarPresetRef {
+export function acuiIsToolbarPresetRef(
+  item: AcUiToolbarItemConfig
+): item is AcUiToolbarPresetRef {
   return 'preset' in item && typeof item.preset === 'string'
 }
 
@@ -46,7 +46,7 @@ export function isToolbarPresetRef(
  *
  * @param item - Toolbar item to inspect.
  */
-export function isDynamicToolbarChildren(item: AcExToolbarItem): boolean {
+export function acuiIsDynamicToolbarChildren(item: AcUiToolbarItem): boolean {
   return (
     typeof Object.getOwnPropertyDescriptor(item, 'children')?.get === 'function'
   )
@@ -59,10 +59,10 @@ export function isDynamicToolbarChildren(item: AcExToolbarItem): boolean {
  * @param getChildren - Factory invoked on each `children` access.
  * @returns `item` with a live `children` getter.
  */
-export function copyDynamicToolbarChildren(
-  item: AcExToolbarItem,
-  getChildren: () => AcExToolbarItem[]
-): AcExToolbarItem {
+export function acuiCopyDynamicToolbarChildren(
+  item: AcUiToolbarItem,
+  getChildren: () => AcUiToolbarItem[]
+): AcUiToolbarItem {
   Object.defineProperty(item, 'children', {
     configurable: true,
     enumerable: true,
@@ -78,13 +78,13 @@ export function copyDynamicToolbarChildren(
  * @param source - Original item that may define a children getter.
  * @returns Whether a getter was copied.
  */
-export function preserveDynamicToolbarChildren(
-  target: AcExToolbarItem,
-  source: AcExToolbarItem
+export function acuiPreserveDynamicToolbarChildren(
+  target: AcUiToolbarItem,
+  source: AcUiToolbarItem
 ): boolean {
   const descriptor = Object.getOwnPropertyDescriptor(source, 'children')
   if (typeof descriptor?.get !== 'function') return false
-  copyDynamicToolbarChildren(target, descriptor.get)
+  acuiCopyDynamicToolbarChildren(target, descriptor.get)
   return true
 }
 
@@ -93,7 +93,7 @@ export function preserveDynamicToolbarChildren(
  *
  * @param id - Optional stable id for debugging.
  */
-export function createToolbarSeparator(id?: string): AcExToolbarSeparator {
+export function acuiCreateToolbarSeparator(id?: string): AcUiToolbarSeparator {
   return { type: 'separator', id }
 }
 
@@ -102,34 +102,34 @@ export function createToolbarSeparator(id?: string): AcExToolbarSeparator {
  *
  * @param preset - Preset id such as `'pan'` or `'measure'`.
  */
-export function toolbarPreset(preset: string): AcExToolbarPresetRef {
+export function acuiToolbarPreset(preset: string): AcUiToolbarPresetRef {
   return { preset }
 }
 
 /** Returns whether a resolved toolbar item list includes the given button id. */
-export function toolbarItemsIncludeItem(
-  items: AcExToolbarItem[],
+export function acuiToolbarItemsIncludeItem(
+  items: AcUiToolbarItem[],
   itemId: string
 ): boolean {
   return items.some(item => {
-    if (isToolbarSeparatorItem(item)) return false
+    if (acuiIsToolbarSeparatorItem(item)) return false
     if (item.id === itemId) return true
     return item.children
-      ? toolbarItemsIncludeItem(item.children, itemId)
+      ? acuiToolbarItemsIncludeItem(item.children, itemId)
       : false
   })
 }
 
 /** Registers button items (and nested children) in a preset lookup map. */
-export function indexToolbarItems(
-  items: AcExToolbarItem[],
-  map: Map<string, AcExToolbarItem>
+export function acuiIndexToolbarItems(
+  items: AcUiToolbarItem[],
+  map: Map<string, AcUiToolbarItem>
 ): void {
   for (const item of items) {
-    if (isToolbarSeparatorItem(item)) continue
+    if (acuiIsToolbarSeparatorItem(item)) continue
     map.set(item.id, item)
-    if (!isDynamicToolbarChildren(item) && item.children?.length) {
-      indexToolbarItems(item.children, map)
+    if (!acuiIsDynamicToolbarChildren(item) && item.children?.length) {
+      acuiIndexToolbarItems(item.children, map)
     }
   }
 }
@@ -140,28 +140,28 @@ export function indexToolbarItems(
  * @param items - Raw toolbar configuration entries.
  * @param presets - Built-in items keyed by id.
  */
-export function expandToolbarItemConfigs(
-  items: AcExToolbarItemConfig[],
-  presets: Map<string, AcExToolbarItem>
-): AcExToolbarItem[] {
+export function acuiExpandToolbarItemConfigs(
+  items: AcUiToolbarItemConfig[],
+  presets: Map<string, AcUiToolbarItem>
+): AcUiToolbarItem[] {
   return items.flatMap(item => {
-    const expanded = expandToolbarItemConfig(item, presets)
+    const expanded = acuiExpandToolbarItemConfig(item, presets)
     return expanded ? [expanded] : []
   })
 }
 
-function expandToolbarItemConfig(
-  item: AcExToolbarItemConfig,
-  presets: Map<string, AcExToolbarItem>
-): AcExToolbarItem | null {
-  if (isToolbarSeparatorItem(item)) {
+function acuiExpandToolbarItemConfig(
+  item: AcUiToolbarItemConfig,
+  presets: Map<string, AcUiToolbarItem>
+): AcUiToolbarItem | null {
+  if (acuiIsToolbarSeparatorItem(item)) {
     return {
       type: 'separator',
       id: item.id ?? `separator-${Math.random().toString(36).slice(2, 9)}`
     }
   }
 
-  if (isToolbarPresetRef(item)) {
+  if (acuiIsToolbarPresetRef(item)) {
     const preset = presets.get(item.preset)
     if (!preset) {
       console.warn(
@@ -169,18 +169,18 @@ function expandToolbarItemConfig(
       )
       return null
     }
-    return cloneToolbarItem(preset)
+    return acuiCloneToolbarItem(preset)
   }
 
-  const buttonItem = item as AcExToolbarItem
-  if (isDynamicToolbarChildren(buttonItem)) {
-    return cloneToolbarItem(buttonItem)
+  const buttonItem = item as AcUiToolbarItem
+  if (acuiIsDynamicToolbarChildren(buttonItem)) {
+    return acuiCloneToolbarItem(buttonItem)
   }
   if (buttonItem.children?.length) {
     return {
       ...buttonItem,
-      children: expandToolbarItemConfigs(
-        buttonItem.children as AcExToolbarItemConfig[],
+      children: acuiExpandToolbarItemConfigs(
+        buttonItem.children as AcUiToolbarItemConfig[],
         presets
       )
     }
@@ -189,9 +189,9 @@ function expandToolbarItemConfig(
   return buttonItem
 }
 
-function cloneToolbarItem(item: AcExToolbarItem): AcExToolbarItem {
-  const clone: AcExToolbarItem = { ...item, children: item.children }
-  if (preserveDynamicToolbarChildren(clone, item)) {
+function acuiCloneToolbarItem(item: AcUiToolbarItem): AcUiToolbarItem {
+  const clone: AcUiToolbarItem = { ...item, children: item.children }
+  if (acuiPreserveDynamicToolbarChildren(clone, item)) {
     return clone
   }
   if (!item.children?.length) {
@@ -199,6 +199,6 @@ function cloneToolbarItem(item: AcExToolbarItem): AcExToolbarItem {
   }
   return {
     ...clone,
-    children: item.children.map(child => cloneToolbarItem(child))
+    children: item.children.map(child => acuiCloneToolbarItem(child))
   }
 }

--- a/packages/cad-simple-ui-plugin/src/config/types.ts
+++ b/packages/cad-simple-ui-plugin/src/config/types.ts
@@ -5,13 +5,13 @@ import type {
 } from '@mlightcad/cad-simple-viewer'
 
 /** Toolbar edge placement relative to the viewer host element. */
-export type AcExToolbarPlacement = 'top' | 'bottom' | 'left' | 'right'
+export type AcUiToolbarPlacement = 'top' | 'bottom' | 'left' | 'right'
 
 /** Dock panel edge placement relative to the viewer host element. */
-export type AcExDockPanelSide = 'top' | 'bottom' | 'left' | 'right'
+export type AcUiDockPanelSide = 'top' | 'bottom' | 'left' | 'right'
 
 /** Supported UI locale codes for plugin strings. */
-export type AcExLocale = 'en' | 'zh' | 'cs' | 'tr'
+export type AcUiLocale = 'en' | 'zh' | 'cs' | 'tr'
 
 /**
  * Controls how a parent button icon relates to its submenu selection.
@@ -19,7 +19,7 @@ export type AcExLocale = 'en' | 'zh' | 'cs' | 'tr'
  * - `'fixed'`: parent keeps its own `icon` (default).
  * - `'selected'`: parent shows the selected child's `icon`.
  */
-export type AcExToolbarChildIconMode = 'fixed' | 'selected'
+export type AcUiToolbarChildIconMode = 'fixed' | 'selected'
 
 /**
  * How nested `children` are presented when the parent button is clicked.
@@ -29,24 +29,24 @@ export type AcExToolbarChildIconMode = 'fixed' | 'selected'
  * - `'sticky-toolbar'`: icon sub-toolbar that stays open until the parent button
  *   is clicked again. Canvas clicks do not dismiss it.
  */
-export type AcExToolbarChildrenUi = 'menu' | 'toolbar' | 'sticky-toolbar'
+export type AcUiToolbarChildrenUi = 'menu' | 'toolbar' | 'sticky-toolbar'
 
 /** Visual separator between toolbar button groups. */
-export interface AcExToolbarSeparator {
+export interface AcUiToolbarSeparator {
   type: 'separator'
   /** Optional stable id for debugging. */
   id?: string
 }
 
 /** Reference to a built-in toolbar button when composing a custom layout. */
-export interface AcExToolbarPresetRef {
+export interface AcUiToolbarPresetRef {
   preset: string
 }
 
 /**
  * Configuration for a single toolbar button or submenu entry.
  */
-export interface AcExToolbarItem {
+export interface AcUiToolbarItem {
   /** Stable identifier used for DOM attributes and debugging. */
   id: string
   /** When `'separator'`, renders a divider instead of a button. */
@@ -75,18 +75,18 @@ export interface AcExToolbarItem {
   disabled?: boolean | (() => boolean)
   /** Nested submenu items shown when the button is clicked.
    * May be a live getter so the list can depend on the active document. */
-  children?: AcExToolbarItem[]
+  children?: AcUiToolbarItem[]
   /**
    * Presentation of {@link children}. Defaults to `'menu'` (popover dropdown).
    * Built-in Measure / Review use `'sticky-toolbar'`; Export, Toolbar
    * Position, and Language use `'toolbar'`.
    */
-  childrenUi?: AcExToolbarChildrenUi
+  childrenUi?: AcUiToolbarChildrenUi
   /**
    * When the button has `children`, controls whether the parent icon follows the
    * selected submenu item. Defaults to `'fixed'`.
    */
-  childIcon?: AcExToolbarChildIconMode
+  childIcon?: AcUiToolbarChildIconMode
   /** Initial submenu selection when {@link childIcon} is `'selected'`. */
   selectedChildId?: string
   /** Two-state button that merges `on` or `off` branch fields based on `getValue`. */
@@ -94,25 +94,25 @@ export interface AcExToolbarItem {
     /** Returns whether the toggle is in the "on" branch. */
     getValue: () => boolean
     /** Fields applied when `getValue` returns true. */
-    on: Partial<AcExToolbarItem>
+    on: Partial<AcUiToolbarItem>
     /** Fields applied when `getValue` returns false. */
-    off: Partial<AcExToolbarItem>
+    off: Partial<AcUiToolbarItem>
   }
 }
 
 /** Resolved toolbar entry: button, separator, or preset reference in config. */
-export type AcExToolbarItemConfig =
-  | AcExToolbarItem
-  | AcExToolbarSeparator
-  | AcExToolbarPresetRef
+export type AcUiToolbarItemConfig =
+  | AcUiToolbarItem
+  | AcUiToolbarSeparator
+  | AcUiToolbarPresetRef
 
 /** Toolbar item list passed to {@link AcApSimpleUiPlugin.setToolbarItems}. */
-export type AcExToolbarItemsInput = AcExToolbarItemConfig[] | 'default'
+export type AcUiToolbarItemsInput = AcUiToolbarItemConfig[] | 'default'
 
 /**
  * Callbacks supplied when building the default toolbar (theme, locale, and placement).
  */
-export interface AcExDefaultToolbarContext {
+export interface AcUiDefaultToolbarContext {
   /** Returns the current UI theme. */
   getTheme: () => AcEdUiTheme
   /** Applies a UI theme change. */
@@ -122,19 +122,19 @@ export interface AcExDefaultToolbarContext {
   /** Sets the application locale. */
   setLocale: (locale: AcApLocale) => void
   /** Returns the current toolbar edge placement. */
-  getPlacement: () => AcExToolbarPlacement
+  getPlacement: () => AcUiToolbarPlacement
   /** Moves the toolbar to the given host edge. */
-  setPlacement: (placement: AcExToolbarPlacement) => void
+  setPlacement: (placement: AcUiToolbarPlacement) => void
 }
 
 /**
- * Options passed to {@link createSimpleUiPlugin} and {@link registerSimpleUiPlugin}.
+ * Options passed to {@link acuiCreateSimpleUiPlugin} and {@link acuiRegisterSimpleUiPlugin}.
  */
-export interface AcExSimpleUiPluginOptions {
+export interface AcUiSimpleUiPluginOptions {
   /** Viewer host element; defaults to the active view container or `document.body`. */
   host?: HTMLElement
   /** @deprecated Locale follows {@link AcApI18n.currentLocale} automatically. */
-  locale?: AcExLocale
+  locale?: AcUiLocale
   /** Chrome DevTools-style dock panel configuration. */
   dockPanel?: {
     /** Explicitly enable the dock panel container. */
@@ -142,7 +142,7 @@ export interface AcExSimpleUiPluginOptions {
     /** @default false */
     defaultOpen?: boolean
     /** @default 'left' */
-    defaultSide?: AcExDockPanelSide
+    defaultSide?: AcUiDockPanelSide
     /** Bottom dock default height in px. @default 240 */
     defaultHeight?: number
     /** Left/right dock default width in px. @default 280 */
@@ -158,11 +158,11 @@ export interface AcExSimpleUiPluginOptions {
     /** When false, the toolbar is not created. */
     enabled?: boolean
     /** Edge placement relative to `host`. */
-    placement?: AcExToolbarPlacement
+    placement?: AcUiToolbarPlacement
     /** Toolbar items, `'default'`, or a custom list (may include presets and separators). */
-    items?: AcExToolbarItemConfig[] | 'default'
+    items?: AcUiToolbarItemConfig[] | 'default'
     /** Extra items merged into `items` (default: appended at the end). */
-    appendItems?: AcExToolbarItemConfig[]
+    appendItems?: AcUiToolbarItemConfig[]
     /**
      * Insert `appendItems` after the root toolbar item with this id.
      * Ignored when {@link appendItemsBefore} is set.

--- a/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
+++ b/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
@@ -12,31 +12,31 @@ import {
 import packageJson from '../package.json'
 import {
   AcApLayerUiCmd,
-  AcExLayerDockController,
-  AcExLayerUiControllerHolder
+  AcUiLayerDockController,
+  AcUiLayerUiControllerHolder
 } from './command/AcApLayerUiCmd'
 import { AcApMarkupPanelUiCmd } from './command/AcApMarkupPanelUiCmd'
-import { prependToolbarLayoutSwitcher } from './config/createToolbarLayoutSwitcher'
-import { normalizePluginOptions } from './config/normalizePluginOptions'
-import { resolveDockMountTarget } from './config/resolveDockMountTarget'
-import { resolveToolbarItems } from './config/resolveToolbarItems'
-import { resolveToolbarMountTarget } from './config/resolveToolbarMountTarget'
-import { toolbarItemsIncludeItem } from './config/toolbarItemUtils'
+import { acuiPrependToolbarLayoutSwitcher } from './config/createToolbarLayoutSwitcher'
+import { acuiNormalizePluginOptions } from './config/normalizePluginOptions'
+import { acuiResolveDockMountTarget } from './config/resolveDockMountTarget'
+import { acuiResolveToolbarItems } from './config/resolveToolbarItems'
+import { acuiResolveToolbarMountTarget } from './config/resolveToolbarMountTarget'
+import { acuiToolbarItemsIncludeItem } from './config/toolbarItemUtils'
 import {
-  AcExDockPanelSide,
-  AcExSimpleUiPluginOptions,
-  AcExToolbarItem,
-  AcExToolbarItemsInput,
-  AcExToolbarPlacement,
+  AcUiDockPanelSide,
+  AcUiSimpleUiPluginOptions,
+  AcUiToolbarItem,
+  AcUiToolbarItemsInput,
+  AcUiToolbarPlacement,
   SIMPLE_UI_PLUGIN_NAME
 } from './config/types'
-import { AcExI18n, registerSimpleUiI18n } from './i18n'
-import { AcExUiThemeSync } from './theme/AcExUiThemeSync'
-import { AcExDockPanel, type AcExDockPanelTab } from './ui/AcExDockPanel'
-import { AcExLayerListView } from './ui/AcExLayerListView'
-import { AcExReviewPaletteView } from './ui/AcExReviewPaletteView'
-import { AcExToolbar } from './ui/AcExToolbar'
-import { removeUiStylesIfUnused } from './ui/styles'
+import { AcUiI18n, acuiRegisterSimpleUiI18n } from './i18n'
+import { AcUiThemeSync } from './theme/AcUiThemeSync'
+import { AcUiDockPanel, type AcUiDockPanelTab } from './ui/AcUiDockPanel'
+import { AcUiLayerListView } from './ui/AcUiLayerListView'
+import { AcUiReviewPaletteView } from './ui/AcUiReviewPaletteView'
+import { AcUiToolbar } from './ui/AcUiToolbar'
+import { acuiRemoveUiStylesIfUnused } from './ui/styles'
 
 const LAYERS_TAB_ID = 'layers'
 const REVIEW_TAB_ID = 'review'
@@ -55,32 +55,33 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   /** Plugin semver string. */
   version = packageJson.version
   /** Human-readable plugin summary. */
-  description = 'Framework-agnostic toolbar, layer manager, and review palette UI'
+  description =
+    'Framework-agnostic toolbar, layer manager, and review palette UI'
 
   /** Layer list view mounted in the dock panel layers tab. */
-  private layerListView?: AcExLayerListView
+  private layerListView?: AcUiLayerListView
   /** Review palette view mounted in the dock panel review tab. */
-  private reviewPaletteView?: AcExReviewPaletteView
+  private reviewPaletteView?: AcUiReviewPaletteView
   /** Chrome DevTools-style dock panel container. */
-  private dockPanel?: AcExDockPanel
+  private dockPanel?: AcUiDockPanel
   /** Dock-mode layer controller (for cleanup). */
-  private layerDockController?: AcExLayerDockController
+  private layerDockController?: AcUiLayerDockController
   /** Mutable delegate for the registered `layer` command. */
-  private readonly layerUiControllerHolder = new AcExLayerUiControllerHolder()
+  private readonly layerUiControllerHolder = new AcUiLayerUiControllerHolder()
   /** Configurable toolbar instance. */
-  private toolbar?: AcExToolbar
+  private toolbar?: AcUiToolbar
   /** Scoped i18n helper for plugin strings. */
-  private i18n?: AcExI18n
+  private i18n?: AcUiI18n
   /** Syncs UI theme with host attribute and database sysvar. */
-  private themeSync?: AcExUiThemeSync
+  private themeSync?: AcUiThemeSync
   /** Viewer host element receiving UI chrome. */
   private hostEl?: HTMLElement
   /** Explicit dock mount override from plugin options. */
   private dockPanelMountTargetOption?: HTMLElement
   /** Resolved toolbar items before layer action wiring. */
-  private baseToolbarItems: AcExToolbarItem[] = []
+  private baseToolbarItems: AcUiToolbarItem[] = []
   /** Raw toolbar items configuration last applied via {@link setToolbarItems}. */
-  private toolbarItemsInput: AcExToolbarItemsInput = 'default'
+  private toolbarItemsInput: AcUiToolbarItemsInput = 'default'
   /** Command stack reference for dynamic layer command registration. */
   private commandManager?: AcEdCommandStack
   /** Whether the toolbar includes a layer button. */
@@ -97,7 +98,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     defaultWidth: number
   }
   /** Current toolbar edge placement (mutable via toolbar settings button). */
-  private toolbarPlacement: AcExToolbarPlacement = 'right'
+  private toolbarPlacement: AcUiToolbarPlacement = 'right'
   /** Whether the viewer toolbar supports collapse/expand. */
   private toolbarCollapsible = false
   /** Canvas element receiving the floating viewer toolbar. */
@@ -110,10 +111,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   private registeredCommands: Array<{ group: string; name: string }> = []
   /** Refreshes toolbar, layer, and review UI when the app locale changes. */
   private handleLocaleChanged = () => {
-    this.toolbar?.setSelectedChild(
-      'locale',
-      `locale-${AcApI18n.currentLocale}`
-    )
+    this.toolbar?.setSelectedChild('locale', `locale-${AcApI18n.currentLocale}`)
     this.layerListView?.refreshLocale()
     this.reviewPaletteView?.refreshLocale()
     this.dockPanel?.refreshLocale()
@@ -135,7 +133,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   /**
    * @param options - Toolbar, layer manager, dock panel, and host configuration.
    */
-  constructor(private readonly options: AcExSimpleUiPluginOptions = {}) {}
+  constructor(private readonly options: AcUiSimpleUiPluginOptions = {}) {}
 
   /**
    * Adds a tab to the dock panel and opens it.
@@ -144,7 +142,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
    * @param tab - Tab definition.
    * @returns Whether the tab was added.
    */
-  addDockPanelTab(tab: AcExDockPanelTab): boolean {
+  addDockPanelTab(tab: AcUiDockPanelTab): boolean {
     if (!tab.labelKey && !tab.label) return false
 
     this.ensureDockReady()
@@ -217,7 +215,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   }
 
   /** Returns the dock panel side, if the dock panel exists. */
-  getDockPanelSide(): AcExDockPanelSide | undefined {
+  getDockPanelSide(): AcUiDockPanelSide | undefined {
     return this.dockPanel?.getSide()
   }
 
@@ -246,7 +244,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   }
 
   /** Returns the toolbar item configuration last passed to {@link setToolbarItems}. */
-  getToolbarItems(): AcExToolbarItemsInput {
+  getToolbarItems(): AcUiToolbarItemsInput {
     return this.toolbarItemsInput
   }
 
@@ -261,15 +259,15 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
    * @param layoutSwitcher - Optional layout submenu button prepended before `items`.
    */
   setToolbarItems(
-    items: AcExToolbarItemsInput,
-    layoutSwitcher?: AcExToolbarItem
+    items: AcUiToolbarItemsInput,
+    layoutSwitcher?: AcUiToolbarItem
   ) {
     if (!this.toolbar) return
 
     this.toolbarItemsInput = items
     const resolved = this.resolveBaseToolbarItems(items)
     this.baseToolbarItems = layoutSwitcher
-      ? prependToolbarLayoutSwitcher(resolved, layoutSwitcher)
+      ? acuiPrependToolbarLayoutSwitcher(resolved, layoutSwitcher)
       : resolved
     this.syncLayerToolbarItem()
     this.syncReviewToolbarItem()
@@ -277,7 +275,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   }
 
   /** Returns the viewer toolbar edge placement. */
-  getToolbarPlacement(): AcExToolbarPlacement {
+  getToolbarPlacement(): AcUiToolbarPlacement {
     return this.toolbarPlacement
   }
 
@@ -287,7 +285,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
    * @param placement - Target edge placement.
    * @returns `true` when applied; `false` when the toolbar is unavailable.
    */
-  setToolbarPlacement(placement: AcExToolbarPlacement): boolean {
+  setToolbarPlacement(placement: AcUiToolbarPlacement): boolean {
     if (!this.toolbar) {
       console.warn(
         '[SimpleUiPlugin] setToolbarPlacement skipped: toolbar is unavailable.'
@@ -381,13 +379,13 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
    * @param commandManager - Command stack used to register `layer` and `markuppanel`.
    */
   onLoad(_context: AcApContext, commandManager: AcEdCommandStack): void {
-    registerSimpleUiI18n()
+    acuiRegisterSimpleUiI18n()
     this.commandManager = commandManager
     // This shell has no command ribbon; keep the draw-style overlay available
     // without persisting isShowRibbon into shared localStorage.
     acapSetDrawStyleHostHasRibbon(false)
 
-    const resolvedOptions = normalizePluginOptions(this.options)
+    const resolvedOptions = acuiNormalizePluginOptions(this.options)
     const host =
       resolvedOptions.host ??
       AcApDocManager.instance.curView?.container ??
@@ -407,10 +405,10 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       defaultWidth: resolvedOptions.dockPanel.defaultWidth ?? 280
     }
 
-    this.themeSync = new AcExUiThemeSync(host, () => this.toolbar?.refresh())
+    this.themeSync = new AcUiThemeSync(host, () => this.toolbar?.refresh())
     this.themeSync.start()
 
-    this.i18n = new AcExI18n()
+    this.i18n = new AcUiI18n()
     AcApI18n.events.localeChanged.addEventListener(this.handleLocaleChanged)
     AcApDocManager.instance.events.documentActivated.addEventListener(
       this.handleDocumentActivatedForDock
@@ -419,14 +417,17 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     const toolbarEnabled = resolvedOptions.toolbar.enabled
     this.toolbarItemsInput = resolvedOptions.toolbar.items ?? 'default'
     this.baseToolbarItems = toolbarEnabled
-      ? resolveToolbarItems(resolvedOptions.toolbar, this.getToolbarContext())
+      ? acuiResolveToolbarItems(
+          resolvedOptions.toolbar,
+          this.getToolbarContext()
+        )
       : []
 
-    this.hasLayerToolbarItem = toolbarItemsIncludeItem(
+    this.hasLayerToolbarItem = acuiToolbarItemsIncludeItem(
       this.baseToolbarItems,
       'layer'
     )
-    this.hasMarkupPanelToolbarItem = toolbarItemsIncludeItem(
+    this.hasMarkupPanelToolbarItem = acuiToolbarItemsIncludeItem(
       this.baseToolbarItems,
       'markup-panel'
     )
@@ -448,7 +449,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     if (toolbarEnabled) {
       const toolbarMountEl = this.getToolbarMountEl() ?? host
       this.toolbarMountEl = toolbarMountEl
-      this.toolbar = new AcExToolbar({
+      this.toolbar = new AcUiToolbar({
         host: toolbarMountEl,
         themeHost: host,
         placement: this.toolbarPlacement,
@@ -470,7 +471,10 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   /** Resolves the canvas element that receives the floating toolbar. */
   private getToolbarMountEl(): HTMLElement | undefined {
     if (!this.hostEl) return undefined
-    return resolveToolbarMountTarget(this.hostEl, this.toolbarMountTargetOption)
+    return acuiResolveToolbarMountTarget(
+      this.hostEl,
+      this.toolbarMountTargetOption
+    )
   }
 
   /**
@@ -481,7 +485,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       return
     }
 
-    const preferred = resolveToolbarMountTarget(this.hostEl)
+    const preferred = acuiResolveToolbarMountTarget(this.hostEl)
     if (preferred === this.toolbarMountEl || preferred === this.hostEl) {
       return
     }
@@ -501,7 +505,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       getLocale: () => AcApI18n.currentLocale,
       setLocale: (locale: AcApLocale) => this.setLocale(locale),
       getPlacement: () => this.toolbarPlacement,
-      setPlacement: (placement: AcExToolbarPlacement) => {
+      setPlacement: (placement: AcUiToolbarPlacement) => {
         this.applyToolbarPlacement(placement)
       }
     }
@@ -509,9 +513,9 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
 
   /** Resolves raw toolbar input into concrete toolbar items. */
   private resolveBaseToolbarItems(
-    items: AcExToolbarItemsInput
-  ): AcExToolbarItem[] {
-    return resolveToolbarItems(
+    items: AcUiToolbarItemsInput
+  ): AcUiToolbarItem[] {
+    return acuiResolveToolbarItems(
       { items, appendItems: undefined },
       this.getToolbarContext()
     )
@@ -525,7 +529,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   /** Mounts or tears down layer UI when the layer toolbar button is added or removed. */
   private syncLayerToolbarItem() {
     const hadLayer = this.hasLayerToolbarItem
-    const hasLayer = toolbarItemsIncludeItem(this.baseToolbarItems, 'layer')
+    const hasLayer = acuiToolbarItemsIncludeItem(this.baseToolbarItems, 'layer')
     this.hasLayerToolbarItem = hasLayer
 
     if (hasLayer && !hadLayer) {
@@ -540,7 +544,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   /** Mounts or tears down review UI when the markup panel button is added or removed. */
   private syncReviewToolbarItem() {
     const hadReview = this.hasMarkupPanelToolbarItem
-    const hasReview = toolbarItemsIncludeItem(
+    const hasReview = acuiToolbarItemsIncludeItem(
       this.baseToolbarItems,
       'markup-panel'
     )
@@ -693,7 +697,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       return
     }
 
-    this.dockPanel = new AcExDockPanel({
+    this.dockPanel = new AcUiDockPanel({
       host: mountEl,
       i18n: this.i18n,
       defaultSide: this.dockPanelDefaults.defaultSide,
@@ -706,7 +710,10 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   /** Resolves the dock mount element (lazy; canvas parent may appear after load). */
   private getDockMountEl(): HTMLElement | undefined {
     if (!this.hostEl) return undefined
-    return resolveDockMountTarget(this.hostEl, this.dockPanelMountTargetOption)
+    return acuiResolveDockMountTarget(
+      this.hostEl,
+      this.dockPanelMountTargetOption
+    )
   }
 
   /**
@@ -717,7 +724,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       return
     }
 
-    const preferred = resolveDockMountTarget(this.hostEl)
+    const preferred = acuiResolveDockMountTarget(this.hostEl)
     const current = this.dockPanel.getMountHost()
 
     if (current === preferred) {
@@ -740,7 +747,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     }
 
     this.layerDockController?.destroy()
-    this.layerDockController = new AcExLayerDockController(
+    this.layerDockController = new AcUiLayerDockController(
       this.dockPanel,
       LAYERS_TAB_ID
     )
@@ -759,7 +766,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       return
     }
 
-    this.layerListView = new AcExLayerListView({
+    this.layerListView = new AcUiLayerListView({
       editor: AcApDocManager.instance,
       i18n: this.i18n,
       host: this.hostEl,
@@ -776,7 +783,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       return
     }
 
-    this.layerDockController = new AcExLayerDockController(
+    this.layerDockController = new AcUiLayerDockController(
       this.dockPanel,
       LAYERS_TAB_ID
     )
@@ -808,7 +815,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       return
     }
 
-    this.reviewPaletteView = new AcExReviewPaletteView({
+    this.reviewPaletteView = new AcUiReviewPaletteView({
       editor: AcApDocManager.instance,
       i18n: this.i18n
     })
@@ -844,7 +851,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   }
 
   /** Updates toolbar placement. */
-  private applyToolbarPlacement(placement: AcExToolbarPlacement) {
+  private applyToolbarPlacement(placement: AcUiToolbarPlacement) {
     this.toolbarPlacement = placement
     this.toolbar?.setPlacement(placement)
   }
@@ -887,7 +894,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     this.themeSync = undefined
     acapSetDrawStyleHostHasRibbon(undefined)
 
-    removeUiStylesIfUnused()
+    acuiRemoveUiStylesIfUnused()
   }
 
   /** Sets {@link AcApI18n.currentLocale} to one of the supported locales. */
@@ -902,8 +909,8 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
  * @param options - Plugin configuration.
  * @returns A new plugin instance ready for {@link AcApPluginManager.loadPlugin}.
  */
-export function createSimpleUiPlugin(
-  options: AcExSimpleUiPluginOptions = {}
+export function acuiCreateSimpleUiPlugin(
+  options: AcUiSimpleUiPluginOptions = {}
 ): AcApSimpleUiPlugin {
   return new AcApSimpleUiPlugin(options)
 }

--- a/packages/cad-simple-ui-plugin/src/i18n/cs.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/cs.ts
@@ -1,5 +1,5 @@
 /**
- * Czech UI strings for {@link registerSimpleUiI18n}.
+ * Czech UI strings for {@link acuiRegisterSimpleUiI18n}.
  *
  * Keys use dot notation (for example `toolbar.select`) and are nested under
  * the `simpleUi` namespace when registered.

--- a/packages/cad-simple-ui-plugin/src/i18n/en.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/en.ts
@@ -1,5 +1,5 @@
 /**
- * English UI strings for {@link registerSimpleUiI18n}.
+ * English UI strings for {@link acuiRegisterSimpleUiI18n}.
  *
  * Keys use dot notation (for example `toolbar.select`) and are nested under
  * the `simpleUi` namespace when registered.

--- a/packages/cad-simple-ui-plugin/src/i18n/index.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/index.ts
@@ -19,7 +19,7 @@ interface LocaleMessageTree {
   [key: string]: string | LocaleMessageTree
 }
 
-/** Whether {@link registerSimpleUiI18n} has already run. */
+/** Whether {@link acuiRegisterSimpleUiI18n} has already run. */
 let isRegistered = false
 
 /**
@@ -50,7 +50,7 @@ function flatToNested(flat: Record<string, string>): LocaleMessageTree {
  *
  * Safe to call multiple times; subsequent calls are no-ops.
  */
-export function registerSimpleUiI18n(): void {
+export function acuiRegisterSimpleUiI18n(): void {
   if (isRegistered) return
   AcApI18n.mergeLocaleMessage('en', {
     command: commandEn,
@@ -78,7 +78,7 @@ export function registerSimpleUiI18n(): void {
 /**
  * Scoped translation helper for plugin UI strings under the `simpleUi` namespace.
  */
-export class AcExI18n {
+export class AcUiI18n {
   /**
    * Translates a key relative to the `simpleUi` namespace.
    *

--- a/packages/cad-simple-ui-plugin/src/i18n/tr.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/tr.ts
@@ -1,5 +1,5 @@
 /**
- * Turkish UI strings for {@link registerSimpleUiI18n}.
+ * Turkish UI strings for {@link acuiRegisterSimpleUiI18n}.
  *
  * Keys use dot notation (for example `toolbar.select`) and are nested under
  * the `simpleUi` namespace when registered.

--- a/packages/cad-simple-ui-plugin/src/i18n/zh.ts
+++ b/packages/cad-simple-ui-plugin/src/i18n/zh.ts
@@ -1,5 +1,5 @@
 /**
- * Chinese UI strings for {@link registerSimpleUiI18n}.
+ * Chinese UI strings for {@link acuiRegisterSimpleUiI18n}.
  *
  * Keys use dot notation (for example `toolbar.select`) and are nested under
  * the `simpleUi` namespace when registered.

--- a/packages/cad-simple-ui-plugin/src/index.ts
+++ b/packages/cad-simple-ui-plugin/src/index.ts
@@ -6,38 +6,38 @@
  */
 export {
   AcApSimpleUiPlugin,
-  createSimpleUiPlugin
+  acuiCreateSimpleUiPlugin
 } from './createSimpleUiPlugin'
-export type { AcExDockPanelTab } from './ui/AcExDockPanel'
-export { registerSimpleUiPlugin } from './register'
+export type { AcUiDockPanelTab } from './ui/AcUiDockPanel'
+export { acuiRegisterSimpleUiPlugin } from './register'
 export {
-  createToolbarLayoutSwitcher,
-  prependToolbarLayoutSwitcher
+  acuiCreateToolbarLayoutSwitcher,
+  acuiPrependToolbarLayoutSwitcher
 } from './config/createToolbarLayoutSwitcher'
 export type {
-  AcExToolbarLayoutPreset,
-  AcExToolbarLayoutSwitcherOptions
+  AcUiToolbarLayoutPreset,
+  AcUiToolbarLayoutSwitcherOptions
 } from './config/createToolbarLayoutSwitcher'
 export type {
-  AcExDefaultToolbarContext,
-  AcExDockPanelSide,
-  AcExLocale,
-  AcExSimpleUiPluginOptions,
-  AcExToolbarItem,
-  AcExToolbarItemConfig,
-  AcExToolbarItemsInput,
-  AcExToolbarChildIconMode,
-  AcExToolbarChildrenUi,
-  AcExToolbarPresetRef,
-  AcExToolbarSeparator,
-  AcExToolbarPlacement
+  AcUiDefaultToolbarContext,
+  AcUiDockPanelSide,
+  AcUiLocale,
+  AcUiSimpleUiPluginOptions,
+  AcUiToolbarItem,
+  AcUiToolbarItemConfig,
+  AcUiToolbarItemsInput,
+  AcUiToolbarChildIconMode,
+  AcUiToolbarChildrenUi,
+  AcUiToolbarPresetRef,
+  AcUiToolbarSeparator,
+  AcUiToolbarPlacement
 } from './config/types'
 export { SIMPLE_UI_PLUGIN_NAME } from './config/types'
-export { createDefaultToolbarPresetMap } from './config/resolveToolbarItems'
+export { acuiCreateDefaultToolbarPresetMap } from './config/resolveToolbarItems'
 export {
-  createToolbarSeparator,
-  toolbarPreset
+  acuiCreateToolbarSeparator,
+  acuiToolbarPreset
 } from './config/toolbarItemUtils'
-export { AcExI18n, registerSimpleUiI18n } from './i18n'
+export { AcUiI18n, acuiRegisterSimpleUiI18n } from './i18n'
 export type { AcApLayerInfo } from '@mlightcad/cad-simple-viewer'
 export { AcApLayerStore } from '@mlightcad/cad-simple-viewer'

--- a/packages/cad-simple-ui-plugin/src/register.ts
+++ b/packages/cad-simple-ui-plugin/src/register.ts
@@ -1,6 +1,6 @@
 import type { AcApPluginManager } from '@mlightcad/cad-simple-viewer'
 
-import type { AcExSimpleUiPluginOptions } from './config/types'
+import type { AcUiSimpleUiPluginOptions } from './config/types'
 
 /**
  * Loads the simple UI plugin on the given plugin manager.
@@ -9,13 +9,13 @@ import type { AcExSimpleUiPluginOptions } from './config/types'
  * bundle is not pulled into the application entry chunk.
  *
  * @param pluginManager - Target plugin manager instance.
- * @param options - Passed through to {@link createSimpleUiPlugin}.
+ * @param options - Passed through to {@link acuiCreateSimpleUiPlugin}.
  */
-export async function registerSimpleUiPlugin(
+export async function acuiRegisterSimpleUiPlugin(
   pluginManager: AcApPluginManager,
-  options: AcExSimpleUiPluginOptions = {}
+  options: AcUiSimpleUiPluginOptions = {}
 ): Promise<void> {
-  const { createSimpleUiPlugin } =
+  const { acuiCreateSimpleUiPlugin } =
     await import('@mlightcad/cad-simple-ui-plugin')
-  await pluginManager.loadPlugin(createSimpleUiPlugin(options))
+  await pluginManager.loadPlugin(acuiCreateSimpleUiPlugin(options))
 }

--- a/packages/cad-simple-ui-plugin/src/theme/AcUiThemeSync.ts
+++ b/packages/cad-simple-ui-plugin/src/theme/AcUiThemeSync.ts
@@ -17,7 +17,7 @@ import {
  * @param host - Viewer host element.
  * @returns `'light'`, `'dark'`, or `undefined` when unset or invalid.
  */
-export function readUiThemeFromHost(
+export function acuiReadUiThemeFromHost(
   host: HTMLElement
 ): AcEdUiTheme | undefined {
   const attr = host.getAttribute('data-ml-ui-theme')
@@ -30,7 +30,9 @@ export function readUiThemeFromHost(
  *
  * @param database - Drawing database.
  */
-export function readUiThemeFromDatabase(database: AcDbDatabase): AcEdUiTheme {
+export function acuiReadUiThemeFromDatabase(
+  database: AcDbDatabase
+): AcEdUiTheme {
   const value = AcDbSysVarManager.instance().getVar(
     AcDbSystemVariables.COLORTHEME,
     database
@@ -41,7 +43,7 @@ export function readUiThemeFromDatabase(database: AcDbDatabase): AcEdUiTheme {
 /**
  * Keeps `data-ml-ui-theme` on the host in sync with `COLORTHEME` and document activation.
  */
-export class AcExUiThemeSync {
+export class AcUiThemeSync {
   /** Applies theme when `COLORTHEME` changes on the active database. */
   private handleSysVarChanged = (args: AcDbSysVarEventArgs) => {
     const database = AcApDocManager.instance.curDocument?.database
@@ -58,7 +60,7 @@ export class AcExUiThemeSync {
   private handleDocumentActivated = (args: {
     doc: { database: AcDbDatabase }
   }) => {
-    this.applyTheme(readUiThemeFromDatabase(args.doc.database))
+    this.applyTheme(acuiReadUiThemeFromDatabase(args.doc.database))
   }
 
   /**
@@ -98,7 +100,7 @@ export class AcExUiThemeSync {
    * Defaults to `'dark'` when the attribute is missing.
    */
   getTheme(): AcEdUiTheme {
-    return readUiThemeFromHost(this.host) ?? 'dark'
+    return acuiReadUiThemeFromHost(this.host) ?? 'dark'
   }
 
   /**
@@ -125,11 +127,11 @@ export class AcExUiThemeSync {
   private syncFromCurrentSource() {
     const database = AcApDocManager.instance.curDocument?.database
     if (database) {
-      this.applyTheme(readUiThemeFromDatabase(database))
+      this.applyTheme(acuiReadUiThemeFromDatabase(database))
       return
     }
 
-    const fromHost = readUiThemeFromHost(this.host)
+    const fromHost = acuiReadUiThemeFromHost(this.host)
     if (fromHost) return
   }
 

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiColorPicker.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiColorPicker.ts
@@ -1,7 +1,7 @@
 import { AcCmColor, AcCmColorMethod } from '@mlightcad/data-model'
 
-import type { AcExI18n } from '../i18n'
-import { ensureUiStyles } from './styles'
+import type { AcUiI18n } from '../i18n'
+import { acuiEnsureUiStyles } from './styles'
 
 const SMALL_COLORS = Array.from({ length: 9 }, (_, i) => i + 1)
 const LARGE_COLORS = Array.from({ length: 240 }, (_, i) => i + 10)
@@ -12,7 +12,7 @@ const GRAY_COLORS = Array.from({ length: 6 }, (_, i) => i + 250)
  *
  * Presents standard AutoCAD Color Index palettes plus numeric or hex input.
  */
-export class AcExColorPicker {
+export class AcUiColorPicker {
   /** Full-screen backdrop containing the dialog. */
   private backdrop: HTMLDivElement
   /** Currently selected ACI index, if any. */
@@ -36,11 +36,11 @@ export class AcExColorPicker {
    * @param initialColor - Optional initial selection.
    */
   constructor(
-    private i18n: AcExI18n,
+    private i18n: AcUiI18n,
     themeHost: HTMLElement,
     initialColor?: AcCmColor
   ) {
-    ensureUiStyles()
+    acuiEnsureUiStyles()
     this.selectedIndex = this.toColorIndex(initialColor)
 
     this.backdrop = document.createElement('div')

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiDockPanel.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiDockPanel.ts
@@ -9,16 +9,16 @@ import {
   ICON_PLACEMENT_RIGHT,
   ICON_PLACEMENT_TOP
 } from '../assets/icons'
-import type { AcExDockPanelSide } from '../config/types'
-import type { AcExI18n } from '../i18n'
-import { ensureUiStyles } from './styles'
+import type { AcUiDockPanelSide } from '../config/types'
+import type { AcUiI18n } from '../i18n'
+import { acuiEnsureUiStyles } from './styles'
 
 const DOCK_MIN_SIZE = 120
 const DOCK_MAX_SIZE_RATIO = 0.75
 const DOCK_TAB_OVERFLOW_BTN_WIDTH = 28
 
-/** Tab definition for {@link AcExDockPanel}. */
-export interface AcExDockPanelTab {
+/** Tab definition for {@link AcUiDockPanel}. */
+export interface AcUiDockPanelTab {
   /** Stable tab identifier. */
   id: string
   /** i18n key under the `simpleUi` namespace. */
@@ -29,14 +29,14 @@ export interface AcExDockPanelTab {
   content: HTMLElement
 }
 
-/** Constructor options for {@link AcExDockPanel}. */
-export interface AcExDockPanelOptions {
+/** Constructor options for {@link AcUiDockPanel}. */
+export interface AcUiDockPanelOptions {
   /** Viewer host element; dock panel is appended as a direct child. */
   host: HTMLElement
   /** i18n helper for labels. */
-  i18n: AcExI18n
+  i18n: AcUiI18n
   /** Initial dock side. @default 'left' */
-  defaultSide?: AcExDockPanelSide
+  defaultSide?: AcUiDockPanelSide
   /** Whether the panel starts open. @default false */
   defaultOpen?: boolean
   /** Bottom dock default height in px. @default 240 */
@@ -57,9 +57,9 @@ interface DockTabRecord {
 /**
  * Chrome DevTools-style dock panel with tabs, open/close, and dock side selection.
  */
-export class AcExDockPanel {
+export class AcUiDockPanel {
   private host: HTMLElement
-  private readonly i18n: AcExI18n
+  private readonly i18n: AcUiI18n
   private readonly root: HTMLDivElement
   private readonly contentEl: HTMLDivElement
   private readonly tabsWrap: HTMLDivElement
@@ -71,7 +71,7 @@ export class AcExDockPanel {
   private readonly closeButton: HTMLButtonElement
   private readonly tabs = new Map<string, DockTabRecord>()
   private activeTabId?: string
-  private side: AcExDockPanelSide
+  private side: AcUiDockPanelSide
   private isPanelOpen: boolean
   private size: number
   private defaultHeight: number
@@ -157,7 +157,7 @@ export class AcExDockPanel {
   /**
    * @param options - Host, i18n, and initial layout options.
    */
-  constructor(options: AcExDockPanelOptions) {
+  constructor(options: AcUiDockPanelOptions) {
     this.host = options.host
     this.i18n = options.i18n
     this.side = options.defaultSide ?? 'left'
@@ -169,7 +169,7 @@ export class AcExDockPanel {
         ? this.defaultHeight
         : this.defaultWidth
 
-    ensureUiStyles()
+    acuiEnsureUiStyles()
     this.ensureHostLayout()
 
     this.root = document.createElement('div')
@@ -276,7 +276,7 @@ export class AcExDockPanel {
    * @param tab - Tab definition.
    * @returns `true` when the tab was added; `false` if it already exists or is invalid.
    */
-  addTab(tab: AcExDockPanelTab): boolean {
+  addTab(tab: AcUiDockPanelTab): boolean {
     if (this.tabs.has(tab.id)) return false
     if (!tab.labelKey && !tab.label) return false
 
@@ -438,7 +438,7 @@ export class AcExDockPanel {
    *
    * @param side - New dock side.
    */
-  setSide(side: AcExDockPanelSide) {
+  setSide(side: AcUiDockPanelSide) {
     if (this.side === side) return
     const previousSide = this.side
     this.side = side
@@ -476,7 +476,7 @@ export class AcExDockPanel {
   }
 
   /** Current dock side. */
-  getSide(): AcExDockPanelSide {
+  getSide(): AcUiDockPanelSide {
     return this.side
   }
 
@@ -717,7 +717,7 @@ export class AcExDockPanel {
     this.sideMenuRoot.replaceChildren()
 
     const sides: Array<{
-      side: AcExDockPanelSide
+      side: AcUiDockPanelSide
       labelKey: string
       icon: string
     }> = [

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiDropdownMenu.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiDropdownMenu.ts
@@ -1,20 +1,20 @@
 import { createIconElement } from '../assets/icons'
-import { isToolbarSeparatorItem } from '../config/toolbarItemUtils'
-import type { AcExToolbarItem } from '../config/types'
-import type { AcExI18n } from '../i18n'
+import { acuiIsToolbarSeparatorItem } from '../config/toolbarItemUtils'
+import type { AcUiToolbarItem } from '../config/types'
+import type { AcUiI18n } from '../i18n'
 
 /**
  * Fixed-position dropdown menu for toolbar submenu items.
  *
  * Closes on outside click and positions itself near the anchor button.
  */
-export class AcExDropdownMenu {
+export class AcUiDropdownMenu {
   /** Menu root element appended to the theme host. */
   private root: HTMLDivElement
   /** Parent button that opened this menu. */
   private anchor: HTMLElement
   /** Handler invoked when a menu item is chosen. */
-  private onSelect?: (item: AcExToolbarItem) => void
+  private onSelect?: (item: AcUiToolbarItem) => void
   /** Handler invoked when the menu is closed. */
   private onClose?: () => void
   /** Closes the menu when the user clicks outside the menu and its anchor. */
@@ -32,8 +32,8 @@ export class AcExDropdownMenu {
    * @param themeHost - Theme host so `--ml-ui-*` CSS variables are inherited.
    */
   constructor(
-    private i18n: AcExI18n,
-    items: AcExToolbarItem[],
+    private i18n: AcUiI18n,
+    items: AcUiToolbarItem[],
     anchor: HTMLElement,
     private themeHost: HTMLElement
   ) {
@@ -43,7 +43,7 @@ export class AcExDropdownMenu {
     this.root.setAttribute('role', 'menu')
 
     items.forEach(item => {
-      if (isToolbarSeparatorItem(item)) {
+      if (acuiIsToolbarSeparatorItem(item)) {
         const separator = document.createElement('div')
         separator.className = 'ml-ex-ui-dropdown-separator'
         separator.setAttribute('role', 'separator')
@@ -87,7 +87,7 @@ export class AcExDropdownMenu {
    *
    * @param handler - Selection handler.
    */
-  setOnSelect(handler: (item: AcExToolbarItem) => void) {
+  setOnSelect(handler: (item: AcUiToolbarItem) => void) {
     this.onSelect = handler
   }
 

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiLayerListView.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiLayerListView.ts
@@ -5,19 +5,19 @@ import {
 } from '@mlightcad/cad-simple-viewer'
 import { AcCmColor } from '@mlightcad/data-model'
 
-import type { AcExI18n } from '../i18n'
-import { AcExColorPicker } from './AcExColorPicker'
-import { ensureUiStyles } from './styles'
+import type { AcUiI18n } from '../i18n'
+import { AcUiColorPicker } from './AcUiColorPicker'
+import { acuiEnsureUiStyles } from './styles'
 
 /** Sort direction for the layer name column. */
-export type AcExLayerNameSortOrder = 'none' | 'asc' | 'desc'
+export type AcUiLayerNameSortOrder = 'none' | 'asc' | 'desc'
 
-/** Constructor options for {@link AcExLayerListView}. */
-export interface AcExLayerListViewOptions {
+/** Constructor options for {@link AcUiLayerListView}. */
+export interface AcUiLayerListViewOptions {
   /** Document manager used to resolve the active document's layer store. */
   editor: AcApDocManager
   /** i18n helper for panel labels. */
-  i18n: AcExI18n
+  i18n: AcUiI18n
   /** Viewer host used for theme CSS variables and color picker. */
   host: HTMLElement
   /** When true, renders a title header above the table. */
@@ -29,7 +29,7 @@ export interface AcExLayerListViewOptions {
  *
  * Used in dock panel tabs (for example the layers tab).
  */
-export class AcExLayerListView {
+export class AcUiLayerListView {
   /** Root element containing optional header and table. */
   readonly element: HTMLDivElement
   /** Layer table body receiving row nodes. */
@@ -53,23 +53,23 @@ export class AcExLayerListView {
   /** Layer store currently subscribed for change notifications. */
   private subscribedLayerStore?: AcApLayerStore
   /** i18n helper for labels and toasts. */
-  private readonly i18n: AcExI18n
+  private readonly i18n: AcUiI18n
   /** Viewer host reference. */
   private readonly host: HTMLElement
   /** Whether a title header is rendered above the table. */
   private readonly showHeader: boolean
   /** Current sort direction for the name column. */
-  private nameSortOrder: AcExLayerNameSortOrder = 'none'
+  private nameSortOrder: AcUiLayerNameSortOrder = 'none'
 
   /**
    * @param options - Editor, i18n, host, and display options.
    */
-  constructor(options: AcExLayerListViewOptions) {
+  constructor(options: AcUiLayerListViewOptions) {
     this.editor = options.editor
     this.i18n = options.i18n
     this.host = options.host
     this.showHeader = options.showHeader ?? false
-    ensureUiStyles()
+    acuiEnsureUiStyles()
 
     this.element = document.createElement('div')
     this.element.className = 'ml-ex-ui-layer-list'
@@ -223,9 +223,7 @@ export class AcExLayerListView {
           : 'layerManager.sortByNameAsc'
     const title = this.i18n.t(sortTitleKey)
     this.nameHeaderEl.title = title
-    this.nameHeaderEl
-      .querySelector('button')
-      ?.setAttribute('aria-label', title)
+    this.nameHeaderEl.querySelector('button')?.setAttribute('aria-label', title)
     this.nameHeaderEl.setAttribute(
       'aria-sort',
       this.nameSortOrder === 'asc'
@@ -360,7 +358,7 @@ export class AcExLayerListView {
     swatch.style.background = layer.cssColor
     swatch.addEventListener('click', async () => {
       const initial = AcCmColor.fromString(layer.color)
-      const picker = new AcExColorPicker(
+      const picker = new AcUiColorPicker(
         this.i18n,
         this.host,
         initial ?? undefined

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiReviewPaletteView.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiReviewPaletteView.ts
@@ -10,15 +10,15 @@ import {
 } from '@mlightcad/cad-simple-viewer'
 
 import { createIconElement, ICON_DOCK_CLOSE } from '../assets/icons'
-import type { AcExI18n } from '../i18n'
-import { ensureUiStyles } from './styles'
+import type { AcUiI18n } from '../i18n'
+import { acuiEnsureUiStyles } from './styles'
 
-/** Constructor options for {@link AcExReviewPaletteView}. */
-export interface AcExReviewPaletteViewOptions {
+/** Constructor options for {@link AcUiReviewPaletteView}. */
+export interface AcUiReviewPaletteViewOptions {
   /** Document manager used to resolve the active view for markup actions. */
   editor: AcApDocManager
   /** i18n helper for panel labels. */
-  i18n: AcExI18n
+  i18n: AcUiI18n
 }
 
 /**
@@ -27,7 +27,7 @@ export interface AcExReviewPaletteViewOptions {
  * Mirrors cad-viewer's Vue review palette using plain DOM: search, table,
  * status/label/comment editing, zoom-to, delete, and clear-all.
  */
-export class AcExReviewPaletteView {
+export class AcUiReviewPaletteView {
   /** Root element mounted in the dock panel review tab. */
   readonly element: HTMLDivElement
   /** Search box filtering the markup table. */
@@ -73,7 +73,7 @@ export class AcExReviewPaletteView {
   /** Document manager whose current view receives markup actions. */
   private readonly editor: AcApDocManager
   /** i18n helper for labels. */
-  private readonly i18n: AcExI18n
+  private readonly i18n: AcUiI18n
   /** Latest markup records from {@link getMarkupStore}. */
   private markups: AcApMarkupRecord[] = []
   /** Currently selected markup id from the store. */
@@ -90,10 +90,10 @@ export class AcExReviewPaletteView {
   /**
    * @param options - Editor and i18n used to render and mutate markups.
    */
-  constructor(options: AcExReviewPaletteViewOptions) {
+  constructor(options: AcUiReviewPaletteViewOptions) {
     this.editor = options.editor
     this.i18n = options.i18n
-    ensureUiStyles()
+    acuiEnsureUiStyles()
 
     this.element = document.createElement('div')
     this.element.className = 'ml-ex-ui-review-palette'
@@ -269,7 +269,8 @@ export class AcExReviewPaletteView {
     })
     this.deleteButton = document.createElement('button')
     this.deleteButton.type = 'button'
-    this.deleteButton.className = 'ml-ex-ui-review-btn ml-ex-ui-review-btn-danger'
+    this.deleteButton.className =
+      'ml-ex-ui-review-btn ml-ex-ui-review-btn-danger'
     this.deleteButton.addEventListener('click', () => {
       const selected = this.selectedMarkup()
       if (selected) this.removeMarkup(selected.id)
@@ -361,9 +362,14 @@ export class AcExReviewPaletteView {
 
   /** Toggles `is-selected` on existing rows without replacing them. */
   private syncRowSelection() {
-    this.tbody.querySelectorAll<HTMLTableRowElement>('tr[data-markup-id]').forEach(row => {
-      row.classList.toggle('is-selected', row.dataset.markupId === this.selectedId)
-    })
+    this.tbody
+      .querySelectorAll<HTMLTableRowElement>('tr[data-markup-id]')
+      .forEach(row => {
+        row.classList.toggle(
+          'is-selected',
+          row.dataset.markupId === this.selectedId
+        )
+      })
   }
 
   /** Rebuilds table rows from the filtered markup list. */

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiSubToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiSubToolbar.ts
@@ -1,19 +1,19 @@
 import { createIconElement } from '../assets/icons'
 import {
-  isToolbarItemDisabled,
-  itemRequiresDocument,
-  resolveEffectiveToolbarItem
+  acuiIsToolbarItemDisabled,
+  acuiItemRequiresDocument,
+  acuiResolveEffectiveToolbarItem
 } from '../config/resolveToolbarItems'
-import { isToolbarSeparatorItem } from '../config/toolbarItemUtils'
-import type { AcExToolbarItem, AcExToolbarPlacement } from '../config/types'
-import type { AcExI18n } from '../i18n'
+import { acuiIsToolbarSeparatorItem } from '../config/toolbarItemUtils'
+import type { AcUiToolbarItem, AcUiToolbarPlacement } from '../config/types'
+import type { AcUiI18n } from '../i18n'
 
-/** Constructor options for {@link AcExSubToolbar}. */
-export interface AcExSubToolbarOptions {
+/** Constructor options for {@link AcUiSubToolbar}. */
+export interface AcUiSubToolbarOptions {
   /** i18n helper for button tooltips. */
-  i18n: AcExI18n
+  i18n: AcUiI18n
   /** Child items to render. */
-  items: AcExToolbarItem[]
+  items: AcUiToolbarItem[]
   /** Parent toolbar button used for positioning and outside-click exclusion. */
   anchor: HTMLElement
   /** Main toolbar root used to place the strip beside the parent bar. */
@@ -21,7 +21,7 @@ export interface AcExSubToolbarOptions {
   /** Canvas mount that receives the strip (positioned absolutely). */
   host: HTMLElement
   /** Parent toolbar edge placement. */
-  placement: AcExToolbarPlacement
+  placement: AcUiToolbarPlacement
   /**
    * When true, canvas / outside clicks do not close the strip.
    * Only the parent button (or an explicit {@link close}) dismisses it.
@@ -30,7 +30,7 @@ export interface AcExSubToolbarOptions {
   /** Whether command buttons should be disabled (document loading / missing). */
   commandsDisabled: boolean
   /** Invoked when a leaf item is activated. */
-  onSelect: (item: AcExToolbarItem) => void
+  onSelect: (item: AcUiToolbarItem) => void
   /** Invoked when the strip is closed. */
   onClose?: () => void
 }
@@ -41,11 +41,11 @@ export interface AcExSubToolbarOptions {
  * Sticky strips stay open until the parent is clicked again. Dismissible strips
  * close on outside click, matching a lightweight flyout toolbar.
  */
-export class AcExSubToolbar {
-  /** Strip root appended to {@link AcExSubToolbarOptions.host}. */
+export class AcUiSubToolbar {
+  /** Strip root appended to {@link AcUiSubToolbarOptions.host}. */
   private root: HTMLDivElement
   /** Child items last passed to the constructor or {@link refresh}. */
-  private items: AcExToolbarItem[]
+  private items: AcUiToolbarItem[]
   /** Whether command buttons are disabled. */
   private commandsDisabled: boolean
   /** Whether {@link close} has already run. */
@@ -62,7 +62,7 @@ export class AcExSubToolbar {
   /**
    * @param options - Host, placement, items, and selection callback.
    */
-  constructor(private options: AcExSubToolbarOptions) {
+  constructor(private options: AcUiSubToolbarOptions) {
     this.items = options.items
     this.commandsDisabled = options.commandsDisabled
     this.root = document.createElement('div')
@@ -98,7 +98,7 @@ export class AcExSubToolbar {
    * @param items - Updated child items (e.g. after a toggle).
    * @param commandsDisabled - Optional override for command disabled state.
    */
-  refresh(items: AcExToolbarItem[], commandsDisabled?: boolean) {
+  refresh(items: AcUiToolbarItem[], commandsDisabled?: boolean) {
     this.items = items
     if (commandsDisabled !== undefined) {
       this.commandsDisabled = commandsDisabled
@@ -168,7 +168,7 @@ export class AcExSubToolbar {
   private renderButtons() {
     this.root.replaceChildren()
     this.items.forEach(item => {
-      if (isToolbarSeparatorItem(item)) {
+      if (acuiIsToolbarSeparatorItem(item)) {
         const separator = document.createElement('div')
         separator.className = 'ml-ex-ui-toolbar-separator'
         separator.setAttribute('role', 'separator')
@@ -179,7 +179,7 @@ export class AcExSubToolbar {
         return
       }
 
-      const effective = resolveEffectiveToolbarItem(item)
+      const effective = acuiResolveEffectiveToolbarItem(item)
       const button = document.createElement('button')
       button.type = 'button'
       button.className = 'ml-ex-ui-toolbar-btn'
@@ -206,8 +206,8 @@ export class AcExSubToolbar {
       }
 
       button.disabled =
-        (itemRequiresDocument(effective) && this.commandsDisabled) ||
-        isToolbarItemDisabled(effective)
+        (acuiItemRequiresDocument(effective) && this.commandsDisabled) ||
+        acuiIsToolbarItemDisabled(effective)
 
       button.addEventListener('click', event => {
         event.stopPropagation()

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiToolbar.ts
@@ -8,36 +8,36 @@ import {
   ICON_CHEVRON_UP
 } from '../assets/icons'
 import {
-  filterVisibleToolbarItems,
-  isToolbarItemDisabled,
-  itemRequiresDocument,
-  resolveEffectiveToolbarItem,
-  resolveParentToolbarDisplay
+  acuiFilterVisibleToolbarItems,
+  acuiIsToolbarItemDisabled,
+  acuiItemRequiresDocument,
+  acuiResolveEffectiveToolbarItem,
+  acuiResolveParentToolbarDisplay
 } from '../config/resolveToolbarItems'
 import {
-  isDynamicToolbarChildren,
-  isToolbarChildrenStrip,
-  isToolbarSeparatorItem,
-  resolveToolbarChildrenUi
+  acuiIsDynamicToolbarChildren,
+  acuiIsToolbarChildrenStrip,
+  acuiIsToolbarSeparatorItem,
+  acuiResolveToolbarChildrenUi
 } from '../config/toolbarItemUtils'
-import type { AcExToolbarItem, AcExToolbarPlacement } from '../config/types'
-import type { AcExI18n } from '../i18n'
-import { AcExDropdownMenu } from './AcExDropdownMenu'
-import { AcExSubToolbar } from './AcExSubToolbar'
-import { ensureUiStyles } from './styles'
+import type { AcUiToolbarItem, AcUiToolbarPlacement } from '../config/types'
+import type { AcUiI18n } from '../i18n'
+import { AcUiDropdownMenu } from './AcUiDropdownMenu'
+import { AcUiSubToolbar } from './AcUiSubToolbar'
+import { acuiEnsureUiStyles } from './styles'
 
-/** Constructor options for {@link AcExToolbar}. */
-export interface AcExToolbarOptions {
+/** Constructor options for {@link AcUiToolbar}. */
+export interface AcUiToolbarOptions {
   /** Viewer canvas element that receives the toolbar root node. */
   host: HTMLElement
   /** Theme host for dropdown menus; defaults to {@link host}. */
   themeHost?: HTMLElement
   /** Edge placement of the toolbar. */
-  placement: AcExToolbarPlacement
+  placement: AcUiToolbarPlacement
   /** Toolbar item definitions to render. */
-  items: AcExToolbarItem[]
+  items: AcUiToolbarItem[]
   /** i18n helper for button labels and tooltips. */
-  i18n: AcExI18n
+  i18n: AcUiI18n
   /** Invoked when a leaf item with a `command` is activated. */
   onCommand: (command: string) => void
   /** When true, append a collapse/expand toggle at the end of the toolbar. */
@@ -56,7 +56,7 @@ export interface AcExToolbarOptions {
  * Disables command buttons while a document is loading and filters items by
  * document open mode.
  */
-export class AcExToolbar {
+export class AcUiToolbar {
   /** Canvas element receiving the toolbar root node. */
   private mountHost: HTMLElement
   /** Host element used for themed dropdown menus. */
@@ -64,9 +64,9 @@ export class AcExToolbar {
   /** Root toolbar container appended to the mount host. */
   private root: HTMLDivElement
   /** Currently open popover submenu, if any. */
-  private openDropdown?: AcExDropdownMenu
+  private openDropdown?: AcUiDropdownMenu
   /** Currently open icon sub-toolbar, if any. */
-  private openSubToolbar?: AcExSubToolbar
+  private openSubToolbar?: AcUiSubToolbar
   /** Parent item id of the open children UI. */
   private openParentId?: string
   /** Sticky sub-toolbar parent id restored after a full re-render. */
@@ -80,8 +80,8 @@ export class AcExToolbar {
   /** Whether an active document is loaded. */
   private hasDocument = false
   /** Item list last passed to {@link updateItems} or the constructor. */
-  private items: AcExToolbarItem[]
-  /** Runtime submenu selection for parents with {@link AcExToolbarItem.childIcon} `'selected'`. */
+  private items: AcUiToolbarItem[]
+  /** Runtime submenu selection for parents with {@link AcUiToolbarItem.childIcon} `'selected'`. */
   private selectedChildByParent = new Map<string, string>()
   /** Whether the toolbar is collapsed to show only the toggle button. */
   private collapsed: boolean
@@ -113,8 +113,8 @@ export class AcExToolbar {
   /**
    * @param options - Host, placement, items, i18n, and command callback.
    */
-  constructor(private options: AcExToolbarOptions) {
-    ensureUiStyles()
+  constructor(private options: AcUiToolbarOptions) {
+    acuiEnsureUiStyles()
     this.mountHost = options.host
     this.themeHost = options.themeHost ?? options.host
     this.edgeOffset = options.edgeOffset ?? 8
@@ -145,7 +145,7 @@ export class AcExToolbar {
    *
    * @param items - New toolbar items.
    */
-  updateItems(items: AcExToolbarItem[]) {
+  updateItems(items: AcUiToolbarItem[]) {
     this.items = items
     this.seedSelectedChildren(items)
     this.renderButtons()
@@ -163,7 +163,7 @@ export class AcExToolbar {
    *
    * @param placement - Target edge placement.
    */
-  setPlacement(placement: AcExToolbarPlacement) {
+  setPlacement(placement: AcUiToolbarPlacement) {
     if (this.options.placement === placement) return
     this.options.placement = placement
     this.selectedChildByParent.set(
@@ -318,7 +318,7 @@ export class AcExToolbar {
     this.root.className = classes.join(' ')
   }
 
-  /** Toggles collapsed state when {@link AcExToolbarOptions.collapsible} is enabled. */
+  /** Toggles collapsed state when {@link AcUiToolbarOptions.collapsible} is enabled. */
   private toggleCollapsed() {
     this.setCollapsed(!this.collapsed)
   }
@@ -379,9 +379,12 @@ export class AcExToolbar {
     this.closeChildrenUi()
     this.root.replaceChildren()
 
-    const visibleItems = filterVisibleToolbarItems(this.items, this.openMode)
+    const visibleItems = acuiFilterVisibleToolbarItems(
+      this.items,
+      this.openMode
+    )
     visibleItems.forEach(item => {
-      if (isToolbarSeparatorItem(item)) {
+      if (acuiIsToolbarSeparatorItem(item)) {
         const separator = document.createElement('div')
         separator.className = 'ml-ex-ui-toolbar-separator'
         separator.setAttribute('role', 'separator')
@@ -392,7 +395,7 @@ export class AcExToolbar {
         return
       }
 
-      const effective = resolveParentToolbarDisplay(
+      const effective = acuiResolveParentToolbarDisplay(
         item,
         this.selectedChildByParent.get(item.id)
       )
@@ -405,7 +408,7 @@ export class AcExToolbar {
       button.setAttribute('aria-label', button.title)
       button.dataset.toolbarItemId = effective.id
 
-      if (effective.children?.length || isDynamicToolbarChildren(item)) {
+      if (effective.children?.length || acuiIsDynamicToolbarChildren(item)) {
         button.classList.add('has-children')
         button.setAttribute('aria-haspopup', 'true')
         button.setAttribute('aria-expanded', 'false')
@@ -422,20 +425,20 @@ export class AcExToolbar {
       }
 
       const disabled =
-        (itemRequiresDocument(effective) &&
+        (acuiItemRequiresDocument(effective) &&
           (this.isDisabled || !this.hasDocument)) ||
-        isToolbarItemDisabled(effective)
+        acuiIsToolbarItemDisabled(effective)
       button.disabled = disabled
 
       button.addEventListener('click', event => {
         event.stopPropagation()
         if (button.disabled) return
 
-        if (effective.children?.length || isDynamicToolbarChildren(item)) {
-          const visibleChildren = filterVisibleToolbarItems(
+        if (effective.children?.length || acuiIsDynamicToolbarChildren(item)) {
+          const visibleChildren = acuiFilterVisibleToolbarItems(
             effective.children ?? [],
             this.openMode
-          ).map(resolveEffectiveToolbarItem)
+          ).map(acuiResolveEffectiveToolbarItem)
           if (visibleChildren.length === 0) return
 
           if (this.openParentId === item.id) {
@@ -540,10 +543,10 @@ export class AcExToolbar {
     }
   }
 
-  /** Seeds submenu selection from {@link AcExToolbarItem.selectedChildId}. */
-  private seedSelectedChildren(items: AcExToolbarItem[]) {
+  /** Seeds submenu selection from {@link AcUiToolbarItem.selectedChildId}. */
+  private seedSelectedChildren(items: AcUiToolbarItem[]) {
     for (const item of items) {
-      if (isToolbarSeparatorItem(item)) continue
+      if (acuiIsToolbarSeparatorItem(item)) continue
       if (item.childIcon === 'selected' && item.selectedChildId) {
         this.selectedChildByParent.set(item.id, item.selectedChildId)
       }
@@ -589,19 +592,19 @@ export class AcExToolbar {
    * @param visibleChildren - Filtered, effective child items.
    */
   private openChildrenUi(
-    item: AcExToolbarItem,
+    item: AcUiToolbarItem,
     button: HTMLButtonElement,
-    visibleChildren: AcExToolbarItem[]
+    visibleChildren: AcUiToolbarItem[]
   ) {
     this.closeChildrenUi()
-    const childrenUi = resolveToolbarChildrenUi(item)
+    const childrenUi = acuiResolveToolbarChildrenUi(item)
     this.openParentId = item.id
     this.markParentOpen(button)
 
-    if (isToolbarChildrenStrip(childrenUi)) {
+    if (acuiIsToolbarChildrenStrip(childrenUi)) {
       const sticky = childrenUi === 'sticky-toolbar'
       this.stickyParentId = sticky ? item.id : undefined
-      const strip = new AcExSubToolbar({
+      const strip = new AcUiSubToolbar({
         i18n: this.options.i18n,
         items: visibleChildren,
         anchor: button,
@@ -624,7 +627,7 @@ export class AcExToolbar {
       return
     }
 
-    const dropdown = new AcExDropdownMenu(
+    const dropdown = new AcUiDropdownMenu(
       this.options.i18n,
       visibleChildren,
       button,
@@ -650,21 +653,21 @@ export class AcExToolbar {
    */
   private openStickyChildrenByParentId(parentId: string) {
     const item = this.items.find(candidate => {
-      if (isToolbarSeparatorItem(candidate)) return false
+      if (acuiIsToolbarSeparatorItem(candidate)) return false
       return candidate.id === parentId
     })
     if (!item?.children?.length) return
-    if (resolveToolbarChildrenUi(item) !== 'sticky-toolbar') return
+    if (acuiResolveToolbarChildrenUi(item) !== 'sticky-toolbar') return
 
     const button = this.root.querySelector<HTMLButtonElement>(
       `[data-toolbar-item-id="${parentId}"]`
     )
     if (!button) return
 
-    const visibleChildren = filterVisibleToolbarItems(
+    const visibleChildren = acuiFilterVisibleToolbarItems(
       item.children,
       this.openMode
-    ).map(resolveEffectiveToolbarItem)
+    ).map(acuiResolveEffectiveToolbarItem)
     if (visibleChildren.length === 0) return
 
     this.openChildrenUi(item, button, visibleChildren)
@@ -678,11 +681,11 @@ export class AcExToolbar {
    * @param sticky - Whether the child UI should stay open.
    */
   private activateChild(
-    parent: AcExToolbarItem,
-    child: AcExToolbarItem,
+    parent: AcUiToolbarItem,
+    child: AcUiToolbarItem,
     sticky: boolean
   ) {
-    if (isToolbarSeparatorItem(child)) return
+    if (acuiIsToolbarSeparatorItem(child)) return
     if (parent.childIcon === 'selected') {
       this.selectedChildByParent.set(parent.id, child.id)
     }
@@ -695,10 +698,10 @@ export class AcExToolbar {
     if (child.toggle && sticky && this.openSubToolbar) {
       window.setTimeout(() => {
         if (!this.openSubToolbar) return
-        const visibleChildren = filterVisibleToolbarItems(
+        const visibleChildren = acuiFilterVisibleToolbarItems(
           parent.children ?? [],
           this.openMode
-        ).map(resolveEffectiveToolbarItem)
+        ).map(acuiResolveEffectiveToolbarItem)
         this.openSubToolbar.refresh(
           visibleChildren,
           this.isDisabled || !this.hasDocument

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -7,7 +7,7 @@ const STYLE_ID = 'ml-ex-ui-styles'
  *
  * Safe to call from multiple components; subsequent calls are no-ops.
  */
-export function ensureUiStyles() {
+export function acuiEnsureUiStyles() {
   if (document.getElementById(STYLE_ID)) return
 
   const style = document.createElement('style')
@@ -1192,7 +1192,7 @@ export function ensureUiStyles() {
 /**
  * Removes injected UI styles when no toolbar or layer manager remains in the DOM.
  */
-export function removeUiStylesIfUnused() {
+export function acuiRemoveUiStylesIfUnused() {
   if (
     document.querySelector(
       '.ml-ex-ui-toolbar, .ml-ex-ui-subtoolbar, .ml-ex-ui-layer-manager, .ml-ex-ui-dock-panel, .ml-ex-ui-review-palette'

--- a/packages/cad-simple-viewer-example/src/agentToolbarItem.ts
+++ b/packages/cad-simple-viewer-example/src/agentToolbarItem.ts
@@ -1,9 +1,9 @@
-import type { AcExToolbarItemConfig } from '@mlightcad/cad-simple-ui-plugin'
+import type { AcUiToolbarItemConfig } from '@mlightcad/cad-simple-ui-plugin'
 
 import { ICON_AGENT } from './icons'
 
 /** Toolbar button that runs the lazy-loaded `agent` command. */
-export const AGENT_TOOLBAR_ITEM: AcExToolbarItemConfig = {
+export const AGENT_TOOLBAR_ITEM: AcUiToolbarItemConfig = {
   id: 'agent',
   label: 'Agent',
   icon: ICON_AGENT,

--- a/packages/cad-simple-viewer-example/src/demoToolbarPresets.ts
+++ b/packages/cad-simple-viewer-example/src/demoToolbarPresets.ts
@@ -1,12 +1,12 @@
 import type {
   AcApSimpleUiPlugin,
-  AcExToolbarItemsInput,
-  AcExToolbarLayoutPreset
+  AcUiToolbarItemsInput,
+  AcUiToolbarLayoutPreset
 } from '@mlightcad/cad-simple-ui-plugin'
 import {
-  createToolbarLayoutSwitcher,
-  createToolbarSeparator,
-  toolbarPreset
+  acuiCreateToolbarLayoutSwitcher,
+  acuiCreateToolbarSeparator,
+  acuiToolbarPreset
 } from '@mlightcad/cad-simple-ui-plugin'
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 
@@ -19,7 +19,7 @@ const ICON_DEMO_ZOOM =
 let demoCustomToolsVisible = true
 
 /** Selectable demo toolbar layouts (full `items` definitions, not appendItems). */
-export const DEMO_TOOLBAR_LAYOUTS: AcExToolbarLayoutPreset[] = [
+export const DEMO_TOOLBAR_LAYOUTS: AcUiToolbarLayoutPreset[] = [
   { id: 'default', label: 'Built-in default' },
   { id: 'minimal', label: 'Minimal view tools' },
   { id: 'draw', label: 'Draw tools' },
@@ -27,17 +27,17 @@ export const DEMO_TOOLBAR_LAYOUTS: AcExToolbarLayoutPreset[] = [
 ]
 
 /** Full toolbar `items` for each demo layout preset. */
-export const DEMO_TOOLBAR_PRESET_ITEMS: Record<string, AcExToolbarItemsInput> =
+export const DEMO_TOOLBAR_PRESET_ITEMS: Record<string, AcUiToolbarItemsInput> =
   {
     default: 'default',
     minimal: [
-      toolbarPreset('select'),
-      toolbarPreset('pan'),
-      toolbarPreset('zoomExtent'),
-      toolbarPreset('layer')
+      acuiToolbarPreset('select'),
+      acuiToolbarPreset('pan'),
+      acuiToolbarPreset('zoomExtent'),
+      acuiToolbarPreset('layer')
     ],
     draw: [
-      toolbarPreset('select'),
+      acuiToolbarPreset('select'),
       {
         id: 'draw-line',
         label: 'Line',
@@ -50,13 +50,13 @@ export const DEMO_TOOLBAR_PRESET_ITEMS: Record<string, AcExToolbarItemsInput> =
         command: 'circle',
         requiresDocument: true
       },
-      toolbarPreset('layer'),
-      createToolbarSeparator('draw-separator'),
-      toolbarPreset('zoomWindow')
+      acuiToolbarPreset('layer'),
+      acuiCreateToolbarSeparator('draw-separator'),
+      acuiToolbarPreset('zoomWindow')
     ],
     custom: [
-      toolbarPreset('select'),
-      toolbarPreset('pan'),
+      acuiToolbarPreset('select'),
+      acuiToolbarPreset('pan'),
       {
         id: 'demo-info',
         label: 'Demo Info',
@@ -111,7 +111,7 @@ export const DEMO_TOOLBAR_PRESET_ITEMS: Record<string, AcExToolbarItemsInput> =
           window.alert(`Layer count: ${count}`)
         }
       },
-      toolbarPreset('layer')
+      acuiToolbarPreset('layer')
     ]
   }
 
@@ -136,7 +136,7 @@ export function applyDemoToolbarLayout(
     return
   }
 
-  const layoutSwitcher = createToolbarLayoutSwitcher({
+  const layoutSwitcher = acuiCreateToolbarLayoutSwitcher({
     presets: DEMO_TOOLBAR_LAYOUTS,
     currentId: presetId,
     onSelect: id => applyDemoToolbarLayout(plugin, id)

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -1,10 +1,10 @@
 import {
   type AcApSimpleUiPlugin,
-  type AcExDockPanelSide,
-  type AcExToolbarPlacement,
+  type AcUiDockPanelSide,
+  type AcUiToolbarPlacement,
   SIMPLE_UI_PLUGIN_NAME
 } from '@mlightcad/cad-simple-ui-plugin'
-import { registerSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin/register'
+import { acuiRegisterSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin/register'
 import {
   AcApDocManager,
   AcApOpenDatabaseOptions,
@@ -415,7 +415,7 @@ class CadViewerApp {
     this.dockButton.setAttribute('aria-expanded', 'false')
   }
 
-  private isDockSizeVertical(side: AcExDockPanelSide | undefined): boolean {
+  private isDockSizeVertical(side: AcUiDockPanelSide | undefined): boolean {
     return side === 'top' || side === 'bottom'
   }
 
@@ -548,7 +548,7 @@ class CadViewerApp {
       button.addEventListener('click', event => {
         event.stopPropagation()
         const placement = button.dataset.viewerToolbarPlacement as
-          | AcExToolbarPlacement
+          | AcUiToolbarPlacement
           | undefined
         if (!placement) return
         void this.applyViewerToolbarPlacement(placement)
@@ -607,7 +607,7 @@ class CadViewerApp {
     this.viewerToolbarButton.setAttribute('aria-expanded', 'false')
   }
 
-  private async applyViewerToolbarPlacement(placement: AcExToolbarPlacement) {
+  private async applyViewerToolbarPlacement(placement: AcUiToolbarPlacement) {
     await this.initialize()
 
     const plugin = this.getSimpleUiPlugin()
@@ -829,7 +829,7 @@ class CadViewerApp {
 
       registerLazyPlugins()
 
-      await registerSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
+      await acuiRegisterSimpleUiPlugin(AcApDocManager.instance.pluginManager, {
         host: this.viewerPane,
         dockPanel: {
           defaultOpen: false,


### PR DESCRIPTION
## Summary
- Rename cad-simple-ui-plugin UI types and classes from `AcEx*` to `AcUi*` (`AcExUiThemeSync` becomes `AcUiThemeSync`).
- Prefix module-level plugin functions with `acui` (for example `acuiCreateSimpleUiPlugin`, `acuiToolbarPreset`).
- Keep `AcAp*` plugin/command classes and `.ml-ex-ui-*` CSS class names unchanged, and update the vanilla example plus README.

## Test plan
- [ ] `nx run @mlightcad/cad-simple-ui-plugin:test` (82 tests passed locally)
- [ ] `nx run @mlightcad/cad-simple-ui-plugin:build`
- [ ] Open cad-simple-viewer-example, load a drawing, and confirm toolbar, dock, layer, and review UI still work
- [ ] Confirm host apps import the new `acui*` / `AcUi*` names