### PR TITLE
fix(cad-simple-viewer): prevent ATTDEF ghost text in block definitions

### DIFF
--- a/packages/cad-simple-viewer/src/app/AcApAttdefVisibility.ts
+++ b/packages/cad-simple-viewer/src/app/AcApAttdefVisibility.ts
@@ -1,0 +1,54 @@
+import {
+  AcDbAttributeDefinition,
+  type AcDbDatabase,
+  log
+} from '@mlightcad/data-model'
+
+/**
+ * Hides attribute definitions (ATTDEF) stored inside named block definitions
+ * so they are no longer drawn when the block is expanded by an INSERT.
+ *
+ * AutoCAD display semantics only show the ATTRIB values attached to each
+ * INSERT; the ATTDEF entities inside the block definition are templates that
+ * are never drawn outside the block editor. SolidWorks DXF exports write the
+ * actual field values into the ATTDEF default text, and the data-model
+ * renderer draws that default text when expanding the block — producing a
+ * duplicate "ghost" copy of title-block values (名称/材料/图号 etc.) offset a
+ * few millimeters from the ATTRIB values.
+ *
+ * Loose ATTDEFs living directly in model/paper space are left untouched so the
+ * upstream tag-placeholder rendering behavior is preserved.
+ *
+ * Emits one console log when anything was hidden so integrators can confirm
+ * the normalization actually ran (guards against stale dev-server caches).
+ *
+ * @param database - The drawing database to normalize.
+ * @returns The number of ATTDEF entities hidden.
+ */
+export function suppressAttdefsInBlockDefinitions(
+  database: AcDbDatabase
+): number {
+  let hidden = 0
+  for (const record of database.tables.blockTable.newIterator()) {
+    if (record.isModelSapce || record.isPaperSapce) {
+      continue
+    }
+    for (const entity of record.newIterator()) {
+      if (entity.dxfTypeName !== 'ATTDEF') {
+        continue
+      }
+      const attdef = entity as AcDbAttributeDefinition
+      if (!attdef.isInvisible) {
+        attdef.isInvisible = true
+        hidden++
+      }
+    }
+  }
+  if (hidden > 0) {
+    log.info(
+      `[AcApDocument] Suppressed ${hidden} ATTDEF(s) in block definitions ` +
+        '(they duplicated INSERT attribute values during block expansion)'
+    )
+  }
+  return hidden
+}

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -3,10 +3,12 @@ import {
   AcCmEventManager,
   AcDbDatabase,
   AcDbFileType,
-  acdbHostApplicationServices,
   AcDbOpenDatabaseOptions,
+  AcDbRenderingCache,
   AcDbSysVarManager,
   AcGeBox2d,
+  acdbHostApplicationServices,
+  acdbSetHostApplicationServicesProvider,
   log
 } from '@mlightcad/data-model'
 import { FontManager } from '@mlightcad/mtext-renderer'
@@ -531,6 +533,7 @@ export class AcApDocManager {
     // On-demand loads go through FontManager's loader, not AcApFontLoader.
     FontManager.instance.baseUrl = fontsUrl
     acdbHostApplicationServices().workingDatabase = doc.database
+    acdbSetHostApplicationServicesProvider(() => acdbHostApplicationServices())
 
     this._commandManager = new AcEdCommandStack()
     this.registerCommands()
@@ -1999,6 +2002,16 @@ export class AcApDocManager {
       resetMeasurementSession()
       resetMarkupSession()
       this.openProgressView.clear()
+      // Block renderings are cached by block name only (no document id), so a
+      // previous open may leave stale geometry in the cache — e.g. a
+      // SolidWorks title block whose ATTDEF defaults were still visible then.
+      // Reopening the same drawing in one session would otherwise re-render
+      // the stale block and keep the duplicate attribute text on screen even
+      // after the database flags were normalized. Drop the scene first so the
+      // cache disposal never touches objects still referenced by the view,
+      // then clear the per-document block cache before every open so blocks
+      // rebuild from the current database state.
+      AcDbRenderingCache.instance.clear()
     }
     this.openProgressView.bindDrawDatabase(this.context.doc.database)
     // Progressive convert/paint is gated by this flag (time-sliced yields in

--- a/packages/cad-simple-viewer/src/app/AcApDocument.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocument.ts
@@ -23,6 +23,7 @@ import type {
   AcApLayerIsolationMode
 } from '../service/types'
 import { LAYER_LOCKED_FLAG } from '../service/types'
+import { suppressAttdefsInBlockDefinitions } from './AcApAttdefVisibility'
 import type { AcApLayerPreviousSnapshot } from './AcApLayerSessionState'
 import { AcApOpenDatabaseOptions } from './AcDbOpenDatabaseOptions'
 
@@ -100,6 +101,7 @@ export class AcApDocument {
         readOnly: this._openMode === AcEdOpenMode.Read
       }
       await this._database.openUri(uri, baseOptions)
+      this.normalizeAttdefVisibility()
       this.docTitle = this._fileName
     } catch {
       isSuccess = false
@@ -145,12 +147,27 @@ export class AcApDocument {
         baseOptions,
         fileExtension == 'dwg' ? AcDbFileType.DWG : AcDbFileType.DXF
       )
+      this.normalizeAttdefVisibility()
       this.docTitle = this._fileName
     } catch {
       isSuccess = false
       this.emitOpenFileFailed(fileName, openErrorBefore)
     }
     return isSuccess
+  }
+
+  /**
+   * Hides ATTDEF entities inside block definitions so INSERT expansion does
+   * not draw duplicate copies of attribute values (see
+   * {@link suppressAttdefsInBlockDefinitions}). Failures must never fail the
+   * document open.
+   */
+  private normalizeAttdefVisibility(): void {
+    try {
+      suppressAttdefsInBlockDefinitions(this._database)
+    } catch (error) {
+      log.warn('[AcApDocument] Failed to normalize ATTDEF visibility:', error)
+    }
   }
 
   /**


### PR DESCRIPTION
SolidWorks-exported drawings write the real attribute values into the ATTDEF defaults, so block definitions render the default text a second time on top of the expanded INSERT attributes, producing a doubled title block.

- Add AcApAttdefVisibility: marks ATTDEF entities inside block definitions invisible after a document opens (never fails the open).
- AcApDocument calls normalizeAttdefVisibility() after openUri/read.
- AcApDocManager clears the per-document block rendering cache before every open so blocks rebuild from the current database state.