### PR TITLE
feat: add a long-press snap loupe for touch point picking

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExSnapLoupe.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapLoupe.spec.ts
@@ -1,0 +1,62 @@
+import {
+  acExCssRectToWcsBox,
+  acExCssTopLeftRectToGl,
+  acExIntersectCssRects,
+  acExWcsBoxToCssRect
+} from '../src/AcExCssRect'
+import { acExLoupeLocalFromCanvasDelta } from '../src/AcExSnapLoupe'
+import { AcExTouchPointSession } from '../src/AcExTouchPointSession'
+
+describe('AcExCssRect', () => {
+  it('converts CSS top-left rectangles to WebGL bottom-left', () => {
+    expect(
+      acExCssTopLeftRectToGl({ x: 8, y: 8, width: 128, height: 128 }, 600)
+    ).toEqual({ x: 8, y: 464, width: 128, height: 128 })
+  })
+
+  it('maps a world box onto a screen rect and back', () => {
+    const viewBox = { minX: 0, minY: 0, maxX: 100, maxY: 50 }
+    const screen = { x: 10, y: 20, width: 200, height: 100 }
+    const css = acExWcsBoxToCssRect(
+      { minX: 25, minY: 10, maxX: 75, maxY: 40 },
+      viewBox,
+      screen
+    )
+    expect(css.x).toBeCloseTo(60)
+    expect(css.width).toBeCloseTo(100)
+    expect(css.height).toBeCloseTo(60)
+    const roundTrip = acExCssRectToWcsBox(css, viewBox, screen)
+    expect(roundTrip.minX).toBeCloseTo(25)
+    expect(roundTrip.maxY).toBeCloseTo(40)
+    expect(acExIntersectCssRects(screen, { x: 0, y: 0, width: 5, height: 5 })).toBeNull()
+  })
+})
+
+describe('AcExTouchPointSession', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('defers the loupe until the long-press timer and commits on end', () => {
+    const onLongPress = jest.fn()
+    const session = new AcExTouchPointSession()
+    session.start(7, 1, 2, onLongPress, 350)
+    expect(session.end()).toBe('commit')
+    session.start(7, 1, 2, onLongPress, 350)
+    jest.advanceTimersByTime(350)
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+    expect(session.end()).toBe('commit')
+  })
+})
+
+describe('acExLoupeLocalFromCanvasDelta', () => {
+  it('scales canvas deltas by the loupe zoom about the center', () => {
+    expect(acExLoupeLocalFromCanvasDelta(2, 4, 128, 3)).toEqual({
+      x: 70,
+      y: 76
+    })
+  })
+})

--- a/packages/cad-html-plugin/src/AcExCssRect.ts
+++ b/packages/cad-html-plugin/src/AcExCssRect.ts
@@ -1,0 +1,104 @@
+/**
+ * Axis-aligned rectangle in CSS pixels with origin at the top-left of the
+ * canvas (or host). Used for the snap-loupe overlay and nested paper-space
+ * viewport scissors in the exported HTML runtime.
+ */
+export interface AcExCssRect {
+  /** Left edge in CSS pixels. */
+  x: number
+  /** Top edge in CSS pixels. */
+  y: number
+  /** Width in CSS pixels. */
+  width: number
+  /** Height in CSS pixels. */
+  height: number
+}
+
+/**
+ * Converts a CSS top-left rectangle to WebGL / Three.js viewport coordinates
+ * (origin at the bottom-left of the canvas).
+ *
+ * @param rect - Rectangle in CSS pixels, origin top-left.
+ * @param canvasCssHeight - Canvas CSS height (same space as `rect.y`).
+ * @returns The same rectangle with `y` measured from the canvas bottom.
+ */
+export function acExCssTopLeftRectToGl(
+  rect: AcExCssRect,
+  canvasCssHeight: number
+): AcExCssRect {
+  return {
+    x: rect.x,
+    y: canvasCssHeight - rect.y - rect.height,
+    width: rect.width,
+    height: rect.height
+  }
+}
+
+/**
+ * Intersection of two CSS rectangles, or `null` when the overlap is empty
+ * or smaller than 1px.
+ *
+ * @param a - First rectangle.
+ * @param b - Second rectangle.
+ * @returns Overlap rectangle, or `null` when there is no usable overlap.
+ */
+export function acExIntersectCssRects(
+  a: AcExCssRect,
+  b: AcExCssRect
+): AcExCssRect | null {
+  const x = Math.max(a.x, b.x)
+  const y = Math.max(a.y, b.y)
+  const right = Math.min(a.x + a.width, b.x + b.width)
+  const bottom = Math.min(a.y + a.height, b.y + b.height)
+  const width = right - x
+  const height = bottom - y
+  if (width < 1 || height < 1) return null
+  return { x, y, width, height }
+}
+
+/**
+ * Maps a world-space axis-aligned box into a CSS rectangle, given that
+ * `viewBox` fills `screen` (Y-up world → Y-down CSS).
+ *
+ * @param box - World box to project (`minX`/`minY`/`maxX`/`maxY`).
+ * @param viewBox - World extents currently mapped onto `screen`.
+ * @param screen - CSS rectangle that displays `viewBox`.
+ * @returns `box` in the same CSS space as `screen`.
+ */
+export function acExWcsBoxToCssRect(
+  box: { minX: number; minY: number; maxX: number; maxY: number },
+  viewBox: { minX: number; minY: number; maxX: number; maxY: number },
+  screen: AcExCssRect
+): AcExCssRect {
+  const vx = Math.max(viewBox.maxX - viewBox.minX, Number.EPSILON)
+  const vy = Math.max(viewBox.maxY - viewBox.minY, Number.EPSILON)
+  return {
+    x: screen.x + ((box.minX - viewBox.minX) / vx) * screen.width,
+    y: screen.y + ((viewBox.maxY - box.maxY) / vy) * screen.height,
+    width: ((box.maxX - box.minX) / vx) * screen.width,
+    height: ((box.maxY - box.minY) / vy) * screen.height
+  }
+}
+
+/**
+ * Inverse of {@link acExWcsBoxToCssRect}: CSS rectangle → world box.
+ *
+ * @param rect - CSS rectangle inside `screen`.
+ * @param viewBox - World extents currently mapped onto `screen`.
+ * @param screen - CSS rectangle that displays `viewBox`.
+ * @returns Axis-aligned world box corresponding to `rect`.
+ */
+export function acExCssRectToWcsBox(
+  rect: AcExCssRect,
+  viewBox: { minX: number; minY: number; maxX: number; maxY: number },
+  screen: AcExCssRect
+): { minX: number; minY: number; maxX: number; maxY: number } {
+  const vx = Math.max(viewBox.maxX - viewBox.minX, Number.EPSILON)
+  const vy = Math.max(viewBox.maxY - viewBox.minY, Number.EPSILON)
+  return {
+    minX: viewBox.minX + ((rect.x - screen.x) / screen.width) * vx,
+    maxX: viewBox.minX + ((rect.x + rect.width - screen.x) / screen.width) * vx,
+    maxY: viewBox.maxY - ((rect.y - screen.y) / screen.height) * vy,
+    minY: viewBox.maxY - ((rect.y + rect.height - screen.y) / screen.height) * vy
+  }
+}

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -66,6 +66,47 @@ export const ACEX_HTML_SHELL_CSS = `
     touch-action: none;
   }
 
+  .mlcad-snap-loupe {
+    position: absolute;
+    left: 8px;
+    top: 56px;
+    width: 128px;
+    height: 128px;
+    box-sizing: border-box;
+    border: 2px solid var(--mlcad-measure-accent, #08e8de);
+    border-radius: 2px;
+    pointer-events: none;
+    z-index: 8;
+    overflow: hidden;
+    box-shadow: var(--mlcad-shadow);
+  }
+  .mlcad-snap-loupe-crosshair {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+  .mlcad-snap-loupe-crosshair::before,
+  .mlcad-snap-loupe-crosshair::after {
+    content: '';
+    position: absolute;
+    background: var(--mlcad-measure-accent, #08e8de);
+    opacity: 0.85;
+  }
+  .mlcad-snap-loupe-crosshair::before {
+    left: 50%;
+    top: 0;
+    width: 1px;
+    height: 100%;
+    transform: translateX(-50%);
+  }
+  .mlcad-snap-loupe-crosshair::after {
+    top: 50%;
+    left: 0;
+    height: 1px;
+    width: 100%;
+    transform: translateY(-50%);
+  }
+
   html[data-mlcad-theme="light"] {
     --mlcad-ui-bg: rgba(255, 255, 255, 0.94);
     --mlcad-ui-bg-elevated: rgba(248, 249, 250, 0.98);
@@ -950,6 +991,7 @@ export const ACEX_HTML_SHELL_CSS = `
       flex-direction: column-reverse;
       align-items: stretch;
       gap: 0;
+      overflow: visible;
     }
     #mlcad-toolbar {
       flex-direction: row;
@@ -1014,15 +1056,27 @@ export const ACEX_HTML_SHELL_CSS = `
     #mlcad-settings-btn {
       display: flex !important;
     }
-    #mlcad-snap-strip-wrap,
-    #mlcad-measure-strip-wrap,
-    #mlcad-markup-strip-wrap,
-    #mlcad-zoom-strip-wrap,
-    #mlcad-settings-strip-wrap,
-    #mlcad-locale-strip-wrap {
-      width: 100%;
+    /* Float above the bottom bar so the wrap does not occupy an in-flow
+       rectangle of page background around the rounded strip. */
+    #mlcad-sidebar > #mlcad-snap-strip-wrap,
+    #mlcad-sidebar > #mlcad-measure-strip-wrap,
+    #mlcad-sidebar > #mlcad-markup-strip-wrap,
+    #mlcad-sidebar > #mlcad-zoom-strip-wrap,
+    #mlcad-sidebar > #mlcad-settings-strip-wrap,
+    #mlcad-sidebar > #mlcad-locale-strip-wrap {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 100%;
+      width: auto;
       flex-direction: column;
       align-items: stretch;
+      background: none;
+      box-shadow: none;
+      backdrop-filter: none;
+      overflow: visible;
+      pointer-events: none;
+      z-index: calc(var(--mlcad-z-chrome) + 1);
     }
     #mlcad-settings-strip-wrap:not([hidden]) {
       display: flex !important;
@@ -1045,13 +1099,17 @@ export const ACEX_HTML_SHELL_CSS = `
       width: auto;
       box-sizing: border-box;
       gap: 0;
-      margin: 4px 8px 0;
+      margin: 4px 8px 8px;
       padding: 4px 0;
       border-radius: 8px;
       /* Match active toolbar button outline. */
       border: 1px solid var(--mlcad-tool-btn-active-border);
       box-shadow: none;
-      overflow: visible;
+      backdrop-filter: none;
+      overflow: hidden;
+      isolation: isolate;
+      clip-path: inset(0 round 8px);
+      pointer-events: auto;
     }
     #mlcad-snap-strip .mlcad-tool-btn,
     #mlcad-measure-strip .mlcad-tool-btn,
@@ -1078,6 +1136,7 @@ export const ACEX_HTML_SHELL_CSS = `
       width: 100%;
       box-sizing: border-box;
       border-radius: 0;
+      pointer-events: auto;
     }
     #mlcad-layer-drawer,
     #mlcad-review-drawer {
@@ -1097,6 +1156,7 @@ export const ACEX_HTML_SHELL_CSS = `
       left: 8px;
       right: 8px;
       bottom: calc(var(--mlcad-toolbar-phone-height) + 52px);
