### PR TITLE
fix(three-renderer): preserve this binding in batch highlight onBeforeRender wrapper

### DIFF
--- a/packages/three-renderer/src/batch/highlight/AcTrBatchHighlightShaders.ts
+++ b/packages/three-renderer/src/batch/highlight/AcTrBatchHighlightShaders.ts
@@ -437,7 +437,19 @@ export function installBatchHighlightRenderer(
     material,
     group
   ) => {
-    previousOnBeforeRender?.(renderer, scene, camera, geometry, material, group)
+    // Preserve `this` binding: `object.onBeforeRender` may be inherited from
+    // the prototype (e.g. `LineSegments2`), so a bare call would lose the
+    // receiver and `this.material` inside the previous handler would be
+    // undefined.
+    previousOnBeforeRender?.call(
+      object,
+      renderer,
+      scene,
+      camera,
+      geometry,
+      material,
+      group
+    )
     if (
       (!state.hasAnyHighlight() && !state.needsCompareUniforms()) ||
       !material


### PR DESCRIPTION
AcTrBatchedGroupHighlight.spec.ts only exercises highlight state and shader
uniform injection — it never calls renderer.render() through the real WebGL
pipeline, so the wrapped onBeforeRender (and its this binding) is never
invoked. The bug only surfaces in a real render loop after a batch highlight
wrapper is installed (e.g. box-select on a drawing with batched wide lines).