### PR TITLE
feat(three-renderer): auto-detect broken linetype shader and fall back to dashed LineMaterial

### DIFF
--- a/packages/three-renderer/__tests__/AcTrLinePatternFallback.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrLinePatternFallback.spec.ts
@@ -1,0 +1,253 @@
+import * as THREE from 'three'
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
+import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
+import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
+
+import { AcTrBatchedLine2 } from '../src/batch/AcTrBatchedLine2'
+import { AcTrLine } from '../src/object/AcTrLine'
+import { AcTrLineSegments } from '../src/object/AcTrLineSegments'
+import { AcTrRenderContext } from '../src/renderer/AcTrRenderContext'
+import { AcTrStyleManager } from '../src/style/AcTrStyleManager'
+import { AcTrSubEntityTraitsUtil } from '../src/util'
+
+/**
+ * Builds traits whose linetype carries the given pattern
+ * `[elementLength, elementTypeFlag]` pairs.
+ */
+function makePatternTraits(
+  pattern: Array<[number, number?]>,
+  lineTypeScale = 1
+) {
+  const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+  traits.lineType = {
+    ...traits.lineType,
+    name: 'CUSTOM',
+    pattern: pattern.map(([elementLength, elementTypeFlag = 0]) => ({
+      elementLength,
+      elementTypeFlag
+    }))
+  }
+  traits.lineTypeScale = lineTypeScale
+  return traits
+}
+
+function makeBrokenContext(): AcTrRenderContext {
+  const context = new AcTrRenderContext()
+  context.styleManager.options.linePatternShaderBroken = true
+  return context
+}
+
+function getDistances(geometry: THREE.BufferGeometry, count?: number) {
+  const start = geometry.getAttribute('instanceDistanceStart')
+  const end = geometry.getAttribute('instanceDistanceEnd')
+  const activeCount = count ?? start.count
+  return {
+    start,
+    end,
+    values: Array.from({ length: activeCount }, (_, i) => [
+      start.getX(i),
+      end.getX(i)
+    ])
+  }
+}
+
+function activeSegmentCount(geometry: THREE.BufferGeometry) {
+  return (geometry as THREE.InstancedBufferGeometry).instanceCount
+}
+
+function segmentGeometry(sx: number, sy: number, ex: number, ey: number) {
+  const geometry = new LineSegmentsGeometry()
+  geometry.setPositions([sx, sy, 0, ex, ey, 0])
+  return geometry
+}
+
+describe('dashed fallback material (broken linetype shader)', () => {
+  it('aggregates dash and gap sizes from a scaled pattern', () => {
+    const styleManager = new AcTrStyleManager()
+    styleManager.options.linePatternShaderBroken = true
+    const material = styleManager.getLineMaterial(
+      makePatternTraits([[100], [-50]], 2)
+    ) as LineMaterial
+
+    expect(material).toBeInstanceOf(LineMaterial)
+    expect(material.dashed).toBe(true)
+    expect(material.dashSize).toBe(200)
+    expect(material.gapSize).toBe(100)
+  })
+
+  it('uses a fixed dash for pure dot patterns', () => {
+    const styleManager = new AcTrStyleManager()
+    styleManager.options.linePatternShaderBroken = true
+    const material = styleManager.getLineMaterial(
+      makePatternTraits([[0], [-25]])
+    ) as LineMaterial
+
+    expect(material.dashed).toBe(true)
+    expect(material.dashSize).toBe(0.5)
+    expect(material.gapSize).toBe(25)
+  })
+
+  it('folds complex-element lengths into the dash sum', () => {
+    const styleManager = new AcTrStyleManager()
+    styleManager.options.linePatternShaderBroken = true
+    const material = styleManager.getLineMaterial(
+      makePatternTraits([[-30, 1], [10], [-5]])
+    ) as LineMaterial
+
+    expect(material.dashSize).toBe(40)
+    expect(material.gapSize).toBe(5)
+  })
+
+  it('keeps the custom shader material on healthy GPUs', () => {
+    const styleManager = new AcTrStyleManager()
+    const material = styleManager.getLineMaterial(
+      makePatternTraits([[100], [-50]])
+    )
+
+    expect(material).toBeInstanceOf(THREE.ShaderMaterial)
+  })
+})
+
+describe('unbatched dashed fat lines', () => {
+  it('computes cumulative instance distances on AcTrLineSegments', () => {
+    const array = new Float32Array([0, 0, 0, 10, 0, 0, 10, 10, 0])
+    const entity = new AcTrLineSegments(
+      array,
+      3,
+      new Uint16Array([0, 1, 1, 2]),
+      makePatternTraits([[12], [-6]]),
+      makeBrokenContext()
+    )
+
+    const line = entity.children.find(
+      child => child instanceof LineSegments2
+    ) as LineSegments2 | undefined
+    expect(line).toBeDefined()
+
+    const { values } = getDistances(line!.geometry as THREE.BufferGeometry)
+    expect(values).toEqual([
+      [0, 10],
+      [10, 20]
+    ])
+  })
+
+  it('computes instance distances on AcTrLine', () => {
+    const entity = new AcTrLine(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 6, y: 8, z: 0 }
+      ],
+      makePatternTraits([[12], [-6]]),
+      makeBrokenContext()
+    )
+
+    const line = entity.children.find(
+      child => child instanceof LineSegments2
+    ) as LineSegments2 | undefined
+    expect(line).toBeDefined()
+
+    const { values } = getDistances(line!.geometry as THREE.BufferGeometry)
+    expect(values).toEqual([[0, 10]])
+  })
+
+  it('skips distance attributes for solid fat lines', () => {
+    const context = new AcTrRenderContext()
+    context.styleManager.showLineWeight = true
+    const traits = AcTrSubEntityTraitsUtil.createDefaultTraits()
+    traits.lineWeight = 30
+    const entity = new AcTrLine(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 }
+      ],
+      traits,
+      context
+    )
+
+    const line = entity.children.find(
+      child => child instanceof LineSegments2
+    ) as LineSegments2 | undefined
+    expect(line).toBeDefined()
+    expect(
+      (line!.geometry as THREE.BufferGeometry).getAttribute(
+        'instanceDistanceStart'
+      )
+    ).toBeUndefined()
+  })
+})
+
+describe('AcTrBatchedLine2 dash distances', () => {
+  function dashedBatch(capacity: number) {
+    return new AcTrBatchedLine2(
+      capacity,
+      new LineMaterial({
+        color: 0xffffff,
+        dashed: true,
+        dashSize: 5,
+        gapSize: 5
+      })
+    )
+  }
+
+  it('chains cumulative distances across appended geometries', () => {
+    const batch = dashedBatch(8)
+    batch.addGeometry(segmentGeometry(0, 0, 10, 0))
+    batch.addGeometry(segmentGeometry(0, 0, 0, 5))
+
+    const { values } = getDistances(
+      batch.geometry as THREE.BufferGeometry,
+      activeSegmentCount(batch.geometry)
+    )
+    expect(values).toEqual([
+      [0, 10],
+      [10, 15]
+    ])
+  })
+
+  it('preserves the distance chain across capacity growth', () => {
+    const batch = dashedBatch(2)
+    batch.addGeometry(segmentGeometry(0, 0, 10, 0))
+    batch.addGeometry(segmentGeometry(0, 0, 0, 5))
+    batch.addGeometry(segmentGeometry(0, 0, 1, 0))
+
+    const { values } = getDistances(
+      batch.geometry as THREE.BufferGeometry,
+      activeSegmentCount(batch.geometry)
+    )
+    expect(values).toEqual([
+      [0, 10],
+      [10, 15],
+      [15, 16]
+    ])
+  })
+
+  it('re-chains downstream distances after rewriting a packed geometry', () => {
+    const batch = dashedBatch(8)
+    batch.addGeometry(segmentGeometry(0, 0, 10, 0))
+    batch.addGeometry(segmentGeometry(0, 0, 0, 5))
+    batch.addGeometry(segmentGeometry(0, 0, 1, 0))
+
+    batch.setGeometryAt(1, segmentGeometry(0, 0, 0, 2))
+
+    const { values } = getDistances(
+      batch.geometry as THREE.BufferGeometry,
+      activeSegmentCount(batch.geometry)
+    )
+    expect(values).toEqual([
+      [0, 10],
+      [10, 12],
+      [12, 13]
+    ])
+  })
+
+  it('skips distance attributes for solid batches', () => {
+    const batch = new AcTrBatchedLine2(8, new LineMaterial({ color: 0xffffff }))
+    batch.addGeometry(segmentGeometry(0, 0, 10, 0))
+
+    expect(
+      (batch.geometry as THREE.BufferGeometry).getAttribute(
+        'instanceDistanceStart'
+      )
+    ).toBeUndefined()
+  })
+})

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -2855,9 +2855,43 @@ export class AcTrBatchedGroup extends THREE.Group {
         source.getAttribute('instanceColorEnd').clone()
       )
     }
