### PR TITLE
fix(three-renderer): declare highp float precision in line pattern shader

### DIFF
--- a/packages/three-renderer/src/style/AcTrLinePatternShaders.ts
+++ b/packages/three-renderer/src/style/AcTrLinePatternShaders.ts
@@ -85,6 +85,8 @@ export class AcTrLinePatternShaders {
             }`
 
     const fragmentShader = /*glsl*/ `
+            precision highp float;
+
             uniform mat4 modelMatrix;
             uniform vec3 diffuse;
             uniform vec3 u_color;


### PR DESCRIPTION
### Summary

Adds an explicit `precision highp float;` declaration to the line-pattern
fragment shader, matching the convention already used by the sibling pattern
shaders in this repo:

- `AcTrHatchPatternShaders.ts` (#43)
- `AcTrGradientHatchShaders.ts` (#244)

### Why it matters

The dash phase is computed as
`mod(vLineDistance, patternLength * u_viewportScale)`, where `vLineDistance`
carries CAD world-coordinate line lengths that can reach very large values
(tens of thousands of drawing units and beyond). If a driver defaults the
fragment stage to `mediump` (fp16, ~10-bit mantissa), the large dividend in
that `mod()` loses precision and patterned lines can degrade into garbage
phases or fully-discarded (invisible) fragments.

three.js normally prepends a highp precision statement itself, so on the
standard path this declaration is redundant — but it costs nothing, and it
makes the requirement explicit and consistent with the hatch shaders, guarding
against any path where the default would be lower.

### Related

- Sibling shader precedent: #43, #244
- gl.LINES GPU compatibility background: #117 (solid lines moved to quads
  there; this hardens the patterned-line shader path)