### PR TITLE
feat: scale measure/markup overlays with zoom and refresh toolbar labels on locale change

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+
+import {
+  acExOverlayTransform,
+  acExOverlayViewScale,
+  acExPositionWcsOverlay,
+  acExResetOverlayViewScale,
+  acExScaledCanvasLineWidth
+} from '../src/AcExHtmlOverlayDom'
+
+describe('AcExHtmlOverlayDom', () => {
+  it('anchors view scale on first layout and scales with zoom', () => {
+    const el = document.createElement('div')
+    el.className = 'mlcad-measure-badge'
+
+    expect(acExOverlayViewScale(2, el)).toBe(1)
+    expect(acExOverlayViewScale(4, el)).toBe(2)
+    expect(acExOverlayTransform(el, 2)).toBe(
+      'translate(-50%, -50%) scale(2)'
+    )
+  })
+
+  it('resets the zoom anchor when the overlay moves in world space', () => {
+    const el = document.createElement('div')
+    acExOverlayViewScale(2, el)
+    acExResetOverlayViewScale(el)
+    expect(acExOverlayViewScale(3, el)).toBe(1)
+  })
+
+  it('positions WCS overlays in root-local coordinates', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const el = document.createElement('div')
+    el.className = 'mlcad-markup-dot'
+    root.appendChild(el)
+
+    acExPositionWcsOverlay(
+      el,
+      { x: 120, y: 80 },
+      new DOMRect(20, 10, 400, 300),
+      2
+    )
+
+    expect(el.style.left).toBe('100px')
+    expect(el.style.top).toBe('70px')
+    expect(el.style.transform).toBe('translate(-50%, -50%)')
+  })
+
+  it('scales canvas stroke width with zoom', () => {
+    const canvas = document.createElement('canvas')
+    expect(acExScaledCanvasLineWidth(2, canvas, 2)).toBe(2)
+    expect(acExScaledCanvasLineWidth(2, canvas, 4)).toBe(4)
+  })
+})