+    if (source.hasAttribute('instanceDistanceStart')) {
+      this.applyInstanceLineDistances(geometry)
+    }
     AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
     AcTrBufferGeometryUtil.safeComputeBoundingSphere(geometry)
     return geometry
+  }
+
+  /**
+   * Repopulates `instanceDistanceStart`/`instanceDistanceEnd` on a cloned
+   * {@link LineSegmentsGeometry} from its `instanceStart`/`instanceEnd`. This
+   * keeps dashed `LineMaterial` patterns intact when a `LineSegments2` is
+   * folded into the wide-line batch (see `cloneLineSegments2Geometry`).
+   * Mirrors `LineSegments2.computeLineDistances()` but operates on the raw
+   * geometry so it can run after `setPositions`.
+   */
+  private applyInstanceLineDistances(geometry: LineSegmentsGeometry) {
+    const instanceStart = geometry.getAttribute('instanceStart')
+    const instanceEnd = geometry.getAttribute('instanceEnd')
+    if (!instanceStart || !instanceEnd) return
+    const count = instanceStart.count
+    const lineDistances = new Float32Array(2 * count)
+    for (let i = 0, j = 0; i < count; i++, j += 2) {
+      _v1.fromBufferAttribute(instanceStart, i)
+      _v2.fromBufferAttribute(instanceEnd, i)
+      lineDistances[j] = j === 0 ? 0 : lineDistances[j - 1]
+      lineDistances[j + 1] = lineDistances[j] + _v1.distanceTo(_v2)
+    }
+    const buffer = new THREE.InstancedInterleavedBuffer(lineDistances, 2, 1)
+    geometry.setAttribute(
+      'instanceDistanceStart',
+      new THREE.InterleavedBufferAttribute(buffer, 1, 0)
+    )
+    geometry.setAttribute(
+      'instanceDistanceEnd',
+      new THREE.InterleavedBufferAttribute(buffer, 1, 1)
+    )
   }
 
   /**

--- a/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedGroup.ts
@@ -2855,43 +2855,13 @@ export class AcTrBatchedGroup extends THREE.Group {
         source.getAttribute('instanceColorEnd').clone()
       )
     }
-    if (source.hasAttribute('instanceDistanceStart')) {
-      this.applyInstanceLineDistances(geometry)
-    }
+    // Note: dash distance attributes are not cloned here. The wide-line
+    // batch (AcTrBatchedLine2) owns distance maintenance and recomputes the
+    // cumulative chain from packed positions for every dashed batch, which
+    // also covers geometries entering via appendLine2Geometry.
     AcTrBufferGeometryUtil.safeComputeBoundingBox(geometry)
     AcTrBufferGeometryUtil.safeComputeBoundingSphere(geometry)
     return geometry
-  }
-
-  /**
-   * Repopulates `instanceDistanceStart`/`instanceDistanceEnd` on a cloned
-   * {@link LineSegmentsGeometry} from its `instanceStart`/`instanceEnd`. This
-   * keeps dashed `LineMaterial` patterns intact when a `LineSegments2` is
-   * folded into the wide-line batch (see `cloneLineSegments2Geometry`).
-   * Mirrors `LineSegments2.computeLineDistances()` but operates on the raw
-   * geometry so it can run after `setPositions`.
-   */
-  private applyInstanceLineDistances(geometry: LineSegmentsGeometry) {
-    const instanceStart = geometry.getAttribute('instanceStart')
-    const instanceEnd = geometry.getAttribute('instanceEnd')
-    if (!instanceStart || !instanceEnd) return
-    const count = instanceStart.count
-    const lineDistances = new Float32Array(2 * count)
-    for (let i = 0, j = 0; i < count; i++, j += 2) {
-      _v1.fromBufferAttribute(instanceStart, i)
-      _v2.fromBufferAttribute(instanceEnd, i)
-      lineDistances[j] = j === 0 ? 0 : lineDistances[j - 1]
-      lineDistances[j + 1] = lineDistances[j] + _v1.distanceTo(_v2)
-    }
-    const buffer = new THREE.InstancedInterleavedBuffer(lineDistances, 2, 1)
-    geometry.setAttribute(
-      'instanceDistanceStart',
-      new THREE.InterleavedBufferAttribute(buffer, 1, 0)
-    )
-    geometry.setAttribute(
-      'instanceDistanceEnd',
-      new THREE.InterleavedBufferAttribute(buffer, 1, 1)
-    )
   }
 
   /**

--- a/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
+++ b/packages/three-renderer/src/batch/AcTrBatchedLine2.ts
@@ -95,6 +95,9 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     )
     ensureSlotIdAttribute(this.geometry, this._maxSegmentCount)
     this._copyStaticAttributes(reference)
+    if (this._isDashedMaterial()) {
+      this._ensureDistanceAttributes()
+    }
     this._geometryInitialized = true
   }
 
@@ -112,12 +115,76 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
       if (
         key === 'instanceStart' ||
         key === 'instanceEnd' ||
-        key === 'slotId'
+        key === 'slotId' ||
+        // Dash distance storage is batch-sized and managed separately
+        // (see _ensureDistanceAttributes / _chainInstanceDistances).
+        key === 'instanceDistanceStart' ||
+        key === 'instanceDistanceEnd'
       ) {
         continue
       }
       dstGeometry.setAttribute(key, reference.getAttribute(key).clone())
     }
+  }
+
+  /** Whether the batch material renders a dash pattern (dashed lines). */
+  private _isDashedMaterial(): boolean {
+    return (this.material as LineMaterial | undefined)?.dashed === true
+  }
+
+  /**
+   * Allocates `instanceDistanceStart`/`instanceDistanceEnd` storage sized to
+   * the packed segment capacity. Dashed {@link LineMaterial} requires these
+   * attributes to render dash patterns; solid batches skip them entirely.
+   */
+  private _ensureDistanceAttributes() {
+    const geometry = this.geometry as LineSegmentsGeometry
+    if (geometry.getAttribute('instanceDistanceStart')) {
+      return
+    }
+    const distances = new Float32Array(this._maxSegmentCount * 2)
+    const buffer = new THREE.InstancedInterleavedBuffer(distances, 2, 1)
+    geometry.setAttribute(
+      'instanceDistanceStart',
+      new THREE.InterleavedBufferAttribute(buffer, 1, 0)
+    )
+    geometry.setAttribute(
+      'instanceDistanceEnd',
+      new THREE.InterleavedBufferAttribute(buffer, 1, 1)
+    )
+  }
+
+  /**
+   * Recomputes cumulative dash distances for packed segments in
+   * `[fromSegment, toSegment)`, chaining from the last distance written
+   * before `fromSegment` so the dash phase continues across segments
+   * (mirrors `LineSegments2.computeLineDistances()` over the packed buffer).
+   */
+  private _chainInstanceDistances(
+    fromSegment: number,
+    toSegment: number = this._nextSegmentStart
+  ) {
+    const distanceStart = this.geometry.getAttribute(
+      'instanceDistanceStart'
+    ) as THREE.InterleavedBufferAttribute | undefined
+    const distanceEnd = this.geometry.getAttribute('instanceDistanceEnd') as
+      | THREE.InterleavedBufferAttribute
+      | undefined
+    if (!distanceStart || !distanceEnd) {
+      return
+    }
+    const instanceStart = this.geometry.getAttribute('instanceStart')
+    const instanceEnd = this.geometry.getAttribute('instanceEnd')
+    let cumulative = fromSegment > 0 ? distanceEnd.getX(fromSegment - 1) : 0
+    for (let i = fromSegment; i < toSegment; i++) {
+      _segmentStart.fromBufferAttribute(instanceStart, i)
+      _segmentEnd.fromBufferAttribute(instanceEnd, i)
+      distanceStart.setX(i, cumulative)
+      cumulative += _segmentStart.distanceTo(_segmentEnd)
+      distanceEnd.setX(i, cumulative)
+    }
+    distanceStart.data.needsUpdate = true
+    distanceEnd.data.needsUpdate = true
   }
 
   private _validateGeometry(geometry: LineSegmentsGeometry) {
@@ -329,6 +396,18 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
       geometryId
     )
 
