### PR TITLE
feat: apply object snap when editing overlay measure and markup grips

### DIFF
--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -655,8 +655,6 @@ async function startViewer(): Promise<void> {
         measureSettingsRef.current?.getTrackingOptions() ?? null,
       onActiveChange: () => {
         setLeftPanForTools()
-        // Measure overlays are pointer-events:none; markup grips are not — suspend
-        // them so endpoint/badge DOM cannot steal OSNAP clicks while measuring.
         markup?.setPeerToolActive(measure?.isActive === true)
       },
       onStyleChange: () => {
@@ -725,9 +723,7 @@ async function startViewer(): Promise<void> {
       },
       onActiveChange: () => {
         setLeftPanForTools()
-        // Measure overlays are pointer-events:none; markup grips are not — suspend
-        // them so endpoint/badge DOM cannot steal OSNAP clicks while measuring.
-        markup?.setPeerToolActive(measure?.isActive === true)
+        measure?.setPeerToolActive(markup?.isActive === true)
       },
       onStyleChange: () => {
         drawStyleToolbarRef.current?.refresh()

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -1545,6 +1545,18 @@ export class AcExMarkupController {
     return point2(this._view.screenToWcs(clientX, clientY))
   }
 
+  private _clientToWorldWithOsnap(
+    clientX: number,
+    clientY: number
+  ): AcExMarkupPoint2d {
+    return point2(this._resolvePointerWithOsnap(clientX, clientY))
+  }
+
+  private _hideOsnapMarker(): void {
+    this._osnapCache = null
+    this._onOsnapMarker(null, null)
+  }
+
   private _placeDomAt(el: HTMLElement, wcs: AcExMarkupPoint2d): void {
     el.dataset.wcsX = String(wcs.x)
     el.dataset.wcsY = String(wcs.y)
@@ -1585,6 +1597,7 @@ export class AcExMarkupController {
   }
 
   private _touchRecord(id: string): void {
+    this._hideOsnapMarker()
     const record = this._findRecord(id)
     if (!record) return
     record.updatedAt = markupNow()
@@ -1615,6 +1628,8 @@ export class AcExMarkupController {
     const cleanups: Array<() => void> = []
     const isEnabled = () => this._gripsEnabled()
     const clientToWorld = (x: number, y: number) => this._clientToWorld(x, y)
+    const clientToWorldOsnap = (x: number, y: number) =>
+      this._clientToWorldWithOsnap(x, y)
     const onSelect = () => this._selectOnly(id)
 
     const shapeOutline = (): AcExMarkupShapeOutline | null => {
@@ -1684,7 +1699,7 @@ export class AcExMarkupController {
       cleanups.push(
         acExBindMarkupPointerDrag({
           el: tipDot,
-          clientToWorld,
+          clientToWorld: clientToWorldOsnap,
           isEnabled,
           onPointerDown: onSelect,
           onMove: world => {
@@ -1758,7 +1773,7 @@ export class AcExMarkupController {
       cleanups.push(
         acExBindMarkupPointerDrag({
           el: startDot,
-          clientToWorld,
+          clientToWorld: clientToWorldOsnap,
           isEnabled,
           onPointerDown: onSelect,
           onMove: world => {
@@ -1777,7 +1792,7 @@ export class AcExMarkupController {
       cleanups.push(
         acExBindMarkupPointerDrag({
           el: endDot,
-          clientToWorld,
+          clientToWorld: clientToWorldOsnap,
           isEnabled,
           onPointerDown: onSelect,
           onMove: world => {
@@ -1803,12 +1818,16 @@ export class AcExMarkupController {
         geometryType === 'rect' ||
         geometryType === 'circle')
     ) {
+      const snapCenter =
+        geometryType === 'cloud' ||
+        geometryType === 'rect' ||
+        geometryType === 'circle'
       let originGeom: AcExMarkupGeometry | null = null
       let originCenter: AcExMarkupPoint2d | null = null
       cleanups.push(
         acExBindMarkupPointerDrag({
           el: centerDot,
-          clientToWorld,
+          clientToWorld: snapCenter ? clientToWorldOsnap : clientToWorld,
           isEnabled,
           cursor: 'move',
           onPointerDown: onSelect,

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -891,6 +891,8 @@ export class AcExMeasureController {
 
   /** Active toolbar mode, or `null` when idle. */
   private _mode: AcExMeasureMode | null = null
+  /** True while a peer create tool (e.g. markup) is armed. */
+  private _peerToolActive = false
   /** Vertices collected for the current in-progress measurement. */
   private _points: THREE.Vector2[] = []
   /**
@@ -981,6 +983,16 @@ export class AcExMeasureController {
   /** Clears the current measurement selection (if any). */
   clearSelection(): void {
     this._deselect(true)
+  }
+
+  /**
+   * Suspends measurement endpoint pointer hit-testing while a peer create
+   * tool (e.g. markup) is armed, so overlay DOM cannot steal OSNAP clicks.
+   */
+  setPeerToolActive(active: boolean): void {
+    if (this._peerToolActive === active) return
+    this._peerToolActive = active
+    this._syncGripPointerEvents()
   }
 
   /**
@@ -1125,6 +1137,7 @@ export class AcExMeasureController {
     this._mode = mode
     this._points = []
     this._updateToolbarActive()
+    this._syncGripPointerEvents()
     this._statusEl.textContent = this._hintForMode(mode)
     this._onActiveChange?.(true)
   }
@@ -1144,6 +1157,7 @@ export class AcExMeasureController {
     this._hidePreview()
     this._onOsnapMarker(null, null)
     this._updateToolbarActive()
+    this._syncGripPointerEvents()
     this._updateIdleStatus()
     this._view.render()
     if (wasActive) this._onActiveChange?.(false)
@@ -1754,7 +1768,7 @@ export class AcExMeasureController {
       acExBindMarkupPointerDrag({
         el: dot,
         clientToWorld: (x, y) => this._clientToWorld(x, y),
-        isEnabled: () => !this._mode,
+        isEnabled: () => this._gripsEnabled(),
         onPointerDown: () => this._selectOnly(id),
         onMove: world => {
           pos.set(world.x, world.y)
@@ -1767,6 +1781,7 @@ export class AcExMeasureController {
         }
       })
     )
+    this._syncGripPointerEvents()
   }
 
   /**
@@ -1887,7 +1902,7 @@ export class AcExMeasureController {
       return dist
     }
 
-    const isEnabled = () => !this._mode
+    const isEnabled = () => this._gripsEnabled()
     const onSelect = () => this._selectOnly(id)
     const onCommit = () => {
       const dist = refresh()
@@ -1919,6 +1934,7 @@ export class AcExMeasureController {
         onCommit
       })
     )
+    this._syncGripPointerEvents()
   }
 
   /**
@@ -2089,7 +2105,7 @@ export class AcExMeasureController {
       return deg
     }
 
-    const isEnabled = () => !this._mode
+    const isEnabled = () => this._gripsEnabled()
     const onSelect = () => this._selectOnly(id)
     const onCommit = () => {
       refresh()
@@ -2110,6 +2126,7 @@ export class AcExMeasureController {
       })
 
     parts.cleanups.push(bind(dotV, vertex), bind(dot1, arm1), bind(dot2, arm2))
+    this._syncGripPointerEvents()
   }
 
   /** Clears locked-arc direction state (Ctrl flip and mouse-follow). @internal */
@@ -2496,11 +2513,12 @@ export class AcExMeasureController {
       refresh()
     }
 
-    const isEnabled = () => !this._mode
+    const isEnabled = () => this._gripsEnabled()
     const onSelect = () => this._selectOnly(id)
     const onCommit = () => {
       if (!syncGeom()) {
         restoreDragStart()
+        this._hideOsnapMarker()
         return
       }
       const len = refresh()
@@ -2533,6 +2551,7 @@ export class AcExMeasureController {
       bind(throughDot, through),
       bind(endDot, end)
     )
+    this._syncGripPointerEvents()
   }
 
   /**
@@ -2645,7 +2664,7 @@ export class AcExMeasureController {
       return len
     }
 
-    const isEnabled = () => !this._mode
+    const isEnabled = () => this._gripsEnabled()
     const onSelect = () => this._selectOnly(id)
     const onCommit = () => {
       const len = refresh()
@@ -2667,6 +2686,7 @@ export class AcExMeasureController {
       })
 
     parts.cleanups.push(bind(startDot, start), bind(endDot, end))
+    this._syncGripPointerEvents()
   }
 
   /**
@@ -2827,7 +2847,7 @@ export class AcExMeasureController {
       return area
     }
 
-    const isEnabled = () => !this._mode
+    const isEnabled = () => this._gripsEnabled()
     const onSelect = () => this._selectOnly(id)
     const onCommit = () => {
       const area = refresh()
@@ -2853,6 +2873,7 @@ export class AcExMeasureController {
         })
       )
     }
+    this._syncGripPointerEvents()
   }
 
   /**
@@ -2903,10 +2924,38 @@ export class AcExMeasureController {
     this._onStyleChange?.()
   }
 
-  /** Client → world converter for grip hosts. @internal */
-  private _clientToWorld(clientX: number, clientY: number): { x: number; y: number } {
-    const w = this._view.screenToWcs(clientX, clientY)
-    return { x: w.x, y: w.y }
+  /** Client → world converter for grip hosts (object snap applied). @internal */
+  private _clientToWorld(
+    clientX: number,
+    clientY: number
+  ): { x: number; y: number } {
+    const p = this._resolvePointerWithOsnap(clientX, clientY)
+    return { x: p.x, y: p.y }
+  }
+
+  private _hideOsnapMarker(): void {
+    this._osnapCache = null
+    this._onOsnapMarker(null, null)
+  }
+
+  /** True when committed endpoint grips may receive pointer events. @internal */
+  private _gripsEnabled(): boolean {
+    return !this._peerToolActive && this._mode === null
+  }
+
+  /**
+   * Enables or disables pointer hits on measurement endpoint dots.
+   * Inline `pointer-events` from grip binding otherwise steal OSNAP clicks.
+   * @internal
+   */
+  private _syncGripPointerEvents(): void {
+    const enable = this._gripsEnabled()
+    for (const measure of this._committed) {
+      for (const el of measure.parts.dom) {
+        if (!el.classList.contains('mlcad-measure-dot')) continue
+        el.style.pointerEvents = enable ? 'auto' : 'none'
+      }
+    }
   }
 
   /**
@@ -2918,6 +2967,7 @@ export class AcExMeasureController {
     quantity: AcExMeasureQuantity | null,
     value: number
   ): void {
+    this._hideOsnapMarker()
     const measure = this._committed.find(m => m.id === id)
     if (!measure) return
     measure.quantity = quantity

--- a/packages/cad-simple-viewer/__tests__/AcApOverlayGripHost.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApOverlayGripHost.spec.ts
@@ -1,0 +1,183 @@
+/** @jest-environment jsdom */
+
+import { acapBindOverlayPointerDrag } from '../src/command/overlay/AcApOverlayGripHost'
+import type { AcTrView2d } from '../src/view'
+
+function dispatchPointer(
+  target: EventTarget,
+  type: string,
+  clientX: number,
+  clientY: number,
+  extra?: { button?: number; detail?: number; pointerId?: number }
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button: extra?.button ?? 0,
+    clientX,
+    clientY,
+    detail: extra?.detail ?? 0
+  })
+  Object.assign(event, { pointerId: extra?.pointerId ?? 1 })
+  target.dispatchEvent(event)
+}
+
+function mockView(overrides: Record<string, unknown> = {}): AcTrView2d {
+  return {
+    viewportToCanvas: ({ x, y }: { x: number; y: number }) => ({ x, y }),
+    screenToWorld: ({ x, y }: { x: number; y: number }) => ({ x, y }),
+    worldToScreen: (pos: { x: number; y: number }) => ({ x: pos.x, y: pos.y }),
+    canvasToContainer: (pos: { x: number; y: number }) => pos,
+    isHtmlDirty: false,
+    container: document.body,
+    osnapResolver: {
+      resolve: jest.fn(() => undefined),
+      clearAcquiredCenters: jest.fn(),
+      acquiredCenterMarks: []
+    },
+    ...overrides
+  } as unknown as AcTrView2d
+}
+
+describe('acapBindOverlayPointerDrag osnap', () => {
+  it('snaps endpoint drags to the osnap resolver result', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const resolve = jest.fn(() => ({
+      x: 100,
+      y: 200,
+      z: 0,
+      type: 1
+    }))
+    const view = mockView({
+      osnapResolver: {
+        resolve,
+        clearAcquiredCenters: jest.fn(),
+        acquiredCenterMarks: []
+      }
+    })
+    const moves: Array<{ x: number; y: number }> = []
+
+    const unbind = acapBindOverlayPointerDrag({
+      view,
+      el,
+      onMove: world => {
+        moves.push({ x: world.x, y: world.y })
+      },
+      onCommit: () => undefined
+    })
+
+    dispatchPointer(el, 'pointerdown', 20, 20)
+    dispatchPointer(window, 'pointermove', 30, 20)
+    dispatchPointer(window, 'pointerup', 30, 20)
+
+    expect(resolve).toHaveBeenCalled()
+    expect(moves[0]).toEqual({ x: 100, y: 200 })
+
+    unbind()
+    el.remove()
+  })
+
+  it('keeps raw world points when useOsnap is false', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const resolve = jest.fn()
+    const view = mockView({
+      osnapResolver: {
+        resolve,
+        clearAcquiredCenters: jest.fn(),
+        acquiredCenterMarks: []
+      }
+    })
+    const moves: Array<{ x: number; y: number }> = []
+
+    const unbind = acapBindOverlayPointerDrag({
+      view,
+      el,
+      useOsnap: false,
+      onMove: world => {
+        moves.push({ x: world.x, y: world.y })
+      },
+      onCommit: () => undefined
+    })
+
+    dispatchPointer(el, 'pointerdown', 20, 20)
+    dispatchPointer(window, 'pointermove', 30, 20)
+    dispatchPointer(window, 'pointerup', 30, 20)
+
+    expect(resolve).not.toHaveBeenCalled()
+    expect(moves[0]).toEqual({ x: 30, y: 20 })
+
+    unbind()
+    el.remove()
+  })
+
+  it('prefers resolveOverlayGripPoint when the view implements it', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const resolve = jest.fn()
+    const resolveOverlayGripPoint = jest.fn(
+      (cursor: { x: number; y: number }) => ({
+        x: cursor.x + 5,
+        y: cursor.y + 7
+      })
+    )
+    const clearOverlayGripOsnap = jest.fn()
+    const view = mockView({
+      resolveOverlayGripPoint,
+      clearOverlayGripOsnap,
+      osnapResolver: {
+        resolve,
+        clearAcquiredCenters: jest.fn(),
+        acquiredCenterMarks: []
+      }
+    })
+    const moves: Array<{ x: number; y: number }> = []
+
+    const unbind = acapBindOverlayPointerDrag({
+      view,
+      el,
+      onMove: world => {
+        moves.push({ x: world.x, y: world.y })
+      },
+      onCommit: () => undefined
+    })
+
+    dispatchPointer(el, 'pointerdown', 20, 20)
+    dispatchPointer(window, 'pointermove', 30, 20)
+    dispatchPointer(window, 'pointerup', 30, 20)
+
+    expect(resolve).not.toHaveBeenCalled()
+    expect(resolveOverlayGripPoint).toHaveBeenCalled()
+    expect(clearOverlayGripOsnap).toHaveBeenCalled()
+    expect(moves[0]).toEqual({ x: 35, y: 27 })
+
+    unbind()
+    el.remove()
+  })
+
+  it('falls back to the cursor when the view has no osnap resolver', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const view = mockView({ osnapResolver: undefined })
+    const moves: Array<{ x: number; y: number }> = []
+
+    const unbind = acapBindOverlayPointerDrag({
+      view,
+      el,
+      onMove: world => {
+        moves.push({ x: world.x, y: world.y })
+      },
+      onCommit: () => undefined
+    })
+
+    dispatchPointer(el, 'pointerdown', 20, 20)
+    dispatchPointer(window, 'pointermove', 30, 20)
+    dispatchPointer(window, 'pointerup', 30, 20)
+
+    expect(moves[0]).toEqual({ x: 30, y: 20 })
+
+    unbind()
+    el.remove()
+  })
+})

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
@@ -247,6 +247,11 @@ export interface AcApMarkupCenterMoveOptions {
   onLiveOffset?: (dx: number, dy: number) => void
   /** Optional attached callout to keep in sync while moving. */
   attached?: AcApMarkupAttachedCalloutVisual
+  /**
+   * When true, the center grip snaps to CAD geometry (rect / circle / cloud).
+   * Default false for text, stamp, and callout whole-object moves.
+   */
+  useOsnap?: boolean
 }
 
 /**
@@ -276,6 +281,7 @@ export function bindMarkupCenterMove(
     view,
     el: centerEl.element,
     cursor: 'move',
+    useOsnap: options.useOsnap === true,
     onDragStart: () => {
       selectMarkupGroup(view, recordId)
       const stored = getMarkupStore().get(recordId)

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupShapeEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupShapeEntity.ts
@@ -193,6 +193,7 @@ export class AcApMarkupShapeEntity extends AcApMarkupEntity {
           recordId: this.record.id,
           centerEl: centerDot,
           attached,
+          useOsnap: true,
           onLiveOffset: (dx, dy) => {
             liveOffset = { dx, dy }
             redrawShape()

--- a/packages/cad-simple-viewer/src/command/overlay/AcApOverlayGripHost.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApOverlayGripHost.ts
@@ -37,6 +37,49 @@ export function acapPointerEventToOverlayWorld(
 }
 
 /**
+ * View methods used for overlay grip object snap. Duck-typed so jsdom tests
+ * can mock a view without loading `@mlightcad/data-model`.
+ */
+interface AcApOverlayOsnapView {
+  osnapResolver?: {
+    resolve?: (options: {
+      cursorWcs: { x: number; y: number; z: number }
+      lastPoint: { x: number; y: number; z: number }
+    }) => { x: number; y: number } | undefined
+    clearAcquiredCenters?: () => void
+  }
+  resolveOverlayGripPoint?: (
+    cursor: { x: number; y: number },
+    lastPoint?: { x: number; y: number }
+  ) => { x: number; y: number }
+  clearOverlayGripOsnap?: () => void
+}
+
+/**
+ * Convert a pointer event to world XY, applying object snap when the view
+ * supports it (same path as CAD entity grip edit).
+ */
+function acapPointerEventToOverlayWorldMaybeOsnap(
+  view: AcTrView2d,
+  ev: PointerEvent,
+  lastPoint: AcApOverlayPoint2d
+): AcApOverlayPoint2d {
+  const raw = acapPointerEventToOverlayWorld(view, ev)
+  const osnapView = view as AcTrView2d & AcApOverlayOsnapView
+  if (typeof osnapView.resolveOverlayGripPoint === 'function') {
+    return osnapView.resolveOverlayGripPoint(raw, lastPoint)
+  }
+  const resolver = osnapView.osnapResolver
+  if (typeof resolver?.resolve !== 'function') return raw
+  const cursorWcs = { x: raw.x, y: raw.y, z: 0 }
+  const snapPoint = resolver.resolve({
+    cursorWcs,
+    lastPoint: { x: lastPoint.x, y: lastPoint.y, z: 0 }
+  })
+  return snapPoint ? { x: snapPoint.x, y: snapPoint.y } : raw
+}
+
+/**
  * Move a published HTML overlay and refresh its transform baseline.
  *
  * @param view - Active 2D view whose HTML transient manager owns `el`.
@@ -81,6 +124,13 @@ export interface AcApOverlayPointerDragOptions {
   onMove: (world: AcApOverlayPoint2d, ev: PointerEvent) => void
   /** Invoked on pointerup / cancel after a drag occurred. */
   onCommit: () => void
+  /**
+   * When true (default), pointer world points go through object snap so
+   * measurement / markup endpoint edits match create-tool snapping.
+   * Set false for whole-object moves that should follow the cursor
+   * (callout bubble, text/stamp). Shape center grips pass true.
+   */
+  useOsnap?: boolean
 }
 
 /**
@@ -98,11 +148,18 @@ export function acapBindOverlayPointerDrag(
 ): () => void {
   const { view, el, onDragStart, onMove, onCommit } = options
   const idleCursor = options.cursor ?? 'grab'
+  const useOsnap = options.useOsnap !== false
 
   el.style.pointerEvents = 'auto'
   el.style.cursor = idleCursor
   el.style.touchAction = 'none'
   el.style.userSelect = 'none'
+  const htmlManager = (
+    view as {
+      htmlTransientManager?: { syncHitTest?: () => void }
+    }
+  ).htmlTransientManager
+  htmlManager?.syncHitTest?.()
 
   /** Detach function for the active window listeners, if any. */
   let detachActiveDrag: (() => void) | undefined
@@ -123,6 +180,13 @@ export function acapBindOverlayPointerDrag(
     const startX = e.clientX
     const startY = e.clientY
     let dragging = false
+    const lastPoint = acapPointerEventToOverlayWorld(view, e)
+    const osnapView = view as AcTrView2d & AcApOverlayOsnapView
+
+    const resolveWorld = (ev: PointerEvent): AcApOverlayPoint2d => {
+      if (!useOsnap) return acapPointerEventToOverlayWorld(view, ev)
+      return acapPointerEventToOverlayWorldMaybeOsnap(view, ev, lastPoint)
+    }
 
     const detach = () => {
       window.removeEventListener(
@@ -156,13 +220,20 @@ export function acapBindOverlayPointerDrag(
         el.style.cursor = 'grabbing'
         onDragStart?.()
       }
-      onMove(acapPointerEventToOverlayWorld(view, ev), ev)
+      onMove(resolveWorld(ev), ev)
       view.isHtmlDirty = true
     }
 
     const onPointerUp = (ev: PointerEvent) => {
       if (ev.pointerId !== pointerId) return
       detach()
+      if (useOsnap && dragging) {
+        if (typeof osnapView.clearOverlayGripOsnap === 'function') {
+          osnapView.clearOverlayGripOsnap()
+        } else {
+          osnapView.osnapResolver?.clearAcquiredCenters?.()
+        }
+      }
       if (!dragging) return
       el.style.cursor = idleCursor
       onCommit()
@@ -290,6 +361,7 @@ export function acapBindOverlayCalloutGrips(
   const unbindBubble = acapBindOverlayPointerDrag({
     view,
     el: bubbleEl.element,
+    useOsnap: false,
     onDragStart: () => {
       dragOrigin = {
         tip: { ...state.tip },

--- a/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
@@ -17,6 +17,7 @@ import type { AcTrSpatialSearchOptions } from '../../spatialIndex/AcTrSpatialInd
 import { AcEdCorsorType, AcEdSelectionSet } from '../input'
 import { AcEditor } from '../input/AcEditor'
 import { AcEdOsnapResolver } from '../input/AcEdOsnapResolver'
+import { AcEdMarkerManager } from '../input/marker'
 import { AcEdHoverController } from './AcEdHoverController'
 import {
   AcEdSelectionAction,
@@ -246,6 +247,9 @@ export abstract class AcEdBaseView {
 
   /** Resolves object snap points using this view's pick and coordinate APIs. */
   private _osnapResolver: AcEdOsnapResolver
+
+  /** OSNAP markers shown while dragging overlay measurement / markup grips. */
+  private _overlayGripOsnapMarkers: AcEdMarkerManager | null = null
 
   /** The HTML canvas element for rendering */
   protected _canvas: HTMLCanvasElement
@@ -995,6 +999,51 @@ export abstract class AcEdBaseView {
    */
   get osnapResolver() {
     return this._osnapResolver
+  }
+
+  /**
+   * Resolves a world XY cursor through object snap and updates overlay grip
+   * snap markers. Used by HTML overlay endpoint drags (measure / markup).
+   *
+   * @param cursor - Raw world XY under the pointer.
+   * @param lastPoint - Grip origin passed to the osnap resolver as lastPoint.
+   * @returns Snapped world XY, or `cursor` when nothing is in aperture.
+   */
+  resolveOverlayGripPoint(
+    cursor: { x: number; y: number },
+    lastPoint?: { x: number; y: number }
+  ): { x: number; y: number } {
+    const cursorWcs = { x: cursor.x, y: cursor.y, z: 0 }
+    this._overlayGripOsnapMarkers ??= new AcEdMarkerManager(this)
+    this._overlayGripOsnapMarkers.hideMarker()
+    const snapPoint = this._osnapResolver.resolve({
+      cursorWcs,
+      lastPoint: lastPoint
+        ? { x: lastPoint.x, y: lastPoint.y, z: 0 }
+        : cursorWcs
+    })
+    this._overlayGripOsnapMarkers.setHintMarkers(
+      AcEdOsnapResolver.displayCenterMarks(
+        this._osnapResolver.acquiredCenterMarks,
+        snapPoint
+      )
+    )
+    if (snapPoint) {
+      this._overlayGripOsnapMarkers.showMarker(
+        snapPoint,
+        AcEdOsnapResolver.osnapModeToMarkerType(snapPoint.type)
+      )
+      return { x: snapPoint.x, y: snapPoint.y }
+    }
+    return { x: cursor.x, y: cursor.y }
+  }
+
+  /**
+   * Hides overlay grip snap markers and clears acquired centers.
+   */
+  clearOverlayGripOsnap(): void {
+    this._overlayGripOsnapMarkers?.clear()
+    this._osnapResolver.clearAcquiredCenters()
   }
 
   protected onWindowResize() {

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -603,6 +603,12 @@ export class AcTrView2d extends AcEdBaseView {
     // This method is called after camera and render are created.
     // Children class can override this method to add its own logic
     this.setCursor(AcEdCorsorType.Crosshair)
+    this.editor.events.commandWillStart.addEventListener(() => {
+      this.htmlTransientManager.setHitTestEnabled(false)
+    })
+    this.editor.events.commandEnded.addEventListener(() => {
+      this.htmlTransientManager.setHitTestEnabled(true)
+    })
   }
 
   /**

--- a/packages/three-renderer/__tests__/AcTrHtmlTransientManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrHtmlTransientManager.spec.ts
@@ -405,4 +405,30 @@ describe('AcTrHtmlTransientManager', () => {
 
     manager.dispose()
   })
+
+  it('disables overlay pointer hits so clicks can pass through to the canvas', () => {
+    const scene = new THREE.Scene()
+    const manager = new AcTrHtmlTransientManager(scene)
+    const child = new AcTrHtmlElement(document.createElement('div'), {
+      id: 'hit-child',
+      worldPosition: { x: 0, y: 0 }
+    })
+    const group = new AcTrHtmlGroup({
+      id: 'hit-group',
+      selectable: true
+    }).add(child)
+    manager.add(group)
+    expect(child.element.style.pointerEvents).toBe('auto')
+
+    manager.setHitTestEnabled(false)
+    expect(child.element.style.pointerEvents).toBe('none')
+
+    child.element.style.pointerEvents = 'auto'
+    manager.syncHitTest()
+    expect(child.element.style.pointerEvents).toBe('none')
+
+    manager.setHitTestEnabled(true)
+    expect(child.element.style.pointerEvents).toBe('auto')
+    manager.dispose()
+  })
 })

--- a/packages/three-renderer/src/html/AcTrHtmlTransientManager.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlTransientManager.ts
@@ -91,6 +91,11 @@ export class AcTrHtmlTransientManager {
   private readonly selectedGroupIds = new Set<string>()
   /** Active layout BTR id used to filter layout-scoped overlays. */
   private _activeLayoutId?: string
+  /**
+   * When false, overlay HTML children do not receive pointer hits so CAD
+   * command / OSNAP clicks pass through to the canvas.
+   */
+  private _hitTestEnabled = true
   /** World matrix captured when each leaf transient was published. */
   private readonly _baselineMatrices = new Map<string, THREE.Matrix4>()
   /** Scratch matrix used to compose world transforms in {@link applyTransforms}. */
@@ -440,6 +445,36 @@ export class AcTrHtmlTransientManager {
   }
 
   /**
+   * Enable or disable pointer hit-testing on published HTML overlays.
+   *
+   * Disabled while a CAD command is acquiring points so measurement / markup
+   * endpoint DOM cannot swallow OSNAP clicks meant for the canvas.
+   *
+   * @param enabled - `true` to allow overlay grips/badges to receive pointers
+   */
+  setHitTestEnabled(enabled: boolean): void {
+    this._hitTestEnabled = enabled
+    this.syncHitTest()
+  }
+
+  /**
+   * Re-apply {@link setHitTestEnabled} to every published CSS2D child.
+   * Call after grip binding, which may set `pointer-events: auto`.
+   */
+  syncHitTest(): void {
+    const pe = this._hitTestEnabled ? 'auto' : 'none'
+    for (const group of this.groups.values()) {
+      for (const child of group.children) {
+        child.element.style.pointerEvents = pe
+      }
+    }
+    for (const entry of this.entries.values()) {
+      if (this.groupChildIds.has(entry.id)) continue
+      entry.element.style.pointerEvents = pe
+    }
+  }
+
+  /**
    * Select a group by id.
    *
    * @param id - Group id
@@ -548,6 +583,7 @@ export class AcTrHtmlTransientManager {
       this.selectGroup(g.id)
     })
     this.applyItemLayoutVisibility(group)
+    this.syncHitTest()
   }
 
   /**


### PR DESCRIPTION
## Summary
- Snap measurement/markup endpoint (and shape-center) grips to CAD geometry the same way create tools do, including OSNAP markers while dragging.
- Disable HTML overlay pointer hits while a CAD command is acquiring points so overlay dots/badges cannot steal OSNAP clicks meant for the canvas.
- In the exported HTML viewer, suspend measurement grips while markup is armed (and keep the existing reverse), so peer-tool overlays cannot intercept placement clicks.

## Test plan
- [ ] Drag a distance/angle/area/arc measurement endpoint near CAD geometry and confirm it snaps with the usual OSNAP marker; release and confirm the marker clears.
- [ ] Drag a markup line/arrow endpoint and a rect/circle/cloud center grip; confirm they snap. Drag a text/stamp/callout bubble and confirm they follow the cursor without snapping.
- [ ] Start LINE (or another point-acquiring command) with existing measurements/markups on screen; click CAD snap points through overlay dots/badges. After the command ends, overlay grips should be draggable again.
- [ ] In the HTML export viewer: arm markup while measurements exist (and vice versa) and confirm the idle tool's endpoint dots do not intercept OSNAP clicks.
- [ ] `pnpm exec jest packages/cad-simple-viewer/__tests__/AcApOverlayGripHost.spec.ts packages/three-renderer/__tests__/AcTrHtmlTransientManager.spec.ts --no-coverage`