--- a/packages/cad-html-plugin/src/AcExHtmlOverlayDom.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlOverlayDom.ts
@@ -1,0 +1,78 @@
+/** Dataset key storing orthographic zoom when an overlay was first positioned. */
+export const ACEX_OVERLAY_BASE_ZOOM = 'overlayBaseZoom'
+
+/**
+ * Scale factor for HTML measure/markup overlays relative to first layout.
+ */
+export function acExOverlayViewScale(zoom: number, el: HTMLElement): number {
+  let base = Number(el.dataset[ACEX_OVERLAY_BASE_ZOOM])
+  if (!Number.isFinite(base) || base === 0) {
+    base = zoom
+    el.dataset[ACEX_OVERLAY_BASE_ZOOM] = String(zoom)
+  }
+  return zoom / base
+}
+
+/** Clears the zoom anchor so the next layout re-bases view scale. */
+export function acExResetOverlayViewScale(el: HTMLElement): void {
+  delete el.dataset[ACEX_OVERLAY_BASE_ZOOM]
+}
+
+/** CSS transform prefix before optional view-synced `scale()`. */
+export function acExOverlayTransformPrefix(el: HTMLElement): string {
+  if (el.classList.contains('mlcad-measure-badge--coordinate')) {
+    return 'translate(-50%, calc(-50% - 16px))'
+  }
+  if (el.classList.contains('mlcad-measure-live-label')) {
+    return 'translate(-50%, -120%)'
+  }
+  return 'translate(-50%, -50%)'
+}
+
+/** Composes centering transform with optional view-synced scale. */
+export function acExOverlayTransform(el: HTMLElement, scale: number): string {
+  const prefix = acExOverlayTransformPrefix(el)
+  if (scale === 1) return prefix
+  return `${prefix} scale(${scale})`
+}
+
+/** Maps a base CSS stroke width to the current view-synced width. */
+export function acExScaledCanvasLineWidth(
+  baseLineWidth: number,
+  canvas: HTMLCanvasElement,
+  zoom: number
+): number {
+  return baseLineWidth * acExOverlayViewScale(zoom, canvas)
+}
+
+/**
+ * Positions one WCS-anchored overlay in root-local coordinates and applies
+ * view-synced scale when `zoom` is provided.
+ */
+export function acExPositionWcsOverlay(
+  el: HTMLElement,
+  screen: { x: number; y: number },
+  rootRect: DOMRect,
+  zoom: number
+): void {
+  el.style.left = `${screen.x - rootRect.left}px`
+  el.style.top = `${screen.y - rootRect.top}px`
+  const scale = acExOverlayViewScale(zoom, el)
+  el.style.transform = acExOverlayTransform(el, scale)
+}
+
+/**
+ * Positions a cursor-following overlay in root-local client coordinates.
+ */
+export function acExPositionClientOverlay(
+  el: HTMLElement,
+  clientX: number,
+  clientY: number,
+  rootRect: DOMRect,
+  zoom: number
+): void {
+  el.style.left = `${clientX - rootRect.left}px`
+  el.style.top = `${clientY - rootRect.top}px`
+  const scale = acExOverlayViewScale(zoom, el)
+  el.style.transform = acExOverlayTransform(el, scale)
+}

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -668,6 +668,7 @@ async function startViewer(): Promise<void> {
         wcsToScreen,
         render,
         getSnapCacheKey: () => snapCacheKey,
+        getCameraZoom: () => camera.zoom,
         resolvePoint: resolveMeasurePoint,
         findCircleOrArcNear: (x, y) => {
           if (!layout.isModelSpace && modelOsnapIndex) {
@@ -739,6 +740,7 @@ async function startViewer(): Promise<void> {
         wcsToScreen,
         render,
         getSnapCacheKey: () => snapCacheKey,
+        getCameraZoom: () => camera.zoom,
         resolvePoint: resolveMeasurePoint,
         zoomToExtents
       }

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -13,6 +13,11 @@ import * as THREE from 'three'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import {
+  acExPositionWcsOverlay,
+  acExResetOverlayViewScale,
+  acExScaledCanvasLineWidth
+} from './AcExHtmlOverlayDom'
+import {
   acExComputeLeaderTipOnShape,
   acExDrawMarkupArrowHead,
   acExDrawMarkupLeader,
@@ -101,6 +106,8 @@ export interface AcExMarkupViewApi {
   wcsToScreen: (wcs: THREE.Vector2) => { x: number; y: number }
   render: () => void
   getSnapCacheKey: () => number
+  /** Current orthographic camera zoom (used to scale DOM overlays). */
+  getCameraZoom: () => number
   resolvePoint: (clientX: number, clientY: number) => AcExResolvedPoint
   /** Frames the camera on world XY extents (review-panel zoom-to). */
   zoomToExtents: (extents: AcExExtents) => void
@@ -979,13 +986,18 @@ export class AcExMarkupController {
       if (!ctx) return
       const tipS = this._worldToOverlay(tip)
       const anchorS = this._worldToOverlay(anchor)
+      const baseWidth = acExMarkupCanvasLineWidth(this._drawLineWeight)
       acExDrawMarkupLeader(
         ctx,
         tipS,
         anchorS,
         this._drawColor,
         true,
-        acExMarkupCanvasLineWidth(this._drawLineWeight)
+        acExScaledCanvasLineWidth(
+          baseWidth,
+          ctx.canvas,
+          this._view.getCameraZoom()
+        )
       )
     }
     paintLeader()
@@ -1227,8 +1239,7 @@ export class AcExMarkupController {
     if (!Number.isFinite(x) || !Number.isFinite(y)) return
     const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
     const screen = this._view.wcsToScreen(new THREE.Vector2(x, y))
-    el.style.left = `${screen.x - rootRect.left}px`
-    el.style.top = `${screen.y - rootRect.top}px`
+    acExPositionWcsOverlay(el, screen, rootRect, this._view.getCameraZoom())
   }
 
   private _commitGeometry(
@@ -1429,6 +1440,7 @@ export class AcExMarkupController {
   private _placeDomAt(el: HTMLElement, wcs: AcExMarkupPoint2d): void {
     el.dataset.wcsX = String(wcs.x)
     el.dataset.wcsY = String(wcs.y)
+    acExResetOverlayViewScale(el)
     this._positionTempDom(el)
   }
 
@@ -1756,6 +1768,11 @@ export class AcExMarkupController {
     color: string,
     lineWidth: number
   ): void {
+    const strokeWidth = acExScaledCanvasLineWidth(
+      lineWidth,
+      ctx.canvas,
+      this._view.getCameraZoom()
+    )
     const worldToScreen = (p: AcExMarkupPoint2d) => this._worldToOverlay(p)
     const screenToWorld = (s: { x: number; y: number }) =>
       this._overlayToWorld(s)
@@ -1766,7 +1783,7 @@ export class AcExMarkupController {
         const a = worldToScreen(g.start)
         const b = worldToScreen(g.end)
         ctx.strokeStyle = color
-        ctx.lineWidth = lineWidth
+        ctx.lineWidth = strokeWidth
         ctx.beginPath()
         ctx.moveTo(a.x, a.y)
         ctx.lineTo(b.x, b.y)
@@ -1780,14 +1797,14 @@ export class AcExMarkupController {
         const a = worldToScreen(g.corner1)
         const b = worldToScreen(g.corner2)
         ctx.strokeStyle = color
-        ctx.lineWidth = lineWidth
+        ctx.lineWidth = strokeWidth
         ctx.strokeRect(
           Math.min(a.x, b.x),
           Math.min(a.y, b.y),
           Math.abs(b.x - a.x),
           Math.abs(b.y - a.y)
         )
-        this._strokeAttachedCallout(ctx, g.callout, color, lineWidth)
+        this._strokeAttachedCallout(ctx, g.callout, color, strokeWidth)
         break
       }
       case 'highlight': {
@@ -1802,7 +1819,7 @@ export class AcExMarkupController {
         ctx.fillRect(x, y, w, h)
         ctx.globalAlpha = 1
         ctx.strokeStyle = color
-        ctx.lineWidth = lineWidth
+        ctx.lineWidth = strokeWidth
         ctx.strokeRect(x, y, w, h)
         break
       }
@@ -1814,11 +1831,11 @@ export class AcExMarkupController {
         })
         const r = Math.hypot(rim.x - c.x, rim.y - c.y)
         ctx.strokeStyle = color
-        ctx.lineWidth = lineWidth
+        ctx.lineWidth = strokeWidth
         ctx.beginPath()
         ctx.arc(c.x, c.y, r, 0, Math.PI * 2)
         ctx.stroke()
-        this._strokeAttachedCallout(ctx, g.callout, color, lineWidth)
+        this._strokeAttachedCallout(ctx, g.callout, color, strokeWidth)
         break
       }
       case 'cloud': {
@@ -1829,15 +1846,15 @@ export class AcExMarkupController {
           worldToScreen,
           screenToWorld,
           color,
-          lineWidth
+          strokeWidth
         )
-        this._strokeAttachedCallout(ctx, g.callout, color, lineWidth)
+        this._strokeAttachedCallout(ctx, g.callout, color, strokeWidth)
         break
       }
       case 'callout': {
         const tip = worldToScreen(g.tip)
         const anchor = worldToScreen(g.anchor)
-        acExDrawMarkupLeader(ctx, tip, anchor, color, true, lineWidth)
+        acExDrawMarkupLeader(ctx, tip, anchor, color, true, strokeWidth)
         break
       }
       default:
@@ -2045,14 +2062,14 @@ export class AcExMarkupController {
 
   private _positionDomOverlays(): void {
     const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
+    const zoom = this._view.getCameraZoom()
     for (const item of this._committed) {
       for (const el of item.parts.dom) {
         const x = Number(el.dataset.wcsX)
         const y = Number(el.dataset.wcsY)
         if (!Number.isFinite(x) || !Number.isFinite(y)) continue
         const screen = this._view.wcsToScreen(new THREE.Vector2(x, y))
-        el.style.left = `${screen.x - rootRect.left}px`
-        el.style.top = `${screen.y - rootRect.top}px`
+        acExPositionWcsOverlay(el, screen, rootRect, zoom)
       }
     }
     const placing = this._placingShapeCallout
@@ -2182,7 +2199,7 @@ export class AcExMarkupController {
         p => this._worldToOverlay(p),
         s => this._overlayToWorld(s),
         color,
-        lineWidth
+        acExScaledCanvasLineWidth(lineWidth, ctx.canvas, this._view.getCameraZoom())
       )
     } else if (this._mode === 'circle') {
       const radius = a.distanceTo(b)
@@ -2195,7 +2212,14 @@ export class AcExMarkupController {
     } else if (this._mode === 'callout') {
       const tip = this._worldToOverlay(point2(a))
       const anchor = this._worldToOverlay(point2(b))
-      acExDrawMarkupLeader(ctx, tip, anchor, color, true, lineWidth)
+      acExDrawMarkupLeader(
+        ctx,
+        tip,
+        anchor,
+        color,
+        true,
+        acExScaledCanvasLineWidth(lineWidth, ctx.canvas, this._view.getCameraZoom())
+      )
     }
   }
 
@@ -2228,7 +2252,7 @@ export class AcExMarkupController {
           p => this._worldToOverlay(p),
           s => this._overlayToWorld(s),
           color,
-          lineWidth
+          acExScaledCanvasLineWidth(lineWidth, ctx.canvas, this._view.getCameraZoom())
         )
       } else {
         this._strokeGeometry(
@@ -2245,7 +2269,14 @@ export class AcExMarkupController {
     }
     const tip = this._worldToOverlay(placing.tip)
     const anchor = this._worldToOverlay(placing.anchor)
-    acExDrawMarkupLeader(ctx, tip, anchor, color, false, lineWidth)
+    acExDrawMarkupLeader(
+      ctx,
+      tip,
+      anchor,
+      color,
+      false,
+      acExScaledCanvasLineWidth(lineWidth, ctx.canvas, this._view.getCameraZoom())
+    )
   }
 
   private _clearPreview(): void {

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -11,6 +11,11 @@ import * as THREE from 'three'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import {
+  acExPositionClientOverlay,
+  acExPositionWcsOverlay,
+  acExScaledCanvasLineWidth
+} from './AcExHtmlOverlayDom'
+import {
   ACEX_MEASUREMENT_FONT_SIZE,
   ACEX_MEASUREMENT_LINE_WEIGHT,
   acExMeasureCanvasLineWidth,
@@ -124,6 +129,9 @@ export interface AcExMeasureViewApi {
    * Monotonic value that changes when pan/zoom invalidates cached pointer picks.
    */
   getSnapCacheKey: () => number
+
+  /** Current orthographic camera zoom (used to scale DOM overlays). */
+  getCameraZoom: () => number
 
   /**
    * Resolves a pointer pick with object snap applied.
@@ -1578,8 +1586,13 @@ export class AcExMeasureController {
     const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
     this._liveLabel.textContent = text
     this._liveLabel.style.display = 'block'
-    this._liveLabel.style.left = `${clientX - rootRect.left}px`
-    this._liveLabel.style.top = `${clientY - rootRect.top}px`
+    acExPositionClientOverlay(
+      this._liveLabel,
+      clientX,
+      clientY,
+      rootRect,
+      this._view.getCameraZoom()
+    )
   }
 
   /**
@@ -2421,7 +2434,11 @@ export class AcExMeasureController {
       else ctx.lineTo(x, y)
     }
     ctx.strokeStyle = strokeCss
-    ctx.lineWidth = lineWidth
+    ctx.lineWidth = acExScaledCanvasLineWidth(
+      lineWidth,
+      canvas,
+      this._view.getCameraZoom()
+    )
     ctx.lineJoin = 'round'
     ctx.lineCap = 'round'
     ctx.stroke()
@@ -2774,6 +2791,7 @@ export class AcExMeasureController {
   /** Projects `data-wcs-*` DOM overlays to root-local screen coordinates. @internal */
   private _positionDomOverlays(): void {
     const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
+    const zoom = this._view.getCameraZoom()
     this._overlayLayer
       .querySelectorAll<HTMLElement>('.mlcad-measure-dot, .mlcad-measure-badge')
       .forEach(el => {
@@ -2781,8 +2799,7 @@ export class AcExMeasureController {
         const y = Number(el.dataset.wcsY)
         if (!Number.isFinite(x) || !Number.isFinite(y)) return
         const screen = this._view.wcsToScreen(new THREE.Vector2(x, y))
-        el.style.left = `${screen.x - rootRect.left}px`
-        el.style.top = `${screen.y - rootRect.top}px`
+        acExPositionWcsOverlay(el, screen, rootRect, zoom)
       })
   }
 
@@ -2846,7 +2863,11 @@ export class AcExMeasureController {
     ctx.beginPath()
     ctx.arc(vx, vy, arc.r, arc.startAngle, arc.endAngle, arc.antiClockwise)
     ctx.strokeStyle = strokeCss ?? this._measureCss()
-    ctx.lineWidth = lineWidth
+    ctx.lineWidth = acExScaledCanvasLineWidth(
+      lineWidth,
+      canvas,
+      this._view.getCameraZoom()
+    )
     ctx.stroke()
     ctx.restore()
   }
@@ -2909,7 +2930,11 @@ export class AcExMeasureController {
     ctx.beginPath()
     ctx.arc(cx, cy, screenR, sa, ea, counterClockwise)
     ctx.strokeStyle = strokeCss ?? this._measureCss()
-    ctx.lineWidth = lineWidth
+    ctx.lineWidth = acExScaledCanvasLineWidth(
+      lineWidth,
+      canvas,
+      this._view.getCameraZoom()
+    )
     ctx.stroke()
     ctx.restore()
   }
@@ -2948,7 +2973,11 @@ export class AcExMeasureController {
     ctx.beginPath()
     ctx.arc(cx, cy, screenR, sa, ea, counterClockwise)
     ctx.strokeStyle = strokeCss ?? this._measureCss()
-    ctx.lineWidth = lineWidth
+    ctx.lineWidth = acExScaledCanvasLineWidth(
+      lineWidth,
+      canvas,
+      this._view.getCameraZoom()
+    )
     ctx.stroke()
     ctx.restore()
   }
@@ -3013,7 +3042,11 @@ export class AcExMeasureController {
     ctx.fillStyle = fill
     ctx.fill()
     ctx.strokeStyle = stroke
-    ctx.lineWidth = lineWidth
+    ctx.lineWidth = acExScaledCanvasLineWidth(
+      lineWidth,
+      canvas,
+      this._view.getCameraZoom()
+    )
     ctx.stroke()
     ctx.restore()
   }

--- a/packages/cad-simple-ui-plugin/__tests__/localeToolbarLabels.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/localeToolbarLabels.spec.ts
@@ -1,0 +1,187 @@
+/** @jest-environment jsdom */
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+beforeAll(() => {
+  global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+})
+
+const localeLabels: Record<string, Record<string, string>> = {
+  en: {
+    'simpleUi.toolbar.layerShort': 'Layers',
+    'simpleUi.toolbar.settings': 'Settings',
+    'simpleUi.toolbar.locale': 'Language'
+  },
+  zh: {
+    'simpleUi.toolbar.layerShort': '图层',
+    'simpleUi.toolbar.settings': '设置',
+    'simpleUi.toolbar.locale': '语言'
+  }
+}
+
+let currentLocale = 'en'
+
+jest.mock('@mlightcad/cad-simple-viewer', () => {
+  const layout = jest.requireActual(
+    '../../cad-simple-viewer/src/editor/global/AcEdUiLayout'
+  ) as typeof import('../../cad-simple-viewer/src/editor/global/AcEdUiLayout')
+
+  return {
+    ...layout,
+    AcApDocManager: {
+      instance: {
+        curDocument: { openMode: 8 },
+        events: {
+          documentActivated: {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+          },
+          documentToBeOpened: {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+          }
+        }
+      }
+    },
+    AcEdOpenMode: {
+      Read: 0,
+      Review: 4,
+      Write: 8
+    },
+    AcApI18n: {
+      get currentLocale() {
+        return currentLocale
+      },
+      setCurrentLocale(locale: string) {
+        currentLocale = locale
+      },
+      t(key: string, opts?: { fallback?: string }) {
+        return (
+          localeLabels[currentLocale]?.[key] ?? opts?.fallback ?? key
+        )
+      },
+      events: {
+        localeChanged: {
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn()
+        }
+      },
+      mergeLocaleMessage: jest.fn()
+    },
+    isMarkupVisible: () => true,
+    isMeasurementVisible: () => true
+  }
+})
+
+jest.mock('@mlightcad/data-model', () => ({
+  acdbHostApplicationServices: () => ({
+    layoutManager: {
+      setCurrentLayoutBtrId: jest.fn()
+    }
+  })
+}))
+
+import { AcApI18n } from '@mlightcad/cad-simple-viewer'
+
+import { acuiCreatePhoneToolbarItems } from '../src/config/defaultToolbarItems'
+import { AcUiI18n } from '../src/i18n'
+import { AcUiToolbar } from '../src/ui/AcUiToolbar'
+
+function getLayerLabel(host: HTMLElement) {
+  return host.querySelector(
+    '[data-toolbar-item-id="layer"] .ml-ex-ui-toolbar-btn-label'
+  )?.textContent
+}
+
+describe('phone toolbar labels on locale change', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    document.getElementById('ml-ex-ui-styles')?.remove()
+    currentLocale = 'en'
+  })
+
+  it('updates visible labels via refreshLocale after locale changes', () => {
+    const host = document.createElement('div')
+    Object.defineProperty(host, 'clientWidth', { value: 800 })
+    Object.defineProperty(host, 'clientHeight', { value: 600 })
+    document.body.appendChild(host)
+
+    const toolbar = new AcUiToolbar({
+      host,
+      placement: 'bottom',
+      showLabels: true,
+      size: 'stretch',
+      items: acuiCreatePhoneToolbarItems({
+        getTheme: () => 'light',
+        setTheme: () => undefined,
+        getLocale: () => AcApI18n.currentLocale as 'en',
+        setLocale: locale => AcApI18n.setCurrentLocale(locale),
+        getPlacement: () => 'bottom',
+        setPlacement: () => undefined
+      }),
+      i18n: new AcUiI18n(),
+      onCommand: jest.fn()
+    })
+
+    expect(getLayerLabel(host)).toBe('Layers')
+
+    AcApI18n.setCurrentLocale('zh')
+    toolbar.refreshLocale()
+
+    expect(getLayerLabel(host)).toBe('图层')
+    toolbar.destroy()
+  })
+
+  it('keeps nested locale strip open on parent mousedown and updates labels', () => {
+    const host = document.createElement('div')
+    Object.defineProperty(host, 'clientWidth', { value: 800 })
+    Object.defineProperty(host, 'clientHeight', { value: 600 })
+    document.body.appendChild(host)
+
+    const toolbar = new AcUiToolbar({
+      host,
+      placement: 'bottom',
+      showLabels: true,
+      size: 'stretch',
+      subToolbar: { showLabels: false },
+      items: acuiCreatePhoneToolbarItems({
+        getTheme: () => 'light',
+        setTheme: () => undefined,
+        getLocale: () => AcApI18n.currentLocale as 'en',
+        setLocale: locale => AcApI18n.setCurrentLocale(locale),
+        getPlacement: () => 'bottom',
+        setPlacement: () => undefined
+      }),
+      i18n: new AcUiI18n(),
+      onCommand: jest.fn()
+    })
+
+    host
+      .querySelector<HTMLButtonElement>('[data-toolbar-item-id="settings"]')
+      ?.click()
+    host
+      .querySelector<HTMLButtonElement>('[data-toolbar-item-id="locale"]')
+      ?.click()
+
+    expect(host.querySelectorAll('.ml-ex-ui-subtoolbar').length).toBe(2)
+
+    const localeZh = host.querySelector<HTMLButtonElement>(
+      '[data-toolbar-item-id="locale-zh"]'
+    )
+    localeZh?.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    )
+
+    expect(host.querySelectorAll('.ml-ex-ui-subtoolbar').length).toBe(2)
+
+    localeZh?.click()
+
+    expect(currentLocale).toBe('zh')
+    expect(getLayerLabel(host)).toBe('图层')
+    toolbar.destroy()
+  })
+})

--- a/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
+++ b/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
@@ -159,6 +159,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     this.dockPanel?.refreshLocale()
     if (this.toolbar) {
       this.toolbar.updateItems(this.baseToolbarItems)
+      this.toolbar.refreshLocale()
     }
   }
   /** Re-resolves mount targets after the viewer view becomes available. */

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiSubToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiSubToolbar.ts
@@ -51,6 +51,11 @@ export interface AcUiSubToolbarMountOptions {
   onSelect: (item: AcUiToolbarItem, button: HTMLButtonElement) => void
   /** Invoked when the strip is closed. */
   onClose?: () => void
+  /**
+   * Keeps a dismissible strip open when the event target lies in related UI
+   * (for example a nested sub-toolbar opened from this strip).
+   */
+  shouldKeepOpenForTarget?: (target: Node) => boolean
 }
 
 /**
@@ -74,6 +79,7 @@ export class AcUiSubToolbar {
     if (!(event.target instanceof Node)) return
     if (this.root.contains(event.target)) return
     if (this.options.anchor.contains(event.target)) return
+    if (this.options.shouldKeepOpenForTarget?.(event.target)) return
     this.close()
   }
 
@@ -126,6 +132,37 @@ export class AcUiSubToolbar {
     this.renderButtons()
     this.applyChromeLayout()
     this.syncPosition()
+  }
+
+  /** Whether `target` lies inside this strip root. */
+  containsTarget(target: Node): boolean {
+    return this.root.contains(target)
+  }
+
+  /** Updates button labels and tooltips after locale change. */
+  refreshLocale() {
+    const { chrome } = this.options
+    for (const button of Array.from(
+      this.root.querySelectorAll<HTMLButtonElement>('.ml-ex-ui-toolbar-btn')
+    )) {
+      const itemId = button.dataset.toolbarItemId
+      if (!itemId) continue
+      const item = this.items.find(candidate => candidate.id === itemId)
+      if (!item || acuiIsToolbarSeparatorItem(item)) continue
+      const effective = acuiResolveEffectiveToolbarItem(item)
+      const label = effective.label
+        ? this.options.i18n.t(effective.label)
+        : effective.id
+      button.title = label
+      button.setAttribute('aria-label', label)
+      const labelEl = button.querySelector('.ml-ex-ui-toolbar-btn-label')
+      if (labelEl) {
+        labelEl.textContent = label
+      } else if (effective.label && !chrome.showLabels) {
+        const text = button.querySelector('span')
+        if (text) text.textContent = label
+      }
+    }
   }
 
   /** Repositions the strip beside the parent toolbar after layout changes. */

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiToolbar.ts
@@ -301,6 +301,34 @@ export class AcUiToolbar {
     this.renderButtons()
   }
 
+  /** Updates button labels and tooltips after locale change. */
+  refreshLocale() {
+    this.syncOverflowButtonLabels()
+    this.syncCollapseToggleButton()
+    for (const { item, element, isSeparator } of this.renderedEntries) {
+      if (isSeparator) continue
+      const button = element as HTMLButtonElement
+      const effective = acuiResolveParentToolbarDisplay(
+        item,
+        this.selectedChildByParent.get(item.id)
+      )
+      const label = effective.label
+        ? this.options.i18n.t(effective.label)
+        : effective.id
+      button.title = label
+      button.setAttribute('aria-label', label)
+      const labelEl = button.querySelector('.ml-ex-ui-toolbar-btn-label')
+      if (labelEl) {
+        labelEl.textContent = label
+      } else if (effective.label && !this.options.showLabels) {
+        const text = button.querySelector('span')
+        if (text) text.textContent = label
+      }
+    }
+    this.openSubToolbar?.refreshLocale()
+    this.openNestedSubToolbar?.refreshLocale()
+  }
+
   /**
    * Moves the toolbar to another host edge and updates orientation classes.
    *
@@ -1125,7 +1153,9 @@ export class AcUiToolbar {
             this.openParentId = undefined
             this.stickyParentId = undefined
           }
-        }
+        },
+        shouldKeepOpenForTarget: target =>
+          this.openNestedSubToolbar?.containsTarget(target) ?? false
       })
       this.openSubToolbar = strip
       return
@@ -1316,6 +1346,13 @@ export class AcUiToolbar {
       effective.action()
     } else if (effective.command) {
       this.options.onCommand(effective.command)
+    }
+
+    const isLocalePick =
+      !acuiIsToolbarSeparatorItem(child) &&
+      effective.id.startsWith('locale-')
+    if (isLocalePick) {
+      this.refreshLocale()
     }
 
     if (child.toggle && sticky && this.openSubToolbar) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeBuilder.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeBuilder.ts
@@ -5,6 +5,7 @@
 import type { AcGePoint2dLike } from '@mlightcad/data-model'
 
 import type { AcEdBaseView } from '../../editor'
+import { acapScaledOverlayLineWidth } from '../overlay/AcApOverlayDrawUtil'
 
 /**
  * Target screen diameter in CSS pixels for each revision-cloud lobe.
@@ -244,7 +245,7 @@ export function strokeMarkupCloud(
   if (world.length < 2) return
   const screen = world.map(p => view.worldToScreen(p))
   ctx.strokeStyle = color
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = acapScaledOverlayLineWidth(lineWidth, ctx.canvas, view)
   ctx.beginPath()
   ctx.moveTo(screen[0].x, screen[0].y)
   for (let i = 1; i < screen.length; i++) {

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupCalloutEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupCalloutEntity.ts
@@ -141,7 +141,8 @@ export class AcApMarkupCalloutEntity extends AcApMarkupEntity {
         view.worldToScreen(live.anchor),
         this.record.style.color,
         true,
-        canvasLineWidth
+        canvasLineWidth,
+        view
       )
     }
     redraw()

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
@@ -134,7 +134,8 @@ export function publishAttachedCallout(
         record.style.lineWeight != null && record.style.lineWeight > 0
           ? record.style.lineWeight
           : MARKUP_LINE_WEIGHT
-      )
+      ),
+      view2d
     )
   }
   redraw()

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupHighlightEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupHighlightEntity.ts
@@ -62,7 +62,8 @@ export class AcApMarkupHighlightEntity extends AcApMarkupEntity {
         view.worldToScreen(geom.corner1),
         view.worldToScreen(geom.corner2),
         this.record.style.color,
-        canvasLineWidth
+        canvasLineWidth,
+        view
       )
     }
     redraw()

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupSegmentEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupSegmentEntity.ts
@@ -13,7 +13,8 @@ import {
   acapDrawOverlayArrowHead,
   acapFitOverlayCanvas,
   type AcApOverlayWorldDrawResult,
-  acapPlaceOverlayHtml
+  acapPlaceOverlayHtml,
+  acapScaledOverlayLineWidth
 } from '../../overlay'
 import { runMarkupEdit } from '../AcApMarkupHistory'
 import { republishMarkup } from '../AcApMarkupRepublish'
@@ -147,7 +148,11 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
       const a = view.worldToScreen(live.start)
       const b = view.worldToScreen(live.end)
       ctx.strokeStyle = this.record.style.color
-      ctx.lineWidth = canvasLineWidth
+      ctx.lineWidth = acapScaledOverlayLineWidth(
+        canvasLineWidth,
+        overlay.canvas,
+        view
+      )
       ctx.beginPath()
       ctx.moveTo(a.x, a.y)
       ctx.lineTo(b.x, b.y)

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
@@ -26,6 +26,7 @@ import {
   formatMeasurementLength
 } from '../../util'
 import { AcTrView2d } from '../../view'
+import { acapScaledOverlayLineWidth } from '../overlay/AcApOverlayDrawUtil'
 import { MEASUREMENT_LIVE_LAYER } from './AcApMeasurementStore'
 import { AcApMeasureAreaEntity } from './entity'
 
@@ -210,7 +211,11 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
         for (let i = 1; i < confirmedSpts.length; i++)
           ctx.lineTo(confirmedSpts[i].x, confirmedSpts[i].y)
         ctx.strokeStyle = acapCssColor(color)
-        ctx.lineWidth = canvasLineWidth
+        ctx.lineWidth = acapScaledOverlayLineWidth(
+          canvasLineWidth,
+          fillCanvas,
+          context.view
+        )
         ctx.setLineDash([8, 5])
         ctx.stroke()
         ctx.setLineDash([])
@@ -224,7 +229,11 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
         ctx.moveTo(last.x, last.y)
         ctx.lineTo(sc.x, sc.y)
         ctx.strokeStyle = acapCssColor(color)
-        ctx.lineWidth = canvasLineWidth
+        ctx.lineWidth = acapScaledOverlayLineWidth(
+          canvasLineWidth,
+          fillCanvas,
+          context.view
+        )
         ctx.stroke()
       }
 

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDrawUtil.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDrawUtil.ts
@@ -6,6 +6,7 @@ import {
 
 import type { AcEdBaseView } from '../../../editor'
 import { acapColorToCssAlpha, acapCssColor } from '../../../util'
+import { acapScaledOverlayLineWidth } from '../../overlay/AcApOverlayDrawUtil'
 
 /**
  * Circle geometry in world XY used by arc-length measurement overlays.
@@ -95,7 +96,7 @@ export function drawMeasureSegmentOnCanvas(
   ctx.moveTo(a.x, a.y)
   ctx.lineTo(b.x, b.y)
   ctx.strokeStyle = acapCssColor(color)
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = acapScaledOverlayLineWidth(lineWidth, canvas, view)
   ctx.stroke()
   ctx.restore()
 }
@@ -133,7 +134,7 @@ export function drawMeasureAngleArcOnCanvas(
   const sa2 = view.worldToScreen(arm2)
 
   ctx.strokeStyle = acapCssColor(color)
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = acapScaledOverlayLineWidth(lineWidth, canvas, view)
   ctx.beginPath()
   ctx.moveTo(sv.x, sv.y)
   ctx.lineTo(sa1.x, sa1.y)
@@ -190,7 +191,7 @@ export function drawMeasureAreaOnCanvas(
   ctx.fillStyle = acapColorToCssAlpha(color, 0.2)
   ctx.fill()
   ctx.strokeStyle = acapCssColor(color)
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = acapScaledOverlayLineWidth(lineWidth, canvas, view)
   ctx.stroke()
   ctx.restore()
 }
@@ -240,7 +241,7 @@ export function strokeMeasureArcOnContext(
   ctx.beginPath()
   ctx.arc(sc.x, sc.y, screenR, sa, ea, antiClockwise)
   ctx.strokeStyle = acapCssColor(color)
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = acapScaledOverlayLineWidth(lineWidth, ctx.canvas, view)
   ctx.stroke()
 }
 

--- a/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
@@ -14,7 +14,8 @@ import type { AcTrView2d } from '../../view'
 import {
   acapDrawOverlayArrowHead,
   acapDrawOverlayHighlight,
-  acapFitOverlayCanvas
+  acapFitOverlayCanvas,
+  acapScaledOverlayLineWidth
 } from './AcApOverlayDrawUtil'
 
 /** World-space 2D point for live preview strokes. */
@@ -131,7 +132,7 @@ export function acapStrokeLiveSegment(
   const sa = view.worldToScreen(a)
   const sb = view.worldToScreen(b)
   ctx.strokeStyle = css
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = acapScaledOverlayLineWidth(lineWidth, ctx.canvas, view)
   if (options?.dashed) ctx.setLineDash([8, 5])
   ctx.beginPath()
   ctx.moveTo(sa.x, sa.y)
@@ -165,7 +166,7 @@ export function acapStrokeLivePolyline(
   const css = typeof color === 'string' ? color : acapCssColor(color)
   const screen = points.map(p => view.worldToScreen(p))
   ctx.strokeStyle = css
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = acapScaledOverlayLineWidth(lineWidth, ctx.canvas, view)
   if (options?.dashed) ctx.setLineDash([8, 5])
   ctx.beginPath()
   ctx.moveTo(screen[0].x, screen[0].y)
@@ -201,7 +202,7 @@ export function acapStrokeLiveCircle(
   const rim = view.worldToScreen({ x: center.x + radius, y: center.y })
   const screenR = Math.hypot(rim.x - sc.x, rim.y - sc.y)
   ctx.strokeStyle = css
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = acapScaledOverlayLineWidth(lineWidth, ctx.canvas, view)
   ctx.beginPath()
   ctx.arc(sc.x, sc.y, screenR, 0, Math.PI * 2)
   ctx.stroke()
@@ -230,7 +231,8 @@ export function acapFillLiveHighlight(
     view.worldToScreen(corner1),
     view.worldToScreen(corner2),
     color,
-    lineWidth
+    lineWidth,
+    view
   )
 }
 

--- a/packages/cad-simple-viewer/src/command/overlay/AcApOverlayDrawUtil.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApOverlayDrawUtil.ts
@@ -2,6 +2,44 @@
  * Shared canvas helpers for markup / measure overlay drawing.
  */
 
+import type { AcEdBaseView } from '../../editor'
+import type { AcTrView2d } from '../../view'
+
+/** Dataset key storing orthographic zoom when an overlay canvas was first drawn. */
+export const ACAP_OVERLAY_BASE_ZOOM = 'overlayBaseZoom'
+
+/** Returns the active orthographic camera zoom, or `null` when unavailable. */
+export function acapGetCameraZoom(view: AcEdBaseView): number | null {
+  const zoom = (view as AcTrView2d).internalCamera?.zoom
+  return typeof zoom === 'number' && zoom > 0 ? zoom : null
+}
+
+/**
+ * Scale factor for one overlay canvas relative to the zoom at first paint.
+ */
+export function acapOverlayViewScale(
+  anchor: HTMLElement,
+  view: AcEdBaseView
+): number {
+  const zoom = acapGetCameraZoom(view)
+  if (zoom == null) return 1
+  let base = Number(anchor.dataset[ACAP_OVERLAY_BASE_ZOOM])
+  if (!Number.isFinite(base) || base === 0) {
+    base = zoom
+    anchor.dataset[ACAP_OVERLAY_BASE_ZOOM] = String(zoom)
+  }
+  return zoom / base
+}
+
+/** Maps a base CSS stroke width to the current view-synced width. */
+export function acapScaledOverlayLineWidth(
+  baseLineWidth: number,
+  anchor: HTMLElement,
+  view: AcEdBaseView
+): number {
+  return baseLineWidth * acapOverlayViewScale(anchor, view)
+}
+
 /**
  * Fit a canvas to its container and return a 2D context cleared for this frame.
  *
@@ -88,10 +126,12 @@ export function acapDrawOverlayLeader(
   anchor: { x: number; y: number },
   color: string,
   withArrow = true,
-  lineWidth = 2
+  lineWidth = 2,
+  view: AcEdBaseView
 ): void {
+  const strokeWidth = acapScaledOverlayLineWidth(lineWidth, ctx.canvas, view)
   ctx.strokeStyle = color
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = strokeWidth
   ctx.beginPath()
   ctx.moveTo(tip.x, tip.y)
   ctx.lineTo(anchor.x, anchor.y)
@@ -115,8 +155,10 @@ export function acapDrawOverlayHighlight(
   a: { x: number; y: number },
   b: { x: number; y: number },
   color: string,
-  lineWidth = 1.5
+  lineWidth = 1.5,
+  view: AcEdBaseView
 ): void {
+  const strokeWidth = acapScaledOverlayLineWidth(lineWidth, ctx.canvas, view)
   const x = Math.min(a.x, b.x)
   const y = Math.min(a.y, b.y)
   const w = Math.abs(a.x - b.x)
@@ -126,6 +168,6 @@ export function acapDrawOverlayHighlight(
   ctx.fillRect(x, y, w, h)
   ctx.globalAlpha = 1
   ctx.strokeStyle = color
-  ctx.lineWidth = lineWidth
+  ctx.lineWidth = strokeWidth
   ctx.strokeRect(x, y, w, h)
 }

--- a/packages/three-renderer/src/html/AcTrHtmlBadge.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlBadge.ts
@@ -32,7 +32,7 @@ export class AcTrHtmlBadge extends AcTrHtmlElement {
         options.fontSize,
         options.transform
       ),
-      options
+      { ...options, scaleWithView: options.scaleWithView ?? true }
     )
   }
 

--- a/packages/three-renderer/src/html/AcTrHtmlCallout.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlCallout.ts
@@ -26,7 +26,7 @@ export class AcTrHtmlCallout extends AcTrHtmlElement {
         options.text ?? '',
         options.fontSize
       ),
-      options
+      { ...options, scaleWithView: options.scaleWithView ?? true }
     )
   }
 

--- a/packages/three-renderer/src/html/AcTrHtmlDot.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlDot.ts
@@ -16,7 +16,10 @@ export interface AcTrHtmlDotOptions extends AcTrHtmlElementOptions {
  */
 export class AcTrHtmlDot extends AcTrHtmlElement {
   constructor(options: AcTrHtmlDotOptions) {
-    super(AcTrHtmlDot.createElement(options.color), options)
+    super(AcTrHtmlDot.createElement(options.color), {
+      ...options,
+      scaleWithView: options.scaleWithView ?? true
+    })
   }
 
   /** Update the marker fill color. */

--- a/packages/three-renderer/src/html/AcTrHtmlElement.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlElement.ts
@@ -25,8 +25,9 @@ export interface AcTrHtmlElementOptions {
   layoutId?: string
   /**
    * When `true`, the DOM element scales with orthographic camera zoom
-   * (relative to first paint). When `false` (default), screen size stays
-   * constant.
+   * (relative to first paint). When `false`, screen size stays constant.
+   * {@link AcTrHtmlBadge}, {@link AcTrHtmlCallout}, and {@link AcTrHtmlDot}
+   * default to `true`; other overlay types default to `false`.
    */
   scaleWithView?: boolean
   /**


### PR DESCRIPTION
## Summary
- Scale HTML export and desktop viewer measure/markup overlays (DOM badges/dots and canvas stroke widths) with orthographic camera zoom, anchored on first layout so annotations stay visually consistent while panning/zooming.
- Default \AcTrHtmlBadge\, \AcTrHtmlCallout\, and \AcTrHtmlDot\ to \scaleWithView: true\.
- Fix phone toolbar labels not updating after locale change via \efreshLocale()\, and keep the settings sub-toolbar open when interacting with the nested locale picker.

## Test plan
- [x] \pnpm test -- packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts packages/cad-simple-ui-plugin/__tests__/localeToolbarLabels.spec.ts\`n- [x] Lint passes for \cad-html-plugin\, \cad-simple-viewer\, \cad-simple-ui-plugin\, and \	hree-renderer\`n- [ ] Manually zoom in/out with existing measure and markup overlays; badges/dots and stroke widths should scale together
- [ ] Switch locale from phone toolbar settings strip; visible labels should update without closing nested sub-toolbars