+      pointer-events: auto;
     }
     .mlcad-layer-action-btn {
       min-height: 28px;

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -80,32 +80,6 @@ export const ACEX_HTML_SHELL_CSS = `
     overflow: hidden;
     box-shadow: var(--mlcad-shadow);
   }
-  .mlcad-snap-loupe-crosshair {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-  }
-  .mlcad-snap-loupe-crosshair::before,
-  .mlcad-snap-loupe-crosshair::after {
-    content: '';
-    position: absolute;
-    background: var(--mlcad-measure-accent, #08e8de);
-    opacity: 0.85;
-  }
-  .mlcad-snap-loupe-crosshair::before {
-    left: 50%;
-    top: 0;
-    width: 1px;
-    height: 100%;
-    transform: translateX(-50%);
-  }
-  .mlcad-snap-loupe-crosshair::after {
-    top: 50%;
-    left: 0;
-    height: 1px;
-    width: 100%;
-    transform: translateY(-50%);
-  }
 
   html[data-mlcad-theme="light"] {
     --mlcad-ui-bg: rgba(255, 255, 255, 0.94);

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -383,7 +383,7 @@ async function startViewer(): Promise<void> {
   const loupeCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 1000)
   loupeCamera.up.set(0, 1, 0)
   const savedViewportBox = new THREE.Vector4()
-  /** DOM chrome (border, crosshair, OSNAP glyph) for the snap loupe. */
+  /** DOM chrome (border and OSNAP glyph) for the snap loupe. */
   const snapLoupe = new AcExSnapLoupe(canvasHost)
   /** Last client sample while the loupe is visible; `null` when hidden. */
   let loupeSample: { clientX: number; clientY: number } | null = null

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -5,6 +5,12 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
+import {
+  acExCssRectToWcsBox,
+  acExCssTopLeftRectToGl,
+  acExIntersectCssRects,
+  acExWcsBoxToCssRect
+} from './AcExCssRect'
 import { setupAcExDrawStyleToolbar } from './AcExDrawStyleToolbar'
 import {
   decryptAcExHtmlSnapshotPayload,
@@ -50,6 +56,13 @@ import {
   createViewerMeshMaterial,
   createViewerPointsMaterial
 } from './AcExPatternSnapshot'
+import {
+  ACEX_SNAP_LOUPE_INSET_PX,
+  ACEX_SNAP_LOUPE_SIZE_PX,
+  ACEX_SNAP_LOUPE_TOP_INSET_PX,
+  ACEX_SNAP_LOUPE_ZOOM,
+  AcExSnapLoupe
+} from './AcExSnapLoupe'
 import { decodeSnapshot } from './AcExSnapshotCodec'
 import type {
   AcExExtents,
@@ -59,6 +72,7 @@ import type {
   AcExSnapshot,
   AcExViewerMode
 } from './AcExSnapshotTypes'
+import { AcExTouchPointSession } from './AcExTouchPointSession'
 import {
   releaseLayerGroupsGeometryCpuArrays,
   releaseSnapshotBatchBuffers,
@@ -365,7 +379,14 @@ async function startViewer(): Promise<void> {
   const modelScene = new THREE.Scene()
   const viewportCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 1000)
   viewportCamera.up.set(0, 1, 0)
+  /** Orthographic camera used only for the snap-loupe scissor pass. */
+  const loupeCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 1000)
+  loupeCamera.up.set(0, 1, 0)
   const savedViewportBox = new THREE.Vector4()
+  /** DOM chrome (border, crosshair, OSNAP glyph) for the snap loupe. */
+  const snapLoupe = new AcExSnapLoupe(canvasHost)
+  /** Last client sample while the loupe is visible; `null` when hidden. */
+  let loupeSample: { clientX: number; clientY: number } | null = null
 
   const getOrCreateLayerGroup = (
     groups: Map<string, THREE.Group>,
@@ -640,6 +661,42 @@ async function startViewer(): Promise<void> {
     return { point, snap: snap ?? null }
   }
 
+  /**
+   * Hides the snap-loupe HUD and drops the last sample so the overlay pass
+   * is skipped on the next frame.
+   */
+  const hideSnapLoupe = () => {
+    loupeSample = null
+    snapLoupe.hide()
+  }
+
+  /**
+   * Positions the loupe HUD (and optional OSNAP glyph) around a client sample.
+   * The sample is stored so the magnified overlay pass can draw on the next
+   * frame.
+   *
+   * @param clientX - Sample X in client CSS pixels.
+   * @param clientY - Sample Y in client CSS pixels.
+   */
+  const refreshSnapLoupeHud = (clientX: number, clientY: number) => {
+    loupeSample = { clientX, clientY }
+    const canvasRect = renderer.domElement.getBoundingClientRect()
+    const canvasX = clientX - canvasRect.left
+    const canvasY = clientY - canvasRect.top
+    const { point, snap } = resolveMeasurePoint(clientX, clientY)
+    if (snap) {
+      const screen = wcsToScreen(point)
+      snapLoupe.show(
+        canvasX,
+        canvasY,
+        { x: screen.x - canvasRect.left, y: screen.y - canvasRect.top },
+        snap.mode
+      )
+    } else {
+      snapLoupe.show(canvasX, canvasY)
+    }
+  }
+
   let measure: AcExMeasureController | null = null
   let markup: AcExMarkupController | null = null
   const measureSettingsRef: {
@@ -762,11 +819,131 @@ async function startViewer(): Promise<void> {
     acexCameraZoomUniform.value = camera.zoom
   }
 
+  /**
+   * Fits an orthographic camera so `extents` fills a CSS rectangle of
+   * `vpW` × `vpH`, matching {@link computeViewportCamera}.
+   *
+   * @param target - Camera to update.
+   * @param extents - World box to show.
+   * @param vpW - Target CSS width in pixels.
+   * @param vpH - Target CSS height in pixels.
+   * @param twist - Optional DVIEW twist in radians.
+   */
+  const applyOrthoFit = (
+    target: THREE.OrthographicCamera,
+    extents: AcExExtents,
+    vpW: number,
+    vpH: number,
+    twist = 0
+  ) => {
+    const fitted = computeViewportCamera(extents, vpW, vpH)
+    target.left = -fitted.aspect * fitted.frustum
+    target.right = fitted.aspect * fitted.frustum
+    target.top = fitted.frustum
+    target.bottom = -fitted.frustum
+    target.position.set(fitted.centerX, fitted.centerY, ACEX_CAMERA_DISTANCE)
+    target.lookAt(fitted.centerX, fitted.centerY, 0)
+    target.up.set(-Math.sin(twist), Math.cos(twist), 0)
+    target.setRotationFromEuler(new THREE.Euler(0, 0, twist))
+    target.zoom = fitted.zoom
+    target.updateProjectionMatrix()
+    acexCameraZoomUniform.value = fitted.zoom
+  }
+
+  /**
+   * Draws the magnified snap loupe into a screen-fixed scissor after the main
+   * layout and paper viewports. Nested paper-space viewports that intersect
+   * the loupe are scissor-clipped so model content stays visible inside it.
+   */
+  const renderSnapLoupe = () => {
+    if (!loupeSample || !snapLoupe.isVisible) return
+    const { width, height } = getCanvasSize()
+    if (width <= 0 || height <= 0) return
+    const half = ACEX_SNAP_LOUPE_SIZE_PX / ACEX_SNAP_LOUPE_ZOOM / 2
+    const p1 = screenToWcs(loupeSample.clientX - half, loupeSample.clientY - half)
+    const p2 = screenToWcs(loupeSample.clientX + half, loupeSample.clientY + half)
+    const viewBox: AcExExtents = {
+      minX: Math.min(p1.x, p2.x),
+      minY: Math.min(p1.y, p2.y),
+      maxX: Math.max(p1.x, p2.x),
+      maxY: Math.max(p1.y, p2.y)
+    }
+    const loupeRect = {
+      x: ACEX_SNAP_LOUPE_INSET_PX,
+      y: ACEX_SNAP_LOUPE_TOP_INSET_PX,
+      width: ACEX_SNAP_LOUPE_SIZE_PX,
+      height: ACEX_SNAP_LOUPE_SIZE_PX
+    }
+    const gl = acExCssTopLeftRectToGl(loupeRect, height)
+    const autoClear = renderer.autoClear
+    renderer.autoClear = false
+    renderer.getViewport(savedViewportBox)
+    renderer.setScissor(gl.x, gl.y, gl.width, gl.height)
+    renderer.setScissorTest(true)
+    renderer.setViewport(gl.x, gl.y, gl.width, gl.height)
+    renderer.clear()
+    applyOrthoFit(loupeCamera, viewBox, loupeRect.width, loupeRect.height)
+    renderer.render(scene, loupeCamera)
+
+    if (
+      !layout.isModelSpace &&
+      layout.viewports?.length &&
+      modelRoot.children.length > 0
+    ) {
+      for (const viewport of layout.viewports) {
+        const magRect = acExWcsBoxToCssRect(viewport.paper, viewBox, loupeRect)
+        const hit = acExIntersectCssRects(magRect, loupeRect)
+        if (!hit) continue
+        const paperHit = acExCssRectToWcsBox(hit, viewBox, loupeRect)
+        const corners = [
+          paperPointToModel(viewport, paperHit.minX, paperHit.minY),
+          paperPointToModel(viewport, paperHit.maxX, paperHit.minY),
+          paperPointToModel(viewport, paperHit.maxX, paperHit.maxY),
+          paperPointToModel(viewport, paperHit.minX, paperHit.maxY)
+        ]
+        const modelBox: AcExExtents = {
+          minX: Math.min(...corners.map(c => c.x)),
+          minY: Math.min(...corners.map(c => c.y)),
+          maxX: Math.max(...corners.map(c => c.x)),
+          maxY: Math.max(...corners.map(c => c.y))
+        }
+        const nestedGl = acExCssTopLeftRectToGl(hit, height)
+        renderer.setScissor(nestedGl.x, nestedGl.y, nestedGl.width, nestedGl.height)
+        renderer.setViewport(
+          nestedGl.x,
+          nestedGl.y,
+          nestedGl.width,
+          nestedGl.height
+        )
+        renderer.clearDepth()
+        applyOrthoFit(
+          loupeCamera,
+          modelBox,
+          hit.width,
+          hit.height,
+          viewport.twist ?? 0
+        )
+        renderer.render(modelScene, loupeCamera)
+      }
+    }
+
+    renderer.setScissorTest(false)
+    renderer.setViewport(
+      savedViewportBox.x,
+      savedViewportBox.y,
+      savedViewportBox.z,
+      savedViewportBox.w
+    )
+    renderer.autoClear = autoClear
+    acexCameraZoomUniform.value = camera.zoom
+  }
+
   const render = () => {
     measure?.syncOverlays()
     markup?.syncOverlays()
     renderer.render(scene, camera)
     renderPaperViewports()
+    renderSnapLoupe()
   }
 
   if (measureEnabled) {
@@ -1067,7 +1244,9 @@ async function startViewer(): Promise<void> {
     getMeasure: () => measure,
     getMarkup: () => markup,
     getNavTools: () => navToolsRef.current,
-    render
+    render,
+    refreshSnapLoupeHud,
+    hideSnapLoupe
   })
 
   setupPanCursorFeedback(
@@ -1734,25 +1913,111 @@ function setupPanCursorFeedback(
   window.addEventListener('pointercancel', clearPanCursor)
 }
 
-/** Pointer wiring for {@link setupToolPointerInput}. */
+/**
+ * Pointer wiring for {@link setupToolPointerInput}.
+ */
 interface AcExToolPointerInputOptions {
+  /** Canvas (or host) that receives pointer events. */
   domElement: HTMLElement
+  /** Active measure controller, or `null` when measure is disabled. */
   getMeasure: () => AcExMeasureController | null
+  /** Active markup controller, or `null` when markup is disabled. */
   getMarkup: () => AcExMarkupController | null
+  /** Navigation tools (zoom-window, etc.), or `null` before they are created. */
   getNavTools: () => ReturnType<typeof setupAcExHtmlNavTools> | null
+  /** Redraws the scene, overlays, paper viewports, and snap loupe. */
   render: () => void
+  /**
+   * Shows the snap-loupe HUD around a client sample while a long-press is
+   * active.
+   *
+   * @param clientX - Sample X in client CSS pixels.
+   * @param clientY - Sample Y in client CSS pixels.
+   */
+  refreshSnapLoupeHud: (clientX: number, clientY: number) => void
+  /** Hides the snap-loupe HUD and clears the overlay sample. */
+  hideSnapLoupe: () => void
 }
 
 /**
  * Left-button tool picking / selection on capture so selection can block
  * OrbitControls pan; while a tool is active left pan is already toggled off.
  * Also drives zoom-window picks in both view and measure modes.
+ * Touch drawing tools defer commit until pointerup so a long-press can open
+ * the snap loupe.
+ *
+ * @param options - Canvas, tool accessors, render callback, and loupe HUD.
  */
 function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
-  const { domElement, getMeasure, getMarkup, getNavTools, render } = options
+  const {
+    domElement,
+    getMeasure,
+    getMarkup,
+    getNavTools,
+    render,
+    refreshSnapLoupeHud,
+    hideSnapLoupe
+  } = options
   let pendingMove: { clientX: number; clientY: number } | null = null
   let moveRaf = 0
+  const touchSession = new AcExTouchPointSession()
 
+  /**
+   * Whether measure or markup is currently drawing.
+   *
+   * @returns True when a drawing tool should receive the next pick.
+   */
+  const isDrawingToolActive = () =>
+    getMeasure()?.isActive === true || getMarkup()?.isActive === true
+
+  /**
+   * Commits a measure or markup point at the given client sample.
+   *
+   * @param clientX - Sample X in client CSS pixels.
+   * @param clientY - Sample Y in client CSS pixels.
+   */
+  const commitDrawingPoint = (clientX: number, clientY: number) => {
+    const measure = getMeasure()
+    const markup = getMarkup()
+    if (measure?.isActive) {
+      if (measure.handlePointerDown(clientX, clientY)) {
+        if (measure.hasSelection) markup?.clearSelection()
+        render()
+      }
+      return
+    }
+    if (markup?.isActive) {
+      if (markup.handlePointerDown(clientX, clientY)) {
+        if (markup.hasSelection) measure?.clearSelection()
+        render()
+      }
+    }
+  }
+
+  /**
+   * Updates the in-progress measure or markup preview without committing.
+   *
+   * @param clientX - Sample X in client CSS pixels.
+   * @param clientY - Sample Y in client CSS pixels.
+   */
+  const previewDrawingPoint = (clientX: number, clientY: number) => {
+    const measure = getMeasure()
+    const markup = getMarkup()
+    if (measure?.isActive) {
+      measure.handlePointerMove(clientX, clientY)
+      render()
+      return
+    }
+    if (markup?.isActive) {
+      markup.handlePointerMove(clientX, clientY)
+      render()
+    }
+  }
+
+  /**
+   * Applies the latest coalesced pointer-move sample: tool preview, loupe HUD
+   * while long-pressing, or zoom-window rubber band.
+   */
   const flushPointerMove = () => {
     moveRaf = 0
     const sample = pendingMove
@@ -1762,15 +2027,47 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     const markup = getMarkup()
     if (measure?.isActive) {
       measure.handlePointerMove(sample.clientX, sample.clientY)
+      if (touchSession.isLoupe) {
+        refreshSnapLoupeHud(sample.clientX, sample.clientY)
+      }
       render()
       return
     }
     if (markup?.isActive) {
       markup.handlePointerMove(sample.clientX, sample.clientY)
+      if (touchSession.isLoupe) {
+        refreshSnapLoupeHud(sample.clientX, sample.clientY)
+      }
       render()
       return
     }
     getNavTools()?.handlePointerMove(sample.clientX, sample.clientY)
+  }
+
+  /**
+   * Ends a touch pick. When `commit` is true, a short tap or loupe release
+   * places the drawing point; otherwise the gesture is aborted.
+   *
+   * @param event - Pointer event that ended or cancelled the gesture.
+   * @param commit - When false, abort without placing a point.
+   */
+  const endTouchPick = (event: PointerEvent, commit: boolean) => {
+    if (event.pointerType !== 'touch') return
+    if (touchSession.phase === 'idle') return
+    if (event.pointerId !== touchSession.pointerId) return
+    if (!commit) {
+      touchSession.cancel()
+      hideSnapLoupe()
+      render()
+      return
+    }
+    const action = touchSession.end()
+    hideSnapLoupe()
+    if (action === 'commit') {
+      commitDrawingPoint(event.clientX, event.clientY)
+    } else {
+      render()
+    }
   }
 
   domElement.addEventListener(
@@ -1779,6 +2076,15 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
       if (event.button !== 0) return
       const measure = getMeasure()
       const markup = getMarkup()
+      if (event.pointerType === 'touch' && isDrawingToolActive()) {
+        touchSession.start(event.pointerId, event.clientX, event.clientY, () => {
+          refreshSnapLoupeHud(touchSession.x, touchSession.y)
+          render()
+        })
+        previewDrawingPoint(event.clientX, event.clientY)
+        domElement.setPointerCapture(event.pointerId)
+        return
+      }
       if (measure?.isActive) {
         if (measure.handlePointerDown(event.clientX, event.clientY)) {
           if (measure.hasSelection) markup?.clearSelection()
@@ -1798,7 +2104,6 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
         event.stopImmediatePropagation()
         return
       }
-      // Capture phase: stop before OrbitControls starts left-button pan.
       if (markup?.handleSelectionPointerDown(event.clientX, event.clientY)) {
         event.stopImmediatePropagation()
         if (markup.hasSelection) measure?.clearSelection()
@@ -1817,11 +2122,20 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     const measure = getMeasure()
     const markup = getMarkup()
     const zoomWindow = getNavTools()?.getMode() === 'zoom-window'
+    if (event.pointerType === 'touch' && touchSession.isPicking) {
+      touchSession.move(event.clientX, event.clientY, false)
+    }
     if (!measure?.isActive && !markup?.isActive && !zoomWindow) return
     pendingMove = { clientX: event.clientX, clientY: event.clientY }
     if (moveRaf === 0) {
       moveRaf = requestAnimationFrame(flushPointerMove)
     }
+  })
+  window.addEventListener('pointerup', event => {
+    endTouchPick(event, true)
+  })
+  window.addEventListener('pointercancel', event => {
+    endTouchPick(event, false)
   })
 }
 

--- a/packages/cad-html-plugin/src/AcExSnapLoupe.ts
+++ b/packages/cad-html-plugin/src/AcExSnapLoupe.ts
@@ -15,11 +15,11 @@ export const ACEX_SNAP_LOUPE_INSET_PX = 8
 export const ACEX_SNAP_LOUPE_TOP_INSET_PX = 56
 
 /**
- * DOM chrome for the offline HTML snap loupe (border, crosshair, OSNAP glyph).
+ * DOM chrome for the offline HTML snap loupe (border and OSNAP glyph).
  * Geometry is drawn into a WebGL scissor by the viewer runtime.
  */
 export class AcExSnapLoupe {
-  /** Root HUD element (border + crosshair), positioned over the overlay. */
+  /** Root HUD element (border), positioned over the overlay. */
   private readonly root: HTMLDivElement
   /** OSNAP glyph drawn inside the loupe when a snap is active. */
   private readonly marker: HTMLDivElement
@@ -41,9 +41,6 @@ export class AcExSnapLoupe {
     this.root.className = 'mlcad-snap-loupe'
     this.root.setAttribute('aria-hidden', 'true')
     this.root.style.display = 'none'
-    const crosshair = document.createElement('div')
-    crosshair.className = 'mlcad-snap-loupe-crosshair'
-    this.root.appendChild(crosshair)
     this.marker = document.createElement('div')
     this.marker.className =
       'mlcad-osnap-marker mlcad-osnap-marker--rect mlcad-osnap-marker--hidden'

--- a/packages/cad-html-plugin/src/AcExSnapLoupe.ts
+++ b/packages/cad-html-plugin/src/AcExSnapLoupe.ts
@@ -1,0 +1,145 @@
+import type { AcExOsnapMode } from './AcExOsnap'
+import { acExOsnapModeToMarkerType } from './AcExOsnap'
+import type { AcExOsnapMarkerShape } from './AcExOsnapMarker'
+
+/** Square loupe size in CSS pixels. */
+export const ACEX_SNAP_LOUPE_SIZE_PX = 128
+/** Magnification relative to the main view. */
+export const ACEX_SNAP_LOUPE_ZOOM = 3
+/** Horizontal offset of the loupe from the canvas host left, in CSS pixels. */
+export const ACEX_SNAP_LOUPE_INSET_PX = 8
+/**
+ * Vertical offset of the loupe from the canvas host top, in CSS pixels.
+ * Leaves room for `#mlcad-status-bar` (top inset + two 12px lines + gap).
+ */
+export const ACEX_SNAP_LOUPE_TOP_INSET_PX = 56
+
+/**
+ * DOM chrome for the offline HTML snap loupe (border, crosshair, OSNAP glyph).
+ * Geometry is drawn into a WebGL scissor by the viewer runtime.
+ */
+export class AcExSnapLoupe {
+  /** Root HUD element (border + crosshair), positioned over the overlay. */
+  private readonly root: HTMLDivElement
+  /** OSNAP glyph drawn inside the loupe when a snap is active. */
+  private readonly marker: HTMLDivElement
+  /** Last applied OSNAP marker CSS shape class suffix. */
+  private markerShape: AcExOsnapMarkerShape = 'rect'
+  /** Whether the HUD is currently displayed. */
+  private visible = false
+
+  /**
+   * Creates the loupe HUD and attaches it to the canvas host.
+   *
+   * @param host - Element that contains the WebGL canvas (typically `#mlcad-canvas-host`).
+   */
+  constructor(host: HTMLElement) {
+    if (getComputedStyle(host).position === 'static') {
+      host.style.position = 'relative'
+    }
+    this.root = document.createElement('div')
+    this.root.className = 'mlcad-snap-loupe'
+    this.root.setAttribute('aria-hidden', 'true')
+    this.root.style.display = 'none'
+    const crosshair = document.createElement('div')
+    crosshair.className = 'mlcad-snap-loupe-crosshair'
+    this.root.appendChild(crosshair)
+    this.marker = document.createElement('div')
+    this.marker.className =
+      'mlcad-osnap-marker mlcad-osnap-marker--rect mlcad-osnap-marker--hidden'
+    this.root.appendChild(this.marker)
+    host.appendChild(this.root)
+  }
+
+  /**
+   * Whether the HUD is currently displayed.
+   *
+   * @returns True after {@link show} until {@link hide} or {@link remove}.
+   */
+  get isVisible(): boolean {
+    return this.visible
+  }
+
+  /**
+   * Shows the HUD below the top status bar. `canvasX`/`canvasY` are the sample
+   * in canvas CSS pixels; `snapCanvas` is the snapped canvas position when an
+   * object snap hits.
+   *
+   * @param canvasX - Sample X in canvas CSS pixels (finger / loupe center).
+   * @param canvasY - Sample Y in canvas CSS pixels.
+   * @param snapCanvas - Snapped point in canvas CSS pixels, if any.
+   * @param mode - Object-snap mode used to choose the glyph shape.
+   */
+  show(
+    canvasX: number,
+    canvasY: number,
+    snapCanvas?: { x: number; y: number },
+    mode?: AcExOsnapMode
+  ) {
+    this.root.style.left = `${ACEX_SNAP_LOUPE_INSET_PX}px`
+    this.root.style.top = `${ACEX_SNAP_LOUPE_TOP_INSET_PX}px`
+    this.root.style.display = 'block'
+    this.visible = true
+    if (snapCanvas && mode) {
+      const shape = acExOsnapModeToMarkerType(mode)
+      if (shape !== this.markerShape) {
+        this.markerShape = shape
+        this.marker.className = `mlcad-osnap-marker mlcad-osnap-marker--${shape}`
+      } else {
+        this.marker.classList.remove('mlcad-osnap-marker--hidden')
+      }
+      const local = acExLoupeLocalFromCanvasDelta(
+        snapCanvas.x - canvasX,
+        snapCanvas.y - canvasY
+      )
+      this.marker.style.left = `${local.x}px`
+      this.marker.style.top = `${local.y}px`
+      this.marker.classList.remove('mlcad-osnap-marker--hidden')
+    } else {
+      this.marker.classList.add('mlcad-osnap-marker--hidden')
+    }
+  }
+
+  /**
+   * Hides the HUD without removing it from the DOM.
+   */
+  hide() {
+    this.visible = false
+    this.root.style.display = 'none'
+    this.marker.classList.add('mlcad-osnap-marker--hidden')
+  }
+
+  /**
+   * Hides the loupe and removes its DOM from the host.
+   */
+  remove() {
+    this.hide()
+    this.root.remove()
+  }
+}
+
+/**
+ * Maps a canvas-space delta (snap − finger) into loupe-local pixels.
+ *
+ * The loupe center corresponds to the finger sample; the snap glyph is
+ * offset from that center by `delta * zoom`.
+ *
+ * @param dx - Canvas-space X from finger to snap (CSS pixels).
+ * @param dy - Canvas-space Y from finger to snap (CSS pixels).
+ * @param size - Loupe width/height in CSS pixels; defaults to
+ *   {@link ACEX_SNAP_LOUPE_SIZE_PX}.
+ * @param zoom - Magnification relative to the main view; defaults to
+ *   {@link ACEX_SNAP_LOUPE_ZOOM}.
+ * @returns Loupe-local coordinates with origin at the loupe top-left.
+ */
+export function acExLoupeLocalFromCanvasDelta(
+  dx: number,
+  dy: number,
+  size: number = ACEX_SNAP_LOUPE_SIZE_PX,
+  zoom: number = ACEX_SNAP_LOUPE_ZOOM
+): { x: number; y: number } {
+  return {
+    x: size / 2 + dx * zoom,
+    y: size / 2 + dy * zoom
+  }
+}

--- a/packages/cad-html-plugin/src/AcExTouchPointSession.ts
+++ b/packages/cad-html-plugin/src/AcExTouchPointSession.ts
@@ -1,0 +1,207 @@
+/**
+ * Long-press delay before the snap loupe appears, in milliseconds.
+ */
+export const ACEX_TOUCH_POINT_LONG_PRESS_MS = 350
+
+/**
+ * Pointer movement in CSS pixels that cancels a pending long-press so the
+ * gesture can be treated as a pan. Offline HTML drawing tools already disable
+ * one-finger pan, so callers typically pass `cancelOnMove: false`.
+ */
+export const ACEX_TOUCH_POINT_MOVE_CANCEL_PX = 10
+
+/**
+ * Phases of a one-finger point-pick gesture.
+ *
+ * - `idle` — no gesture in progress.
+ * - `pending` — finger is down; waiting for a short tap, long-press, or pan.
+ * - `loupe` — long-press fired; the magnifier is visible.
+ * - `panning` — moved past the cancel threshold before the timer; pick aborted.
+ */
+export type AcExTouchPointPhase = 'idle' | 'pending' | 'loupe' | 'panning'
+
+/**
+ * Long-press / short-tap state machine for touch point picking in the
+ * exported HTML viewer.
+ *
+ * - Short tap (`pending` → end): commit at the last sample.
+ * - Hold until {@link ACEX_TOUCH_POINT_LONG_PRESS_MS}: enter `loupe`.
+ * - Move beyond {@link ACEX_TOUCH_POINT_MOVE_CANCEL_PX} before the timer
+ *   (when `cancelOnMove` is true): enter `panning` and do not commit.
+ */
+export class AcExTouchPointSession {
+  /** Current gesture phase. */
+  private _phase: AcExTouchPointPhase = 'idle'
+  /** Pointer id of the active finger, or `-1` when idle. */
+  private _pointerId = -1
+  /** Client X of the finger-down sample. */
+  private _startX = 0
+  /** Client Y of the finger-down sample. */
+  private _startY = 0
+  /** Latest sample X in the same space as {@link start}. */
+  private _x = 0
+  /** Latest sample Y in the same space as {@link start}. */
+  private _y = 0
+  /** Pending long-press timer, or `null` when none is scheduled. */
+  private _timer: ReturnType<typeof setTimeout> | null = null
+  /** Callback invoked once when the session enters the `loupe` phase. */
+  private _onLongPress: (() => void) | null = null
+
+  /**
+   * Current gesture phase.
+   *
+   * @returns One of {@link AcExTouchPointPhase}.
+   */
+  get phase(): AcExTouchPointPhase {
+    return this._phase
+  }
+
+  /**
+   * Active pointer id, or `-1` when idle.
+   *
+   * @returns The pointer id passed to {@link start}, or `-1`.
+   */
+  get pointerId(): number {
+    return this._pointerId
+  }
+
+  /**
+   * Latest sample X in the same space as {@link start}.
+   *
+   * @returns Client X of the last sample.
+   */
+  get x(): number {
+    return this._x
+  }
+
+  /**
+   * Latest sample Y in the same space as {@link start}.
+   *
+   * @returns Client Y of the last sample.
+   */
+  get y(): number {
+    return this._y
+  }
+
+  /**
+   * Whether a pick is in progress (including while the loupe is visible).
+   *
+   * @returns True in the `pending` or `loupe` phase.
+   */
+  get isPicking(): boolean {
+    return this._phase === 'pending' || this._phase === 'loupe'
+  }
+
+  /**
+   * Whether the long-press magnifier is currently shown.
+   *
+   * @returns True in the `loupe` phase.
+   */
+  get isLoupe(): boolean {
+    return this._phase === 'loupe'
+  }
+
+  /**
+   * Begins a touch pick. Invokes `onLongPress` after the long-press delay
+   * unless the session is cancelled or converted to a pan.
+   *
+   * @param pointerId - Pointer id of the finger that started the gesture.
+   * @param x - Sample X in client CSS pixels.
+   * @param y - Sample Y in client CSS pixels.
+   * @param onLongPress - Called once when the session enters the `loupe` phase.
+   * @param longPressMs - Delay before the loupe appears; defaults to
+   *   {@link ACEX_TOUCH_POINT_LONG_PRESS_MS}.
+   */
+  start(
+    pointerId: number,
+    x: number,
+    y: number,
+    onLongPress: () => void,
+    longPressMs: number = ACEX_TOUCH_POINT_LONG_PRESS_MS
+  ) {
+    this.reset()
+    this._phase = 'pending'
+    this._pointerId = pointerId
+    this._startX = x
+    this._startY = y
+    this._x = x
+    this._y = y
+    this._onLongPress = onLongPress
+    this._timer = setTimeout(() => {
+      this._timer = null
+      if (this._phase !== 'pending') return
+      this._phase = 'loupe'
+      this._onLongPress?.()
+    }, longPressMs)
+  }
+
+  /**
+   * Updates the sample position.
+   *
+   * @param x - New sample X in the same space as {@link start}.
+   * @param y - New sample Y in the same space as {@link start}.
+   * @param cancelOnMove - When true, movement past the cancel threshold
+   *   before the loupe appears aborts the pick.
+   * @param cancelPx - Movement threshold in CSS pixels; defaults to
+   *   {@link ACEX_TOUCH_POINT_MOVE_CANCEL_PX}.
+   * @returns `'panning'` when the pick was aborted, otherwise `'continue'`.
+   */
+  move(
+    x: number,
+    y: number,
+    cancelOnMove: boolean,
+    cancelPx: number = ACEX_TOUCH_POINT_MOVE_CANCEL_PX
+  ): 'continue' | 'panning' {
+    if (this._phase === 'idle' || this._phase === 'panning') return 'continue'
+    this._x = x
+    this._y = y
+    if (this._phase !== 'pending' || !cancelOnMove) return 'continue'
+    const dx = x - this._startX
+    const dy = y - this._startY
+    if (dx * dx + dy * dy < cancelPx * cancelPx) return 'continue'
+    this.clearTimer()
+    this._phase = 'panning'
+    this._onLongPress = null
+    return 'panning'
+  }
+
+  /**
+   * Ends the gesture.
+   *
+   * @returns `'commit'` for a short tap or loupe release, `'ignore'` otherwise.
+   */
+  end(): 'commit' | 'ignore' {
+    const phase = this._phase
+    this.reset()
+    if (phase === 'pending' || phase === 'loupe') return 'commit'
+    return 'ignore'
+  }
+
+  /**
+   * Aborts without committing (for example on `pointercancel`).
+   */
+  cancel() {
+    this.reset()
+  }
+
+  /**
+   * Clears the pending long-press timer, if any.
+   */
+  private clearTimer() {
+    if (this._timer != null) {
+      clearTimeout(this._timer)
+      this._timer = null
+    }
+  }
+
+  /**
+   * Returns the session to {@link AcExTouchPointPhase | idle} and drops the
+   * long-press callback.
+   */
+  private reset() {
+    this.clearTimer()
+    this._phase = 'idle'
+    this._pointerId = -1
+    this._onLongPress = null
+  }
+}

--- a/packages/cad-simple-viewer/__tests__/AcEdTouchPointSession.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdTouchPointSession.spec.ts
@@ -1,0 +1,58 @@
+import { AcEdTouchPointSession } from '../src/editor/input/ui/AcEdTouchPointSession'
+import { acedLoupeLocalFromCanvasDelta } from '../src/editor/input/ui/AcEdSnapLoupeMath'
+
+describe('AcEdTouchPointSession', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('commits a short tap without opening the loupe', () => {
+    const onLongPress = jest.fn()
+    const session = new AcEdTouchPointSession()
+    session.start(1, 10, 20, onLongPress, 350)
+    expect(session.phase).toBe('pending')
+    expect(session.end()).toBe('commit')
+    expect(onLongPress).not.toHaveBeenCalled()
+    expect(session.phase).toBe('idle')
+  })
+
+  it('opens the loupe after the long-press delay and commits on end', () => {
+    const onLongPress = jest.fn()
+    const session = new AcEdTouchPointSession()
+    session.start(1, 10, 20, onLongPress, 350)
+    jest.advanceTimersByTime(350)
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+    expect(session.phase).toBe('loupe')
+    expect(session.end()).toBe('commit')
+  })
+
+  it('cancels to pan when moved before the timer', () => {
+    const onLongPress = jest.fn()
+    const session = new AcEdTouchPointSession()
+    session.start(1, 0, 0, onLongPress, 350)
+    expect(session.move(20, 0, true)).toBe('panning')
+    expect(session.phase).toBe('panning')
+    jest.advanceTimersByTime(350)
+    expect(onLongPress).not.toHaveBeenCalled()
+    expect(session.end()).toBe('ignore')
+  })
+
+  it('does not cancel to pan when cancelOnMove is false', () => {
+    const session = new AcEdTouchPointSession()
+    session.start(1, 0, 0, () => undefined, 350)
+    expect(session.move(40, 0, false)).toBe('continue')
+    expect(session.phase).toBe('pending')
+  })
+})
+
+describe('acedLoupeLocalFromCanvasDelta', () => {
+  it('places the snap glyph at the magnified offset from center', () => {
+    expect(acedLoupeLocalFromCanvasDelta(10, -4, 128, 3)).toEqual({
+      x: 64 + 30,
+      y: 64 - 12
+    })
+  })
+})

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -22,6 +22,8 @@ import {
 } from './AcEdFloatingInputTypes'
 import { AcEdFloatingMessage } from './AcEdFloatingMessage'
 import { AcEdRubberBand } from './AcEdRubberBand'