+    // Refresh dash distances for this reserved range and any packed segments
+    // after it (rewrites mid-chain shift the cumulative dash phase).
+    if (this._isDashedMaterial()) {
+      this._chainInstanceDistances(
+        segmentStart,
+        Math.max(
+          this._nextSegmentStart,
+          segmentStart + geometryInfo.reservedVertexCount
+        )
+      )
+    }
+
     return geometryId
   }
 
@@ -382,6 +461,11 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     const instanceEnd = this.geometry.getAttribute('instanceEnd')
     instanceStart.needsUpdate = true
     instanceEnd.needsUpdate = true
+
+    // Compaction moves segments, invalidating the cumulative dash chain.
+    if (this._isDashedMaterial()) {
+      this._chainInstanceDistances(0)
+    }
 
     syncBatchDrawVisibilityAfterOptimize(this.geometry, this._geometryInfo)
 
@@ -460,6 +544,23 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
     const newPacked = this._getPackedSegmentArray()
     copyArrayContents(oldPacked, newPacked)
     this._copyStaticAttributes(oldGeometry)
+    if (this._isDashedMaterial()) {
+      // Dash distance storage is not cloned with static attributes; rebuild
+      // it at the new capacity and copy the existing chain over.
+      const oldDistanceStart = oldGeometry.getAttribute(
+        'instanceDistanceStart'
+      ) as THREE.InterleavedBufferAttribute | undefined
+      this._ensureDistanceAttributes()
+      if (oldDistanceStart && oldDistanceStart.data?.array) {
+        const newDistanceStart = this.geometry.getAttribute(
+          'instanceDistanceStart'
+        ) as THREE.InterleavedBufferAttribute
+        const dst = newDistanceStart.data.array as Float32Array
+        const src = oldDistanceStart.data.array as Float32Array
+        dst.set(src.subarray(0, Math.min(src.length, dst.length)))
+        newDistanceStart.data.needsUpdate = true
+      }
+    }
     const slotIdAttr = ensureSlotIdAttribute(this.geometry, maxSegmentCount)
     if (oldSlotIdArray) {
       ;(slotIdAttr.array as Float32Array).set(
@@ -677,9 +778,7 @@ export class AcTrBatchedLine2 extends AcTrBatchedLine2Base {
       _segmentStart
         .fromBufferAttribute(instanceStart, i)
         .applyMatrix4(matrixWorld)
-      _segmentEnd
-        .fromBufferAttribute(instanceEnd, i)
-        .applyMatrix4(matrixWorld)
+      _segmentEnd.fromBufferAttribute(instanceEnd, i).applyMatrix4(matrixWorld)
 
       const distSq = raycaster.ray.distanceSqToSegment(
         _segmentStart,

--- a/packages/three-renderer/src/object/AcTrLine.ts
+++ b/packages/three-renderer/src/object/AcTrLine.ts
@@ -41,10 +41,16 @@ export class AcTrLine extends AcTrEntity {
     this.wcsBbox = built.wcsBbox
 
     if (built.kind === 'fat') {
+      const fatMaterial = material as LineMaterial
       const line = new LineSegments2(
         built.geometry as LineSegmentsGeometry,
-        material as LineMaterial
+        fatMaterial
       )
+      // Dashed LineMaterial requires per-instance line distances on the
+      // geometry to render the dash pattern.
+      if (fatMaterial.dashed) {
+        line.computeLineDistances()
+      }
       line.position.copy(built.worldOffset)
       getSceneDrawableUserData(line).styleMaterialId = material.id
       this.add(line)

--- a/packages/three-renderer/src/object/AcTrLineSegments.ts
+++ b/packages/three-renderer/src/object/AcTrLineSegments.ts
@@ -59,6 +59,13 @@ export class AcTrLineSegments extends AcTrEntity {
       )
 
       const line = new LineSegments2(lineGeometry, material)
+      // Dashed LineMaterial requires per-instance line distances on the
+      // geometry to render the dash pattern (patterned lines fall back to
+      // dashed LineMaterial when the custom linetype shader is unusable,
+      // see AcTrLineMaterialManager.createDashedFatLineMaterial).
+      if (material.dashed) {
+        line.computeLineDistances()
+      }
       line.position.set(localOrigin.x, localOrigin.y, localOrigin.z)
       getSceneDrawableUserData(line).styleMaterialId = material.id
       this.add(line)

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -31,8 +31,8 @@ import {
   AcTrPolygon,
   AcTrShape
 } from '../object'
-import { AcTrMaterialManager } from '../style/AcTrMaterialManager'
 import { AcTrLinePatternShaderProbe } from '../style/AcTrLinePatternShaderProbe'
+import { AcTrMaterialManager } from '../style/AcTrMaterialManager'
 import { AcTrSubEntityTraitsUtil } from '../util'
 import { AcTrCamera } from '../viewport/AcTrCamera'
 import {

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -32,6 +32,7 @@ import {
   AcTrShape
 } from '../object'
 import { AcTrMaterialManager } from '../style/AcTrMaterialManager'
+import { AcTrLinePatternShaderProbe } from '../style/AcTrLinePatternShaderProbe'
 import { AcTrSubEntityTraitsUtil } from '../util'
 import { AcTrCamera } from '../viewport/AcTrCamera'
 import {
@@ -138,6 +139,8 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
     this._context = new AcTrRenderContext()
     const size = renderer.getSize(new THREE.Vector2())
     this._context.styleManager.updateLineResolution(size.x, size.y)
+    this._context.styleManager.options.linePatternShaderBroken =
+      !AcTrLinePatternShaderProbe.test(renderer)
     AcTrMTextRenderer.getInstance().overrideStyleManager(
       this._context.styleManager
     )

--- a/packages/three-renderer/src/style/AcTrLineMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrLineMaterialManager.ts
@@ -76,13 +76,17 @@ export class AcTrLineMaterialManager extends AcTrMaterialManager<AcTrLineMateria
     const scale = scales.ltscale * scales.celtscale * traits.lineTypeScale
 
     if (this.isShaderMaterial(traits, options)) {
-      material = AcTrLinePatternShaders.createLineShaderMaterial(
-        traits.lineType.pattern!,
-        rgb,
-        scale,
-        this.options.viewportScaleUniform,
-        AcTrMaterialManager.CameraZoomUniform
-      )
+      if (this.options.linePatternShaderBroken) {
+        material = this.createDashedFatLineMaterial(traits, rgb, scale)
+      } else {
+        material = AcTrLinePatternShaders.createLineShaderMaterial(
+          traits.lineType.pattern!,
+          rgb,
+          scale,
+          this.options.viewportScaleUniform,
+          AcTrMaterialManager.CameraZoomUniform
+        )
+      }
     } else if (options.basicMaterialOnly || traits.lineWeight < 0) {
       material = new THREE.LineBasicMaterial({
         color: rgb
@@ -108,6 +112,39 @@ export class AcTrLineMaterialManager extends AcTrMaterialManager<AcTrLineMateria
   private resolveLineWidth(lineWeight: AcGiLineWeight): number {
     if (lineWeight < 0) return 1
     return Math.max(1, lineWeight / 40)
+  }
+
+  /**
+   * Builds a dashed {@link LineMaterial} for patterned lines when the GPU
+   * cannot render the custom linetype shader on native `gl.LINES` (see
+   * {@link AcTrStyleManagerOptions.linePatternShaderBroken}). The CAD pattern
+   * is approximated as one dash (sum of pen-down segments) and one gap (sum of
+   * pen-up segments), scaled by the active linetype scale.
+   */
+  private createDashedFatLineMaterial(
+    traits: AcGiSubEntityTraits,
+    rgb: number,
+    scale: number
+  ): THREE.Material {
+    let dashSize = 0
+    let gapSize = 0
+    for (const el of traits.lineType.pattern!) {
+      let len = el.elementLength
+      if (len < 0 && el.elementTypeFlag !== 0) len = Math.abs(len)
+      len *= scale
+      if (len >= 0) dashSize += len
+      else gapSize += Math.abs(len)
+    }
+    if (dashSize === 0) dashSize = 0.5
+    const dashedLineMaterial = new LineMaterial({
+      color: rgb,
+      linewidth: this.resolveLineWidth(traits.lineWeight),
+      dashed: true,
+      dashSize,
+      gapSize
+    })
+    dashedLineMaterial.resolution.copy(this.options.resolution)
+    return dashedLineMaterial
   }
 
   updateResolution() {

--- a/packages/three-renderer/src/style/AcTrLineMaterialManager.ts
+++ b/packages/three-renderer/src/style/AcTrLineMaterialManager.ts
@@ -135,6 +135,10 @@ export class AcTrLineMaterialManager extends AcTrMaterialManager<AcTrLineMateria
       if (len >= 0) dashSize += len
       else gapSize += Math.abs(len)
     }
+    // Note: zero-length elements (dots) are folded into the dash sum and only
+    // collapse to a fixed 0.5 dash when the pattern has no pen-down length at
+    // all (pure dot linetypes). The shader path instead renders each dot as a
+    // fixed 0.5 dash — an acceptable approximation for this degraded path.
     if (dashSize === 0) dashSize = 0.5
     const dashedLineMaterial = new LineMaterial({
       color: rgb,

--- a/packages/three-renderer/src/style/AcTrLinePatternShaderProbe.ts
+++ b/packages/three-renderer/src/style/AcTrLinePatternShaderProbe.ts
@@ -1,0 +1,108 @@
+import { AcGiLineTypePatternElement } from '@mlightcad/data-model'
+import * as THREE from 'three'
+
+import { AcTrLinePatternShaders } from './AcTrLinePatternShaders'
+
+/**
+ * Detects whether the active GPU/driver can render the custom line-pattern
+ * shader on native `gl.LINES`.
+ *
+ * Some drivers (notably integrated AMD Radeon graphics through ANGLE /
+ * Direct3D 11) fail to rasterize `gl.LINES` combined with the custom
+ * `ShaderMaterial` used for CAD linetype dash patterns — the program compiles
+ * and draw calls are submitted, but zero fragments are produced. On such
+ * drivers, patterned lines must fall back to `LineMaterial` rendered on
+ * `LineSegments2` (triangle-quad meshes) instead of native lines.
+ *
+ * The probe renders two short lines into a tiny offscreen render target:
+ *  - a `LineBasicMaterial` line (control) — proves `gl.LINES` and the probe
+ *    setup itself work on this GPU.
+ *  - a custom line-pattern shader line — proves the linetype shader renders.
+ *
+ * @returns `true` when the shader line produces fragments (GPU is fine), or
+ *   when the probe is inconclusive (to avoid false positives on healthy GPUs);
+ *   `false` only when the control renders but the shader does not.
+ */
+export class AcTrLinePatternShaderProbe {
+  static test(renderer: THREE.WebGLRenderer): boolean {
+    const W = 64
+    const H = 32
+
+    let target: THREE.WebGLRenderTarget | null = null
+    let controlMaterial: THREE.LineBasicMaterial | null = null
+    let shaderMaterial: THREE.Material | null = null
+
+    try {
+      target = new THREE.WebGLRenderTarget(W, H)
+
+      const scene = new THREE.Scene()
+      const camera = new THREE.OrthographicCamera(-10, 30, 10, -10, 0.1, 10)
+
+      const controlGeometry = new THREE.BufferGeometry()
+      controlGeometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute([0, -2, -1, 20, -2, -1], 3)
+      )
+      controlMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
+      scene.add(new THREE.LineSegments(controlGeometry, controlMaterial))
+
+      const shaderGeometry = new THREE.BufferGeometry()
+      shaderGeometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute([0, 2, -1, 20, 2, -1], 3)
+      )
+      shaderGeometry.setAttribute(
+        'lineDistance',
+        new THREE.Float32BufferAttribute([0, 20], 1)
+      )
+      const pattern = [
+        { elementLength: 100, elementTypeFlag: 0 },
+        { elementLength: -1, elementTypeFlag: 0 }
+      ] as AcGiLineTypePatternElement[]
+      shaderMaterial = AcTrLinePatternShaders.createLineShaderMaterial(
+        pattern,
+        0x00ff00,
+        1,
+        1,
+        { value: 1 }
+      )
+      scene.add(new THREE.LineSegments(shaderGeometry, shaderMaterial))
+
+      const previousTarget = renderer.getRenderTarget()
+      const previousClear = new THREE.Color()
+      renderer.getClearColor(previousClear)
+      const previousAlpha = renderer.getClearAlpha()
+
+      renderer.setRenderTarget(target)
+      renderer.setClearColor(0x000000, 1)
+      renderer.clear()
+      renderer.render(scene, camera)
+
+      const pixels = new Uint8Array(W * H * 4)
+      renderer.readRenderTargetPixels(target, 0, 0, W, H, pixels)
+
+      renderer.setRenderTarget(previousTarget)
+      renderer.setClearColor(previousClear, previousAlpha)
+
+      let hasRed = false
+      let hasGreen = false
+      for (let i = 0; i < pixels.length; i += 4) {
+        const r = pixels[i]
+        const g = pixels[i + 1]
+        const b = pixels[i + 2]
+        if (!hasRed && r > 120 && g < 80 && b < 80) hasRed = true
+        else if (!hasGreen && g > 120 && r < 80 && b < 80) hasGreen = true
+      }
+
+      if (hasGreen) return true
+      if (hasRed) return false
+      return true
+    } catch {
+      return true
+    } finally {
+      target?.dispose()
+      controlMaterial?.dispose()
+      shaderMaterial?.dispose()
+    }
+  }
+}

--- a/packages/three-renderer/src/style/AcTrLinePatternShaderProbe.ts
+++ b/packages/three-renderer/src/style/AcTrLinePatternShaderProbe.ts
@@ -29,6 +29,8 @@ export class AcTrLinePatternShaderProbe {
     const H = 32
 
     let target: THREE.WebGLRenderTarget | null = null
+    let controlGeometry: THREE.BufferGeometry | null = null
+    let shaderGeometry: THREE.BufferGeometry | null = null
     let controlMaterial: THREE.LineBasicMaterial | null = null
     let shaderMaterial: THREE.Material | null = null
 
@@ -38,7 +40,7 @@ export class AcTrLinePatternShaderProbe {
       const scene = new THREE.Scene()
       const camera = new THREE.OrthographicCamera(-10, 30, 10, -10, 0.1, 10)
 
-      const controlGeometry = new THREE.BufferGeometry()
+      controlGeometry = new THREE.BufferGeometry()
       controlGeometry.setAttribute(
         'position',
         new THREE.Float32BufferAttribute([0, -2, -1, 20, -2, -1], 3)
@@ -46,7 +48,7 @@ export class AcTrLinePatternShaderProbe {
       controlMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 })
       scene.add(new THREE.LineSegments(controlGeometry, controlMaterial))
 
-      const shaderGeometry = new THREE.BufferGeometry()
+      shaderGeometry = new THREE.BufferGeometry()
       shaderGeometry.setAttribute(
         'position',
         new THREE.Float32BufferAttribute([0, 2, -1, 20, 2, -1], 3)
@@ -101,6 +103,8 @@ export class AcTrLinePatternShaderProbe {
       return true
     } finally {
       target?.dispose()
+      controlGeometry?.dispose()
+      shaderGeometry?.dispose()
       controlMaterial?.dispose()
       shaderMaterial?.dispose()
     }

--- a/packages/three-renderer/src/style/AcTrStyleManager.ts
+++ b/packages/three-renderer/src/style/AcTrStyleManager.ts
@@ -45,6 +45,7 @@ export class AcTrStyleManager {
     maxFragmentUniforms: 1024,
     resolution: new THREE.Vector2(1, 1),
     showLineWeight: false,
+    linePatternShaderBroken: false,
     currentBackgroundColor: ACGI_MODEL_SPACE_BACKGROUND
   }
   private pointMgr: AcTrPointMaterialManager

--- a/packages/three-renderer/src/style/AcTrStyleManagerOptions.ts
+++ b/packages/three-renderer/src/style/AcTrStyleManagerOptions.ts
@@ -36,6 +36,20 @@ export interface AcTrStyleManagerOptions {
   showLineWeight: boolean
 
   /**
+   * Whether the active GPU/driver cannot render the custom line-pattern
+   * shader on native `gl.LINES`.
+   *
+   * Set automatically by `AcTrLinePatternShaderProbe` during renderer
+   * initialization. When `true`, patterned (dashed/dot-dash) lines are
+   * rendered via `LineMaterial` on `LineSegments2` (triangle-quad meshes)
+   * instead of the custom shader on native lines, because some drivers
+   * (e.g. integrated AMD Radeon via ANGLE/Direct3D 11) produce zero
+   * fragments for that combination. On healthy GPUs this stays `false`
+   * and the original high-fidelity linetype shader is used.
+   */
+  linePatternShaderBroken: boolean
+
+  /**
    * Current canvas background colour, as a 24-bit RGB number.
    *
    * Used by material managers to initialize theme-sensitive colours, such

--- a/test/mocks/three/LineMaterial.js
+++ b/test/mocks/three/LineMaterial.js
@@ -23,6 +23,11 @@ class LineMaterial {
     this.userData = {}
     this.color = new MockColor(parameters.color ?? 0xffffff)
     this.linewidth = parameters.linewidth ?? 1
+    this.dashed = parameters.dashed ?? false
+    this.dashScale = parameters.dashScale ?? 1
+    this.dashSize = parameters.dashSize ?? 1
+    this.dashOffset = parameters.dashOffset ?? 0
+    this.gapSize = parameters.gapSize ?? 1
     this.resolution = {
       x: 1,
       y: 1,

--- a/test/mocks/three/LineSegments2.js
+++ b/test/mocks/three/LineSegments2.js
@@ -1,8 +1,43 @@
 const THREE = require('three')
 
+const _v1 = new THREE.Vector3()
+const _v2 = new THREE.Vector3()
+
 class LineSegments2 extends THREE.Mesh {
   constructor(geometry = new THREE.BufferGeometry(), material = null) {
     super(geometry, material)
+  }
+
+  // Mirrors three.js LineSegments2.computeLineDistances(): writes cumulative
+  // instanceDistanceStart/End attributes used by dashed LineMaterial.
+  computeLineDistances() {
+    const geometry = this.geometry
+    const instanceStart = geometry.attributes.instanceStart
+    const instanceEnd = geometry.attributes.instanceEnd
+    if (!instanceStart || !instanceEnd) {
+      return this
+    }
+    const lineDistances = new Float32Array(2 * instanceStart.count)
+    for (let i = 0, j = 0; i < instanceStart.count; i++, j += 2) {
+      _v1.fromBufferAttribute(instanceStart, i)
+      _v2.fromBufferAttribute(instanceEnd, i)
+      lineDistances[j] = j === 0 ? 0 : lineDistances[j - 1]
+      lineDistances[j + 1] = lineDistances[j] + _v1.distanceTo(_v2)
+    }
+    const instanceBuffer = new THREE.InstancedInterleavedBuffer(
+      lineDistances,
+      2,
+      1
+    )
+    geometry.setAttribute(
+      'instanceDistanceStart',
+      new THREE.InterleavedBufferAttribute(instanceBuffer, 1, 0)
+    )
+    geometry.setAttribute(
+      'instanceDistanceEnd',
+      new THREE.InterleavedBufferAttribute(instanceBuffer, 1, 1)
+    )
+    return this
   }
 }
 


### PR DESCRIPTION
## Title

feat(three-renderer): auto-detect broken linetype shader and fall back to dashed LineMaterial

## Body

### Problem

On some integrated AMD Radeon GPUs (ANGLE / Direct3D 11), the custom linetype
`ShaderMaterial` on native `gl.LINES` compiles and submits draw calls but
produces zero fragments — patterned layers (dashed / dot-dash / center lines)
become completely invisible. This is the patterned-line remainder of the
gl.LINES GPU compatibility work from #117 (solid lines already moved to
`LineSegments2` quads).

### Approach

1. `AcTrLinePatternShaderProbe` renders a control line (`LineBasicMaterial`)
   and a pattern-shader line into a tiny offscreen render target at renderer
   initialization.
   - control renders + shader renders → GPU fine, keep the high-fidelity shader
   - control renders + shader does not → GPU broken, enable fallback
   - neither renders → inconclusive, keep the original path (avoids false
     positives on healthy GPUs)
2. When broken, patterned lines get a dashed `LineMaterial` rendered on
   `LineSegments2` (triangle quads): the CAD pattern is approximated as one
   dash (sum of pen-down elements) and one gap (sum of pen-up elements),
   scaled by ltscale/celtscale/entity scale. Pure dot linetypes collapse to a
   fixed 0.5 dash (documented approximation).
3. Dash distances are written on every path a dashed material can take:
   - `AcTrLine` / `AcTrLineSegments` call `computeLineDistances()` at creation
   - `AcTrBatchedLine2` allocates batch-sized `instanceDistanceStart/End` and
     re-chains cumulative distances on append / rewrite / compaction / growth
     (covers both `addLine2` folding and `appendLine2Geometry` direct appends)

### Trade-offs (fallback only, broken GPUs)

| Capability | Shader path | Fallback |
|------------|-------------|----------|
| Multi-segment dash/gap/dot | Full pattern | Collapsed to one dash + one gap |
| Complex linetype (text/shape) | Partial | Length approximation only |
| Performance | Native lines, lighter | Wide-line meshes, heavier |
| Lineweight | 1px + shader | Real lineweight via LineMaterial |

### QA / manual override

The probe result is exposed on
`styleManager.options.linePatternShaderBroken`. Set it to `true` before
opening a drawing to force the fallback on a healthy GPU for verification.

### Tests

`AcTrLinePatternFallback.spec.ts` (11 tests): material aggregation (scaled
pattern, dot pattern, complex elements, healthy-GPU gate), unbatched distance
attributes, batch chaining / growth / rewrite re-chaining, solid negative
cases.