### PR TITLE
feat: add in-canvas-parent toolbar layout so phone chrome sits beside the canvas

### DIFF
--- a/packages/cad-simple-ui-plugin/README.md
+++ b/packages/cad-simple-ui-plugin/README.md
@@ -9,6 +9,7 @@ This plugin provides ready-to-use CAD viewer chrome without Vue, React, or Eleme
 - Configurable toolbar with predefined CAD commands, separators, and preset references
 - Nested sub-toolbars (sticky or dismissible) and optional popover menus, with flyout arrows
 - Toolbar placement: `top`, `bottom`, `left`, `right`
+- Optional in-canvas-parent layout: sit against the canvas edge instead of floating over it
 - Default toolbar includes view, measure, review, then export, plus toolbar placement, theme toggle, and a language picker
 - UI theme follows `COLORTHEME` sysvar and `--ml-ui-*` tokens on `host` automatically
 - Locale follows `AcApI18n.currentLocale` automatically
@@ -196,6 +197,31 @@ toolbar: {
 }
 ```
 
+### In-canvas-parent toolbar
+
+By default the toolbar floats over the drawing (`position: absolute`). Set `toolbar.inCanvasParent: true` to place it as a flex sibling of the canvas inside the **same parent the dock panel uses** (the viewer canvas parent when it lies inside `host`). The toolbar then sits against the canvas edge instead of covering it. `placement` still picks the edge; `edgeOffset` and `sideOffset` still apply as the gap from the canvas and the orthogonal insets.
+
+```typescript
+toolbar: {
+  placement: 'bottom',
+  inCanvasParent: true,
+  edgeOffset: 0
+}
+```
+
+Phone layouts can enable this without affecting desktop overlay chrome:
+
+```typescript
+layouts: {
+  phone: {
+    toolbar: {
+      placement: 'bottom',
+      inCanvasParent: true
+    }
+  }
+}
+```
+
 ### Responsive layouts (phone / pad / desktop)
 
 By default the plugin uses `layout: 'auto'` and follows viewport width via `acedGetUiLayout()` from `@mlightcad/cad-simple-viewer`:
@@ -218,7 +244,7 @@ acuiCreateSimpleUiPlugin({
   layouts: {
     phone: {
       toolbar: {
-        // optional overrides; phone inherits only enabled/mountTarget from toolbar
+        // optional overrides; phone inherits enabled/mountTarget/inCanvasParent
         // subToolbar.position: 'front' (default) | 'end' | 'center' | 'auto'
       }
     }

--- a/packages/cad-simple-ui-plugin/__tests__/AcUiToolbar.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcUiToolbar.spec.ts
@@ -774,3 +774,118 @@ describe('AcUiToolbar children UI', () => {
     endToolbar.destroy()
   })
 })
+
+describe('AcUiToolbar in-canvas-parent layout', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    document.getElementById('ml-ex-ui-styles')?.remove()
+  })
+
+  it('wraps canvas children and sits as a flex sibling', async () => {
+    const host = document.createElement('div')
+    Object.defineProperty(host, 'clientWidth', { value: 400 })
+    Object.defineProperty(host, 'clientHeight', { value: 600 })
+    const canvas = document.createElement('div')
+    canvas.id = 'canvas'
+    host.appendChild(canvas)
+    document.body.appendChild(host)
+
+    const toolbar = new AcUiToolbar({
+      host,
+      placement: 'bottom',
+      size: 'stretch',
+      edgeOffset: 4,
+      sideOffset: 2,
+      inCanvasParent: true,
+      items: [{ id: 'zoom', label: 'toolbar.zoom', command: 'zoom' }],
+      i18n: new AcUiI18n(),
+      onCommand: jest.fn()
+    })
+
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+
+    const root = host.querySelector<HTMLElement>('.ml-ex-ui-toolbar')
+    const main = host.querySelector<HTMLElement>('.ml-ex-ui-toolbar-main')
+    expect(root?.classList.contains('is-in-parent')).toBe(true)
+    expect(host.classList.contains('ml-ex-ui-toolbar-in-parent-bottom')).toBe(
+      true
+    )
+    expect(main).not.toBeNull()
+    expect(main?.contains(canvas)).toBe(true)
+    expect(root?.previousElementSibling).toBe(main)
+    expect(root?.style.top).toBe('')
+    expect(root?.style.left).toBe('')
+    expect(root?.style.width).toBe('')
+    expect(root?.style.marginTop).toBe('4px')
+    expect(root?.style.marginLeft).toBe('2px')
+
+    toolbar.destroy()
+    expect(host.querySelector('.ml-ex-ui-toolbar-main')).toBeNull()
+    expect(host.contains(canvas)).toBe(true)
+  })
+
+  it('lays out inside dock-main so dock side changes keep the toolbar on the canvas', () => {
+    const host = document.createElement('div')
+    const dockMain = document.createElement('div')
+    dockMain.className = 'ml-ex-ui-dock-main'
+    const canvas = document.createElement('div')
+    dockMain.appendChild(canvas)
+    const dockPanel = document.createElement('div')
+    dockPanel.className = 'ml-ex-ui-dock-panel'
+    host.appendChild(dockMain)
+    host.appendChild(dockPanel)
+    document.body.appendChild(host)
+
+    const toolbar = new AcUiToolbar({
+      host,
+      placement: 'bottom',
+      inCanvasParent: true,
+      items: [{ id: 'zoom', label: 'toolbar.zoom', command: 'zoom' }],
+      i18n: new AcUiI18n(),
+      onCommand: jest.fn()
+    })
+
+    expect(dockMain.querySelector('.ml-ex-ui-toolbar-main')?.contains(canvas)).toBe(
+      true
+    )
+    expect(dockMain.querySelector('.ml-ex-ui-toolbar')).not.toBeNull()
+    expect(dockPanel.parentElement).toBe(host)
+    expect(host.querySelector(':scope > .ml-ex-ui-toolbar')).toBeNull()
+
+    toolbar.destroy()
+  })
+
+  it('restores overlay layout when inCanvasParent is turned off', async () => {
+    const host = document.createElement('div')
+    Object.defineProperty(host, 'clientWidth', { value: 400 })
+    Object.defineProperty(host, 'clientHeight', { value: 600 })
+    const canvas = document.createElement('div')
+    host.appendChild(canvas)
+    document.body.appendChild(host)
+
+    const toolbar = new AcUiToolbar({
+      host,
+      placement: 'bottom',
+      size: 'stretch',
+      edgeOffset: 0,
+      inCanvasParent: true,
+      items: [{ id: 'zoom', label: 'toolbar.zoom', command: 'zoom' }],
+      i18n: new AcUiI18n(),
+      onCommand: jest.fn()
+    })
+
+    toolbar.applyViewOptions({ inCanvasParent: false })
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+
+    const root = host.querySelector<HTMLElement>('.ml-ex-ui-toolbar')
+    expect(root?.classList.contains('is-in-parent')).toBe(false)
+    expect(host.querySelector('.ml-ex-ui-toolbar-main')).toBeNull()
+    expect(host.contains(canvas)).toBe(true)
+    expect(root?.style.bottom).toBe('0px')
+    toolbar.destroy()
+  })
+})

--- a/packages/cad-simple-ui-plugin/__tests__/createSimpleUiPlugin.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/createSimpleUiPlugin.spec.ts
@@ -677,4 +677,118 @@ describe('AcApSimpleUiPlugin', () => {
     expect(canvasParent.querySelector('.ml-ex-ui-toolbar')).not.toBeNull()
     expect(host.querySelector(':scope > .ml-ex-ui-toolbar')).toBeNull()
   })
+
+  it('places an in-canvas-parent toolbar as a sibling of the canvas slot', () => {
+    const { host, canvasParent, canvas } = createHostTree()
+    loadPlugin({
+      host,
+      layout: 'phone',
+      toolbar: {
+        inCanvasParent: true
+      },
+      layouts: {
+        phone: {
+          toolbar: {
+            items: [acuiToolbarPreset('select')],
+            inCanvasParent: true
+          }
+        }
+      }
+    })
+
+    const toolbar = canvasParent.querySelector('.ml-ex-ui-toolbar')
+    const main = canvasParent.querySelector('.ml-ex-ui-toolbar-main')
+    expect(toolbar).not.toBeNull()
+    expect(main).not.toBeNull()
+    expect(main?.contains(canvas)).toBe(true)
+    expect(toolbar?.classList.contains('is-in-parent')).toBe(true)
+    expect(toolbar?.classList.contains('is-bottom')).toBe(true)
+    expect(canvasParent.classList.contains('ml-ex-ui-toolbar-in-parent-bottom')).toBe(
+      true
+    )
+  })
+
+  it('keeps an in-canvas-parent toolbar inside dock-main on the canvas parent', () => {
+    const { host, canvasParent, canvas } = createHostTree()
+    loadPlugin({
+      host,
+      layout: 'phone',
+      toolbar: {
+        items: [acuiToolbarPreset('layer')],
+        inCanvasParent: true
+      }
+    })
+
+    const dockMain = canvasParent.querySelector('.ml-ex-ui-dock-main')
+    expect(dockMain).not.toBeNull()
+    expect(dockMain?.querySelector('.ml-ex-ui-toolbar-main')?.contains(canvas)).toBe(
+      true
+    )
+    expect(dockMain?.querySelector('.ml-ex-ui-toolbar')).not.toBeNull()
+    expect(canvasParent.querySelector(':scope > .ml-ex-ui-toolbar')).toBeNull()
+    expect(canvasParent.querySelector(':scope > .ml-ex-ui-dock-panel')).not.toBeNull()
+  })
+
+  it('restores overlay chrome when leaving phone in-canvas-parent layout', () => {
+    const { host, canvasParent, canvas } = createHostTree()
+    const { plugin } = loadPlugin({
+      host,
+      layout: 'phone',
+      layouts: {
+        phone: {
+          toolbar: {
+            items: [acuiToolbarPreset('select')],
+            inCanvasParent: true
+          }
+        }
+      }
+    })
+
+    expect(
+      canvasParent.querySelector('.ml-ex-ui-toolbar-main')?.contains(canvas)
+    ).toBe(true)
+
+    expect(plugin.setLayout('desktop')).toBe(true)
+
+    const toolbar = canvasParent.querySelector('.ml-ex-ui-toolbar')
+    expect(toolbar).not.toBeNull()
+    expect(toolbar?.isConnected).toBe(true)
+    expect(toolbar?.classList.contains('is-in-parent')).toBe(false)
+    expect(toolbar?.classList.contains('is-right')).toBe(true)
+    expect(canvasParent.querySelector('.ml-ex-ui-toolbar-main')).toBeNull()
+    expect(canvasParent.contains(canvas)).toBe(true)
+  })
+
+  it('restores overlay chrome inside dock-main after leaving in-canvas-parent', () => {
+    const { host, canvasParent, canvas } = createHostTree()
+    const { plugin } = loadPlugin({
+      host,
+      layout: 'phone',
+      toolbar: {
+        items: [acuiToolbarPreset('layer')]
+      },
+      layouts: {
+        phone: {
+          toolbar: {
+            inCanvasParent: true
+          }
+        }
+      }
+    })
+
+    expect(
+      canvasParent.querySelector('.ml-ex-ui-dock-main .ml-ex-ui-toolbar-main')
+        ?.contains(canvas)
+    ).toBe(true)
+
+    expect(plugin.setLayout('desktop')).toBe(true)
+
+    const dockMain = canvasParent.querySelector('.ml-ex-ui-dock-main')
+    const toolbar = dockMain?.querySelector('.ml-ex-ui-toolbar')
+    expect(toolbar).not.toBeNull()
+    expect(toolbar?.classList.contains('is-in-parent')).toBe(false)
+    expect(dockMain?.querySelector('.ml-ex-ui-toolbar-main')).toBeNull()
+    expect(dockMain?.contains(canvas)).toBe(true)
+    expect(canvasParent.querySelector(':scope > .ml-ex-ui-dock-panel')).not.toBeNull()
+  })
 })

--- a/packages/cad-simple-ui-plugin/__tests__/mergeToolbarOptionsForLayout.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/mergeToolbarOptionsForLayout.spec.ts
@@ -32,19 +32,21 @@ describe('acuiMergeToolbarOptionsForLayout', () => {
     expect(merged.appendItemsAfter).toBeUndefined()
   })
 
-  it('inherits mountTarget and enabled on phone from top-level toolbar', () => {
+  it('inherits mountTarget, enabled, and inCanvasParent on phone from top-level toolbar', () => {
     const mountTarget = {} as HTMLElement
     const merged = acuiMergeToolbarOptionsForLayout(
       'phone',
       {
         enabled: true,
         mountTarget,
+        inCanvasParent: true,
         appendItems: [{ id: 'agent', command: 'agent' }]
       },
       undefined
     )
     expect(merged.mountTarget).toBe(mountTarget)
     expect(merged.enabled).toBe(true)
+    expect(merged.inCanvasParent).toBe(true)
     expect(merged.appendItems).toBeUndefined()
   })
 

--- a/packages/cad-simple-ui-plugin/__tests__/normalizePluginOptions.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/normalizePluginOptions.spec.ts
@@ -36,6 +36,7 @@ describe('acuiNormalizePluginOptions', () => {
   it('defaults toolbar edge offset', () => {
     const resolved = acuiNormalizePluginOptions({})
     expect(resolved.toolbar.edgeOffset).toBe(8)
+    expect(resolved.toolbar.inCanvasParent).toBe(false)
   })
 
   it('defaults layout mode to auto', () => {

--- a/packages/cad-simple-ui-plugin/__tests__/resolveDockMountTarget.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveDockMountTarget.spec.ts
@@ -46,4 +46,37 @@ describe('acuiResolveDockMountTarget', () => {
     mockCurView.container = canvas
     expect(acuiResolveDockMountTarget(host)).toBe(host)
   })
+
+  it('skips dock-main when it has become the canvas parent', () => {
+    const canvasParent = { classList: { contains: () => false } } as unknown as HTMLElement
+    const dockMain = {
+      classList: { contains: (name: string) => name === 'ml-ex-ui-dock-main' },
+      parentElement: canvasParent
+    } as unknown as HTMLElement
+    const host = {
+      contains: (node: unknown) => node === dockMain || node === canvasParent
+    } as unknown as HTMLElement
+
+    mockCurView.container = { parentElement: dockMain }
+    expect(acuiResolveDockMountTarget(host)).toBe(canvasParent)
+  })
+
+  it('skips toolbar-main when it has become the canvas parent', () => {
+    const canvasParent = {
+      classList: { contains: () => false }
+    } as unknown as HTMLElement
+    const toolbarMain = {
+      classList: {
+        contains: (name: string) => name === 'ml-ex-ui-toolbar-main'
+      },
+      parentElement: canvasParent
+    } as unknown as HTMLElement
+    const host = {
+      contains: (node: unknown) =>
+        node === toolbarMain || node === canvasParent
+    } as unknown as HTMLElement
+
+    mockCurView.container = { parentElement: toolbarMain }
+    expect(acuiResolveDockMountTarget(host)).toBe(canvasParent)
+  })
 })

--- a/packages/cad-simple-ui-plugin/__tests__/resolveToolbarMountTarget.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveToolbarMountTarget.spec.ts
@@ -58,4 +58,40 @@ describe('acuiResolveToolbarMountTarget', () => {
     mockCurView.container = canvasContainer
     expect(acuiResolveToolbarMountTarget(host)).toBe(host)
   })
+
+  it('skips toolbar-main so overlay does not mount on the in-flow canvas wrapper', () => {
+    const canvasParent = {
+      classList: { contains: () => false }
+    } as unknown as HTMLElement
+    const toolbarMain = {
+      classList: {
+        contains: (name: string) => name === 'ml-ex-ui-toolbar-main'
+      },
+      parentElement: canvasParent
+    } as unknown as HTMLElement
+    const host = {
+      contains: (node: unknown) => node === toolbarMain || node === canvasParent
+    } as unknown as HTMLElement
+
+    mockCurView.container = { parentElement: toolbarMain } as HTMLElement
+    expect(acuiResolveToolbarMountTarget(host)).toBe(canvasParent)
+  })
+
+  it('keeps dock-main as the overlay mount so chrome stays on the canvas slot', () => {
+    const canvasParent = {
+      classList: { contains: () => false }
+    } as unknown as HTMLElement
+    const dockMain = {
+      classList: {
+        contains: (name: string) => name === 'ml-ex-ui-dock-main'
+      },
+      parentElement: canvasParent
+    } as unknown as HTMLElement
+    const host = {
+      contains: (node: unknown) => node === dockMain || node === canvasParent
+    } as unknown as HTMLElement
+
+    mockCurView.container = { parentElement: dockMain } as HTMLElement
+    expect(acuiResolveToolbarMountTarget(host)).toBe(dockMain)
+  })
 })

--- a/packages/cad-simple-ui-plugin/src/config/mergeToolbarOptionsForLayout.ts
+++ b/packages/cad-simple-ui-plugin/src/config/mergeToolbarOptionsForLayout.ts
@@ -56,7 +56,8 @@ export function acuiBuiltinToolbarOptionsForLayout(
  */
 const PHONE_INHERITED_TOP_LEVEL_KEYS: (keyof AcUiToolbarOptions)[] = [
   'mountTarget',
-  'enabled'
+  'enabled',
+  'inCanvasParent'
 ]
 
 /**

--- a/packages/cad-simple-ui-plugin/src/config/normalizePluginOptions.ts
+++ b/packages/cad-simple-ui-plugin/src/config/normalizePluginOptions.ts
@@ -55,6 +55,7 @@ export function acuiNormalizePluginOptions(
       overflow: options.toolbar?.overflow,
       showBorder: options.toolbar?.showBorder ?? true,
       showSeparators: options.toolbar?.showSeparators ?? true,
+      inCanvasParent: options.toolbar?.inCanvasParent === true,
       subToolbar: options.toolbar?.subToolbar
     },
     shouldCreateDockPanel: dockPanelEnabled

--- a/packages/cad-simple-ui-plugin/src/config/resolveDockMountTarget.ts
+++ b/packages/cad-simple-ui-plugin/src/config/resolveDockMountTarget.ts
@@ -1,5 +1,35 @@
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 
+const DEFAULT_UI_LAYOUT_WRAPPERS = [
+  'ml-ex-ui-dock-main',
+  'ml-ex-ui-toolbar-main'
+] as const
+
+/**
+ * Walks up from plugin-owned canvas wrappers to the application canvas parent.
+ * Dock wrapping changes `canvas.parentElement` to `dock-main`; in-flow chrome
+ * should still mount on the stable parent.
+ *
+ * @param el - Candidate mount element.
+ * @param host - Plugin host; walking stops here.
+ * @param wrappers - Class names to skip. Defaults to dock-main and toolbar-main.
+ */
+export function acuiSkipUiLayoutWrappers(
+  el: HTMLElement,
+  host: HTMLElement,
+  wrappers: readonly string[] = DEFAULT_UI_LAYOUT_WRAPPERS
+): HTMLElement {
+  let current = el
+  while (
+    current !== host &&
+    current.parentElement &&
+    wrappers.some(name => current.classList?.contains(name) === true)
+  ) {
+    current = current.parentElement
+  }
+  return current
+}
+
 /**
  * Resolves the DOM element that receives the dock panel and flex shrink layout.
  *
@@ -21,7 +51,7 @@ export function acuiResolveDockMountTarget(
   const canvasContainer = AcApDocManager.instance.curView?.container
   const canvasParent = canvasContainer?.parentElement
   if (canvasParent && (canvasParent === host || host.contains(canvasParent))) {
-    return canvasParent
+    return acuiSkipUiLayoutWrappers(canvasParent, host)
   }
 
   return host

--- a/packages/cad-simple-ui-plugin/src/config/resolveToolbarMountTarget.ts
+++ b/packages/cad-simple-ui-plugin/src/config/resolveToolbarMountTarget.ts
@@ -1,11 +1,18 @@
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 
+import { acuiSkipUiLayoutWrappers } from './resolveDockMountTarget'
+
 /**
  * Resolves the DOM element that receives the floating viewer toolbar.
  *
  * Prefers the canvas container's parent when it lies inside `host`, matching
  * {@link acuiResolveDockMountTarget} so the toolbar stays within the visible
- * viewer clip (not an oversized inner canvas box).
+ * viewer clip (not an oversized inner canvas box). Overlay toolbars also fall
+ * back to the canvas container itself when that node is inside `host`.
+ *
+ * In-flow (`inCanvasParent`) toolbars should call
+ * {@link acuiResolveDockMountTarget} instead so they share the dock panel's
+ * parent exactly and can sit as a flex sibling of the canvas.
  *
  * @param host - Plugin host element (theme root and outer layout).
  * @param mountTarget - Optional explicit toolbar mount element.
@@ -24,7 +31,11 @@ export function acuiResolveToolbarMountTarget(
     canvasParent &&
     (canvasParent === host || host.contains(canvasParent))
   ) {
-    return canvasParent
+    // Skip in-flow canvas wrappers only. Keep `dock-main` so overlay chrome
+    // stays on the drawing slot rather than covering the dock panel.
+    return acuiSkipUiLayoutWrappers(canvasParent, host, [
+      'ml-ex-ui-toolbar-main'
+    ])
   }
 
   if (

--- a/packages/cad-simple-ui-plugin/src/config/types.ts
+++ b/packages/cad-simple-ui-plugin/src/config/types.ts
@@ -235,6 +235,15 @@ export interface AcUiToolbarOptions extends AcUiToolbarChromeOptions {
    */
   mountTarget?: HTMLElement
   /**
+   * When true, the toolbar is laid out as a flex sibling of the canvas inside
+   * the canvas parent (the same mount target as the dock panel) instead of
+   * floating over the drawing. {@link placement} still selects which edge;
+   * {@link edgeOffset} and {@link sideOffset} remain insets.
+   *
+   * @default false
+   */
+  inCanvasParent?: boolean
+  /**
    * Sub-toolbar chrome and position overrides. Unset chrome fields inherit from
    * the main toolbar. {@link AcUiSubToolbarOptions.position} defaults to
    * `'front'`.
@@ -246,8 +255,8 @@ export interface AcUiToolbarOptions extends AcUiToolbarChromeOptions {
  * Per-layout overrides for {@link AcUiSimpleUiPluginOptions.layouts}.
  *
  * Each entry's `toolbar` is merged on top of built-in defaults and the top-level
- * {@link AcUiToolbarOptions} baseline (phone inherits only `enabled` and
- * `mountTarget` from the top-level toolbar — see
+ * {@link AcUiToolbarOptions} baseline (phone inherits only `enabled`,
+ * `mountTarget`, and `inCanvasParent` from the top-level toolbar — see
  * {@link acuiMergeToolbarOptionsForLayout}).
  */
 export interface AcUiLayoutOptions {
@@ -329,8 +338,9 @@ export interface AcUiSimpleUiPluginOptions {
   }
   /**
    * Toolbar baseline configuration. Applied fully to pad/desktop. Phone inherits
-   * only {@link AcUiToolbarOptions.mountTarget} and `enabled` from this baseline;
-   * phone chrome and items come from built-in phone defaults plus
+   * only {@link AcUiToolbarOptions.mountTarget}, `enabled`, and
+   * {@link AcUiToolbarOptions.inCanvasParent} from this baseline; phone chrome
+   * and items come from built-in phone defaults plus
    * {@link layouts.phone.toolbar} (append items are not inherited on phone).
    */
   toolbar?: AcUiToolbarOptions

--- a/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
+++ b/packages/cad-simple-ui-plugin/src/createSimpleUiPlugin.ts
@@ -130,6 +130,10 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
   private toolbarEdgeOffset = 8
   /** Cross-axis inset of the viewer toolbar from host edges in px. */
   private toolbarSideOffset = 0
+  /**
+   * When true, the toolbar is a flex sibling of the canvas in the canvas parent.
+   */
+  private toolbarInCanvasParent = false
   /** Whether the main toolbar shows labels below icons. */
   private toolbarShowLabels = false
   /** Whether the toolbar container border is shown. */
@@ -174,6 +178,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     this.dockPanel?.ensureMounted()
     this.ensureViewerToolbar()
     this.tryUpgradeToolbarMountTarget()
+    this.toolbar?.syncInParentLayout()
   }
 
   /**
@@ -573,6 +578,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
         overflow: this.toolbarOverflow,
         showBorder: this.toolbarShowBorder,
         showSeparators: this.toolbarShowSeparators,
+        inCanvasParent: this.toolbarInCanvasParent,
         subToolbar: this.toolbarSubToolbar,
         onCollapse: () => {
           this.dockPanel?.close()
@@ -593,9 +599,15 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     }
   }
 
-  /** Resolves the canvas element that receives the floating toolbar. */
+  /** Resolves the canvas element that receives the viewer toolbar. */
   private getToolbarMountEl(): HTMLElement | undefined {
     if (!this.hostEl) return undefined
+    if (this.toolbarInCanvasParent) {
+      return acuiResolveDockMountTarget(
+        this.hostEl,
+        this.toolbarMountTargetOption
+      )
+    }
     return acuiResolveToolbarMountTarget(
       this.hostEl,
       this.toolbarMountTargetOption
@@ -611,8 +623,8 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       return
     }
 
-    const preferred = acuiResolveToolbarMountTarget(this.hostEl)
-    if (preferred === this.toolbarMountEl) {
+    const preferred = this.getToolbarMountEl()
+    if (!preferred || preferred === this.toolbarMountEl) {
       return
     }
 
@@ -628,6 +640,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
 
     this.toolbar.reparentTo(preferred)
     this.toolbarMountEl = preferred
+    this.toolbar.syncInParentLayout()
   }
 
   /**
@@ -670,6 +683,10 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
     this.toolbarSize = toolbarOpts.size ?? 'auto'
     this.toolbarOverflow = toolbarOpts.overflow ?? 'menu'
     this.toolbarSubToolbar = toolbarOpts.subToolbar
+    const nextInCanvasParent = toolbarOpts.inCanvasParent === true
+    const inCanvasParentChanged =
+      nextInCanvasParent !== this.toolbarInCanvasParent
+    this.toolbarInCanvasParent = nextInCanvasParent
     this.rebuildToolbarItems(kind, toolbarOpts)
     this.syncLayerToolbarItem()
     this.syncReviewToolbarItem()
@@ -678,6 +695,8 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       return
     }
 
+    // Unwrap/wrap before remounting so overlay resolution never sees a
+    // transient `toolbar-main` as `canvas.parentElement`.
     this.toolbar.applyViewOptions({
       placement: this.toolbarPlacement,
       edgeOffset: this.toolbarEdgeOffset,
@@ -690,8 +709,19 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       showBorder: this.toolbarShowBorder,
       showSeparators: this.toolbarShowSeparators,
       subToolbar: this.toolbarSubToolbar,
+      inCanvasParent: this.toolbarInCanvasParent,
       items: this.baseToolbarItems
     })
+
+    if (inCanvasParentChanged || !this.toolbar.isRootConnected()) {
+      const preferred = this.getToolbarMountEl()
+      if (preferred) {
+        this.toolbar.reparentTo(preferred)
+        this.toolbarMountEl = preferred
+      }
+    }
+
+    this.toolbar.syncInParentLayout()
   }
 
   /** Context passed when resolving default toolbar presets. */
@@ -902,6 +932,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
 
     this.tryUpgradeDockMountTarget()
     this.dockPanel.ensureMounted()
+    this.toolbar?.syncInParentLayout()
   }
 
   /** Ensures the dock panel exists, is mounted on the current target, and has tabs when applicable. */
@@ -937,6 +968,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
       defaultHeight: this.dockPanelDefaults.defaultHeight,
       defaultWidth: this.dockPanelDefaults.defaultWidth
     })
+    this.syncToolbarMountAfterDockChange()
   }
 
   /** Resolves the dock mount element (lazy; canvas parent may appear after load). */
@@ -970,6 +1002,7 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
 
     this.dockPanel.reparentTo(preferred)
     this.refreshLayerDockController()
+    this.syncToolbarMountAfterDockChange()
   }
 
   /** Rebinds the layer dock controller after the dock panel moves. */
@@ -1080,6 +1113,22 @@ export class AcApSimpleUiPlugin implements AcApPlugin {
 
     this.dockPanel.destroy()
     this.dockPanel = undefined
+    this.syncToolbarMountAfterDockChange()
+  }
+
+  /**
+   * Re-resolves the toolbar mount after dock wrap/unwrap, which can detach a
+   * stale `dock-main` host or change `canvas.parentElement`.
+   */
+  private syncToolbarMountAfterDockChange() {
+    if (!this.toolbar || !this.hostEl) return
+    const preferred = this.getToolbarMountEl()
+    if (!preferred) return
+    if (preferred !== this.toolbarMountEl || !this.toolbar.isRootConnected()) {
+      this.toolbar.reparentTo(preferred)
+      this.toolbarMountEl = preferred
+    }
+    this.toolbar.syncInParentLayout()
   }
 
   /** Updates toolbar placement. */

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiToolbar.ts
@@ -76,6 +76,11 @@ export interface AcUiToolbarMountOptions {
   showSeparators?: boolean
   /** Sub-toolbar chrome and position overrides; unset chrome inherits from this toolbar. */
   subToolbar?: AcUiSubToolbarOptions
+  /**
+   * When true, sit as a flex sibling of the canvas inside the mount host instead
+   * of floating over the drawing. @default false
+   */
+  inCanvasParent?: boolean
 }
 
 /**
@@ -125,6 +130,14 @@ export class AcUiToolbar {
   private showBorder: boolean
   /** Whether separator dividers are rendered between toolbar groups. */
   private showSeparators: boolean
+  /**
+   * When true, the toolbar is a flex sibling of the canvas rather than an overlay.
+   */
+  private inCanvasParent: boolean
+  /** Canvas-slot wrapper used when {@link inCanvasParent} is enabled. */
+  private toolbarMain?: HTMLDivElement
+  /** Flex host that currently owns the in-canvas-parent layout classes. */
+  private inParentHost?: HTMLElement
   /** Keeps the toolbar inside the canvas when the host is resized. */
   private resizeObserver?: ResizeObserver
   private layoutFrame?: number
@@ -171,6 +184,7 @@ export class AcUiToolbar {
     this.sideOffset = options.sideOffset ?? 0
     this.showBorder = options.showBorder ?? true
     this.showSeparators = options.showSeparators ?? true
+    this.inCanvasParent = options.inCanvasParent === true
     this.items = options.items
     this.collapsed =
       Boolean(options.collapsible) && Boolean(options.defaultCollapsed)
@@ -198,6 +212,7 @@ export class AcUiToolbar {
     })
 
     this.mountHost.appendChild(this.root)
+    this.ensureInParentLayout()
     this.setupResizeObserver()
 
     AcApDocManager.instance.events.documentActivated.addEventListener(
@@ -245,6 +260,7 @@ export class AcUiToolbar {
         | 'showSeparators'
         | 'subToolbar'
         | 'items'
+        | 'inCanvasParent'
       >
     >
   ) {
@@ -285,11 +301,16 @@ export class AcUiToolbar {
     if (view.subToolbar !== undefined) {
       this.options.subToolbar = view.subToolbar
     }
+    if (view.inCanvasParent !== undefined) {
+      this.inCanvasParent = view.inCanvasParent
+      this.options.inCanvasParent = view.inCanvasParent
+    }
     if (view.items !== undefined) {
       this.items = view.items
       this.seedSelectedChildren(view.items)
     }
     this.syncRootClasses()
+    this.ensureInParentLayout()
     this.renderButtons()
     this.scheduleSyncPosition()
   }
@@ -342,6 +363,7 @@ export class AcUiToolbar {
       `placement-${placement}`
     )
     this.syncRootClasses()
+    this.ensureInParentLayout()
     this.renderButtons()
   }
 
@@ -416,13 +438,31 @@ export class AcUiToolbar {
    * @param newHost - New canvas container.
    */
   reparentTo(newHost: HTMLElement) {
-    if (this.mountHost === newHost) return
+    if (this.mountHost === newHost) {
+      if (!this.root.isConnected && newHost.isConnected) {
+        newHost.appendChild(this.root)
+      }
+      this.syncInParentLayout()
+      return
+    }
 
     this.resizeObserver?.disconnect()
+    this.releaseInParentLayout({ keepRoot: true })
     this.root.remove()
     this.mountHost = newHost
     this.ensureMountHostLayout()
     this.mountHost.appendChild(this.root)
+    this.ensureInParentLayout()
+    this.setupResizeObserver()
+    this.scheduleSyncPosition()
+  }
+
+  /**
+   * Re-applies in-canvas-parent flex layout after the dock panel wraps or
+   * reparents the canvas slot.
+   */
+  syncInParentLayout() {
+    this.ensureInParentLayout()
     this.setupResizeObserver()
     this.scheduleSyncPosition()
   }
@@ -517,6 +557,7 @@ export class AcUiToolbar {
     AcApDocManager.instance.events.documentToBeOpened.removeEventListener(
       this.handleDocumentToBeOpened
     )
+    this.releaseInParentLayout({ keepRoot: false })
     this.root.remove()
   }
 
@@ -548,6 +589,7 @@ export class AcUiToolbar {
     if (this.isDisabled) classes.push('is-disabled')
     if (this.options.showLabels) classes.push('has-labels')
     if (this.options.size === 'stretch') classes.push('is-stretch')
+    if (this.inCanvasParent) classes.push('is-in-parent')
     if (this.options.overflow === 'wrap') classes.push('is-overflow-wrap')
     if (this.options.overflow === 'menu') classes.push('is-overflow-menu')
     if (!this.showBorder) classes.push('no-border')
@@ -786,33 +828,42 @@ export class AcUiToolbar {
       entry.element.hidden = false
     })
 
-    const offset = this.edgeOffset
+    const offset = this.inCanvasParent ? this.sideOffset : this.edgeOffset
     const crossInset = this.getCrossAxisInset()
     const horizontal = this.getOrientationClass() === 'horizontal'
+    const host = this.getLayoutHost()
     if (horizontal) {
-      const maxWidth = Math.max(0, this.mountHost.clientWidth - offset * 2)
+      const maxWidth = Math.max(0, host.clientWidth - offset * 2)
       this.root.style.setProperty(
         '--ml-ex-ui-toolbar-max-width',
         `${maxWidth}px`
       )
-      const maxHeight = Math.max(
-        0,
-        this.mountHost.clientHeight - crossInset.near - crossInset.far
-      )
-      this.root.style.setProperty(
-        '--ml-ex-ui-toolbar-max-height',
-        `${maxHeight}px`
-      )
+      if (this.inCanvasParent) {
+        this.root.style.removeProperty('--ml-ex-ui-toolbar-max-height')
+      } else {
+        const maxHeight = Math.max(
+          0,
+          host.clientHeight - crossInset.near - crossInset.far
+        )
+        this.root.style.setProperty(
+          '--ml-ex-ui-toolbar-max-height',
+          `${maxHeight}px`
+        )
+      }
     } else {
-      const maxWidth = Math.max(
-        0,
-        this.mountHost.clientWidth - crossInset.near - crossInset.far
-      )
-      this.root.style.setProperty(
-        '--ml-ex-ui-toolbar-max-width',
-        `${maxWidth}px`
-      )
-      const maxHeight = Math.max(0, this.mountHost.clientHeight - offset * 2)
+      if (this.inCanvasParent) {
+        this.root.style.removeProperty('--ml-ex-ui-toolbar-max-width')
+      } else {
+        const maxWidth = Math.max(
+          0,
+          host.clientWidth - crossInset.near - crossInset.far
+        )
+        this.root.style.setProperty(
+          '--ml-ex-ui-toolbar-max-width',
+          `${maxWidth}px`
+        )
+      }
+      const maxHeight = Math.max(0, host.clientHeight - offset * 2)
       this.root.style.setProperty(
         '--ml-ex-ui-toolbar-max-height',
         `${maxHeight}px`
@@ -969,10 +1020,9 @@ export class AcUiToolbar {
 
   /** Returns the host axis limit for toolbar content (inside edge offsets). */
   private getOverflowHostLimit(horizontal: boolean): number {
-    const offset = this.edgeOffset
-    const hostSize = horizontal
-      ? this.mountHost.clientWidth
-      : this.mountHost.clientHeight
+    const offset = this.inCanvasParent ? this.sideOffset : this.edgeOffset
+    const host = this.getLayoutHost()
+    const hostSize = horizontal ? host.clientWidth : host.clientHeight
     return Math.max(0, hostSize - offset * 2)
   }
 
@@ -1023,12 +1073,185 @@ export class AcUiToolbar {
     this.mountHost.classList.add('ml-ex-ui-toolbar-host')
   }
 
+  /**
+   * Flex container used for overflow and in-canvas-parent sizing.
+   *
+   * Overlay toolbars measure the mount host. In-canvas-parent toolbars measure
+   * the canvas-slot flex host so the bar tracks the drawing area, not the
+   * outer dock chrome.
+   */
+  private getLayoutHost(): HTMLElement {
+    if (this.inCanvasParent) {
+      return this.inParentHost ?? this.mountHost
+    }
+    return this.mountHost
+  }
+
+  /**
+   * Positioning host for sub-toolbars: the canvas slot when in-canvas-parent
+   * so strips overlay the drawing, not the outer flex host.
+   */
+  private getOverlayHost(): HTMLElement {
+    if (this.inCanvasParent && this.toolbarMain) {
+      return this.toolbarMain
+    }
+    return this.mountHost
+  }
+
+  private static readonly IN_PARENT_HOST_CLASSES = [
+    'ml-ex-ui-toolbar-in-parent',
+    'ml-ex-ui-toolbar-in-parent-top',
+    'ml-ex-ui-toolbar-in-parent-bottom',
+    'ml-ex-ui-toolbar-in-parent-left',
+    'ml-ex-ui-toolbar-in-parent-right'
+  ] as const
+
+  /**
+   * Wraps canvas children and places the toolbar as a flex sibling when
+   * {@link inCanvasParent} is enabled. Prefers an existing dock-main slot so
+   * dock side changes do not pull the toolbar onto the dock axis.
+   */
+  private ensureInParentLayout() {
+    if (!this.inCanvasParent) {
+      this.releaseInParentLayout({ keepRoot: true })
+      return
+    }
+
+    const wrapRoot = this.resolveInParentWrapRoot()
+    this.applyInParentHostClasses(wrapRoot)
+    this.ensureToolbarMainWrapper(wrapRoot)
+    this.placeToolbarInWrapRoot(wrapRoot)
+  }
+
+  /** Dock-main when present, otherwise the toolbar mount host. */
+  private resolveInParentWrapRoot(): HTMLElement {
+    const dockMain = this.mountHost.querySelector(':scope > .ml-ex-ui-dock-main')
+    return dockMain instanceof HTMLElement ? dockMain : this.mountHost
+  }
+
+  private applyInParentHostClasses(wrapRoot: HTMLElement) {
+    if (this.inParentHost && this.inParentHost !== wrapRoot) {
+      this.clearInParentHostClasses(this.inParentHost)
+    }
+    this.inParentHost = wrapRoot
+    wrapRoot.classList.add('ml-ex-ui-toolbar-in-parent')
+    wrapRoot.classList.remove(
+      'ml-ex-ui-toolbar-in-parent-top',
+      'ml-ex-ui-toolbar-in-parent-bottom',
+      'ml-ex-ui-toolbar-in-parent-left',
+      'ml-ex-ui-toolbar-in-parent-right'
+    )
+    wrapRoot.classList.add(
+      `ml-ex-ui-toolbar-in-parent-${this.options.placement}`
+    )
+  }
+
+  private clearInParentHostClasses(host?: HTMLElement) {
+    if (!host) return
+    host.classList.remove(...AcUiToolbar.IN_PARENT_HOST_CLASSES)
+  }
+
+  private shouldSkipInParentMove(node: Node): boolean {
+    if (!(node instanceof HTMLElement)) return false
+    return (
+      node === this.root ||
+      node.classList.contains('ml-ex-ui-toolbar') ||
+      node.classList.contains('ml-ex-ui-toolbar-main') ||
+      node.classList.contains('ml-ex-ui-dock-panel') ||
+      node.classList.contains('ml-ex-ui-subtoolbar') ||
+      node.classList.contains('ml-ex-ui-dropdown')
+    )
+  }
+
+  private ensureToolbarMainWrapper(wrapRoot: HTMLElement) {
+    if (this.toolbarMain?.parentElement === wrapRoot) return
+
+    const existing = wrapRoot.querySelector(':scope > .ml-ex-ui-toolbar-main')
+    if (existing instanceof HTMLElement) {
+      this.toolbarMain = existing as HTMLDivElement
+      return
+    }
+
+    const movable: Node[] = []
+    Array.from(wrapRoot.childNodes).forEach(child => {
+      if (this.shouldSkipInParentMove(child)) return
+      movable.push(child)
+    })
+
+    const wrapper = document.createElement('div')
+    wrapper.className = 'ml-ex-ui-toolbar-main'
+    movable.forEach(node => wrapper.appendChild(node))
+    wrapRoot.appendChild(wrapper)
+    this.toolbarMain = wrapper
+  }
+
+  private placeToolbarInWrapRoot(wrapRoot: HTMLElement) {
+    const placement = this.options.placement
+    if (placement === 'top' || placement === 'left') {
+      wrapRoot.insertBefore(this.root, wrapRoot.firstChild)
+      return
+    }
+    wrapRoot.appendChild(this.root)
+  }
+
+  /**
+   * Unwraps the canvas slot and restores overlay mounting.
+   *
+   * @param options.keepRoot - When true, leaves the toolbar root in the DOM.
+   */
+  private releaseInParentLayout(options: { keepRoot: boolean }) {
+    const wasInParent = Boolean(this.inParentHost || this.toolbarMain)
+    this.clearInParentHostClasses(this.inParentHost)
+    this.inParentHost = undefined
+    this.releaseToolbarMainWrapper()
+    this.clearInParentOffsetStyles()
+    if (
+      wasInParent &&
+      options.keepRoot &&
+      this.root.isConnected &&
+      this.root.parentElement !== this.mountHost &&
+      this.mountHost.isConnected
+    ) {
+      this.mountHost.appendChild(this.root)
+    }
+  }
+
+  private releaseToolbarMainWrapper() {
+    if (!this.toolbarMain?.isConnected) {
+      this.toolbarMain = undefined
+      return
+    }
+
+    const parent = this.toolbarMain.parentElement
+    if (parent) {
+      while (this.toolbarMain.firstChild) {
+        parent.insertBefore(this.toolbarMain.firstChild, this.toolbarMain)
+      }
+    }
+    this.toolbarMain.remove()
+    this.toolbarMain = undefined
+  }
+
+  private clearInParentOffsetStyles() {
+    this.root.style.marginTop = ''
+    this.root.style.marginRight = ''
+    this.root.style.marginBottom = ''
+    this.root.style.marginLeft = ''
+  }
+
   private setupResizeObserver() {
     this.resizeObserver?.disconnect()
     this.resizeObserver = new ResizeObserver(() => {
       this.scheduleSyncPosition()
     })
     this.resizeObserver.observe(this.mountHost)
+    const layoutHost = this.getLayoutHost()
+    if (layoutHost !== this.mountHost) {
+      this.resizeObserver.observe(layoutHost)
+    }
+    if (this.toolbarMain && this.toolbarMain !== layoutHost) {
+      this.resizeObserver.observe(this.toolbarMain)
+    }
   }
 
   private scheduleSyncPosition() {
@@ -1052,6 +1275,13 @@ export class AcUiToolbar {
   /** Positions the toolbar inside the canvas, clamped to the current host bounds. */
   private syncPosition() {
     if (!this.root.isConnected || this.root.hidden) return
+
+    if (this.inCanvasParent) {
+      this.applyInParentPosition()
+      return
+    }
+
+    this.clearInParentOffsetStyles()
 
     const offset = this.edgeOffset
     const hostWidth = this.mountHost.clientWidth
@@ -1114,6 +1344,38 @@ export class AcUiToolbar {
       this.root.style.left = `${offset}px`
     } else {
       this.root.style.right = `${offset}px`
+    }
+  }
+
+  /**
+   * Applies edge/side offsets as margins so an in-canvas-parent toolbar sits
+   * against the canvas without overlay positioning.
+   */
+  private applyInParentPosition() {
+    this.root.style.top = ''
+    this.root.style.bottom = ''
+    this.root.style.left = ''
+    this.root.style.right = ''
+    this.root.style.transform = ''
+    this.root.style.width = ''
+    this.root.style.height = ''
+    this.root.style.maxWidth = ''
+    this.root.style.maxHeight = ''
+
+    const offset = this.edgeOffset
+    const side = this.sideOffset
+    const placement = this.options.placement
+
+    if (placement === 'top' || placement === 'bottom') {
+      this.root.style.marginTop = placement === 'bottom' ? `${offset}px` : '0'
+      this.root.style.marginBottom = placement === 'top' ? `${offset}px` : '0'
+      this.root.style.marginLeft = `${side}px`
+      this.root.style.marginRight = `${side}px`
+    } else {
+      this.root.style.marginLeft = placement === 'right' ? `${offset}px` : '0'
+      this.root.style.marginRight = placement === 'left' ? `${offset}px` : '0'
+      this.root.style.marginTop = `${side}px`
+      this.root.style.marginBottom = `${side}px`
     }
   }
 
@@ -1185,7 +1447,7 @@ export class AcUiToolbar {
         items: visibleChildren,
         anchor: button,
         toolbarRoot: this.root,
-        host: this.mountHost,
+        host: this.getOverlayHost(),
         placement: this.options.placement,
         sticky,
         chrome: this.resolveSubToolbarChrome(),
@@ -1356,7 +1618,7 @@ export class AcUiToolbar {
       items: visibleChildren,
       anchor: button,
       toolbarRoot: this.root,
-      host: this.mountHost,
+      host: this.getOverlayHost(),
       placement: this.options.placement,
       sticky: nestedSticky,
       chrome: this.resolveSubToolbarChrome(),

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -36,6 +36,45 @@ export function acuiEnsureUiStyles() {
       position: relative;
     }
 
+    .ml-ex-ui-toolbar.is-in-parent {
+      position: relative;
+      inset: auto;
+      z-index: 30;
+      flex: 0 0 auto;
+    }
+
+    .ml-ex-ui-toolbar.is-in-parent.is-stretch {
+      align-self: stretch;
+    }
+
+    .ml-ex-ui-toolbar.is-in-parent:not(.is-stretch) {
+      align-self: center;
+    }
+
+    .ml-ex-ui-toolbar-in-parent {
+      display: flex;
+      min-width: 0;
+      min-height: 0;
+    }
+
+    .ml-ex-ui-toolbar-in-parent-top,
+    .ml-ex-ui-toolbar-in-parent-bottom {
+      flex-direction: column;
+    }
+
+    .ml-ex-ui-toolbar-in-parent-left,
+    .ml-ex-ui-toolbar-in-parent-right {
+      flex-direction: row;
+    }
+
+    .ml-ex-ui-toolbar-main {
+      flex: 1 1 auto;
+      min-height: 0;
+      min-width: 0;
+      position: relative;
+      overflow: hidden;
+    }
+
     .ml-ex-ui-toolbar.is-horizontal {
       flex-direction: row;
       align-items: center;

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -877,6 +877,7 @@ class CadViewerApp {
               size: 'stretch',
               edgeOffset: 0,
               collapsible: false,
+              inCanvasParent: true,
               subToolbar: {
                 showLabels: false,
                 showSeparators: false,


### PR DESCRIPTION
## Summary
- Add `toolbar.inCanvasParent` so the viewer toolbar can sit as a flex sibling of the canvas (same parent as the dock panel) instead of floating over the drawing. Phone layouts inherit this flag from the top-level toolbar; the simple-viewer example enables it on phone only.
- Keep in-flow chrome inside `dock-main` when the dock panel wraps the canvas, and skip plugin-owned `dock-main` / `toolbar-main` wrappers when resolving the stable mount target.
- Unwrap before remounting overlay chrome when leaving in-canvas-parent layout, and skip `toolbar-main` in overlay mount resolution so layout switches do not attach the toolbar to a wrapper that is about to be removed.

## Test plan
- [ ] Open the simple viewer example on a phone-width viewport: the bottom toolbar should sit under the drawing, not overlay it, and the canvas should still resize to the remaining space.
- [ ] Open a layer/review dock tab on phone with the in-canvas-parent toolbar: changing dock side should keep the toolbar on the canvas slot, not on the dock axis.
- [ ] Resize to desktop/pad: the toolbar should return to the floating overlay on the canvas (right by default), with the canvas still in the tree and no leftover `toolbar-main` wrapper.
- [ ] Toggle a sticky sub-toolbar / overflow menu on the phone bottom bar and confirm it overlays the drawing, not the outer chrome.
- [ ] `pnpm exec jest packages/cad-simple-ui-plugin --no-coverage`