+import { AcEdSnapLoupe } from './AcEdSnapLoupe'
+import { AcEdTouchPointSession } from './AcEdTouchPointSession'
 
 /**
  * A UI component providing a small floating input box used inside CAD editing
@@ -76,6 +78,20 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
 
   /** Cached click handler */
   private boundOnClick: (e: MouseEvent) => void
+  /** Cached touch `pointerdown` handler for delayed pick / snap loupe. */
+  private boundOnPointerDown: (e: PointerEvent) => void
+  /** Cached touch `pointermove` handler for pick preview and loupe tracking. */
+  private boundOnPointerMove: (e: PointerEvent) => void
+  /** Cached touch `pointerup` handler that commits the pick. */
+  private boundOnPointerUp: (e: PointerEvent) => void
+  /** Cached `pointercancel` handler that aborts the pick. */
+  private boundOnPointerCancel: (e: PointerEvent) => void
+  /** Long-press / short-tap state for one-finger point picking. */
+  private readonly touchSession = new AcEdTouchPointSession()
+  /** Magnifier HUD shown after a long-press on touch. */
+  private snapLoupe?: AcEdSnapLoupe
+  /** When true, the synthetic `click` that follows a touch `pointerup` is ignored. */
+  private ignoreNextClick = false
   /** Whether to suppress UI display while keeping input active */
   private suppressDisplay: boolean = false
   /** Cached sysvar handler */
