### PR TITLE
feat: disable dynamic input on phone and pad UIs

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcEdDynamicInput.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdDynamicInput.spec.ts
@@ -1,0 +1,154 @@
+import {
+  AcDbDatabase,
+  AcDbSystemVariables,
+  AcDbSysVarManager
+} from '@mlightcad/data-model'
+
+import {
+  ML_UI_COARSE_POINTER_MEDIA_QUERY,
+  ML_UI_COMPACT_MEDIA_QUERY,
+  ML_UI_MOBILE_MEDIA_QUERY
+} from '../src/editor/global/AcEdUiLayout'
+import { acedIsDynamicInputEnabled } from '../src/editor/input/AcEdDynamicInput'
+
+const DESKTOP_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0'
+const IPAD_UA =
+  'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15'
+
+function installEnvironment(options: {
+  media?: (query: string) => boolean
+  userAgent?: string
+  platform?: string
+  maxTouchPoints?: number
+}) {
+  const previousWindow = (globalThis as { window?: Window }).window
+  const previousNavigator = (globalThis as { navigator?: Navigator }).navigator
+  const media = options.media ?? (() => false)
+  const navigatorStub = {
+    userAgent: options.userAgent ?? DESKTOP_UA,
+    platform: options.platform ?? 'Win32',
+    maxTouchPoints: options.maxTouchPoints ?? 0
+  }
+  const windowStub = {
+    matchMedia: (query: string) => ({
+      matches: media(query),
+      media: query,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined
+    }),
+    navigator: navigatorStub
+  }
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: windowStub
+  })
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    writable: true,
+    value: navigatorStub
+  })
+
+  return {
+    restore() {
+      if (previousWindow === undefined) {
+        delete (globalThis as { window?: Window }).window
+      } else {
+        Object.defineProperty(globalThis, 'window', {
+          configurable: true,
+          writable: true,
+          value: previousWindow
+        })
+      }
+      if (previousNavigator === undefined) {
+        delete (globalThis as { navigator?: Navigator }).navigator
+      } else {
+        Object.defineProperty(globalThis, 'navigator', {
+          configurable: true,
+          writable: true,
+          value: previousNavigator
+        })
+      }
+    }
+  }
+}
+
+describe('acedIsDynamicInputEnabled', () => {
+  let database: AcDbDatabase
+
+  beforeEach(() => {
+    database = new AcDbDatabase()
+  })
+
+  it('follows DYNMODE on desktop layouts', () => {
+    const env = installEnvironment({})
+    try {
+      AcDbSysVarManager.instance().setVar(
+        AcDbSystemVariables.DYNMODE,
+        3,
+        database
+      )
+      expect(acedIsDynamicInputEnabled(database)).toBe(true)
+
+      AcDbSysVarManager.instance().setVar(
+        AcDbSystemVariables.DYNMODE,
+        0,
+        database
+      )
+      expect(acedIsDynamicInputEnabled(database)).toBe(false)
+    } finally {
+      env.restore()
+    }
+  })
+
+  it('stays disabled on phone layout even when DYNMODE is enabled', () => {
+    const env = installEnvironment({
+      media: query => query === ML_UI_MOBILE_MEDIA_QUERY
+    })
+    try {
+      AcDbSysVarManager.instance().setVar(
+        AcDbSystemVariables.DYNMODE,
+        3,
+        database
+      )
+      expect(acedIsDynamicInputEnabled(database)).toBe(false)
+    } finally {
+      env.restore()
+    }
+  })
+
+  it('stays disabled on pad layout even when DYNMODE is enabled', () => {
+    const env = installEnvironment({
+      media: query => query === ML_UI_COMPACT_MEDIA_QUERY
+    })
+    try {
+      AcDbSysVarManager.instance().setVar(
+        AcDbSystemVariables.DYNMODE,
+        3,
+        database
+      )
+      expect(acedIsDynamicInputEnabled(database)).toBe(false)
+    } finally {
+      env.restore()
+    }
+  })
+
+  it('stays disabled on wide handheld devices even when DYNMODE is enabled', () => {
+    const env = installEnvironment({
+      media: query => query === ML_UI_COARSE_POINTER_MEDIA_QUERY,
+      userAgent: IPAD_UA
+    })
+    try {
+      AcDbSysVarManager.instance().setVar(
+        AcDbSystemVariables.DYNMODE,
+        3,
+        database
+      )
+      expect(acedIsDynamicInputEnabled(database)).toBe(false)
+    } finally {
+      env.restore()
+    }
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcEdUiLayout.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdUiLayout.spec.ts
@@ -147,4 +147,16 @@ describe('AcEdUiLayout', () => {
 
     media.restore()
   })
+
+  it('does not treat any-pointer coarse (touch laptop) as handheld', () => {
+    const media = installMatchMedia(
+      query => query === '(any-pointer: coarse)'
+    )
+
+    expect(acedGetUiLayout()).toBe('desktop')
+    expect(acedIsHandheldDevice()).toBe(false)
+    expect(acedIsMobileOrPadUi()).toBe(false)
+
+    media.restore()
+  })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdUiLayout.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdUiLayout.spec.ts
@@ -3,8 +3,11 @@
 import {
   acedGetUiLayout,
   acedIsCompactUiLayout,
+  acedIsHandheldDevice,
+  acedIsMobileOrPadUi,
   acedIsMobileUiLayout,
   acedSubscribeUiLayout,
+  ML_UI_COARSE_POINTER_MEDIA_QUERY,
   ML_UI_COMPACT_MAX_WIDTH,
   ML_UI_COMPACT_MEDIA_QUERY,
   ML_UI_MOBILE_MAX_WIDTH,
@@ -119,6 +122,29 @@ describe('AcEdUiLayout', () => {
     expect(listener).toHaveBeenCalledWith('desktop')
 
     unsubscribe()
+    media.restore()
+  })
+
+  it('treats pad viewport as mobile-or-pad UI', () => {
+    const media = installMatchMedia(
+      query => query === ML_UI_COMPACT_MEDIA_QUERY
+    )
+
+    expect(acedGetUiLayout()).toBe('pad')
+    expect(acedIsMobileOrPadUi()).toBe(true)
+
+    media.restore()
+  })
+
+  it('treats coarse pointer as a handheld device at desktop width', () => {
+    const media = installMatchMedia(
+      query => query === ML_UI_COARSE_POINTER_MEDIA_QUERY
+    )
+
+    expect(acedGetUiLayout()).toBe('desktop')
+    expect(acedIsHandheldDevice()).toBe(true)
+    expect(acedIsMobileOrPadUi()).toBe(true)
+
     media.restore()
   })
 })

--- a/packages/cad-simple-viewer/src/editor/global/AcEdUiLayout.ts
+++ b/packages/cad-simple-viewer/src/editor/global/AcEdUiLayout.ts
@@ -26,7 +26,12 @@ export function acedIsCompactUiLayout(): boolean {
   return window.matchMedia?.(ML_UI_COMPACT_MEDIA_QUERY).matches ?? false
 }
 
-/** Media query matching a coarse primary pointer (typical phones and pads). */
+/**
+ * Media query matching a coarse *primary* pointer (typical phones and pads).
+ *
+ * Uses `pointer`, not `any-pointer`, so a mouse-first laptop with a touch
+ * screen (`pointer: fine` + `any-pointer: coarse`) stays desktop.
+ */
 export const ML_UI_COARSE_POINTER_MEDIA_QUERY = '(pointer: coarse)'
 
 const MOBILE_OR_PAD_UA =
@@ -37,6 +42,8 @@ const MOBILE_OR_PAD_UA =
  *
  * Covers landscape / wide tablets that exceed {@link ML_UI_COMPACT_MAX_WIDTH},
  * including iPadOS which reports as Macintosh with a touch screen.
+ * Coarse-pointer detection uses the primary pointer only; see
+ * {@link ML_UI_COARSE_POINTER_MEDIA_QUERY}.
  */
 export function acedIsHandheldDevice(): boolean {
   if (typeof navigator === 'undefined') return false

--- a/packages/cad-simple-viewer/src/editor/global/AcEdUiLayout.ts
+++ b/packages/cad-simple-viewer/src/editor/global/AcEdUiLayout.ts
@@ -26,6 +26,26 @@ export function acedIsCompactUiLayout(): boolean {
   return window.matchMedia?.(ML_UI_COMPACT_MEDIA_QUERY).matches ?? false
 }
 
+/** Media query matching a coarse primary pointer (typical phones and pads). */
+export const ML_UI_COARSE_POINTER_MEDIA_QUERY = '(pointer: coarse)'
+
+const MOBILE_OR_PAD_UA =
+  /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
+
+/**
+ * Whether the browser looks like a phone or pad, independent of viewport width.
+ *
+ * Covers landscape / wide tablets that exceed {@link ML_UI_COMPACT_MAX_WIDTH},
+ * including iPadOS which reports as Macintosh with a touch screen.
+ */
+export function acedIsHandheldDevice(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const nav = navigator as Navigator & { msMaxTouchPoints?: number }
+  if (MOBILE_OR_PAD_UA.test(nav.userAgent || '')) return true
+  if (nav.platform === 'MacIntel' && (nav.maxTouchPoints ?? 0) > 1) return true
+  return window.matchMedia?.(ML_UI_COARSE_POINTER_MEDIA_QUERY).matches ?? false
+}
+
 /**
  * Coarse UI layout kind derived from viewport width.
  *
@@ -44,6 +64,14 @@ export function acedGetUiLayout(): AcEdUiLayoutKind {
   if (acedIsMobileUiLayout()) return 'phone'
   if (acedIsCompactUiLayout()) return 'pad'
   return 'desktop'
+}
+
+/**
+ * Whether the UI should behave as phone or pad: compact viewport, or a
+ * handheld / touch device at any width (including landscape).
+ */
+export function acedIsMobileOrPadUi(): boolean {
+  return acedGetUiLayout() !== 'desktop' || acedIsHandheldDevice()
 }
 
 /**

--- a/packages/cad-simple-viewer/src/editor/input/AcEdDynamicInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdDynamicInput.ts
@@ -1,0 +1,28 @@
+import {
+  AcDbDatabase,
+  acdbHostApplicationServices,
+  AcDbSystemVariables,
+  AcDbSysVarManager
+} from '@mlightcad/data-model'
+
+import { acedIsMobileOrPadUi } from '../global/AcEdUiLayout'
+
+/**
+ * Returns whether cursor dynamic input should be active.
+ *
+ * Phone and pad UIs always return `false`: floating input next to the cursor is
+ * not usable on touch devices, regardless of **DYNMODE**. This includes
+ * landscape / wide tablets, not only the phone breakpoint.
+ *
+ * @param database - Drawing whose **DYNMODE** value is read. Defaults to the
+ *   current working database.
+ * @returns `true` when **DYNMODE** is non-zero and the UI is not phone or pad.
+ */
+export function acedIsDynamicInputEnabled(database?: AcDbDatabase): boolean {
+  if (acedIsMobileOrPadUi()) return false
+  const db = database ?? acdbHostApplicationServices().workingDatabase
+  const mode = Number(
+    AcDbSysVarManager.instance().getVar(AcDbSystemVariables.DYNMODE, db)
+  )
+  return mode !== 0
+}

--- a/packages/cad-simple-viewer/src/editor/input/index.ts
+++ b/packages/cad-simple-viewer/src/editor/input/index.ts
@@ -1,4 +1,5 @@
 export * from './AcEdCursorManager'
+export * from './AcEdDynamicInput'
 export * from './AcEdInputModifiers'
 export * from './AcEdInputToggles'
 export * from './AcEdOrthoMode'

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputTypes.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputTypes.ts
@@ -122,7 +122,8 @@ export interface AcEdFloatingInputOptions<T> {
 
   /**
    * Whether the prompt label is allowed to be shown at all.
-   * Actual visibility is still controlled by DYNMODE/DYNPROMPT.
+   * Actual visibility is still controlled by DYNMODE/DYNPROMPT, and is always
+   * off on phone and pad UIs.
    */
   allowPrompt?: boolean
 

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingMessage.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingMessage.ts
@@ -6,6 +6,7 @@ import {
 } from '@mlightcad/data-model'
 
 import { AcEdBaseView } from '../../view'
+import { acedIsDynamicInputEnabled } from '../AcEdDynamicInput'
 
 /**
  * AcEdFloatingMessage
@@ -314,8 +315,7 @@ export class AcEdFloatingMessage {
   }
 
   protected isDynamicInputEnabled() {
-    const mode = this.getSysVarValue(AcDbSystemVariables.DYNMODE) as number
-    return mode !== 0
+    return acedIsDynamicInputEnabled()
   }
 
   protected isDynamicPromptEnabled() {

--- a/packages/cad-viewer/src/component/statusBar/MlStatusBar.vue
+++ b/packages/cad-viewer/src/component/statusBar/MlStatusBar.vue
@@ -50,6 +50,7 @@
           off-color="var(--el-text-color-regular)"
         />
         <ml-sys-var-toggle-button
+          v-if="!isMobileOrPad"
           :sys-var-name="AcDbSystemVariables.DYNMODE"
           :on-icon="dynamicInput"
           :off-icon="dynamicInput"
@@ -98,7 +99,7 @@ const props = defineProps<{
 const { text: posText } = useCurrentPos(AcApDocManager.instance.curView)
 const features = useSettings()
 const { isDocumentOpening } = useDocument()
-const { isMobile } = useIsMobile()
+const { isMobile, isMobileOrPad } = useIsMobile()
 const { t } = useI18n()
 const isStatusBarDisabled = computed(() => isDocumentOpening.value)
 

--- a/packages/cad-viewer/src/composable/useIsMobile.ts
+++ b/packages/cad-viewer/src/composable/useIsMobile.ts
@@ -1,4 +1,5 @@
 import {
+  acedIsMobileOrPadUi,
   ML_UI_COARSE_POINTER_MEDIA_QUERY,
   ML_UI_COMPACT_MEDIA_QUERY,
   ML_UI_MOBILE_MEDIA_QUERY
@@ -14,7 +15,6 @@ export function useIsMobile() {
 
   const hasTouchCapability = ref(false)
   const isMobileUserAgent = ref(false)
-  const isIpadOs = ref(false)
 
   onMounted(() => {
     try {
@@ -30,12 +30,9 @@ export function useIsMobile() {
         /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
           ua
         )
-      isIpadOs.value =
-        nav.platform === 'MacIntel' && (nav.maxTouchPoints ?? 0) > 1
     } catch {
       hasTouchCapability.value = false
       isMobileUserAgent.value = false
-      isIpadOs.value = false
     }
   })
 
@@ -48,12 +45,10 @@ export function useIsMobile() {
   })
 
   const isMobileOrPad = computed(() => {
-    return (
-      !!isCompactViewport.value ||
-      isMobileUserAgent.value ||
-      isIpadOs.value ||
-      !!isCoarsePointer.value
-    )
+    // Depend on these so resize / primary-pointer changes re-run the shared check.
+    void isCompactViewport.value
+    void isCoarsePointer.value
+    return acedIsMobileOrPadUi()
   })
 
   return { isMobile, isMobileOrPad, isSmallViewport }

--- a/packages/cad-viewer/src/composable/useIsMobile.ts
+++ b/packages/cad-viewer/src/composable/useIsMobile.ts
@@ -1,20 +1,27 @@
-import { ML_UI_MOBILE_MEDIA_QUERY } from '@mlightcad/cad-simple-viewer'
+import {
+  ML_UI_COARSE_POINTER_MEDIA_QUERY,
+  ML_UI_COMPACT_MEDIA_QUERY,
+  ML_UI_MOBILE_MEDIA_QUERY
+} from '@mlightcad/cad-simple-viewer'
 import { useMediaQuery } from '@vueuse/core'
 import { computed, onMounted, ref } from 'vue'
 
 // Heuristic mobile detection combining viewport, touch capability, and user agent
 export function useIsMobile() {
   const isSmallViewport = useMediaQuery(ML_UI_MOBILE_MEDIA_QUERY)
+  const isCompactViewport = useMediaQuery(ML_UI_COMPACT_MEDIA_QUERY)
+  const isCoarsePointer = useMediaQuery(ML_UI_COARSE_POINTER_MEDIA_QUERY)
 
   const hasTouchCapability = ref(false)
   const isMobileUserAgent = ref(false)
+  const isIpadOs = ref(false)
 
   onMounted(() => {
     try {
       const nav = window.navigator as Navigator & { msMaxTouchPoints?: number }
       const maxTouchPoints = nav.maxTouchPoints ?? nav.msMaxTouchPoints ?? 0
       const coarsePointer =
-        window.matchMedia?.('(pointer: coarse)').matches ?? false
+        window.matchMedia?.(ML_UI_COARSE_POINTER_MEDIA_QUERY).matches ?? false
       hasTouchCapability.value =
         maxTouchPoints > 0 || coarsePointer || 'ontouchstart' in window
 
@@ -23,9 +30,12 @@ export function useIsMobile() {
         /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
           ua
         )
+      isIpadOs.value =
+        nav.platform === 'MacIntel' && (nav.maxTouchPoints ?? 0) > 1
     } catch {
       hasTouchCapability.value = false
       isMobileUserAgent.value = false
+      isIpadOs.value = false
     }
   })
 
@@ -37,5 +47,14 @@ export function useIsMobile() {
     )
   })
 
-  return { isMobile }
+  const isMobileOrPad = computed(() => {
+    return (
+      !!isCompactViewport.value ||
+      isMobileUserAgent.value ||
+      isIpadOs.value ||
+      !!isCoarsePointer.value
+    )
+  })
+
+  return { isMobile, isMobileOrPad, isSmallViewport }
 }


### PR DESCRIPTION
## Summary
- Force cursor dynamic input off on phone, pad, and handheld/touch devices (including landscape tablets and iPadOS), regardless of **DYNMODE**.
- Hide the status-bar DYNMODE toggle on those UIs so users cannot turn on an input mode that cannot be used.
- Add `acedIsHandheldDevice` / `acedIsMobileOrPadUi` and `acedIsDynamicInputEnabled`, with unit tests for layout and DYNMODE gating.

## Test plan
- [ ] Desktop: DYNMODE still follows the status-bar toggle; floating input/prompt appear when enabled.
- [ ] Phone viewport (≤600px): floating input stays off even if DYNMODE is already 3; status-bar DYNMODE button is hidden.
- [ ] Pad viewport (≤960px): same as phone.
- [ ] Landscape / wide tablet (or iPad with desktop-width viewport): dynamic input stays off; status-bar DYNMODE button is hidden.
- [ ] Desktop with a mouse (`pointer: fine`): DYNMODE toggle remains visible and works.