@@ -160,6 +176,16 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     // -----------------------------
     this.boundOnClick = e => this.handleClick(e)
     this.parent.addEventListener('click', this.boundOnClick)
+    this.boundOnPointerDown = e => this.handlePointerDown(e)
+    this.boundOnPointerMove = e => this.handlePointerMove(e)
+    this.boundOnPointerUp = e => this.handlePointerUp(e)
+    this.boundOnPointerCancel = e => this.handlePointerCancel(e)
+    this.parent.addEventListener('pointerdown', this.boundOnPointerDown)
+    this.parent.addEventListener('pointermove', this.boundOnPointerMove)
+    // Release can happen off-canvas; listen on window like the HTML viewer.
+    window.addEventListener('pointerup', this.boundOnPointerUp)
+    window.addEventListener('pointercancel', this.boundOnPointerCancel)
+    this.snapLoupe = new AcEdSnapLoupe(view)
 
     // -----------------------------
     // Dynamic input settings listener
@@ -245,6 +271,15 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     super.dispose()
 
     this.parent.removeEventListener('click', this.boundOnClick)
+    this.parent.removeEventListener('pointerdown', this.boundOnPointerDown)
+    this.parent.removeEventListener('pointermove', this.boundOnPointerMove)
+    window.removeEventListener('pointerup', this.boundOnPointerUp)
+    window.removeEventListener('pointercancel', this.boundOnPointerCancel)
+    this.releaseTouchCapture()
+    this.touchSession.cancel()
+    this.snapLoupe?.dispose()
+    this.view.setNavigationEnabled(true)
+    this.view.setSnapLoupe(null)
     AcDbSysVarManager.instance().events.sysVarChanged.removeEventListener(
       this.boundOnInputSysVarChanged
     )
@@ -264,7 +299,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   protected override handleMouseMove(e: MouseEvent) {
     if (!this.visible) return
 
-    const wcsPos = this.getPosition(e)
+    const wcsPos = this.getPosition({ x: e.clientX, y: e.clientY })
     this.updateDynamicPreview(wcsPos)
   }
 
@@ -292,12 +327,139 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
 
   private handleClick(e: MouseEvent) {
     if (!this.visible) return
+    if (this.ignoreNextClick) {
+      this.ignoreNextClick = false
+      return
+    }
 
-    const wcsPos = this.getPosition(e)
+    const wcsPos = this.getPosition({ x: e.clientX, y: e.clientY })
     const defaults = this.getDynamicValue(wcsPos)
     const committed = this.onCommit?.(defaults.value, wcsPos) ?? true
     if (committed) {
       this.lastPoint = wcsPos
+    }
+  }
+
+  /**
+   * Starts a one-finger pick. Short taps still commit on `pointerup`; a
+   * long-press opens the snap loupe and disables navigation until release.
+   *
+   * @param e - Pointer event; only `touch` with button 0 is handled.
+   */
+  private handlePointerDown(e: PointerEvent) {
+    if (!this.visible || e.pointerType !== 'touch') return
+    if (e.button !== 0) return
+    this.touchSession.start(e.pointerId, e.clientX, e.clientY, () => {
+      this.view.setNavigationEnabled(false)
+      this.applyClientSample(this.touchSession.x, this.touchSession.y)
+      this.refreshLoupe()
+    })
+    this.applyClientSample(e.clientX, e.clientY)
+    this.parent.setPointerCapture(e.pointerId)
+  }
+
+  /**
+   * Updates the pick preview while the finger is down. Movement past the
+   * cancel threshold before the long-press fires is treated as a pan.
+   *
+   * @param e - Pointer event for the active touch session.
+   */
+  private handlePointerMove(e: PointerEvent) {
+    if (e.pointerType !== 'touch') return
+    if (e.pointerId !== this.touchSession.pointerId) return
+    const moved = this.touchSession.move(e.clientX, e.clientY, true)
+    if (moved === 'panning') return
+    if (!this.visible || !this.touchSession.isPicking) return
+    this.applyClientSample(e.clientX, e.clientY)
+    if (this.touchSession.isLoupe) this.refreshLoupe()
+  }
+
+  /**
+   * Ends the touch pick. A short tap or loupe release commits the point;
+   * a pan-aborted gesture does not. The following `click` is swallowed.
+   *
+   * @param e - Pointer event that ended the gesture.
+   */
+  private handlePointerUp(e: PointerEvent) {
+    if (e.pointerType !== 'touch') return
+    if (this.touchSession.phase === 'idle') return
+    if (e.pointerId !== this.touchSession.pointerId) return
+    this.ignoreNextClick = true
+    this.releaseTouchCapture()
+    const action = this.touchSession.end()
+    this.view.setNavigationEnabled(true)
+    this.snapLoupe?.hide()
+    if (!this.visible || action !== 'commit') return
+    this.applyClientSample(e.clientX, e.clientY)
+    const wcsPos = this.lastDynamicPoint
+      ? new AcGePoint2d(this.lastDynamicPoint.x, this.lastDynamicPoint.y)
+      : this.getPosition({ x: e.clientX, y: e.clientY })
+    const defaults = this.getDynamicValue(wcsPos)
+    const committed = this.onCommit?.(defaults.value, wcsPos) ?? true
+    if (committed) {
+      this.lastPoint = wcsPos
+    }
+  }
+
+  /**
+   * Aborts the touch pick without committing (for example on `pointercancel`).
+   *
+   * @param e - Pointer event; only `touch` is handled.
+   */
+  private handlePointerCancel(e: PointerEvent) {
+    if (e.pointerType !== 'touch') return
+    if (this.touchSession.phase === 'idle') return
+    if (e.pointerId !== this.touchSession.pointerId) return
+    this.ignoreNextClick = true
+    this.releaseTouchCapture()
+    this.touchSession.cancel()
+    this.view.setNavigationEnabled(true)
+    this.snapLoupe?.hide()
+  }
+
+  /**
+   * Releases pointer capture taken in {@link handlePointerDown}, if any.
+   */
+  private releaseTouchCapture() {
+    const pointerId = this.touchSession.pointerId
+    if (pointerId === -1) return
+    if (this.parent.hasPointerCapture(pointerId)) {
+      this.parent.releasePointerCapture(pointerId)
+    }
+  }
+
+  /**
+   * Converts a client sample to WCS (with OSNAP) and refreshes the dynamic
+   * preview / rubber band.
+   *
+   * @param clientX - Sample X in client CSS pixels.
+   * @param clientY - Sample Y in client CSS pixels.
+   */
+  private applyClientSample(clientX: number, clientY: number) {
+    const wcsPos = this.getPosition({ x: clientX, y: clientY })
+    this.updateDynamicPreview(wcsPos)
+  }
+
+  /**
+   * Positions the snap-loupe HUD and overlay viewport around the current
+   * touch sample, including an OSNAP glyph when a snap is active.
+   */
+  private refreshLoupe() {
+    if (!this.snapLoupe) return
+    const canvas = this.view.viewportToCanvas({
+      x: this.touchSession.x,
+      y: this.touchSession.y
+    })
+    if (this.lastOsnapPoint) {
+      const snapScreen = this.view.worldToScreen(this.lastOsnapPoint)
+      this.snapLoupe.show(
+        canvas.x,
+        canvas.y,
+        { x: snapScreen.x, y: snapScreen.y },
+        AcEdOsnapResolver.osnapModeToMarkerType(this.lastOsnapPoint.type)
+      )
+    } else {
+      this.snapLoupe.show(canvas.x, canvas.y)
     }
   }
 
@@ -346,7 +508,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   /**
    * Gets the current cursor position in WCS, considering OSNAP.
    */
-  private getPosition(e: MouseEvent) {
+  private getPosition(e: AcGePoint2dLike) {
     // Update floating UI position (screen space)
     const mousePos = super.setPosition(e)
 

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdSnapLoupe.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdSnapLoupe.ts
@@ -17,7 +17,7 @@ export {
 } from './AcEdSnapLoupeMath'
 
 /**
- * DOM chrome for the mobile snap loupe: border, crosshair, and OSNAP glyph.
+ * DOM chrome for the mobile snap loupe: border and OSNAP glyph.
  *
  * CAD geometry is drawn by the view's overlay viewport; this widget only
  * drives that viewport and paints HUD on top.
@@ -28,7 +28,7 @@ export class AcEdSnapLoupe {
 
   /** View whose overlay viewport shows the magnified CAD content. */
   private readonly view: AcEdBaseView
-  /** Root HUD element (border + crosshair), positioned over the overlay. */
+  /** Root HUD element (border), positioned over the overlay. */
   private readonly root: HTMLDivElement
   /** OSNAP glyph drawn inside the loupe when a snap is active. */
   private readonly marker: AcEdMarker
@@ -44,9 +44,6 @@ export class AcEdSnapLoupe {
     this.root = document.createElement('div')
     this.root.className = 'ml-snap-loupe'
     this.root.setAttribute('aria-hidden', 'true')
-    const crosshair = document.createElement('div')
-    crosshair.className = 'ml-snap-loupe-crosshair'
-    this.root.appendChild(crosshair)
     const hostPosition = getComputedStyle(view.container).position
     if (hostPosition === 'static') {
       view.container.style.position = 'relative'
@@ -133,32 +130,6 @@ export class AcEdSnapLoupe {
         z-index: 20;
         overflow: hidden;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
-      }
-      .ml-snap-loupe-crosshair {
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-      }
-      .ml-snap-loupe-crosshair::before,
-      .ml-snap-loupe-crosshair::after {
-        content: '';
-        position: absolute;
-        background: var(--ml-ui-canvas-line, #0f0);
-        opacity: 0.85;
-      }
-      .ml-snap-loupe-crosshair::before {
-        left: 50%;
-        top: 0;
-        width: 1px;
-        height: 100%;
-        transform: translateX(-50%);
-      }
-      .ml-snap-loupe-crosshair::after {
-        top: 50%;
-        left: 0;
-        height: 1px;
-        width: 100%;
-        transform: translateY(-50%);
       }
     `
     document.head.appendChild(style)

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdSnapLoupe.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdSnapLoupe.ts
@@ -1,0 +1,188 @@
+import { AcGeBox2d, AcGePoint2d } from '@mlightcad/data-model'
+
+import { AcEdBaseView } from '../../view'
+import { AcEdMarker, AcEdMarkerType } from '../marker/AcEdMarker'
+import {
+  ACED_SNAP_LOUPE_INSET_PX,
+  ACED_SNAP_LOUPE_SIZE_PX,
+  ACED_SNAP_LOUPE_ZOOM,
+  acedLoupeLocalFromCanvasDelta
+} from './AcEdSnapLoupeMath'
+
+export {
+  ACED_SNAP_LOUPE_INSET_PX,
+  ACED_SNAP_LOUPE_SIZE_PX,
+  ACED_SNAP_LOUPE_ZOOM,
+  acedLoupeLocalFromCanvasDelta
+} from './AcEdSnapLoupeMath'
+
+/**
+ * DOM chrome for the mobile snap loupe: border, crosshair, and OSNAP glyph.
+ *
+ * CAD geometry is drawn by the view's overlay viewport; this widget only
+ * drives that viewport and paints HUD on top.
+ */
+export class AcEdSnapLoupe {
+  /** Whether the loupe stylesheet has been injected into `document.head`. */
+  private static stylesInjected = false
+
+  /** View whose overlay viewport shows the magnified CAD content. */
+  private readonly view: AcEdBaseView
+  /** Root HUD element (border + crosshair), positioned over the overlay. */
+  private readonly root: HTMLDivElement
+  /** OSNAP glyph drawn inside the loupe when a snap is active. */
+  private readonly marker: AcEdMarker
+
+  /**
+   * Creates the loupe HUD and attaches it to the view container.
+   *
+   * @param view - View that owns the overlay viewport and coordinate helpers.
+   */
+  constructor(view: AcEdBaseView) {
+    this.view = view
+    AcEdSnapLoupe.injectCss()
+    this.root = document.createElement('div')
+    this.root.className = 'ml-snap-loupe'
+    this.root.setAttribute('aria-hidden', 'true')
+    const crosshair = document.createElement('div')
+    crosshair.className = 'ml-snap-loupe-crosshair'
+    this.root.appendChild(crosshair)
+    const hostPosition = getComputedStyle(view.container).position
+    if (hostPosition === 'static') {
+      view.container.style.position = 'relative'
+    }
+    view.container.appendChild(this.root)
+    this.marker = new AcEdMarker(
+      'rect',
+      12,
+      'var(--ml-ui-canvas-line, green)',
+      this.root
+    )
+    this.hide()
+  }
+
+  /**
+   * Shows the loupe at the canvas-local sample and updates the overlay viewport.
+   *
+   * @param canvasX - Sample X in canvas CSS pixels.
+   * @param canvasY - Sample Y in canvas CSS pixels.
+   * @param snapCanvas - Snapped point in canvas CSS pixels, if any.
+   * @param snapType - OSNAP marker shape when snapped.
+   */
+  show(
+    canvasX: number,
+    canvasY: number,
+    snapCanvas?: { x: number; y: number },
+    snapType?: AcEdMarkerType
+  ) {
+    const size = ACED_SNAP_LOUPE_SIZE_PX
+    const inset = ACED_SNAP_LOUPE_INSET_PX
+    const viewBox = acedLoupeViewBoxFromCanvasSample(this.view, canvasX, canvasY)
+    this.view.setSnapLoupe({ x: inset, y: inset, size, viewBox })
+
+    const host = this.view.canvasToContainer({ x: inset, y: inset })
+    this.root.style.left = `${host.x}px`
+    this.root.style.top = `${host.y}px`
+    this.root.style.display = 'block'
+
+    if (snapCanvas && snapType) {
+      this.marker.type = snapType
+      this.marker.setPosition(
+        acedLoupeLocalFromCanvasDelta(snapCanvas.x - canvasX, snapCanvas.y - canvasY)
+      )
+    } else {
+      this.marker.setPosition({ x: -1000, y: -1000 })
+    }
+  }
+
+  /**
+   * Hides the HUD and the overlay viewport.
+   */
+  hide() {
+    this.root.style.display = 'none'
+    this.view.setSnapLoupe(null)
+    this.marker.setPosition({ x: -1000, y: -1000 })
+  }
+
+  /**
+   * Hides the loupe and removes its DOM from the view container.
+   */
+  dispose() {
+    this.hide()
+    this.marker.destroy()
+    this.root.remove()
+  }
+
+  /**
+   * Injects loupe HUD styles into `document.head` once per page.
+   */
+  private static injectCss() {
+    if (AcEdSnapLoupe.stylesInjected) return
+    AcEdSnapLoupe.stylesInjected = true
+    const style = document.createElement('style')
+    style.id = 'ml-snap-loupe-style'
+    style.textContent = `
+      .ml-snap-loupe {
+        position: absolute;
+        width: ${ACED_SNAP_LOUPE_SIZE_PX}px;
+        height: ${ACED_SNAP_LOUPE_SIZE_PX}px;
+        box-sizing: border-box;
+        border: 2px solid var(--ml-ui-canvas-line, #0f0);
+        border-radius: 2px;
+        pointer-events: none;
+        z-index: 20;
+        overflow: hidden;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
+      }
+      .ml-snap-loupe-crosshair {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+      }
+      .ml-snap-loupe-crosshair::before,
+      .ml-snap-loupe-crosshair::after {
+        content: '';
+        position: absolute;
+        background: var(--ml-ui-canvas-line, #0f0);
+        opacity: 0.85;
+      }
+      .ml-snap-loupe-crosshair::before {
+        left: 50%;
+        top: 0;
+        width: 1px;
+        height: 100%;
+        transform: translateX(-50%);
+      }
+      .ml-snap-loupe-crosshair::after {
+        top: 50%;
+        left: 0;
+        height: 1px;
+        width: 100%;
+        transform: translateY(-50%);
+      }
+    `
+    document.head.appendChild(style)
+  }
+}
+
+/**
+ * World box around a canvas sample that fills the loupe at {@link ACED_SNAP_LOUPE_ZOOM}.
+ *
+ * @param view - View used to convert canvas samples to world coordinates.
+ * @param canvasX - Sample X in canvas CSS pixels (loupe center).
+ * @param canvasY - Sample Y in canvas CSS pixels (loupe center).
+ * @returns Axis-aligned world box mapped onto the square loupe.
+ */
+export function acedLoupeViewBoxFromCanvasSample(
+  view: AcEdBaseView,
+  canvasX: number,
+  canvasY: number
+): AcGeBox2d {
+  const half = ACED_SNAP_LOUPE_SIZE_PX / ACED_SNAP_LOUPE_ZOOM / 2
+  const p1 = view.screenToWorld({ x: canvasX - half, y: canvasY - half })
+  const p2 = view.screenToWorld({ x: canvasX + half, y: canvasY + half })
+  const box = new AcGeBox2d()
+  box.expandByPoint(new AcGePoint2d(p1.x, p1.y))
+  box.expandByPoint(new AcGePoint2d(p2.x, p2.y))
+  return box
+}

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdSnapLoupeMath.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdSnapLoupeMath.ts
@@ -1,0 +1,32 @@
+/** Square loupe size in CSS pixels. */
+export const ACED_SNAP_LOUPE_SIZE_PX = 128
+/** Magnification relative to the main view. */
+export const ACED_SNAP_LOUPE_ZOOM = 3
+/** Offset of the loupe from the canvas top-left, in CSS pixels. */
+export const ACED_SNAP_LOUPE_INSET_PX = 8
+
+/**
+ * Maps a canvas-space delta (snap − finger) into loupe-local pixels.
+ *
+ * The loupe center corresponds to the finger sample; the snap glyph is
+ * offset from that center by `delta * zoom`.
+ *
+ * @param dx - Canvas-space X from finger to snap (CSS pixels).
+ * @param dy - Canvas-space Y from finger to snap (CSS pixels).
+ * @param size - Loupe width/height in CSS pixels; defaults to
+ *   {@link ACED_SNAP_LOUPE_SIZE_PX}.
+ * @param zoom - Magnification relative to the main view; defaults to
+ *   {@link ACED_SNAP_LOUPE_ZOOM}.
+ * @returns Loupe-local coordinates with origin at the loupe top-left.
+ */
+export function acedLoupeLocalFromCanvasDelta(
+  dx: number,
+  dy: number,
+  size: number = ACED_SNAP_LOUPE_SIZE_PX,
+  zoom: number = ACED_SNAP_LOUPE_ZOOM
+): { x: number; y: number } {
+  return {
+    x: size / 2 + dx * zoom,
+    y: size / 2 + dy * zoom
+  }
+}

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdTouchPointSession.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdTouchPointSession.ts
@@ -1,0 +1,205 @@
+/**
+ * Long-press delay before the snap loupe appears, in milliseconds.
+ */
+export const ACED_TOUCH_POINT_LONG_PRESS_MS = 350
+
+/**
+ * Pointer movement in CSS pixels that cancels a pending long-press so the
+ * gesture can be treated as a pan instead of a pick.
+ */
+export const ACED_TOUCH_POINT_MOVE_CANCEL_PX = 10
+
+/**
+ * Phases of a one-finger point-pick gesture.
+ *
+ * - `idle` — no gesture in progress.
+ * - `pending` — finger is down; waiting for a short tap, long-press, or pan.
+ * - `loupe` — long-press fired; the magnifier is visible.
+ * - `panning` — moved past the cancel threshold before the timer; pick aborted.
+ */
+export type AcEdTouchPointPhase = 'idle' | 'pending' | 'loupe' | 'panning'
+
+/**
+ * Long-press / short-tap state machine for touch point picking.
+ *
+ * - Short tap (`pending` → end): commit at the last sample.
+ * - Hold until {@link ACED_TOUCH_POINT_LONG_PRESS_MS}: enter `loupe`.
+ * - Move beyond {@link ACED_TOUCH_POINT_MOVE_CANCEL_PX} before the timer
+ *   (when `cancelOnMove` is true): enter `panning` and do not commit.
+ */
+export class AcEdTouchPointSession {
+  /** Current gesture phase. */
+  private _phase: AcEdTouchPointPhase = 'idle'
+  /** Pointer id of the active finger, or `-1` when idle. */
+  private _pointerId = -1
+  /** Client X of the finger-down sample. */
+  private _startX = 0
+  /** Client Y of the finger-down sample. */
+  private _startY = 0
+  /** Latest sample X in the same space as {@link start}. */
+  private _x = 0
+  /** Latest sample Y in the same space as {@link start}. */
+  private _y = 0
+  /** Pending long-press timer, or `null` when none is scheduled. */
+  private _timer: ReturnType<typeof setTimeout> | null = null
+  /** Callback invoked once when the session enters the `loupe` phase. */
+  private _onLongPress: (() => void) | null = null
+
+  /**
+   * Current gesture phase.
+   *
+   * @returns One of {@link AcEdTouchPointPhase}.
+   */
+  get phase(): AcEdTouchPointPhase {
+    return this._phase
+  }
+
+  /**
+   * Active pointer id, or `-1` when idle.
+   *
+   * @returns The pointer id passed to {@link start}, or `-1`.
+   */
+  get pointerId(): number {
+    return this._pointerId
+  }
+
+  /**
+   * Latest sample X in the same space as {@link start}.
+   *
+   * @returns Client (or canvas-host) X of the last sample.
+   */
+  get x(): number {
+    return this._x
+  }
+
+  /**
+   * Latest sample Y in the same space as {@link start}.
+   *
+   * @returns Client (or canvas-host) Y of the last sample.
+   */
+  get y(): number {
+    return this._y
+  }
+
+  /**
+   * Begins a touch pick. Invokes `onLongPress` after the long-press delay
+   * unless the session is cancelled or converted to a pan.
+   *
+   * @param pointerId - Pointer id of the finger that started the gesture.
+   * @param x - Sample X in client (or canvas-host) CSS pixels.
+   * @param y - Sample Y in client (or canvas-host) CSS pixels.
+   * @param onLongPress - Called once when the session enters the `loupe` phase.
+   * @param longPressMs - Delay before the loupe appears; defaults to
+   *   {@link ACED_TOUCH_POINT_LONG_PRESS_MS}.
+   */
+  start(
+    pointerId: number,
+    x: number,
+    y: number,
+    onLongPress: () => void,
+    longPressMs: number = ACED_TOUCH_POINT_LONG_PRESS_MS
+  ) {
+    this.reset()
+    this._phase = 'pending'
+    this._pointerId = pointerId
+    this._startX = x
+    this._startY = y
+    this._x = x
+    this._y = y
+    this._onLongPress = onLongPress
+    this._timer = setTimeout(() => {
+      this._timer = null
+      if (this._phase !== 'pending') return
+      this._phase = 'loupe'
+      this._onLongPress?.()
+    }, longPressMs)
+  }
+
+  /**
+   * Updates the sample position.
+   *
+   * @param x - New sample X in the same space as {@link start}.
+   * @param y - New sample Y in the same space as {@link start}.
+   * @param cancelOnMove - When true, movement past the cancel threshold
+   *   before the loupe appears aborts the pick (live viewer pan).
+   * @param cancelPx - Movement threshold in CSS pixels; defaults to
+   *   {@link ACED_TOUCH_POINT_MOVE_CANCEL_PX}.
+   * @returns `'panning'` when the pick was aborted, otherwise `'continue'`.
+   */
+  move(
+    x: number,
+    y: number,
+    cancelOnMove: boolean,
+    cancelPx: number = ACED_TOUCH_POINT_MOVE_CANCEL_PX
+  ): 'continue' | 'panning' {
+    if (this._phase === 'idle' || this._phase === 'panning') return 'continue'
+    this._x = x
+    this._y = y
+    if (this._phase !== 'pending' || !cancelOnMove) return 'continue'
+    const dx = x - this._startX
+    const dy = y - this._startY
+    if (dx * dx + dy * dy < cancelPx * cancelPx) return 'continue'
+    this.clearTimer()
+    this._phase = 'panning'
+    this._onLongPress = null
+    return 'panning'
+  }
+
+  /**
+   * Ends the gesture.
+   *
+   * @returns `'commit'` for a short tap or loupe release, `'ignore'` otherwise.
+   */
+  end(): 'commit' | 'ignore' {
+    const phase = this._phase
+    this.reset()
+    if (phase === 'pending' || phase === 'loupe') return 'commit'
+    return 'ignore'
+  }
+
+  /**
+   * Aborts without committing (for example on `pointercancel`).
+   */
+  cancel() {
+    this.reset()
+  }
+
+  /**
+   * Whether a pick is in progress (including while the loupe is visible).
+   *
+   * @returns True in the `pending` or `loupe` phase.
+   */
+  get isPicking(): boolean {
+    return this._phase === 'pending' || this._phase === 'loupe'
+  }
+
+  /**
+   * Whether the long-press magnifier is currently shown.
+   *
+   * @returns True in the `loupe` phase.
+   */
+  get isLoupe(): boolean {
+    return this._phase === 'loupe'
+  }
+
+  /**
+   * Clears the pending long-press timer, if any.
+   */
+  private clearTimer() {
+    if (this._timer != null) {
+      clearTimeout(this._timer)
+      this._timer = null
+    }
+  }
+
+  /**
+   * Returns the session to {@link AcEdTouchPointPhase | idle} and drops the
+   * long-press callback.
+   */
+  private reset() {
+    this.clearTimer()
+    this._phase = 'idle'
+    this._pointerId = -1
+    this._onLongPress = null
+  }
+}

--- a/packages/cad-simple-viewer/src/editor/input/ui/index.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/index.ts
@@ -2,6 +2,8 @@ export * from './AcEdCommandLine'
 export * from './AcEdInputManager'
 export * from './AcEdMessageType'
 export * from './AcEdMTextEditor'
+export * from './AcEdSnapLoupe'
+export * from './AcEdTouchPointSession'
 export type {
   MTextToolbarColorPickerContext,
   MTextToolbarColorPickerFactory,

--- a/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
@@ -75,6 +75,21 @@ export interface AcEdViewHoverEventArgs {
 }
 
 /**
+ * Screen-fixed snap-loupe overlay: CSS rectangle on the canvas plus the
+ * world box shown inside it.
+ */
+export interface AcEdSnapLoupeViewState {
+  /** Canvas-local left of the loupe (CSS pixels). */
+  x: number
+  /** Canvas-local top of the loupe (CSS pixels). */
+  y: number
+  /** Width and height of the square loupe (CSS pixels). */
+  size: number
+  /** World-space box mapped onto the loupe. */
+  viewBox: AcGeBox2d
+}
+
+/**
  * Interface to define arguments of render frame events.
  */
 export interface AcEdViewRenderFrameEventArgs {
@@ -999,6 +1014,26 @@ export abstract class AcEdBaseView {
    */
   get osnapResolver() {
     return this._osnapResolver
+  }
+
+  /**
+   * Enables or disables camera pan/zoom (OrbitControls) for this view.
+   * Default is a no-op; {@link AcTrView2d} toggles the active layout controls.
+   *
+   * @param _enabled - When false, the user cannot pan or zoom this view.
+   */
+  setNavigationEnabled(_enabled: boolean): void {
+    // Optional; 2D view overrides this.
+  }
+
+  /**
+   * Shows or hides the screen-fixed snap loupe overlay viewport.
+   * Pass `null` to hide. Default is a no-op.
+   *
+   * @param _state - Loupe screen rectangle and world box, or `null` to hide.
+   */
+  setSnapLoupe(_state: AcEdSnapLoupeViewState | null): void {
+    // Optional; 2D view overrides this.
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
@@ -1,11 +1,11 @@
 import { AcGeBox2d } from '@mlightcad/data-model'
 import {
   AcTrBaseView,
+  acTrCssRectToWcsBox,
+  acTrIntersectCssRects,
   AcTrOverlayViewport,
   AcTrRenderer,
   AcTrViewportView,
-  acTrCssRectToWcsBox,
-  acTrIntersectCssRects,
   acTrWcsBoxToCssRect
 } from '@mlightcad/three-renderer'
 import { AxesGizmo, ObjectPosition } from '@mlightcad/three-viewcube'

--- a/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayoutView.ts
@@ -1,8 +1,12 @@
 import { AcGeBox2d } from '@mlightcad/data-model'
 import {
   AcTrBaseView,
+  AcTrOverlayViewport,
   AcTrRenderer,
-  AcTrViewportView
+  AcTrViewportView,
+  acTrCssRectToWcsBox,
+  acTrIntersectCssRects,
+  acTrWcsBoxToCssRect
 } from '@mlightcad/three-renderer'
 import { AxesGizmo, ObjectPosition } from '@mlightcad/three-viewcube'
 import * as THREE from 'three'
@@ -50,6 +54,8 @@ export class AcTrLayoutView extends AcTrBaseView {
   private _mode: AcEdViewMode
   /** Map of viewport views indexed by viewport ID */
   private _viewportViews: Map<string, AcTrViewportView>
+  /** Screen-fixed overlay viewport (snap loupe, etc.). */
+  private readonly _overlayViewport: AcTrOverlayViewport
 
   /**
    * Construct one instance of this class.
@@ -70,6 +76,7 @@ export class AcTrLayoutView extends AcTrBaseView {
     this._mode = AcEdViewMode.SELECTION
     this._axesGizmo = this.createAxesGizmo()
     this._viewportViews = new Map()
+    this._overlayViewport = new AcTrOverlayViewport(renderer)
   }
 
   /**
@@ -123,6 +130,15 @@ export class AcTrLayoutView extends AcTrBaseView {
    */
   get viewportViews(): Iterable<AcTrViewportView> {
     return this._viewportViews.values()
+  }
+
+  /**
+   * Screen-fixed overlay viewport drawn after the layout and paper viewports.
+   *
+   * @returns The overlay used for the snap loupe and similar HUD viewports.
+   */
+  get overlayViewport(): AcTrOverlayViewport {
+    return this._overlayViewport
   }
 
   /**
@@ -197,6 +213,7 @@ export class AcTrLayoutView extends AcTrBaseView {
     if (modelSpaceLayout) {
       this.drawViewports(modelSpaceLayout.internalObject)
     }
+    this.drawOverlay(scene)
     this._axesGizmo?.update()
     return needsRedraw
   }
@@ -254,5 +271,71 @@ export class AcTrLayoutView extends AcTrBaseView {
       // Restore autoClear flag vlaue
       this._renderer.autoClear = autoClear
     }
+  }
+
+  /**
+   * Draws the screen-fixed overlay viewport (magnified snap loupe) on top of
+   * the main layout. Nested paper-space viewports that intersect the overlay
+   * are scissor-clipped so model content stays visible inside the loupe.
+   *
+   * @param scene - Scene containing the active layout and model-space layout.
+   */
+  private drawOverlay(scene: AcTrScene) {
+    const overlay = this._overlayViewport
+    if (!overlay.visible) return
+    overlay.render(scene.internalScene, this._height)
+    const modelSpaceLayout = scene.modelSpaceLayout
+    if (!modelSpaceLayout || this._viewportViews.size === 0) return
+    this.drawOverlayViewports(modelSpaceLayout.internalObject, overlay)
+  }
+
+  /**
+   * For each paper-space viewport that intersects the overlay, draws the
+   * corresponding model-space content into the overlap with a nested scissor.
+   *
+   * @param modelScene - Model-space scene graph to draw inside nested viewports.
+   * @param overlay - Overlay whose screen rect and view box define the loupe.
+   */
+  private drawOverlayViewports(
+    modelScene: THREE.Object3D,
+    overlay: AcTrOverlayViewport
+  ) {
+    const loupe = overlay.screenRect
+    const viewBox = overlay.viewBox
+    const visibility = modelScene.visible
+    modelScene.visible = true
+    this._viewportViews.forEach(viewportView => {
+      const magRect = acTrWcsBoxToCssRect(
+        viewportView.viewport.box,
+        viewBox,
+        loupe
+      )
+      const hit = acTrIntersectCssRects(magRect, loupe)
+      if (!hit) return
+      const paperHit = acTrCssRectToWcsBox(hit, viewBox, loupe)
+      const modelBox = new AcGeBox2d()
+      modelBox.expandByPoint(
+        viewportView.paperPointToModel({ x: paperHit.minX, y: paperHit.minY })
+      )
+      modelBox.expandByPoint(
+        viewportView.paperPointToModel({ x: paperHit.maxX, y: paperHit.minY })
+      )
+      modelBox.expandByPoint(
+        viewportView.paperPointToModel({ x: paperHit.maxX, y: paperHit.maxY })
+      )
+      modelBox.expandByPoint(
+        viewportView.paperPointToModel({ x: paperHit.minX, y: paperHit.maxY })
+      )
+      if (modelBox.isEmpty()) return
+      overlay.renderNested(
+        modelScene,
+        modelBox,
+        hit,
+        hit,
+        this._height,
+        viewportView.viewport.viewTwistAngle
+      )
+    })
+    modelScene.visible = visibility
   }
 }

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -43,6 +43,7 @@ import { isMarkupHtmlTextEditing } from '../command/markup/AcApMarkupTextEdit'
 import {
   AcEdBaseView,
   AcEdCalculateSizeCallback,
+  AcEdSnapLoupeViewState,
   AcEdConditionWaiter,
   AcEdCorsorType,
   AcEdGripManager,
@@ -629,6 +630,36 @@ export class AcTrView2d extends AcEdBaseView {
    */
   set mode(value: AcEdViewMode) {
     this.activeLayoutView.mode = value
+  }
+
+  /**
+   * Enables or disables OrbitControls on the active layout view.
+   *
+   * @param enabled - When false, pan and zoom are disabled (e.g. while the
+   *   snap loupe is tracking a long-press).
+   */
+  override setNavigationEnabled(enabled: boolean) {
+    const layoutView = this.activeLayoutView
+    if (layoutView) layoutView.enabled = enabled
+  }
+
+  /**
+   * Shows or hides the screen-fixed snap loupe overlay viewport.
+   *
+   * @param state - Loupe screen rectangle and world box, or `null` to hide.
+   */
+  override setSnapLoupe(state: AcEdSnapLoupeViewState | null) {
+    const overlay = this.activeLayoutView?.overlayViewport
+    if (!overlay) return
+    if (!state) {
+      overlay.visible = false
+      this._isDirty = true
+      return
+    }
+    overlay.setScreenRect(state.x, state.y, state.size, state.size)
+    overlay.setViewBox(state.viewBox)
+    overlay.visible = true
+    this._isDirty = true
   }
 
   /**

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -43,12 +43,12 @@ import { isMarkupHtmlTextEditing } from '../command/markup/AcApMarkupTextEdit'
 import {
   AcEdBaseView,
   AcEdCalculateSizeCallback,
-  AcEdSnapLoupeViewState,
   AcEdConditionWaiter,
   AcEdCorsorType,
   AcEdGripManager,
   AcEdMTextEditor,
   AcEdOpenMode,
+  AcEdSnapLoupeViewState,
   AcEdSpatialQueryResultItem,
   AcEdSpatialQueryResultItemEx,
   AcEdViewMode,

--- a/packages/cad-viewer-example/e2e/tests/measure-mobile-form.spec.ts
+++ b/packages/cad-viewer-example/e2e/tests/measure-mobile-form.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Regression: starting a measure command on a narrow viewport used to log
+ * `ElementPlusError: [ElForm] unexpected width NaN` because the Measurement
+ * ribbon units panel used `label-width="auto"` while overflow groups were hidden.
+ */
+test.use({
+  viewport: { width: 390, height: 844 },
+  hasTouch: true,
+  isMobile: true,
+  userAgent:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1'
+})
+
+test('measure distance does not log ElForm unexpected width NaN', async ({
+  page
+}) => {
+  const formWidthWarnings: string[] = []
+  page.on('console', message => {
+    const text = message.text()
+    if (text.includes('unexpected width NaN')) {
+      formWidthWarnings.push(text)
+    }
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: 'New Drawing' }).click()
+  await expect(page.locator('.ml-cad-container')).toBeVisible({
+    timeout: 30_000
+  })
+
+  await page.getByRole('tab', { name: 'Measurement' }).click()
+  const commandInput = page.getByRole('textbox', { name: 'Type command' })
+  await expect(commandInput).toBeVisible()
+  await commandInput.fill('measuredistance')
+  await commandInput.press('Enter')
+
+  await expect(page.locator('.ml-ribbon-measure-units').first()).toBeAttached({
+    timeout: 10_000
+  })
+  await page.waitForTimeout(400)
+
+  expect(formWidthWarnings).toEqual([])
+})

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonMeasurementUnitsPanel.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonMeasurementUnitsPanel.vue
@@ -1,7 +1,6 @@
 <template>
   <el-form
     label-position="left"
-    label-width="auto"
     class="ml-ribbon-measure-units"
     size="small"
   >
@@ -46,6 +45,9 @@ import { drawingUnitPrecisionOptions } from '../../util/drawingUnitPrecision'
 
 /**
  * Length or angle type/precision controls for one Measurement ribbon group.
+ *
+ * Labels are aligned with CSS grid instead of `label-width="auto"`, which
+ * makes ElForm report `unexpected width NaN` when overflow groups are hidden.
  */
 interface RibbonMeasurementUnitsPanelProps {
   kind: 'length' | 'angle'
@@ -136,19 +138,27 @@ const precisionOptions = computed(() =>
 <style scoped>
 .ml-ribbon-measure-units {
   --ml-ribbon-measure-units-scale: var(--ml-rb-scale, 1);
+  display: grid;
+  grid-template-columns: max-content auto;
+  align-items: center;
+  row-gap: calc(4px * var(--ml-ribbon-measure-units-scale));
+  column-gap: calc(6px * var(--ml-ribbon-measure-units-scale));
 }
 
 .ml-ribbon-measure-units :deep(.el-form-item) {
-  margin-bottom: calc(4px * var(--ml-ribbon-measure-units-scale));
-}
-
-.ml-ribbon-measure-units :deep(.el-form-item:last-child) {
+  display: contents;
   margin-bottom: 0;
 }
 
 .ml-ribbon-measure-units :deep(.el-form-item__label) {
+  width: auto !important;
   font-size: calc(11px * var(--ml-ribbon-measure-units-scale));
-  padding-right: calc(6px * var(--ml-ribbon-measure-units-scale));
+  padding-right: 0;
+  justify-content: flex-start;
+}
+
+.ml-ribbon-measure-units :deep(.el-form-item__content) {
+  margin-left: 0 !important;
 }
 
 .ml-ribbon-measure-units__control {

--- a/packages/three-renderer/__tests__/AcTrCssRect.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrCssRect.spec.ts
@@ -1,0 +1,49 @@
+import {
+  acTrCssRectToWcsBox,
+  acTrCssTopLeftRectToGl,
+  acTrIntersectCssRects,
+  acTrWcsBoxToCssRect
+} from '../src/viewport/AcTrCssRect'
+
+describe('AcTrCssRect', () => {
+  it('converts CSS top-left rectangles to WebGL bottom-left', () => {
+    expect(
+      acTrCssTopLeftRectToGl({ x: 8, y: 8, width: 128, height: 128 }, 600)
+    ).toEqual({ x: 8, y: 464, width: 128, height: 128 })
+  })
+
+  it('intersects rectangles and rejects empty overlap', () => {
+    expect(
+      acTrIntersectCssRects(
+        { x: 0, y: 0, width: 100, height: 100 },
+        { x: 50, y: 50, width: 100, height: 100 }
+      )
+    ).toEqual({ x: 50, y: 50, width: 50, height: 50 })
+    expect(
+      acTrIntersectCssRects(
+        { x: 0, y: 0, width: 10, height: 10 },
+        { x: 20, y: 20, width: 10, height: 10 }
+      )
+    ).toBeNull()
+  })
+
+  it('maps a world box onto a screen rect and back', () => {
+    const viewBox = { min: { x: 0, y: 0 }, max: { x: 100, y: 50 } }
+    const screen = { x: 10, y: 20, width: 200, height: 100 }
+    const css = acTrWcsBoxToCssRect(
+      { min: { x: 25, y: 10 }, max: { x: 75, y: 40 } },
+      viewBox,
+      screen
+    )
+    expect(css.x).toBeCloseTo(60)
+    expect(css.width).toBeCloseTo(100)
+    expect(css.height).toBeCloseTo(60)
+    expect(css.y).toBeCloseTo(40)
+
+    const roundTrip = acTrCssRectToWcsBox(css, viewBox, screen)
+    expect(roundTrip.minX).toBeCloseTo(25)
+    expect(roundTrip.maxX).toBeCloseTo(75)
+    expect(roundTrip.minY).toBeCloseTo(10)
+    expect(roundTrip.maxY).toBeCloseTo(40)
+  })
+})

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -298,6 +298,27 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
     this._renderer.setViewport(x, y, width, height)
   }
 
+  /**
+   * Sets the WebGL scissor rectangle in CSS pixels (origin bottom-left).
+   *
+   * @param x - Left edge in CSS pixels.
+   * @param y - Bottom edge in CSS pixels.
+   * @param width - Width in CSS pixels.
+   * @param height - Height in CSS pixels.
+   */
+  setScissor(x: number, y: number, width: number, height: number) {
+    this._renderer.setScissor(x, y, width, height)
+  }
+
+  /**
+   * Enables or disables scissor clipping for subsequent draws.
+   *
+   * @param enabled - When true, drawing is clipped to the last {@link setScissor}.
+   */
+  setScissorTest(enabled: boolean) {
+    this._renderer.setScissorTest(enabled)
+  }
+
   clear() {
     this._renderer.clear()
   }

--- a/packages/three-renderer/src/viewport/AcTrCssRect.ts
+++ b/packages/three-renderer/src/viewport/AcTrCssRect.ts
@@ -1,0 +1,110 @@
+/**
+ * Axis-aligned rectangle in CSS pixels with origin at the top-left of the
+ * canvas (or host). Used for overlay viewports, scissor conversion, and
+ * loupe layout.
+ */
+export interface AcTrCssRect {
+  /** Left edge in CSS pixels. */
+  x: number
+  /** Top edge in CSS pixels. */
+  y: number
+  /** Width in CSS pixels. */
+  width: number
+  /** Height in CSS pixels. */
+  height: number
+}
+
+/**
+ * Converts a CSS top-left rectangle to WebGL / Three.js viewport coordinates
+ * (origin at the bottom-left of the canvas).
+ *
+ * Three.js `setViewport` / `setScissor` take these CSS-pixel values and apply
+ * `pixelRatio` internally.
+ *
+ * @param rect - Rectangle in CSS pixels, origin top-left.
+ * @param canvasCssHeight - Canvas CSS height (same space as `rect.y`).
+ * @returns The same rectangle with `y` measured from the canvas bottom.
+ */
+export function acTrCssTopLeftRectToGl(
+  rect: AcTrCssRect,
+  canvasCssHeight: number
+): AcTrCssRect {
+  return {
+    x: rect.x,
+    y: canvasCssHeight - rect.y - rect.height,
+    width: rect.width,
+    height: rect.height
+  }
+}
+
+/**
+ * Intersection of two CSS rectangles, or `null` when the overlap is empty
+ * or smaller than 1px.
+ *
+ * @param a - First rectangle.
+ * @param b - Second rectangle.
+ * @returns Overlap rectangle, or `null` when there is no usable overlap.
+ */
+export function acTrIntersectCssRects(
+  a: AcTrCssRect,
+  b: AcTrCssRect
+): AcTrCssRect | null {
+  const x = Math.max(a.x, b.x)
+  const y = Math.max(a.y, b.y)
+  const right = Math.min(a.x + a.width, b.x + b.width)
+  const bottom = Math.min(a.y + a.height, b.y + b.height)
+  const width = right - x
+  const height = bottom - y
+  if (width < 1 || height < 1) return null
+  return { x, y, width, height }
+}
+
+/**
+ * Maps a world-space axis-aligned box into a CSS rectangle, given that
+ * `viewBox` fills `screen` (Y-up world → Y-down CSS).
+ *
+ * @param box - World box to project.
+ * @param viewBox - World extents currently mapped onto `screen`.
+ * @param screen - CSS rectangle that displays `viewBox`.
+ * @returns `box` in the same CSS space as `screen`.
+ */
+export function acTrWcsBoxToCssRect(
+  box: { min: { x: number; y: number }; max: { x: number; y: number } },
+  viewBox: { min: { x: number; y: number }; max: { x: number; y: number } },
+  screen: AcTrCssRect
+): AcTrCssRect {
+  const vx = Math.max(viewBox.max.x - viewBox.min.x, Number.EPSILON)
+  const vy = Math.max(viewBox.max.y - viewBox.min.y, Number.EPSILON)
+  const x = screen.x + ((box.min.x - viewBox.min.x) / vx) * screen.width
+  const y = screen.y + ((viewBox.max.y - box.max.y) / vy) * screen.height
+  return {
+    x,
+    y,
+    width: ((box.max.x - box.min.x) / vx) * screen.width,
+    height: ((box.max.y - box.min.y) / vy) * screen.height
+  }
+}
+
+/**
+ * Inverse of {@link acTrWcsBoxToCssRect}: CSS rectangle → world box.
+ *
+ * @param rect - CSS rectangle inside `screen`.
+ * @param viewBox - World extents currently mapped onto `screen`.
+ * @param screen - CSS rectangle that displays `viewBox`.
+ * @returns Axis-aligned world box corresponding to `rect`.
+ */
+export function acTrCssRectToWcsBox(
+  rect: AcTrCssRect,
+  viewBox: { min: { x: number; y: number }; max: { x: number; y: number } },
+  screen: AcTrCssRect
+): { minX: number; minY: number; maxX: number; maxY: number } {
+  const vx = Math.max(viewBox.max.x - viewBox.min.x, Number.EPSILON)
+  const vy = Math.max(viewBox.max.y - viewBox.min.y, Number.EPSILON)
+  const minX = viewBox.min.x + ((rect.x - screen.x) / screen.width) * vx
+  const maxX =
+    viewBox.min.x + ((rect.x + rect.width - screen.x) / screen.width) * vx
+  const maxY = viewBox.max.y - ((rect.y - screen.y) / screen.height) * vy
+  const minY =
+    viewBox.max.y - ((rect.y + rect.height - screen.y) / screen.height) * vy
+  return { minX, minY, maxX, maxY }
+}

--- a/packages/three-renderer/src/viewport/AcTrOverlayViewport.ts
+++ b/packages/three-renderer/src/viewport/AcTrOverlayViewport.ts
@@ -1,0 +1,247 @@
+import { AcGeBox2d, AcGeVector2d } from '@mlightcad/data-model'
+import * as THREE from 'three'
+
+import { AcTrRenderer } from '../renderer/AcTrRenderer'
+import { AcTrCamera } from './AcTrCamera'
+import { type AcTrCssRect, acTrCssTopLeftRectToGl } from './AcTrCssRect'
+
+/**
+ * Screen-fixed overlay viewport: a CSS-pixel rectangle on the canvas that
+ * shows an independent orthographic view of a world-space box.
+ *
+ * Used for paper-space CAD viewports (after mapping paper WCS → screen) and
+ * for transient magnifiers. Unlike {@link AcTrViewportView}, the screen
+ * rectangle is not derived from a paper-space entity.
+ */
+export class AcTrOverlayViewport {
+  /** Shared WebGL renderer (same canvas as the main layout view). */
+  private readonly _renderer: AcTrRenderer
+  /** Orthographic camera fitted to {@link viewBox} inside {@link screenRect}. */
+  private readonly _camera: AcTrCamera
+  /** When false, {@link render} is a no-op. */
+  private _visible = false
+  /** On-canvas rectangle in CSS pixels (origin top-left). */
+  private _screenRect: AcTrCssRect = { x: 0, y: 0, width: 1, height: 1 }
+  /** World-space extents shown in {@link screenRect}. */
+  private readonly _viewBox = new AcGeBox2d()
+  /** CSS width used when fitting the camera to {@link viewBox}. */
+  private _width = 1
+  /** CSS height used when fitting the camera to {@link viewBox}. */
+  private _height = 1
+
+  /**
+   * Creates an overlay viewport that draws into `renderer`'s canvas.
+   *
+   * @param renderer - Shared WebGL renderer (same canvas as the main view).
+   */
+  constructor(renderer: AcTrRenderer) {
+    this._renderer = renderer
+    const camera = new THREE.OrthographicCamera(-0.5, 0.5, 0.5, -0.5, 0.1, 1000)
+    camera.position.set(0, 0, 500)
+    camera.up.set(0, 1, 0)
+    camera.updateProjectionMatrix()
+    this._camera = new AcTrCamera(camera)
+  }
+
+  /**
+   * Whether this overlay is drawn during the layout's overlay pass.
+   *
+   * When false, {@link render} is a no-op.
+   */
+  get visible() {
+    return this._visible
+  }
+  /**
+   * @param value - When false, {@link render} is a no-op.
+   */
+  set visible(value: boolean) {
+    this._visible = value
+  }
+
+  /**
+   * CSS rectangle of this overlay (origin at the top-left of the canvas).
+   */
+  get screenRect(): Readonly<AcTrCssRect> {
+    return this._screenRect
+  }
+
+  /**
+   * World-space box shown in {@link screenRect}.
+   */
+  get viewBox(): AcGeBox2d {
+    return this._viewBox
+  }
+
+  /**
+   * Sets the on-canvas rectangle in CSS pixels (origin top-left).
+   *
+   * @param x - Left edge in CSS pixels.
+   * @param y - Top edge in CSS pixels.
+   * @param width - Width in CSS pixels.
+   * @param height - Height in CSS pixels.
+   */
+  setScreenRect(x: number, y: number, width: number, height: number) {
+    this._screenRect = { x, y, width, height }
+    this._width = Math.max(width, 1)
+    this._height = Math.max(height, 1)
+    this.applyViewBox()
+  }
+
+  /**
+   * Sets the world-space extents shown in the screen rectangle.
+   *
+   * @param box - World box mapped onto {@link screenRect}.
+   */
+  setViewBox(box: AcGeBox2d) {
+    this._viewBox.min.copy(box.min)
+    this._viewBox.max.copy(box.max)
+    this.applyViewBox()
+  }
+
+  /**
+   * Renders `scene` into {@link screenRect}, clearing that region first so
+   * the overlay replaces the main view's pixels.
+   *
+   * @param scene - Scene graph to draw (typically the active layout).
+   * @param canvasCssHeight - Canvas CSS height used to convert top-left → GL.
+   */
+  render(scene: THREE.Object3D, canvasCssHeight: number) {
+    if (!this._visible || this._viewBox.isEmpty()) return
+    if (this._screenRect.width < 1 || this._screenRect.height < 1) return
+    this.renderRect(scene, this._screenRect, this._screenRect, canvasCssHeight, {
+      clearColor: true
+    })
+  }
+
+  /**
+   * Draws `scene` with a camera fitted to `viewBox` filling `viewportRect`,
+   * clipped to `scissorRect`. Does not clear color (for nested paper-space
+   * model passes). Restores the overlay's own {@link viewBox} camera afterward.
+   *
+   * @param scene - Geometry to draw.
+   * @param viewBox - World box mapped onto `viewportRect`.
+   * @param viewportRect - CSS rectangle the view box fills.
+   * @param scissorRect - CSS clip rectangle (usually intersection with loupe).
+   * @param canvasCssHeight - Canvas CSS height.
+   * @param twist - Optional DVIEW twist in radians (camera up / rotation).
+   */
+  renderNested(
+    scene: THREE.Object3D,
+    viewBox: AcGeBox2d,
+    viewportRect: AcTrCssRect,
+    scissorRect: AcTrCssRect,
+    canvasCssHeight: number,
+    twist?: number
+  ) {
+    if (scissorRect.width < 1 || scissorRect.height < 1) return
+    this.fitCamera(viewBox, viewportRect.width, viewportRect.height, twist)
+    this.renderRect(scene, viewportRect, scissorRect, canvasCssHeight, {
+      clearColor: false
+    })
+    this.applyViewBox()
+  }
+
+  /**
+   * Refits the overlay camera to the stored {@link viewBox} and screen size.
+   */
+  private applyViewBox() {
+    if (this._viewBox.isEmpty()) return
+    this.fitCamera(this._viewBox, this._width, this._height)
+  }
+
+  /**
+   * Fits the orthographic camera so `box` fills a CSS rectangle of
+   * `width` × `height`.
+   *
+   * @param box - World extents to show.
+   * @param width - Target CSS width in pixels.
+   * @param height - Target CSS height in pixels.
+   * @param twist - Optional DVIEW twist in radians.
+   */
+  private fitCamera(
+    box: AcGeBox2d,
+    width: number,
+    height: number,
+    twist?: number
+  ) {
+    const size = new AcGeVector2d()
+    box.getSize(size)
+    const center = new AcGeVector2d()
+    box.getCenter(center)
+
+    const frustum = Math.max(height, 1) / 2
+    const aspect = Math.max(width, 1) / Math.max(height, 1)
+    const fitWidth = Math.max(Math.abs(size.x), Number.EPSILON)
+    const fitHeight = Math.max(Math.abs(size.y), Number.EPSILON)
+    const zoom = Math.min(
+      (2 * aspect * frustum) / fitWidth,
+      (2 * frustum) / fitHeight
+    )
+
+    const camera = this._camera.internalCamera
+    camera.left = -aspect * frustum
+    camera.right = aspect * frustum
+    camera.top = frustum
+    camera.bottom = -frustum
+    camera.position.set(center.x, center.y, camera.position.z)
+    camera.lookAt(center.x, center.y, 0)
+    const angle = Number.isFinite(twist) ? (twist as number) : 0
+    camera.up.set(-Math.sin(angle), Math.cos(angle), 0)
+    camera.setRotationFromEuler(new THREE.Euler(0, 0, angle))
+    camera.zoom = zoom
+    camera.updateProjectionMatrix()
+  }
+
+  /**
+   * Issues one scissor/viewport pass: optionally clear, then draw `scene`.
+   *
+   * @param scene - Geometry to draw.
+   * @param viewportRect - CSS rectangle mapped to the camera frustum.
+   * @param scissorRect - CSS clip rectangle.
+   * @param canvasCssHeight - Canvas CSS height for GL conversion.
+   * @param options.clearColor - When true, clear color+depth in the scissor;
+   *   otherwise only depth is cleared.
+   */
+  private renderRect(
+    scene: THREE.Object3D,
+    viewportRect: AcTrCssRect,
+    scissorRect: AcTrCssRect,
+    canvasCssHeight: number,
+    options: { clearColor: boolean }
+  ) {
+    const glViewport = acTrCssTopLeftRectToGl(viewportRect, canvasCssHeight)
+    const glScissor = acTrCssTopLeftRectToGl(scissorRect, canvasCssHeight)
+    const autoClear = this._renderer.autoClear
+    this._renderer.autoClear = false
+    const oldViewport = new THREE.Vector4()
+    this._renderer.getViewport(oldViewport)
+
+    this._renderer.setScissor(
+      glScissor.x,
+      glScissor.y,
+      glScissor.width,
+      glScissor.height
+    )
+    this._renderer.setScissorTest(true)
+    this._renderer.setViewport(
+      glViewport.x,
+      glViewport.y,
+      glViewport.width,
+      glViewport.height
+    )
+    if (options.clearColor) {
+      this._renderer.clear()
+    } else {
+      this._renderer.clearDepth()
+    }
+    this._renderer.render(scene, this._camera)
+    this._renderer.setScissorTest(false)
+    this._renderer.setViewport(
+      oldViewport.x,
+      oldViewport.y,
+      oldViewport.z,
+      oldViewport.w
+    )
+    this._renderer.autoClear = autoClear
+  }
+}

--- a/packages/three-renderer/src/viewport/AcTrViewportView.ts
+++ b/packages/three-renderer/src/viewport/AcTrViewportView.ts
@@ -282,15 +282,10 @@ export class AcTrViewportView extends AcTrBaseView {
 
       const y = this._parentView.height - viewportWindowBox.min.y - vpH
       this._renderer.setViewport(viewportWindowBox.min.x, y, vpW, vpH)
-      this._renderer.internalRenderer.setScissor(
-        viewportWindowBox.min.x,
-        y,
-        vpW,
-        vpH
-      )
-      this._renderer.internalRenderer.setScissorTest(true)
+      this._renderer.setScissor(viewportWindowBox.min.x, y, vpW, vpH)
+      this._renderer.setScissorTest(true)
       this._renderer.render(scene, this._camera)
-      this._renderer.internalRenderer.setScissorTest(false)
+      this._renderer.setScissorTest(false)
     }
   }
 }

--- a/packages/three-renderer/src/viewport/index.ts
+++ b/packages/three-renderer/src/viewport/index.ts
@@ -1,3 +1,5 @@
 export * from './AcTrBaseView'
 export * from './AcTrCamera'
+export * from './AcTrCssRect'
+export * from './AcTrOverlayViewport'
 export * from './AcTrViewportView'


### PR DESCRIPTION
## Summary
- Adds a screen-fixed magnified overlay (snap loupe) that opens after a long-press while picking measure, markup, or drawing points on touch, so object snaps are easier to hit under a finger.
- Draws nested paper-space viewports inside the loupe so model content stays visible, and uses the same overlay path in both the live viewer and exported HTML runtime.
- Hardens the touch pick lifecycle: capture the pointer, end the gesture on `window` pointerup/cancel, and swallow the following synthetic click so a pan or off-canvas release cannot place a stray point.

## Test plan
- [ ] On a phone or touch emulator, start a measure/draw command and short-tap to place a point (loupe should not appear).
- [ ] Long-press until the loupe appears, drag onto an object snap, and release to commit at the snapped point.
- [ ] In paper space with viewports, confirm model geometry shows inside the loupe overlap.
- [ ] Start a pick, move past the pan threshold before the timer, and confirm no point is placed.
- [ ] Long-press, drag off the canvas, and release: navigation should re-enable and the loupe should hide.
- [ ] Export HTML and repeat the long-press loupe flow in the offline viewer.
