### PR TITLE
feat: default overlay strokes to hairline and keep measure decorations in world space

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 
 import {
+  ACEX_OVERLAY_ARROW_WCS,
   ACEX_OVERLAY_BASE_ZOOM,
   ACEX_OVERLAY_CLOUD_WCS,
   ACEX_OVERLAY_STROKE_WCS,
@@ -10,6 +11,7 @@ import {
   acExPositionWcsOverlay,
   acExResetOverlayViewScale,
   acExScaledCanvasLineWidth,
+  acExScaledOverlayArrowSize,
   acExSeedOverlaySizesFromWcs
 } from '../src/AcExHtmlOverlayDom'
 
@@ -77,6 +79,38 @@ describe('AcExHtmlOverlayDom', () => {
       })
     })
     expect(width2).toBe(5)
+  })
+
+  it('uses a 1px hairline and clears stored WCS when base width is 0', () => {
+    const canvas = document.createElement('canvas')
+    canvas.dataset[ACEX_OVERLAY_STROKE_WCS] = '0.4'
+    const wcsToScreen = (wcs: { x: number; y: number }) => ({
+      x: wcs.x * 10,
+      y: wcs.y * 10
+    })
+
+    expect(
+      acExScaledCanvasLineWidth(0, canvas, 1, {
+        strokeWidthWcs: 0.4,
+        wcsToScreen
+      })
+    ).toBe(1)
+    expect(canvas.dataset[ACEX_OVERLAY_STROKE_WCS]).toBeUndefined()
+  })
+
+  it('clears stored stroke WCS when seeding a hairline overlay', () => {
+    const canvas = document.createElement('canvas')
+    canvas.dataset[ACEX_OVERLAY_STROKE_WCS] = '0.4'
+    const wcsToScreen = (wcs: { x: number; y: number }) => ({
+      x: wcs.x * 10,
+      y: wcs.y * 10
+    })
+
+    acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
+      strokeScreenPx: 0,
+      canvases: [canvas]
+    })
+    expect(canvas.dataset[ACEX_OVERLAY_STROKE_WCS]).toBeUndefined()
   })
 
   it('honors re-seeded stroke WCS when explicit width is omitted', () => {
@@ -160,5 +194,20 @@ describe('AcExHtmlOverlayDom', () => {
     })
     expect(grip.dataset[ACEX_OVERLAY_BASE_ZOOM]).toBe('2')
     expect(badge.dataset[ACEX_OVERLAY_BASE_ZOOM]).toBe('2')
+  })
+
+  it('scales distance arrows in WCS independently of hairline stroke', () => {
+    const canvas = document.createElement('canvas')
+    const at10 = (wcs: { x: number; y: number }) => ({
+      x: wcs.x * 10,
+      y: wcs.y * 10
+    })
+    const at5 = (wcs: { x: number; y: number }) => ({
+      x: wcs.x * 5,
+      y: wcs.y * 5
+    })
+    expect(acExScaledOverlayArrowSize(canvas, at10)).toBe(12)
+    expect(Number(canvas.dataset[ACEX_OVERLAY_ARROW_WCS])).toBeCloseTo(1.2)
+    expect(acExScaledOverlayArrowSize(canvas, at5)).toBeCloseTo(6)
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
@@ -13,6 +13,15 @@ describe('ACEX_HTML_SHELL_CSS', () => {
     )
   })
 
+  it('centers the phone sheet grabber on the full sheet width', () => {
+    expect(ACEX_HTML_SHELL_CSS).toContain(
+      '.mlcad-drawer-sheet-chrome {\n    display: none;\n    position: relative;'
+    )
+    expect(ACEX_HTML_SHELL_CSS).toContain('.mlcad-drawer-grabber::before {')
+    expect(ACEX_HTML_SHELL_CSS).toContain('left: 50%;')
+    expect(ACEX_HTML_SHELL_CSS).toContain('transform: translate(-50%, -50%);')
+  })
+
   it('uses a narrower portrait slot for sub-toolbar buttons', () => {
     expect(ACEX_HTML_SHELL_CSS).toContain('--mlcad-subtoolbar-btn-width: 28px')
     expect(ACEX_HTML_SHELL_CSS).toContain(

--- a/packages/cad-html-plugin/__tests__/AcExMarkupGeometry.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMarkupGeometry.spec.ts
@@ -147,4 +147,8 @@ describe('acExOverlayArrowSize', () => {
     expect(acExOverlayArrowSize(2, 2)).toBe(12)
     expect(acExOverlayArrowSize(4, 2)).toBe(24)
   })
+
+  it('keeps a 12px arrow for hairline strokes', () => {
+    expect(acExOverlayArrowSize(1, 0)).toBe(12)
+  })
 })

--- a/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
@@ -89,6 +89,24 @@ describe('AcExMeasurementSidecar', () => {
     expect(parsed.measurements[0]?.style.strokeWidthWcs).toBe(0.1)
   })
 
+  it('keeps hairline line weight 0 in sidecar styles', () => {
+    const parsed = parseAcExMeasurementSidecar(
+      JSON.stringify({
+        version: 1,
+        measurements: [
+          {
+            id: 'hairline',
+            type: 'point',
+            style: { color: '#08e8de', lineWeight: 0, fontSize: 13 },
+            geometry: { type: 'point', position: { x: 1, y: 2 } }
+          }
+        ]
+      })
+    )
+    expect(parsed.measurements[0]?.style.lineWeight).toBe(0)
+    expect(parsed.measurements[0]?.style.strokeWidthWcs).toBeUndefined()
+  })
+
   it('rejects invalid payloads', () => {
     expect(() => parseAcExMeasurementSidecar('not-json')).toThrow(/not JSON/)
     expect(() =>

--- a/packages/cad-html-plugin/src/AcExDrawStyleToolbar.ts
+++ b/packages/cad-html-plugin/src/AcExDrawStyleToolbar.ts
@@ -309,16 +309,18 @@ function aciIndexOf(color: AcCmColor): number | undefined {
 }
 
 function numericLineWeights(): number[] {
-  return Array.from(
+  const weights = Array.from(
     new Set(
       Object.values(AcGiLineWeight).filter(
         (value): value is number => typeof value === 'number' && value > 0
       )
     )
   ).sort((a, b) => a - b)
+  return [0, ...weights]
 }
 
-function formatLineWeight(value: number): string {
+function formatLineWeight(value: number, hairlineLabel: string): string {
+  if (!(value > 0)) return hairlineLabel
   return `${(value / 100).toFixed(2)} mm`
 }
 
@@ -330,6 +332,7 @@ interface AcExLineWeightPicker {
   root: HTMLDivElement
   setValue: (weight: number) => void
   setTitle: (title: string) => void
+  refreshLabels: () => void
   close: () => void
   isOpen: () => boolean
   contains: (node: Node | null) => boolean
@@ -337,11 +340,13 @@ interface AcExLineWeightPicker {
 
 function createLineWeightPicker(
   onChange: (weight: number) => void,
-  onOpen: () => void
+  onOpen: () => void,
+  hairlineLabel: () => string
 ): AcExLineWeightPicker {
   const prefix = 'mlcad-draw-style-toolbar'
   const weights = numericLineWeights()
   let open = false
+  let currentWeight = weights[0] ?? 0
 
   const root = document.createElement('div')
   root.className = `${prefix}__lineweight`
@@ -369,11 +374,12 @@ function createLineWeightPicker(
   menu.setAttribute('role', 'listbox')
 
   const paintTrigger = (weight: number) => {
+    currentWeight = weight
     preview.style.setProperty(
       '--ml-lineweight-height',
-      `${previewLineHeightPx(weight)}px`
+      `${previewLineHeightPx(weight > 0 ? weight : 1)}px`
     )
-    label.textContent = formatLineWeight(weight)
+    label.textContent = formatLineWeight(weight, hairlineLabel())
   }
 
   const markSelected = (weight: number) => {
@@ -407,12 +413,12 @@ function createLineWeightPicker(
     itemPreview.className = `${prefix}__lineweight-preview`
     itemPreview.style.setProperty(
       '--ml-lineweight-height',
-      `${previewLineHeightPx(weight)}px`
+      `${previewLineHeightPx(weight > 0 ? weight : 1)}px`
     )
 
     const itemLabel = document.createElement('span')
     itemLabel.className = `${prefix}__lineweight-text`
-    itemLabel.textContent = formatLineWeight(weight)
+    itemLabel.textContent = formatLineWeight(weight, hairlineLabel())
 
     item.append(itemPreview, itemLabel)
     item.addEventListener('click', event => {
@@ -436,19 +442,28 @@ function createLineWeightPicker(
   })
 
   root.append(trigger, menu)
-  paintTrigger(weights[0] ?? 25)
-  markSelected(weights[0] ?? 25)
+  paintTrigger(currentWeight)
+  markSelected(currentWeight)
 
   return {
     root,
     setValue: weight => {
-      if (!(weight > 0)) return
+      if (!Number.isFinite(weight) || weight < 0) return
       if (!menu.querySelector(`[data-value="${weight}"]`)) addItem(weight)
       paintTrigger(weight)
       markSelected(weight)
     },
     setTitle: title => {
       trigger.title = title
+    },
+    refreshLabels: () => {
+      menu.querySelectorAll(`.${prefix}__lineweight-item`).forEach(node => {
+        const item = node as HTMLElement
+        const weight = Number(item.dataset.value)
+        const text = item.querySelector(`.${prefix}__lineweight-text`)
+        if (text) text.textContent = formatLineWeight(weight, hairlineLabel())
+      })
+      paintTrigger(currentWeight)
     },
     close,
     isOpen: () => open,
@@ -614,7 +629,7 @@ export function setupAcExDrawStyleToolbar(
   }
 
   const applyLineWeight = (weight: number) => {
-    if (!currentKind || !(weight > 0)) return
+    if (!currentKind || !Number.isFinite(weight) || weight < 0) return
     ctx.applyStyle(currentKind, { lineWeight: weight })
   }
 
@@ -626,6 +641,7 @@ export function setupAcExDrawStyleToolbar(
   const relabel = () => {
     swatch.title = ctx.i18n.t('drawStyle.color')
     lineWeightUi.picker?.setTitle(ctx.i18n.t('drawStyle.lineWeight'))
+    lineWeightUi.picker?.refreshLabels()
     fontSizeSelect.title = ctx.i18n.t('drawStyle.fontSize')
   }
 
@@ -650,7 +666,11 @@ export function setupAcExDrawStyleToolbar(
   })
   colorWrap.addEventListener('mouseenter', () => clearColorLeaveTimer())
   colorWrap.addEventListener('mouseleave', () => scheduleHideColorPanel())
-  lineWeightUi.picker = createLineWeightPicker(applyLineWeight, hideColorPanel)
+  lineWeightUi.picker = createLineWeightPicker(
+    applyLineWeight,
+    hideColorPanel,
+    () => ctx.i18n.t('drawStyle.lineWeightHairline')
+  )
   root.insertBefore(lineWeightUi.picker.root, fontSizeSelect)
   fontSizeSelect.addEventListener('change', () => {
     applyFontSize(Number(fontSizeSelect.value))

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -81,6 +81,7 @@ export type AcExHtmlMessageKey =
   | 'settings.polarAngles'
   | 'drawStyle.color'
   | 'drawStyle.lineWeight'
+  | 'drawStyle.lineWeightHairline'
   | 'drawStyle.fontSize'
   | 'layers.title'
   | 'layers.close'
@@ -242,6 +243,7 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
     drawStyle: {
       color: 'Color',
       lineWeight: 'Lineweight',
+      lineWeightHairline: 'Hairline',
       fontSize: 'Text height'
     },
     layers: {
@@ -417,6 +419,7 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
     drawStyle: {
       color: '颜色',
       lineWeight: '线宽',
+      lineWeightHairline: '无线宽',
       fontSize: '字高'
     },
     layers: {
@@ -584,6 +587,7 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
     drawStyle: {
       color: 'Barva',
       lineWeight: 'Tloušťka čáry',
+      lineWeightHairline: 'Bez tloušťky',
       fontSize: 'Výška textu'
     },
     layers: {
@@ -759,6 +763,7 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
     drawStyle: {
       color: 'Renk',
       lineWeight: 'Çizgi kalınlığı',
+      lineWeightHairline: 'Kılcal',
       fontSize: 'Yazı yüksekliği'
     },
     layers: {
@@ -938,6 +943,7 @@ const AR_MESSAGES: AcExMessageTree = {
   'drawStyle': {
     'color': 'اللون',
     'lineWeight': 'سُمك الخط',
+    'lineWeightHairline': 'بلا سماكة',
     'fontSize': 'ارتفاع النص'
   },
   'layers': {

--- a/packages/cad-html-plugin/src/AcExHtmlOverlayDom.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlOverlayDom.ts
@@ -10,6 +10,12 @@ export const ACEX_OVERLAY_CLOUD_WCS = 'overlayCloudWcs'
 /** Target screen diameter in CSS pixels for each revision-cloud lobe at creation. */
 export const ACEX_OVERLAY_CLOUD_DIAMETER_PX = 8
 
+/** Dataset key storing overlay arrow-head length in world units. */
+export const ACEX_OVERLAY_ARROW_WCS = 'overlayArrowWcs'
+
+/** Arrow-head length in CSS pixels at first paint; stored as WCS thereafter. */
+export const ACEX_OVERLAY_ARROW_SIZE_PX = 12
+
 /**
  * Scale factor for HTML measure/markup overlays relative to first layout.
  */
@@ -83,6 +89,10 @@ export function acExScaledCanvasLineWidth(
     wcsToScreen?: (wcs: { x: number; y: number }) => { x: number; y: number }
   }
 ): number {
+  if (!(baseLineWidth > 0)) {
+    delete canvas.dataset[ACEX_OVERLAY_STROKE_WCS]
+    return 1
+  }
   if (options?.wcsToScreen) {
     const ppu = acExPixelsPerWorldUnit(options.wcsToScreen)
     let wcs =
@@ -98,6 +108,31 @@ export function acExScaledCanvasLineWidth(
     return Math.max(0.5, wcs * ppu)
   }
   return baseLineWidth * acExOverlayViewScale(zoom, canvas)
+}
+
+/**
+ * Arrow-head length in CSS pixels that stays a fixed world size.
+ *
+ * Distance measurements use this so arrows follow zoom even when the stroke
+ * is hairline. Seeds {@link ACEX_OVERLAY_ARROW_SIZE_PX} as WCS on first paint.
+ */
+export function acExScaledOverlayArrowSize(
+  canvas: HTMLCanvasElement,
+  wcsToScreen: (wcs: { x: number; y: number }) => { x: number; y: number },
+  arrowSizeWcs?: number
+): number {
+  const ppu = acExPixelsPerWorldUnit(wcsToScreen)
+  let wcs =
+    arrowSizeWcs != null && arrowSizeWcs > 0
+      ? arrowSizeWcs
+      : Number(canvas.dataset[ACEX_OVERLAY_ARROW_WCS])
+  if (!Number.isFinite(wcs) || wcs <= 0) {
+    wcs = ACEX_OVERLAY_ARROW_SIZE_PX / ppu
+    canvas.dataset[ACEX_OVERLAY_ARROW_WCS] = String(wcs)
+  } else if (arrowSizeWcs != null && arrowSizeWcs > 0) {
+    canvas.dataset[ACEX_OVERLAY_ARROW_WCS] = String(wcs)
+  }
+  return Math.max(0.5, wcs * ppu)
 }
 
 /** Seed DOM baseZoom so CSS size matches WCS at current camera. */
@@ -131,6 +166,10 @@ export function acExSeedOverlaySizesFromWcs(
   if (strokeWidthWcs != null && strokeWidthWcs > 0) {
     for (const canvas of canvases ?? []) {
       acExSeedOverlayStrokeWcs(canvas, strokeWidthWcs)
+    }
+  } else if (options.strokeScreenPx === 0) {
+    for (const canvas of canvases ?? []) {
+      delete canvas.dataset[ACEX_OVERLAY_STROKE_WCS]
     }
   }
 

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -329,6 +329,7 @@ export const ACEX_HTML_SHELL_CSS = `
 
   .mlcad-drawer-sheet-chrome {
     display: none;
+    position: relative;
   }
   .mlcad-drawer-grabber {
     flex: 1 1 auto;
@@ -341,6 +342,10 @@ export const ACEX_HTML_SHELL_CSS = `
   }
   .mlcad-drawer-grabber::before {
     content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     width: 36px;
     height: 4px;
     border-radius: 2px;
@@ -352,6 +357,9 @@ export const ACEX_HTML_SHELL_CSS = `
     border: none; background: transparent;
     color: var(--mlcad-ui-muted); cursor: pointer;
     display: inline-flex; align-items: center; justify-content: center;
+    flex: 0 0 auto;
+    position: relative;
+    z-index: 1;
   }
   .mlcad-drawer-sheet-close:hover { color: var(--mlcad-ui-text); }
   .mlcad-drawer-sheet-close svg { width: 18px; height: 18px; }

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -71,8 +71,8 @@ export const ACEX_MARKUP_COLOR = '#e53935'
 /** @deprecated Selection uses CSS glow; original stroke color is preserved. */
 export const ACEX_MARKUP_SELECT_COLOR = '#ffd54f'
 
-/** Default CAD line weight (≈ 0.70 mm → ~2.5 px). */
-const ACEX_MARKUP_LINE_WEIGHT = 70
+/** Default overlay line weight: hairline (1 CSS px, not zoom-scaled). */
+const ACEX_MARKUP_LINE_WEIGHT = 0
 
 /** Default font size for text / callout badges (CSS px). */
 const ACEX_MARKUP_FONT_SIZE = 12
@@ -173,6 +173,12 @@ function createMarkupId(prefix = 'markup'): string {
 
 function markupNow(): string {
   return new Date().toISOString()
+}
+
+function resolveMarkupLineWeight(weight?: number): number {
+  return typeof weight === 'number' && Number.isFinite(weight) && weight >= 0
+    ? weight
+    : ACEX_MARKUP_LINE_WEIGHT
 }
 
 function defaultStyle(
@@ -364,7 +370,11 @@ export class AcExMarkupController {
     fontSize?: number
   }): void {
     if (patch.color) this._drawColor = patch.color
-    if (patch.lineWeight != null && patch.lineWeight > 0) {
+    if (
+      patch.lineWeight != null &&
+      Number.isFinite(patch.lineWeight) &&
+      patch.lineWeight >= 0
+    ) {
       this._drawLineWeight = patch.lineWeight
     }
     if (patch.fontSize != null && patch.fontSize > 0) {
@@ -389,19 +399,15 @@ export class AcExMarkupController {
       style.fontSize != null && style.fontSize > 0
         ? style.fontSize
         : ACEX_MARKUP_FONT_SIZE
-    const lineWeight =
-      style.lineWeight != null && style.lineWeight > 0
-        ? style.lineWeight
-        : ACEX_MARKUP_LINE_WEIGHT
+    const lineWeight = resolveMarkupLineWeight(style.lineWeight)
+    const strokePx = acExMarkupCanvasLineWidth(lineWeight)
     const wcsToScreen = (p: { x: number; y: number }) =>
       this._wcsToScreenPoint(p)
     return {
       ...style,
       textHeightWcs: acExScreenPxToWcs(fontSize, wcsToScreen),
-      strokeWidthWcs: acExScreenPxToWcs(
-        acExMarkupCanvasLineWidth(lineWeight),
-        wcsToScreen
-      )
+      strokeWidthWcs:
+        strokePx > 0 ? acExScreenPxToWcs(strokePx, wcsToScreen) : undefined
     }
   }
 
@@ -442,14 +448,17 @@ export class AcExMarkupController {
       if (!item) continue
       const style = item.record.style
       if (patch.color) style.color = patch.color
-      if (patch.lineWeight != null && patch.lineWeight > 0) {
-        const prevWeight =
-          style.lineWeight != null && style.lineWeight > 0
-            ? style.lineWeight
-            : ACEX_MARKUP_LINE_WEIGHT
+      if (
+        patch.lineWeight != null &&
+        Number.isFinite(patch.lineWeight) &&
+        patch.lineWeight >= 0
+      ) {
+        const prevWeight = resolveMarkupLineWeight(style.lineWeight)
         const prevPx = acExMarkupCanvasLineWidth(prevWeight)
         const nextPx = acExMarkupCanvasLineWidth(patch.lineWeight)
-        if (
+        if (!(nextPx > 0)) {
+          style.strokeWidthWcs = undefined
+        } else if (
           style.strokeWidthWcs != null &&
           style.strokeWidthWcs > 0 &&
           prevPx > 0

--- a/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  ACEX_OVERLAY_ARROW_SIZE_PX,
   ACEX_OVERLAY_CLOUD_DIAMETER_PX,
   ACEX_OVERLAY_CLOUD_WCS
 } from './AcExHtmlOverlayDom'
@@ -17,7 +18,11 @@ import type {
 } from './AcExMarkupTypes'
 import type { AcExExtents } from './AcExSnapshotTypes'
 
-export { ACEX_OVERLAY_CLOUD_DIAMETER_PX, ACEX_OVERLAY_CLOUD_WCS }
+export {
+  ACEX_OVERLAY_ARROW_SIZE_PX,
+  ACEX_OVERLAY_CLOUD_DIAMETER_PX,
+  ACEX_OVERLAY_CLOUD_WCS
+}
 
 /** Shape outline used to auto-place the leader tip on the perimeter. */
 export type AcExMarkupShapeOutline =
@@ -77,9 +82,6 @@ export function acExComputeLeaderTipOnShape(
 /** Extra hit slop for revision-cloud lobes around the AABB. */
 const CLOUD_HIT_EXTRA_PX = 8
 
-/** Arrow-head length in CSS pixels at the overlay's creation-scale stroke. */
-export const ACEX_OVERLAY_ARROW_SIZE_PX = 12
-
 /**
  * Screen length of an overlay arrow head, tracking the same WCS scale as the stroke.
  */
@@ -88,7 +90,7 @@ export function acExOverlayArrowSize(
   baseLineWidth = 2
 ): number {
   const base =
-    baseLineWidth > 0 && Number.isFinite(baseLineWidth) ? baseLineWidth : 2
+    baseLineWidth > 0 && Number.isFinite(baseLineWidth) ? baseLineWidth : 1
   return Math.max(1, scaledLineWidth * (ACEX_OVERLAY_ARROW_SIZE_PX / base))
 }
 
@@ -291,7 +293,7 @@ export function acExDrawMarkupLeader(
 
 /** Map CAD line weight to canvas stroke width in CSS pixels. */
 export function acExMarkupCanvasLineWidth(weight?: number): number {
-  if (weight == null || !Number.isFinite(weight) || weight <= 0) return 2
+  if (weight == null || !Number.isFinite(weight) || weight <= 0) return 0
   return Math.max(1, weight / 28)
 }
 

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -11,13 +11,16 @@ import * as THREE from 'three'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import {
+  acExPixelsPerWorldUnit,
   acExPositionClientOverlay,
   acExPositionWcsOverlay,
   acExResetOverlayViewScale,
   acExScaledCanvasLineWidth,
+  acExScaledOverlayArrowSize,
   acExScreenPxToWcs,
   acExSeedOverlaySizesFromWcs
 } from './AcExHtmlOverlayDom'
+import { acExDrawMarkupArrowHead } from './AcExMarkupGeometry'
 import { acExBindMarkupPointerDrag } from './AcExMarkupGripDrag'
 import {
   ACEX_MEASUREMENT_FONT_SIZE,
@@ -405,15 +408,35 @@ function distPointToArcPx(
   return best
 }
 
+/** Fraction of the shorter world-space arm used as the dimension arc radius. */
+const ANGLE_ARC_RADIUS_WCS_FRACTION = 0.3
+
 /**
- * Screen-space interior angle arc (viewport pixels), matching {@link AcExMeasureController._drawAngleArc}.
+ * World-space radius of the interior angle dimension arc.
+ * @internal
+ */
+function angleArcRadiusWcs(
+  vertex: THREE.Vector2,
+  arm1: THREE.Vector2,
+  arm2: THREE.Vector2
+): number {
+  const len1 = Math.hypot(arm1.x - vertex.x, arm1.y - vertex.y)
+  const len2 = Math.hypot(arm2.x - vertex.x, arm2.y - vertex.y)
+  return Math.min(len1, len2) * ANGLE_ARC_RADIUS_WCS_FRACTION
+}
+
+/**
+ * Interior angle arc in overlay pixels. Radius is
+ * {@link ANGLE_ARC_RADIUS_WCS_FRACTION} of the shorter world-space arm,
+ * then converted with `wcsToScreen`, so the arc stays between the arms when
+ * the camera zooms. Matches {@link AcExMeasureController._drawAngleArc}.
  * @internal
  */
 function interiorAngleArcScreenMetrics(
   vertex: THREE.Vector2,
   arm1: THREE.Vector2,
   arm2: THREE.Vector2,
-  wcsToScreen: (wcs: THREE.Vector2) => { x: number; y: number }
+  wcsToScreen: (wcs: { x: number; y: number }) => { x: number; y: number }
 ): {
   cx: number
   cy: number
@@ -427,9 +450,8 @@ function interiorAngleArcScreenMetrics(
   const sa2 = wcsToScreen(arm2)
   const cx = sv.x
   const cy = sv.y
-  const len1 = Math.hypot(sa1.x - cx, sa1.y - cy)
-  const len2 = Math.hypot(sa2.x - cx, sa2.y - cy)
-  const r = Math.max(Math.min(len1, len2) * 0.3, 15)
+  const rWcs = angleArcRadiusWcs(vertex, arm1, arm2)
+  const r = rWcs * acExPixelsPerWorldUnit(wcsToScreen)
   const startAngle = Math.atan2(sa1.y - cy, sa1.x - cx)
   const endAngle = Math.atan2(sa2.y - cy, sa2.x - cx)
   const antiClockwise = normaliseAngle(endAngle - startAngle) > Math.PI
@@ -486,7 +508,9 @@ function hitTestAngleMeasure(
     return true
   }
 
-  const arc = interiorAngleArcScreenMetrics(vertex, arm1, arm2, wcsToScreen)
+  const arc = interiorAngleArcScreenMetrics(vertex, arm1, arm2, p =>
+    wcsToScreen(new THREE.Vector2(p.x, p.y))
+  )
   if (
     distPointToArcPx(
       clientX,
@@ -1097,7 +1121,7 @@ export class AcExMeasureController {
       if (measure) {
         return {
           color: measure.record.style.color || this._measureCss(),
-          lineWeight: measure.record.style.lineWeight || this._drawLineWeight,
+          lineWeight: measure.record.style.lineWeight ?? this._drawLineWeight,
           fontSize: measure.record.style.fontSize || this._drawFontSize
         }
       }
@@ -1129,7 +1153,11 @@ export class AcExMeasureController {
         colorChanged = true
       }
     }
-    if (patch.lineWeight != null && patch.lineWeight > 0) {
+    if (
+      patch.lineWeight != null &&
+      Number.isFinite(patch.lineWeight) &&
+      patch.lineWeight >= 0
+    ) {
       this._drawLineWeight = patch.lineWeight
     }
     if (patch.fontSize != null && patch.fontSize > 0) {
@@ -1150,7 +1178,11 @@ export class AcExMeasureController {
     if (colorChanged || patch.colorHex != null || patch.color) {
       selectionPatch.color = this._measureCss()
     }
-    if (patch.lineWeight != null && patch.lineWeight > 0) {
+    if (
+      patch.lineWeight != null &&
+      Number.isFinite(patch.lineWeight) &&
+      patch.lineWeight >= 0
+    ) {
       selectionPatch.lineWeight = patch.lineWeight
     }
     if (patch.fontSize != null && patch.fontSize > 0) {
@@ -1829,7 +1861,10 @@ export class AcExMeasureController {
    * Uses the current draw-style color and line weight.
    * @internal
    */
-  private _setPreviewLine(points: THREE.Vector2[]): void {
+  private _setPreviewLine(
+    points: THREE.Vector2[],
+    options?: { bothArrows?: boolean }
+  ): void {
     let canvas = this._overlayLayer.querySelector<HTMLCanvasElement>(
       '.mlcad-measure-canvas--preview-line'
     )
@@ -1845,7 +1880,9 @@ export class AcExMeasureController {
       canvas,
       points,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(this._drawLineWeight)
+      acExMeasureCanvasLineWidth(this._drawLineWeight),
+      undefined,
+      options?.bothArrows
     )
   }
 
@@ -1994,14 +2031,15 @@ export class AcExMeasureController {
       return
     }
     const anchor = this._points[0]!
-    this._setPreviewLine([anchor, point])
+    this._setPreviewLine([anchor, point], { bothArrows: true })
     const dist = dist2(anchor, point)
     this._showLiveLabel(this._view.formatLength(dist), clientX, clientY)
     this._requestRender()
   }
 
   /**
-   * Persists a distance measurement: line, endpoint dots, and midpoint badge.
+   * Persists a distance measurement: line with endpoint arrows, endpoint dots,
+   * and midpoint badge.
    * @internal
    */
   private _commitDistance(
@@ -2013,7 +2051,7 @@ export class AcExMeasureController {
     const end = b.clone()
     const dist = dist2(start, end)
     const id = this._startCommit(existing?.id)
-    this._addPersistentLine([start, end])
+    this._addPersistentLine([start, end], { bothArrows: true })
     const dot1 = this._addDot(start)
     const dot2 = this._addDot(end)
     const mid = new THREE.Vector2((start.x + end.x) / 2, (start.y + end.y) / 2)
@@ -3057,7 +3095,10 @@ export class AcExMeasureController {
    * Adds a committed polyline as a style-aware canvas overlay (color + line weight).
    * @internal
    */
-  private _addPersistentLine(points: THREE.Vector2[]): void {
+  private _addPersistentLine(
+    points: THREE.Vector2[],
+    options?: { bothArrows?: boolean }
+  ): void {
     if (points.length < 2) return
     const parts = this._commitParts
     if (!parts) return
@@ -3066,6 +3107,7 @@ export class AcExMeasureController {
     const commitId = parts.id
     // Keep the caller's Vector2 refs so grip edits can mutate them in place.
     const pts = points
+    const bothArrows = options?.bothArrows === true
     const redraw = () => {
       const style = this._styleForCommit(commitId)
       this._drawPolyline(
@@ -3073,7 +3115,8 @@ export class AcExMeasureController {
         pts,
         style.color || this._measureCss(),
         acExMeasureCanvasLineWidth(style.lineWeight),
-        style.strokeWidthWcs
+        style.strokeWidthWcs,
+        bothArrows
       )
     }
     redraw()
@@ -3161,7 +3204,8 @@ export class AcExMeasureController {
     points: THREE.Vector2[],
     strokeCss: string,
     lineWidth: number,
-    strokeWidthWcs?: number
+    strokeWidthWcs?: number,
+    bothArrows = false
   ): void {
     if (points.length < 2) return
     const synced = this._syncCanvas(canvas)
@@ -3171,23 +3215,37 @@ export class AcExMeasureController {
     ctx.save()
     ctx.scale(dpr, dpr)
     const rootRect = this._overlayRootOffset()
+    const screen: { x: number; y: number }[] = []
     ctx.beginPath()
     for (let i = 0; i < points.length; i++) {
       const s = this._view.wcsToScreen(points[i]!)
       const x = s.x - rootRect.left
       const y = s.y - rootRect.top
+      screen.push({ x, y })
       if (i === 0) ctx.moveTo(x, y)
       else ctx.lineTo(x, y)
     }
     ctx.strokeStyle = strokeCss
-    ctx.lineWidth = this._scaledCanvasLineWidth(
+    const scaled = this._scaledCanvasLineWidth(
       lineWidth,
       canvas,
       strokeWidthWcs
     )
+    ctx.lineWidth = scaled
     ctx.lineJoin = 'round'
     ctx.lineCap = 'round'
     ctx.stroke()
+    if (bothArrows && screen.length === 2) {
+      const a = screen[0]!
+      const b = screen[1]!
+      const arrowSize = acExScaledOverlayArrowSize(canvas, p =>
+        this._wcsToScreenPoint(p)
+      )
+      if (Math.hypot(b.x - a.x, b.y - a.y) >= arrowSize) {
+        acExDrawMarkupArrowHead(ctx, b, a, strokeCss, arrowSize)
+        acExDrawMarkupArrowHead(ctx, a, b, strokeCss, arrowSize)
+      }
+    }
     ctx.restore()
   }
 
@@ -3312,6 +3370,7 @@ export class AcExMeasureController {
   ): AcExMeasurementSidecarStyle {
     const wcsToScreen = (p: { x: number; y: number }) =>
       this._wcsToScreenPoint(p)
+    const strokePx = acExMeasureCanvasLineWidth(style.lineWeight)
     return {
       ...style,
       textHeightWcs:
@@ -3321,10 +3380,9 @@ export class AcExMeasureController {
       strokeWidthWcs:
         style.strokeWidthWcs != null && style.strokeWidthWcs > 0
           ? style.strokeWidthWcs
-          : acExScreenPxToWcs(
-              acExMeasureCanvasLineWidth(style.lineWeight),
-              wcsToScreen
-            )
+          : strokePx > 0
+            ? acExScreenPxToWcs(strokePx, wcsToScreen)
+            : undefined
     }
   }
 
@@ -3334,13 +3392,12 @@ export class AcExMeasureController {
   ): AcExMeasurementSidecarStyle {
     const wcsToScreen = (p: { x: number; y: number }) =>
       this._wcsToScreenPoint(p)
+    const strokePx = acExMeasureCanvasLineWidth(style.lineWeight)
     return {
       ...style,
       textHeightWcs: acExScreenPxToWcs(style.fontSize, wcsToScreen),
-      strokeWidthWcs: acExScreenPxToWcs(
-        acExMeasureCanvasLineWidth(style.lineWeight),
-        wcsToScreen
-      )
+      strokeWidthWcs:
+        strokePx > 0 ? acExScreenPxToWcs(strokePx, wcsToScreen) : undefined
     }
   }
 
@@ -3595,11 +3652,17 @@ export class AcExMeasureController {
       if (!measure) continue
       const style = measure.record.style
       if (patch.color) style.color = patch.color
-      if (patch.lineWeight != null && patch.lineWeight > 0) {
+      if (
+        patch.lineWeight != null &&
+        Number.isFinite(patch.lineWeight) &&
+        patch.lineWeight >= 0
+      ) {
         const prevWeight = style.lineWeight
         const prevPx = acExMeasureCanvasLineWidth(prevWeight)
         const nextPx = acExMeasureCanvasLineWidth(patch.lineWeight)
-        if (
+        if (!(nextPx > 0)) {
+          style.strokeWidthWcs = undefined
+        } else if (
           style.strokeWidthWcs != null &&
           style.strokeWidthWcs > 0 &&
           prevPx > 0
@@ -3733,22 +3796,24 @@ export class AcExMeasureController {
     ctx.save()
     ctx.scale(dpr, dpr)
 
-    const arc = interiorAngleArcScreenMetrics(vertex, arm1, arm2, wcs =>
-      this._view.wcsToScreen(wcs)
+    const arc = interiorAngleArcScreenMetrics(vertex, arm1, arm2, p =>
+      this._wcsToScreenPoint(p)
     )
     const rootRect = this._overlayRootOffset()
     const vx = arc.cx - rootRect.left
     const vy = arc.cy - rootRect.top
 
-    ctx.beginPath()
-    ctx.arc(vx, vy, arc.r, arc.startAngle, arc.endAngle, arc.antiClockwise)
-    ctx.strokeStyle = strokeCss ?? this._measureCss()
-    ctx.lineWidth = this._scaledCanvasLineWidth(
-      lineWidth,
-      canvas,
-      strokeWidthWcs
-    )
-    ctx.stroke()
+    if (arc.r > 0) {
+      ctx.beginPath()
+      ctx.arc(vx, vy, arc.r, arc.startAngle, arc.endAngle, arc.antiClockwise)
+      ctx.strokeStyle = strokeCss ?? this._measureCss()
+      ctx.lineWidth = this._scaledCanvasLineWidth(
+        lineWidth,
+        canvas,
+        strokeWidthWcs
+      )
+      ctx.stroke()
+    }
     ctx.restore()
   }
 

--- a/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
@@ -15,15 +15,15 @@ import type {
   AcExMeasurementType
 } from './AcExMeasurementTypes'
 
-/** Default CAD line weight (matches simple-viewer `LineWeight070`). */
-export const ACEX_MEASUREMENT_LINE_WEIGHT = 70
+/** Default overlay line weight: hairline (1 CSS px, not zoom-scaled). */
+export const ACEX_MEASUREMENT_LINE_WEIGHT = 0
 
 /** Default badge font size in CSS pixels (matches simple-viewer). */
 export const ACEX_MEASUREMENT_FONT_SIZE = 13
 
 /** Map CAD line weight to canvas stroke width in CSS pixels. */
 export function acExMeasureCanvasLineWidth(weight?: number): number {
-  if (weight == null || !Number.isFinite(weight) || weight <= 0) return 2
+  if (weight == null || !Number.isFinite(weight) || weight <= 0) return 0
   return Math.max(1, weight / 28)
 }
 
@@ -65,7 +65,9 @@ function parsePositiveNumber(value: unknown): number | undefined {
 function parseStyle(raw: unknown): AcExMeasurementSidecarStyle | undefined {
   if (!isPlainObject(raw) || typeof raw.color !== 'string') return undefined
   const lineWeight =
-    typeof raw.lineWeight === 'number' && raw.lineWeight > 0
+    typeof raw.lineWeight === 'number' &&
+    Number.isFinite(raw.lineWeight) &&
+    raw.lineWeight >= 0
       ? raw.lineWeight
       : ACEX_MEASUREMENT_LINE_WEIGHT
   const fontSize =

--- a/packages/cad-simple-ui-plugin/__tests__/AcUiDockPanel.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcUiDockPanel.spec.ts
@@ -479,6 +479,12 @@ describe('AcUiDockPanel', () => {
     expect(document.getElementById('ml-ex-ui-styles')?.textContent).toContain(
       '.ml-ex-ui-host-dock-sheet {'
     )
+    expect(document.getElementById('ml-ex-ui-styles')?.textContent).toContain(
+      '.ml-ex-ui-dock-sheet-grabber::before'
+    )
+    expect(document.getElementById('ml-ex-ui-styles')?.textContent).toContain(
+      'transform: translate(-50%, -50%);'
+    )
 
     panel.setPanelSize(800)
     expect(panel.getSize()).toBe(525)

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -1375,6 +1375,7 @@ export function acuiEnsureUiStyles() {
 
     .ml-ex-ui-dock-sheet-chrome {
       display: none;
+      position: relative;
     }
 
     .ml-ex-ui-dock-sheet-grabber {
@@ -1389,6 +1390,10 @@ export function acuiEnsureUiStyles() {
 
     .ml-ex-ui-dock-sheet-grabber::before {
       content: '';
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
       width: 36px;
       height: 4px;
       border-radius: 2px;
@@ -1407,6 +1412,8 @@ export function acuiEnsureUiStyles() {
       color: var(--ml-ui-text-muted, #606266);
       cursor: pointer;
       flex: 0 0 auto;
+      position: relative;
+      z-index: 1;
     }
 
     .ml-ex-ui-dock-sheet-close:hover {

--- a/packages/cad-simple-viewer/__tests__/AcApMarkupUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupUtil.spec.ts
@@ -1,9 +1,14 @@
-import { AcCmColor, AcCmColorMethod } from '@mlightcad/data-model'
+import { AcCmColor, AcCmColorMethod, AcGiLineWeight } from '@mlightcad/data-model'
 
 import {
   createDefaultMarkupColor,
   cssToMarkupColor,
-  markupColorToCss
+  MARKUP_LINE_WEIGHT,
+  markupCanvasLineWidth,
+  markupColorToCss,
+  resolveMarkupLineWeight,
+  setMarkupDrawLineWeight,
+  getMarkupLineWeight
 } from '../src/command/markup/AcApMarkupUtil'
 
 describe('cssToMarkupColor', () => {
@@ -37,5 +42,35 @@ describe('cssToMarkupColor', () => {
     const restored = cssToMarkupColor(markupColorToCss(yellow))
     expect(restored.isByACI).toBe(true)
     expect(restored.colorIndex).toBe(2)
+  })
+})
+
+describe('markup line weight', () => {
+  afterEach(() => {
+    setMarkupDrawLineWeight(MARKUP_LINE_WEIGHT)
+  })
+
+  it('defaults to hairline and maps it to a 0 canvas width sentinel', () => {
+    expect(MARKUP_LINE_WEIGHT).toBe(0)
+    expect(markupCanvasLineWidth(MARKUP_LINE_WEIGHT)).toBe(0)
+    expect(markupCanvasLineWidth(AcGiLineWeight.LineWeight070)).toBeCloseTo(
+      2.5
+    )
+  })
+
+  it('keeps hairline and falls back only for missing or negative values', () => {
+    expect(resolveMarkupLineWeight(0)).toBe(0)
+    expect(resolveMarkupLineWeight(70)).toBe(70)
+    expect(resolveMarkupLineWeight(undefined)).toBe(MARKUP_LINE_WEIGHT)
+    expect(resolveMarkupLineWeight(AcGiLineWeight.ByLayer)).toBe(
+      MARKUP_LINE_WEIGHT
+    )
+  })
+
+  it('accepts hairline as a session draw line weight', () => {
+    setMarkupDrawLineWeight(AcGiLineWeight.LineWeight013)
+    setMarkupDrawLineWeight(0 as AcGiLineWeight)
+    expect(getMarkupLineWeight()).toBe(0)
+    setMarkupDrawLineWeight(MARKUP_LINE_WEIGHT)
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcApMeasureDrawUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasureDrawUtil.spec.ts
@@ -1,0 +1,27 @@
+import {
+  MEASURE_ANGLE_ARC_RADIUS_FRACTION,
+  measureAngleArcRadiusWcs
+} from '../src/command/measure/AcApMeasureAngleArc'
+
+describe('measureAngleArcRadiusWcs', () => {
+  it('uses 30% of the shorter world-space arm', () => {
+    expect(
+      measureAngleArcRadiusWcs(
+        { x: 0, y: 0 },
+        { x: 20, y: 0 },
+        { x: 0, y: 10 }
+      )
+    ).toBe(10 * MEASURE_ANGLE_ARC_RADIUS_FRACTION)
+    expect(MEASURE_ANGLE_ARC_RADIUS_FRACTION).toBe(0.3)
+  })
+
+  it('does not apply a screen-pixel minimum', () => {
+    expect(
+      measureAngleArcRadiusWcs(
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+        { x: 0, y: 4 }
+      )
+    ).toBeCloseTo(1.2)
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementGeometry.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementGeometry.spec.ts
@@ -48,6 +48,46 @@ describe('hitTestMeasurementGeometry', () => {
     ).toBe(false)
   })
 
+  it('hits the angle arc at the world-space radius, not a 15px screen floor', () => {
+    const geometry: AcApMeasurementGeometry = {
+      type: 'angle',
+      vertex: { x: 0, y: 0 },
+      arm1: { x: 20, y: 0 },
+      arm2: { x: 0, y: 20 }
+    }
+    const onArc = 20 * 0.3 * Math.SQRT1_2
+    expect(
+      hitTestMeasurementGeometry(
+        geometry,
+        { x: onArc, y: onArc },
+        identity,
+        threshold
+      )
+    ).toBe(true)
+    // Former screen-space floor of 15px along the bisector.
+    expect(
+      hitTestMeasurementGeometry(
+        geometry,
+        { x: 15 * Math.SQRT1_2, y: 15 * Math.SQRT1_2 },
+        identity,
+        threshold
+      )
+    ).toBe(false)
+
+    const zoomOut = (point: { x: number; y: number }) => ({
+      x: point.x * 0.25,
+      y: point.y * 0.25
+    })
+    expect(
+      hitTestMeasurementGeometry(
+        geometry,
+        { x: 15 * Math.SQRT1_2, y: 15 * Math.SQRT1_2 },
+        zoomOut,
+        threshold
+      )
+    ).toBe(false)
+  })
+
   it('hits an area measurement on the fill and the outline', () => {
     const geometry: AcApMeasurementGeometry = {
       type: 'area',

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementSidecar.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementSidecar.spec.ts
@@ -139,6 +139,24 @@ describe('AcApMeasurementSidecar', () => {
     expect(parsed.measurements[0].style.strokeWidthWcs).toBeUndefined()
   })
 
+  it('keeps hairline line weight 0 in sidecar styles', () => {
+    const parsed = parseMeasurementSidecar(
+      JSON.stringify({
+        version: 1,
+        measurements: [
+          {
+            id: 'hairline',
+            type: 'point',
+            style: { color: '#abcabc', lineWeight: 0, fontSize: 13 },
+            geometry: { type: 'point', position: { x: 1, y: 2 } }
+          }
+        ]
+      })
+    )
+    expect(parsed.measurements[0].style.lineWeight).toBe(0)
+    expect(parsed.measurements[0].style.strokeWidthWcs).toBeUndefined()
+  })
+
   it('suggests sidecar file names', () => {
     expect(measurementSidecarFileName('plan.dwg')).toBe('plan.measurement.json')
     expect(measurementSidecarFileName('plan.DXF')).toBe('plan.measurement.json')

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementStore.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementStore.spec.ts
@@ -1,0 +1,166 @@
+import { AcCmColor, AcGiLineWeight } from '@mlightcad/data-model'
+import type { AcTrHtmlGroup } from '@mlightcad/three-renderer'
+
+import {
+  AcApMarkupHistory,
+  AcApSessionUndo
+} from '../src/command/markup/AcApMarkupHistory'
+import { acapSetMarkupBagFactory } from '../src/command/markup/AcApMarkupSession'
+import { AcApMarkupStore } from '../src/command/markup/AcApMarkupStore'
+import { resetMeasurementSession } from '../src/command/measure/AcApMeasurementHistory'
+import { stringifyMeasurementSidecar } from '../src/command/measure/AcApMeasurementSidecar'
+import {
+  applyMeasurementStyle,
+  collectMeasurementRecords,
+  commitMeasurementGroup,
+  MEASUREMENT_LAYER
+} from '../src/command/measure/AcApMeasurementStore'
+import type { AcApMeasurementRecord } from '../src/command/measure/AcApMeasurementTypes'
+import {
+  MEASUREMENT_FONT_SIZE,
+  OVERLAY_HAIRLINE_LINE_WEIGHT
+} from '../src/util/AcApMeasurementUtil'
+import type { AcTrView2d } from '../src/view'
+
+acapSetMarkupBagFactory(() => ({
+  store: new AcApMarkupStore(),
+  presenter: {
+    forgetPublished() {}
+  } as never,
+  history: new AcApMarkupHistory(),
+  sessionUndo: new AcApSessionUndo()
+}))
+
+function createView() {
+  const groups = new Map<string, AcTrHtmlGroup>()
+  const manager = {
+    groupsOnLayer(layer: string) {
+      return [...groups.values()].filter(group => group.layer === layer)
+    },
+    add(group: AcTrHtmlGroup) {
+      groups.set(group.id, group)
+    },
+    detach(id: string) {
+      const group = groups.get(id)
+      groups.delete(id)
+      return group
+    },
+    reattach(group: AcTrHtmlGroup) {
+      groups.set(group.id, group)
+    },
+    has(id: string) {
+      return groups.has(id)
+    },
+    getGroup(id: string) {
+      return groups.get(id)
+    }
+  }
+  const view = {
+    htmlTransientManager: manager,
+    isDirty: false,
+    isHtmlDirty: false,
+    internalCamera: { zoom: 1 },
+    worldToScreen: (p: { x: number; y: number }) => ({
+      x: p.x * 10,
+      y: p.y * 10
+    }),
+    removeTransientEntity: jest.fn(),
+    addTransientEntity: jest.fn(),
+    highlight: jest.fn(),
+    unhighlight: jest.fn(),
+    setTransientEntityVisible: jest.fn()
+  } as unknown as AcTrView2d
+  return { view, manager }
+}
+
+function makeGroup(id: string): AcTrHtmlGroup {
+  return {
+    id,
+    layer: MEASUREMENT_LAYER,
+    children: [],
+    canvases: [],
+    dispose: jest.fn()
+  } as unknown as AcTrHtmlGroup
+}
+
+function numericSnapshot(id: string): AcApMeasurementRecord {
+  const color = new AcCmColor()
+  color.setRGB(10, 20, 30)
+  return {
+    id,
+    type: 'point',
+    style: {
+      color: 'rgb(10,20,30)',
+      lineWeight: AcGiLineWeight.LineWeight070,
+      fontSize: MEASUREMENT_FONT_SIZE,
+      textHeightWcs: 1.3,
+      strokeWidthWcs: 0.25
+    },
+    geometry: { type: 'point', position: { x: 1, y: 2 } }
+  }
+}
+
+describe('AcApMeasurementStore hairline stroke WCS', () => {
+  afterEach(() => {
+    resetMeasurementSession()
+  })
+
+  it('omits strokeWidthWcs after switching a measurement to hairline', () => {
+    const { view, manager } = createView()
+    const group = makeGroup('hairline-edit')
+    const color = new AcCmColor()
+    color.setRGB(10, 20, 30)
+    commitMeasurementGroup(view, group, {
+      style: {
+        color,
+        lineWeight: AcGiLineWeight.LineWeight070,
+        fontSize: MEASUREMENT_FONT_SIZE
+      },
+      snapshot: numericSnapshot(group.id)
+    })
+    expect(manager.getGroup('hairline-edit')).toBe(group)
+
+    applyMeasurementStyle(view, group, {
+      lineWeight: OVERLAY_HAIRLINE_LINE_WEIGHT
+    })
+
+    const [record] = collectMeasurementRecords(view)
+    expect(record?.style.lineWeight).toBe(0)
+    expect(record?.style.strokeWidthWcs).toBeUndefined()
+
+    const json = stringifyMeasurementSidecar({
+      version: 1,
+      measurements: collectMeasurementRecords(view)
+    })
+    expect(json).not.toMatch(/"strokeWidthWcs"\s*:/)
+  })
+
+  it('does not invent a 0 WCS stroke for a hairline snapshot', () => {
+    const { view } = createView()
+    const group = makeGroup('hairline-commit')
+    const color = new AcCmColor()
+    color.setRGB(8, 232, 222)
+    commitMeasurementGroup(view, group, {
+      style: {
+        color,
+        lineWeight: OVERLAY_HAIRLINE_LINE_WEIGHT,
+        fontSize: MEASUREMENT_FONT_SIZE
+      },
+      snapshot: {
+        id: group.id,
+        type: 'point',
+        style: {
+          color: 'rgb(8,232,222)',
+          lineWeight: OVERLAY_HAIRLINE_LINE_WEIGHT,
+          fontSize: MEASUREMENT_FONT_SIZE,
+          textHeightWcs: 1.3
+        },
+        geometry: { type: 'point', position: { x: 0, y: 0 } }
+      }
+    })
+
+    const [record] = collectMeasurementRecords(view)
+    expect(record?.style.lineWeight).toBe(0)
+    expect(record?.style.strokeWidthWcs).toBeUndefined()
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts
@@ -30,8 +30,9 @@ describe('AcApMeasurementUtil', () => {
     acapResetMeasurementDrawStyle()
   })
 
-  it('keeps factory line weight and font size until they are changed', () => {
+  it('defaults to hairline until a numeric line weight is chosen', () => {
     expect(acapGetMeasurementLineWeight()).toBe(MEASUREMENT_LINE_WEIGHT)
+    expect(acapGetMeasurementLineWeight()).toBe(0)
     expect(acapGetMeasurementFontSize()).toBe(MEASUREMENT_FONT_SIZE)
   })
 
@@ -63,14 +64,23 @@ describe('AcApMeasurementUtil', () => {
   })
 
   it('maps CAD line weight 070 to a 2.5px canvas stroke', () => {
-    expect(acapMeasurementCanvasLineWidth(MEASUREMENT_LINE_WEIGHT)).toBeCloseTo(2.5)
+    expect(
+      acapMeasurementCanvasLineWidth(AcGiLineWeight.LineWeight070)
+    ).toBeCloseTo(2.5)
   })
 
-  it('ignores non-positive line weights', () => {
+  it('maps hairline to a 0 canvas width sentinel', () => {
+    expect(acapMeasurementCanvasLineWidth(0 as AcGiLineWeight)).toBe(0)
+  })
+
+  it('accepts hairline and ignores negative CAD specials', () => {
     acapSetMeasurementDrawLineWeight(AcGiLineWeight.LineWeight211)
     acapSetMeasurementDrawLineWeight(AcGiLineWeight.ByLayer)
     acapSetMeasurementDrawLineWeight(AcGiLineWeight.ByBlock)
     expect(acapGetMeasurementLineWeight()).toBe(AcGiLineWeight.LineWeight211)
+
+    acapSetMeasurementDrawLineWeight(0 as AcGiLineWeight)
+    expect(acapGetMeasurementLineWeight()).toBe(0)
   })
 })
 

--- a/packages/cad-simple-viewer/__tests__/AcApOverlayDrawUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApOverlayDrawUtil.spec.ts
@@ -1,9 +1,11 @@
 /** @jest-environment jsdom */
 
 import {
+  ACAP_OVERLAY_ARROW_WCS,
   ACAP_OVERLAY_STROKE_WCS,
   acapOverlayArrowSize,
   acapOverlayDash,
+  acapScaledOverlayArrowSize,
   acapScaledOverlayLineWidth,
   acapSeedOverlaySizesFromWcs
 } from '../src/command/overlay/AcApOverlayDrawUtil'
@@ -40,6 +42,27 @@ describe('AcApOverlayDrawUtil WCS stroke', () => {
     // Explicit stale WCS would overwrite the seeded dataset (the bug we fixed).
     expect(acapScaledOverlayLineWidth(2.5, canvas, view, 0.2)).toBe(2)
     expect(canvas.dataset[ACAP_OVERLAY_STROKE_WCS]).toBe('0.2')
+  })
+
+  it('uses a 1px hairline and clears stored WCS when base width is 0', () => {
+    const view = mockView(10)
+    const canvas = document.createElement('canvas')
+    canvas.dataset[ACAP_OVERLAY_STROKE_WCS] = '0.4'
+
+    expect(acapScaledOverlayLineWidth(0, canvas, view, 0.4)).toBe(1)
+    expect(canvas.dataset[ACAP_OVERLAY_STROKE_WCS]).toBeUndefined()
+  })
+
+  it('clears stored stroke WCS when seeding a hairline overlay', () => {
+    const view = mockView(10)
+    const canvas = document.createElement('canvas')
+    canvas.dataset[ACAP_OVERLAY_STROKE_WCS] = '0.4'
+
+    acapSeedOverlaySizesFromWcs(view, {
+      strokeScreenPx: 0,
+      canvases: [canvas]
+    })
+    expect(canvas.dataset[ACAP_OVERLAY_STROKE_WCS]).toBeUndefined()
   })
 
   it('seeds element baseZoom only from matched text screen/WCS pair', () => {
@@ -80,6 +103,17 @@ describe('AcApOverlayDrawUtil arrow and dash scale', () => {
   it('scales dash pattern with the view-synced stroke', () => {
     expect(acapOverlayDash(2, 2)).toEqual([8, 5])
     expect(acapOverlayDash(4, 2)).toEqual([16, 10])
+  })
+
+  it('keeps a 12px arrow for hairline strokes', () => {
+    expect(acapOverlayArrowSize(1, 0)).toBe(12)
+  })
+
+  it('scales distance arrows in WCS independently of hairline stroke', () => {
+    const canvas = document.createElement('canvas')
+    expect(acapScaledOverlayArrowSize(canvas, mockView(10))).toBe(12)
+    expect(Number(canvas.dataset[ACAP_OVERLAY_ARROW_WCS])).toBeCloseTo(1.2)
+    expect(acapScaledOverlayArrowSize(canvas, mockView(5))).toBeCloseTo(6)
   })
 
   it('seeds cloud lobe WCS from the stroke screen/WCS pair', () => {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
@@ -17,8 +17,16 @@ export function createDefaultMarkupColor(): AcCmColor {
   return new AcCmColor(AcCmColorMethod.ByACI, 1)
 }
 
+/**
+ * Overlay line weight meaning "no CAD lineweight" (hairline).
+ *
+ * Drawn as 1 CSS pixel and not scaled with zoom until the user picks a
+ * numeric lineweight from the drawing-style / style toolbar.
+ */
+export const MARKUP_HAIRLINE_LINE_WEIGHT = 0 as AcGiLineWeight
+
 /** Factory default CAD line weight for markup geometry. */
-export const MARKUP_LINE_WEIGHT = AcGiLineWeight.LineWeight070
+export const MARKUP_LINE_WEIGHT = MARKUP_HAIRLINE_LINE_WEIGHT
 
 /** Factory default screen font size (CSS px) for text / callout markups. */
 export const MARKUP_FONT_SIZE = 12
@@ -69,7 +77,7 @@ export function setMarkupDrawColor(color: AcCmColor): void {
 
 /** Update the session markup draw line weight. */
 export function setMarkupDrawLineWeight(weight: AcGiLineWeight): void {
-  if (!(weight > 0)) return
+  if (!Number.isFinite(weight) || weight < 0) return
   markupDrawLineWeight = weight
   notifyMarkupDrawStyleChanged()
 }
@@ -81,10 +89,22 @@ export function setMarkupDrawFontSize(size: number): void {
   notifyMarkupDrawStyleChanged()
 }
 
+/**
+ * Resolve a stored markup line weight, treating missing / negative CAD
+ * specials as the session default. `0` is hairline and is kept.
+ */
+export function resolveMarkupLineWeight(
+  weight: number | undefined | null
+): AcGiLineWeight {
+  return typeof weight === 'number' && Number.isFinite(weight) && weight >= 0
+    ? (weight as AcGiLineWeight)
+    : MARKUP_LINE_WEIGHT
+}
+
 /** Map a CAD line weight to a canvas stroke width in CSS pixels. */
 export function markupCanvasLineWidth(weight: AcGiLineWeight | number): number {
   const n = Number(weight)
-  if (!Number.isFinite(n) || n <= 0) return 2
+  if (!Number.isFinite(n) || n <= 0) return 0
   return Math.max(1, n / 28)
 }
 
@@ -116,14 +136,13 @@ export function withMarkupStyleWcs(
     style.fontSize != null && style.fontSize > 0
       ? style.fontSize
       : MARKUP_FONT_SIZE
-  const lineWeight =
-    style.lineWeight != null && style.lineWeight > 0
-      ? style.lineWeight
-      : MARKUP_LINE_WEIGHT
+  const lineWeight = resolveMarkupLineWeight(style.lineWeight)
+  const strokePx = markupCanvasLineWidth(lineWeight)
   return {
     ...style,
     textHeightWcs: acapScreenPxToWcs(fontSize, view),
-    strokeWidthWcs: acapScreenPxToWcs(markupCanvasLineWidth(lineWeight), view)
+    strokeWidthWcs:
+      strokePx > 0 ? acapScreenPxToWcs(strokePx, view) : undefined
   }
 }
 
@@ -145,14 +164,8 @@ export function patchMarkupStyleWcs(
       : MARKUP_FONT_SIZE
   const nextFont =
     next.fontSize != null && next.fontSize > 0 ? next.fontSize : MARKUP_FONT_SIZE
-  const prevWeight =
-    previous.lineWeight != null && previous.lineWeight > 0
-      ? previous.lineWeight
-      : MARKUP_LINE_WEIGHT
-  const nextWeight =
-    next.lineWeight != null && next.lineWeight > 0
-      ? next.lineWeight
-      : MARKUP_LINE_WEIGHT
+  const prevWeight = resolveMarkupLineWeight(previous.lineWeight)
+  const nextWeight = resolveMarkupLineWeight(next.lineWeight)
 
   const fontSizeChanged =
     patch.fontSize != null && patch.fontSize !== previous.fontSize
@@ -171,19 +184,18 @@ export function patchMarkupStyleWcs(
   }
 
   let strokeWidthWcs = previous.strokeWidthWcs ?? next.strokeWidthWcs
-  if (lineWeightChanged) {
+  const nextPx = markupCanvasLineWidth(nextWeight)
+  if (!(nextPx > 0)) {
+    strokeWidthWcs = undefined
+  } else if (lineWeightChanged) {
     const prevPx = markupCanvasLineWidth(prevWeight)
-    const nextPx = markupCanvasLineWidth(nextWeight)
     if (strokeWidthWcs != null && strokeWidthWcs > 0 && prevPx > 0) {
       strokeWidthWcs = strokeWidthWcs * (nextPx / prevPx)
     } else {
       strokeWidthWcs = acapScreenPxToWcs(nextPx, view)
     }
   } else if (strokeWidthWcs == null || !(strokeWidthWcs > 0)) {
-    strokeWidthWcs = acapScreenPxToWcs(
-      markupCanvasLineWidth(nextWeight),
-      view
-    )
+    strokeWidthWcs = acapScreenPxToWcs(nextPx, view)
   }
 
   return {

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntity.ts
@@ -27,8 +27,8 @@ import type { AcApMarkupRecord } from '../AcApMarkupTypes'
 import {
   cssToMarkupColor,
   MARKUP_FONT_SIZE,
-  MARKUP_LINE_WEIGHT,
-  markupCanvasLineWidth
+  markupCanvasLineWidth,
+  resolveMarkupLineWeight
 } from '../AcApMarkupUtil'
 
 /**
@@ -56,10 +56,7 @@ export interface AcApMarkupDrawStyle {
 export function markupDrawStyleFromRecord(
   record: AcApMarkupRecord
 ): AcApMarkupDrawStyle {
-  const lineWeight =
-    record.style.lineWeight != null && record.style.lineWeight > 0
-      ? (record.style.lineWeight as AcGiLineWeight)
-      : MARKUP_LINE_WEIGHT
+  const lineWeight = resolveMarkupLineWeight(record.style.lineWeight)
   return {
     color: cssToMarkupColor(record.style.color),
     lineWeight,
@@ -246,10 +243,7 @@ export abstract class AcApMarkupEntity
       strokeWidthWcs: this.record.style.strokeWidthWcs,
       fontSizePx: this.record.style.fontSize ?? MARKUP_FONT_SIZE,
       strokeScreenPx: markupCanvasLineWidth(
-        this.record.style.lineWeight != null &&
-          this.record.style.lineWeight > 0
-          ? this.record.style.lineWeight
-          : MARKUP_LINE_WEIGHT
+        resolveMarkupLineWeight(this.record.style.lineWeight)
       ),
       elements,
       canvases

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntityGrips.ts
@@ -37,8 +37,8 @@ import type {
 } from '../AcApMarkupTypes'
 import {
   MARKUP_FONT_SIZE,
-  MARKUP_LINE_WEIGHT,
-  markupCanvasLineWidth
+  markupCanvasLineWidth,
+  resolveMarkupLineWeight
 } from '../AcApMarkupUtil'
 import type { AcApMarkupDrawStyle } from './AcApMarkupEntity'
 
@@ -133,9 +133,7 @@ export function publishAttachedCallout(
       record.style.color,
       false,
       markupCanvasLineWidth(
-        record.style.lineWeight != null && record.style.lineWeight > 0
-          ? record.style.lineWeight
-          : MARKUP_LINE_WEIGHT
+        resolveMarkupLineWeight(record.style.lineWeight)
       ),
       view2d,
       record.style.strokeWidthWcs
@@ -168,9 +166,7 @@ export function publishAttachedCallout(
     strokeWidthWcs: record.style.strokeWidthWcs,
     fontSizePx: record.style.fontSize ?? MARKUP_FONT_SIZE,
     strokeScreenPx: markupCanvasLineWidth(
-      record.style.lineWeight != null && record.style.lineWeight > 0
-        ? record.style.lineWeight
-        : MARKUP_LINE_WEIGHT
+      resolveMarkupLineWeight(record.style.lineWeight)
     ),
     elements: [bubble, tipDot],
     canvases: [overlay.canvas]

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleArc.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleArc.ts
@@ -1,0 +1,27 @@
+/**
+ * Angle-dimension arc radius in world space.
+ *
+ * Shared by canvas drawing and hit-testing so the painted arc and pick
+ * target stay aligned across zoom.
+ */
+
+/** Fraction of the shorter world-space arm used as the dimension arc radius. */
+export const MEASURE_ANGLE_ARC_RADIUS_FRACTION = 0.3
+
+/**
+ * World-space radius of the interior angle dimension arc.
+ *
+ * @param vertex - Angle vertex in world coordinates
+ * @param arm1 - First arm endpoint in world coordinates
+ * @param arm2 - Second arm endpoint in world coordinates
+ * @returns Radius in world units (`0` when either arm is degenerate)
+ */
+export function measureAngleArcRadiusWcs(
+  vertex: { x: number; y: number },
+  arm1: { x: number; y: number },
+  arm2: { x: number; y: number }
+): number {
+  const len1 = Math.hypot(arm1.x - vertex.x, arm1.y - vertex.y)
+  const len2 = Math.hypot(arm2.x - vertex.x, arm2.y - vertex.y)
+  return Math.min(len1, len2) * MEASURE_ANGLE_ARC_RADIUS_FRACTION
+}

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
@@ -123,7 +123,15 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
       acapGetMeasurementLineWeight()
     )
     this._preview.acapSetDraw((ctx, view) => {
-      acapStrokeLiveSegment(ctx, view, this._p1, this._p2, this._color, lineWidth)
+      acapStrokeLiveSegment(
+        ctx,
+        view,
+        this._p1,
+        this._p2,
+        this._color,
+        lineWidth,
+        { arrow: 'both' }
+      )
     })
 
     if (dist < 0.0001) {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementGeometry.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementGeometry.ts
@@ -8,6 +8,7 @@ import {
   distPointToSegmentPx,
   pointInPolygonPx
 } from '../../util/AcApScreenHitTest'
+import { measureAngleArcRadiusWcs } from './AcApMeasureAngleArc'
 import type { AcApMeasurementGeometry } from './AcApMeasurementTypes'
 
 type WorldToScreen = (point: { x: number; y: number }) => AcApScreenPoint
@@ -101,13 +102,20 @@ export function hitTestMeasurementGeometry(
       ) {
         return true
       }
-      const len1 = Math.hypot(arm1.x - vertex.x, arm1.y - vertex.y)
-      const len2 = Math.hypot(arm2.x - vertex.x, arm2.y - vertex.y)
-      const r = Math.max(Math.min(len1, len2) * 0.3, 15)
       const startAngle = Math.atan2(arm1.y - vertex.y, arm1.x - vertex.x)
       const endAngle = Math.atan2(arm2.y - vertex.y, arm2.x - vertex.x)
       const antiClockwise =
         AcGeMathUtil.normalizeAngle(endAngle - startAngle) > Math.PI
+      const origin = worldToScreen({ x: 0, y: 0 })
+      const unit = worldToScreen({ x: 1, y: 0 })
+      const ppu = Math.hypot(unit.x - origin.x, unit.y - origin.y)
+      const r =
+        measureAngleArcRadiusWcs(
+          geometry.vertex,
+          geometry.arm1,
+          geometry.arm2
+        ) * (ppu > 0 && Number.isFinite(ppu) ? ppu : 1)
+      if (!(r > 0)) return false
       return (
         distPointToArcPx(
           canvas.x,

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementSidecar.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementSidecar.ts
@@ -57,7 +57,9 @@ function parsePositiveNumber(value: unknown): number | undefined {
 function parseStyle(raw: unknown): AcApMeasurementSidecarStyle | undefined {
   if (!isPlainObject(raw) || typeof raw.color !== 'string') return undefined
   const lineWeight =
-    typeof raw.lineWeight === 'number' && raw.lineWeight > 0
+    typeof raw.lineWeight === 'number' &&
+    Number.isFinite(raw.lineWeight) &&
+    raw.lineWeight >= 0
       ? (raw.lineWeight as AcGiLineWeight)
       : MEASUREMENT_LINE_WEIGHT
   const fontSize =
@@ -142,10 +144,10 @@ export function serializeMeasurementStyle(
   }
   if (view) {
     result.textHeightWcs = acapScreenPxToWcs(style.fontSize, view)
-    result.strokeWidthWcs = acapScreenPxToWcs(
-      acapMeasurementCanvasLineWidth(style.lineWeight),
-      view
-    )
+    const strokePx = acapMeasurementCanvasLineWidth(style.lineWeight)
+    if (strokePx > 0) {
+      result.strokeWidthWcs = acapScreenPxToWcs(strokePx, view)
+    }
   }
   return result
 }
@@ -157,7 +159,7 @@ export function deserializeMeasurementStyle(
   return {
     color: acapCssToMeasurementColor(style.color),
     lineWeight:
-      style.lineWeight > 0 ? style.lineWeight : MEASUREMENT_LINE_WEIGHT,
+      style.lineWeight >= 0 ? style.lineWeight : MEASUREMENT_LINE_WEIGHT,
     fontSize: style.fontSize > 0 ? style.fontSize : MEASUREMENT_FONT_SIZE
   }
 }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -326,16 +326,21 @@ function resolveUpdatedTextHeightWcs(
   return prevTextHeightWcs
 }
 
-/** Scale or recompute stroke WCS when line weight changes; otherwise keep. */
+/**
+ * Scale or recompute stroke WCS when line weight changes; otherwise keep.
+ *
+ * Hairline (`nextPx === 0`) returns `undefined` so sidecar serialization
+ * omits world-space stroke instead of writing `0`.
+ */
 function resolveUpdatedStrokeWidthWcs(
   view: AcTrView2d,
   nextLineWeight: AcApMeasurementStyle['lineWeight'],
   prevLineWeight: AcApMeasurementStyle['lineWeight'] | undefined,
   prevStrokeWidthWcs: number | undefined,
   lineWeightChanged: boolean
-): number {
+): number | undefined {
   const nextPx = acapMeasurementCanvasLineWidth(nextLineWeight)
-  if (!(nextPx > 0)) return 0
+  if (!(nextPx > 0)) return undefined
   if (
     lineWeightChanged &&
     prevStrokeWidthWcs != null &&
@@ -426,16 +431,17 @@ export function collectMeasurementRecords(
       // Keep live color / weights / fontSize, but preserve creation-time WCS
       // from the snapshot (do not recompute from the current zoom).
       const base = serializeMeasurementStyle(live)
+      const strokePx = acapMeasurementCanvasLineWidth(base.lineWeight)
       style = {
         ...base,
         textHeightWcs:
           snapStyle.textHeightWcs ?? acapScreenPxToWcs(base.fontSize, view),
         strokeWidthWcs:
-          snapStyle.strokeWidthWcs ??
-          acapScreenPxToWcs(
-            acapMeasurementCanvasLineWidth(base.lineWeight),
-            view
-          )
+          snapStyle.strokeWidthWcs != null && snapStyle.strokeWidthWcs > 0
+            ? snapStyle.strokeWidthWcs
+            : strokePx > 0
+              ? acapScreenPxToWcs(strokePx, view)
+              : undefined
       }
     }
     records.push({

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -335,6 +335,7 @@ function resolveUpdatedStrokeWidthWcs(
   lineWeightChanged: boolean
 ): number {
   const nextPx = acapMeasurementCanvasLineWidth(nextLineWeight)
+  if (!(nextPx > 0)) return 0
   if (
     lineWeightChanged &&
     prevStrokeWidthWcs != null &&

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDistanceEntity.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDistanceEntity.ts
@@ -46,9 +46,9 @@ function calcDist(p1: { x: number; y: number }, p2: { x: number; y: number }): n
 /**
  * Distance measurement overlay entity.
  *
- * Renders an HTML canvas segment between two endpoints, HTML dots at each end,
- * and a length badge at the midpoint. Endpoint grips update the measured value
- * live and republish on commit.
+ * Renders an HTML canvas segment with arrows at both endpoints, HTML dots at
+ * each end, and a length badge at the midpoint. Endpoint grips update the
+ * measured value live and republish on commit.
  */
 export class AcApMeasureDistanceEntity extends AcApMeasureEntity {
   /** First endpoint of the measured segment in world coordinates. */

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDrawUtil.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDrawUtil.ts
@@ -6,7 +6,15 @@ import {
 
 import type { AcEdBaseView } from '../../../editor'
 import { acapColorToCssAlpha, acapCssColor } from '../../../util'
-import { acapScaledOverlayLineWidth } from '../../overlay/AcApOverlayDrawUtil'
+import {
+  acapDrawOverlayArrowHead,
+  acapScaledOverlayArrowSize,
+  acapScaledOverlayLineWidth,
+  acapWcsToScreenPx
+} from '../../overlay/AcApOverlayDrawUtil'
+import { measureAngleArcRadiusWcs } from '../AcApMeasureAngleArc'
+
+export { MEASURE_ANGLE_ARC_RADIUS_FRACTION } from '../AcApMeasureAngleArc'
 
 /**
  * Circle geometry in world XY used by arc-length measurement overlays.
@@ -79,6 +87,9 @@ function prepareMeasureCanvas(
  * @param color - Stroke color
  * @param lineWidth - Stroke width in CSS pixels (default `2`)
  * @param strokeWidthWcs - Optional imported world-space stroke width
+ *
+ * Arrow heads at both endpoints are a fixed world length (seeded from 12 CSS
+ * px on first paint) so they scale with camera zoom even for hairline strokes.
  */
 export function drawMeasureSegmentOnCanvas(
   canvas: HTMLCanvasElement,
@@ -97,14 +108,21 @@ export function drawMeasureSegmentOnCanvas(
   ctx.beginPath()
   ctx.moveTo(a.x, a.y)
   ctx.lineTo(b.x, b.y)
-  ctx.strokeStyle = acapCssColor(color)
-  ctx.lineWidth = acapScaledOverlayLineWidth(
+  const css = acapCssColor(color)
+  ctx.strokeStyle = css
+  const strokeWidth = acapScaledOverlayLineWidth(
     lineWidth,
     canvas,
     view,
     strokeWidthWcs
   )
+  ctx.lineWidth = strokeWidth
   ctx.stroke()
+  const arrowSize = acapScaledOverlayArrowSize(canvas, view)
+  if (Math.hypot(b.x - a.x, b.y - a.y) >= arrowSize) {
+    acapDrawOverlayArrowHead(ctx, b, a, css, arrowSize)
+    acapDrawOverlayArrowHead(ctx, a, b, css, arrowSize)
+  }
   ctx.restore()
 }
 
@@ -112,8 +130,9 @@ export function drawMeasureSegmentOnCanvas(
  * Draws angle arm lines plus the measurement arc on a measure overlay canvas.
  *
  * Converts `vertex`, `arm1`, and `arm2` to screen space, strokes both arms,
- * then draws the shorter angular sector with a radius derived from the shorter
- * arm length (with a minimum).
+ * then draws the shorter angular sector. Arc radius is
+ * {@link MEASURE_ANGLE_ARC_RADIUS_FRACTION} of the shorter **world-space**
+ * arm so it stays attached to the arms across zoom.
  *
  * @param canvas - Overlay canvas to paint
  * @param view - View for world-to-screen conversion and canvas sizing
@@ -156,18 +175,20 @@ export function drawMeasureAngleArcOnCanvas(
   ctx.lineTo(sa2.x, sa2.y)
   ctx.stroke()
 
-  const len1 = Math.hypot(sa1.x - sv.x, sa1.y - sv.y)
-  const len2 = Math.hypot(sa2.x - sv.x, sa2.y - sv.y)
-  const arcR = Math.max(Math.min(len1, len2) * 0.3, 15)
-
   const startAngle = Math.atan2(sa1.y - sv.y, sa1.x - sv.x)
   const endAngle = Math.atan2(sa2.y - sv.y, sa2.x - sv.x)
   const antiClockwise =
     AcGeMathUtil.normalizeAngle(endAngle - startAngle) > Math.PI
 
-  ctx.beginPath()
-  ctx.arc(sv.x, sv.y, arcR, startAngle, endAngle, antiClockwise)
-  ctx.stroke()
+  const arcR = acapWcsToScreenPx(
+    measureAngleArcRadiusWcs(vertex, arm1, arm2),
+    view
+  )
+  if (arcR > 0) {
+    ctx.beginPath()
+    ctx.arc(sv.x, sv.y, arcR, startAngle, endAngle, antiClockwise)
+    ctx.stroke()
+  }
   ctx.restore()
 }
 

--- a/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
@@ -17,6 +17,7 @@ import {
   acapFitOverlayCanvas,
   acapOverlayArrowSize,
   acapOverlayDash,
+  acapScaledOverlayArrowSize,
   acapScaledOverlayLineWidth
 } from './AcApOverlayDrawUtil'
 
@@ -119,7 +120,8 @@ export class AcApHtmlLivePreview {
  * @param b - Segment end (world).
  * @param color - CSS or AcCmColor stroke color.
  * @param lineWidth - Stroke width in CSS pixels.
- * @param options - Optional dash pattern and arrow head at `b`.
+ * @param options - Optional dash pattern and arrow head (`true` at `b`,
+ *   `'both'` at both endpoints).
  */
 export function acapStrokeLiveSegment(
   ctx: CanvasRenderingContext2D,
@@ -128,7 +130,7 @@ export function acapStrokeLiveSegment(
   b: AcApHtmlLivePoint,
   color: string | AcCmColor,
   lineWidth: number,
-  options?: { dashed?: boolean; arrow?: boolean }
+  options?: { dashed?: boolean; arrow?: boolean | 'both' }
 ): void {
   const css = typeof color === 'string' ? color : acapCssColor(color)
   const sa = view.worldToScreen(a)
@@ -143,13 +145,16 @@ export function acapStrokeLiveSegment(
   ctx.stroke()
   if (options?.dashed) ctx.setLineDash([])
   if (options?.arrow) {
-    acapDrawOverlayArrowHead(
-      ctx,
-      sa,
-      sb,
-      css,
-      acapOverlayArrowSize(strokeWidth, lineWidth)
-    )
+    if (options.arrow === 'both') {
+      const size = acapScaledOverlayArrowSize(ctx.canvas, view)
+      if (Math.hypot(sb.x - sa.x, sb.y - sa.y) >= size) {
+        acapDrawOverlayArrowHead(ctx, sb, sa, css, size)
+        acapDrawOverlayArrowHead(ctx, sa, sb, css, size)
+      }
+    } else {
+      const size = acapOverlayArrowSize(strokeWidth, lineWidth)
+      acapDrawOverlayArrowHead(ctx, sa, sb, css, size)
+    }
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/overlay/AcApOverlayDrawUtil.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApOverlayDrawUtil.ts
@@ -58,6 +58,9 @@ export function acapSeedOverlayStrokeWcs(
  * else convert `baseLineWidth` to WCS on first paint and keep that pen size as
  * the camera zooms. Callers that re-seed after style edits should omit the
  * explicit WCS argument so the dataset wins.
+ *
+ * A non-positive `baseLineWidth` is hairline: always 1 CSS pixel, with any
+ * stored WCS width cleared.
  */
 export function acapScaledOverlayLineWidth(
   baseLineWidth: number,
@@ -65,6 +68,10 @@ export function acapScaledOverlayLineWidth(
   view: AcEdBaseView,
   strokeWidthWcs?: number
 ): number {
+  if (!(baseLineWidth > 0)) {
+    delete anchor.dataset[ACAP_OVERLAY_STROKE_WCS]
+    return 1
+  }
   const ppu = acapPixelsPerWorldUnit(view)
   let wcs =
     strokeWidthWcs != null && strokeWidthWcs > 0
@@ -83,6 +90,9 @@ export function acapScaledOverlayLineWidth(
   return Math.max(0.5, wcs * ppu)
 }
 
+/** Dataset key storing overlay arrow-head length in world units. */
+export const ACAP_OVERLAY_ARROW_WCS = 'overlayArrowWcs'
+
 /** Arrow-head length in CSS pixels at the overlay's creation-scale stroke. */
 export const ACAP_OVERLAY_ARROW_SIZE_PX = 12
 
@@ -97,8 +107,34 @@ export function acapOverlayArrowSize(
   baseLineWidth = 2
 ): number {
   const base =
-    baseLineWidth > 0 && Number.isFinite(baseLineWidth) ? baseLineWidth : 2
+    baseLineWidth > 0 && Number.isFinite(baseLineWidth) ? baseLineWidth : 1
   return Math.max(1, scaledLineWidth * (ACAP_OVERLAY_ARROW_SIZE_PX / base))
+}
+
+/**
+ * Arrow-head length in CSS pixels that stays a fixed world size.
+ *
+ * Used by distance measurements so arrows shrink/grow with zoom even when
+ * the stroke is hairline (1 CSS px). Seeds {@link ACAP_OVERLAY_ARROW_SIZE_PX}
+ * as WCS on first paint unless `arrowSizeWcs` is provided.
+ */
+export function acapScaledOverlayArrowSize(
+  canvas: HTMLElement,
+  view: AcEdBaseView,
+  arrowSizeWcs?: number
+): number {
+  const ppu = acapPixelsPerWorldUnit(view)
+  let wcs =
+    arrowSizeWcs != null && arrowSizeWcs > 0
+      ? arrowSizeWcs
+      : Number(canvas.dataset[ACAP_OVERLAY_ARROW_WCS])
+  if (!Number.isFinite(wcs) || wcs <= 0) {
+    wcs = ACAP_OVERLAY_ARROW_SIZE_PX / ppu
+    canvas.dataset[ACAP_OVERLAY_ARROW_WCS] = String(wcs)
+  } else if (arrowSizeWcs != null && arrowSizeWcs > 0) {
+    canvas.dataset[ACAP_OVERLAY_ARROW_WCS] = String(wcs)
+  }
+  return Math.max(0.5, wcs * ppu)
 }
 
 /**
@@ -109,7 +145,7 @@ export function acapOverlayDash(
   baseLineWidth = 2
 ): number[] {
   const base =
-    baseLineWidth > 0 && Number.isFinite(baseLineWidth) ? baseLineWidth : 2
+    baseLineWidth > 0 && Number.isFinite(baseLineWidth) ? baseLineWidth : 1
   const s = scaledLineWidth / base
   return [8 * s, 5 * s]
 }
@@ -153,6 +189,10 @@ export function acapSeedOverlaySizesFromWcs(
   if (strokeWidthWcs != null && strokeWidthWcs > 0) {
     for (const canvas of canvases ?? []) {
       acapSeedOverlayStrokeWcs(canvas, strokeWidthWcs)
+    }
+  } else if (options.strokeScreenPx === 0) {
+    for (const canvas of canvases ?? []) {
+      delete canvas.dataset[ACAP_OVERLAY_STROKE_WCS]
     }
   }
 

--- a/packages/cad-simple-viewer/src/i18n/ar/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/ar/main.ts
@@ -57,6 +57,7 @@ export default {
   drawStyle: {
     color: 'اللون',
     lineWeight: 'سُمك الخط',
+    lineWeightHairline: 'بلا سماكة',
     fontSize: 'ارتفاع النص'
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/cs/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/cs/main.ts
@@ -57,6 +57,7 @@ export default {
   drawStyle: {
     color: 'Barva',
     lineWeight: 'Tloušťka čáry',
+    lineWeightHairline: 'Bez tloušťky',
     fontSize: 'Výška textu'
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/en/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/main.ts
@@ -57,6 +57,7 @@ export default {
   drawStyle: {
     color: 'Color',
     lineWeight: 'Lineweight',
+    lineWeightHairline: 'Hairline',
     fontSize: 'Text height'
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/tr/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/tr/main.ts
@@ -57,6 +57,7 @@ export default {
   drawStyle: {
     color: 'Renk',
     lineWeight: 'Çizgi kalınlığı',
+    lineWeightHairline: 'Kılcal',
     fontSize: 'Yazı yüksekliği'
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/zh/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/main.ts
@@ -57,6 +57,7 @@ export default {
   drawStyle: {
     color: '颜色',
     lineWeight: '线宽',
+    lineWeightHairline: '无线宽',
     fontSize: '字号'
   }
 }

--- a/packages/cad-simple-viewer/src/ui/AcApDrawStyleToolbar.ts
+++ b/packages/cad-simple-viewer/src/ui/AcApDrawStyleToolbar.ts
@@ -309,7 +309,7 @@ const GRAY_ACI = Array.from({ length: 6 }, (_, i) => i + 250)
  * @returns Positive values in hundredths of a millimeter (for example 25 = 0.25 mm).
  */
 function numericLineWeights(): AcGiLineWeight[] {
-  return Array.from(
+  const weights = Array.from(
     new Set(
       Object.values(AcGiLineWeight).filter(
         (value): value is AcGiLineWeight =>
@@ -317,15 +317,17 @@ function numericLineWeights(): AcGiLineWeight[] {
       )
     )
   ).sort((a, b) => a - b)
+  return [0 as AcGiLineWeight, ...weights]
 }
 
 /**
  * Formats a line weight for the dropdown label.
  *
- * @param value - Line weight in hundredths of a millimeter.
- * @returns Label such as `"0.25 mm"`.
+ * @param value - Line weight in hundredths of a millimeter, or `0` for hairline.
+ * @returns Label such as `"Hairline"` or `"0.25 mm"`.
  */
 function formatLineWeight(value: AcGiLineWeight): string {
+  if (!(value > 0)) return AcApI18n.t('main.drawStyle.lineWeightHairline')
   return `${(value / 100).toFixed(2)} mm`
 }
 
@@ -347,6 +349,8 @@ interface AcApLineWeightPicker {
   setValue: (weight: number) => void
   /** Sets the localized tooltip on the trigger. */
   setTitle: (title: string) => void
+  /** Relabels menu items after a locale change (hairline label). */
+  refreshLabels: () => void
   /** Closes the popover menu. */
   close: () => void
   /** Whether the popover menu is open. */
@@ -369,6 +373,7 @@ function createLineWeightPicker(
   const prefix = 'ml-draw-style-toolbar'
   const weights = numericLineWeights()
   let open = false
+  let currentWeight = weights[0] ?? (0 as AcGiLineWeight)
 
   const root = document.createElement('div')
   root.className = `${prefix}__lineweight`
@@ -396,11 +401,12 @@ function createLineWeightPicker(
   menu.setAttribute('role', 'listbox')
 
   const paintTrigger = (weight: number) => {
+    currentWeight = weight as AcGiLineWeight
     preview.style.setProperty(
       '--ml-lineweight-height',
-      `${previewLineHeightPx(weight)}px`
+      `${previewLineHeightPx(weight > 0 ? weight : 1)}px`
     )
-    label.textContent = formatLineWeight(weight)
+    label.textContent = formatLineWeight(weight as AcGiLineWeight)
   }
 
   const markSelected = (weight: number) => {
@@ -434,12 +440,12 @@ function createLineWeightPicker(
     itemPreview.className = `${prefix}__lineweight-preview`
     itemPreview.style.setProperty(
       '--ml-lineweight-height',
-      `${previewLineHeightPx(weight)}px`
+      `${previewLineHeightPx(weight > 0 ? weight : 1)}px`
     )
 
     const itemLabel = document.createElement('span')
     itemLabel.className = `${prefix}__lineweight-text`
-    itemLabel.textContent = formatLineWeight(weight)
+    itemLabel.textContent = formatLineWeight(weight as AcGiLineWeight)
 
     item.append(itemPreview, itemLabel)
     item.addEventListener('click', event => {
@@ -463,19 +469,28 @@ function createLineWeightPicker(
   })
 
   root.append(trigger, menu)
-  paintTrigger(weights[0] ?? 25)
-  markSelected(weights[0] ?? 25)
+  paintTrigger(currentWeight)
+  markSelected(currentWeight)
 
   return {
     root,
     setValue: weight => {
-      if (!(weight > 0)) return
+      if (!Number.isFinite(weight) || weight < 0) return
       if (!menu.querySelector(`[data-value="${weight}"]`)) addItem(weight)
       paintTrigger(weight)
       markSelected(weight)
     },
     setTitle: title => {
       trigger.title = title
+    },
+    refreshLabels: () => {
+      menu.querySelectorAll(`.${prefix}__lineweight-item`).forEach(node => {
+        const item = node as HTMLElement
+        const weight = Number(item.dataset.value)
+        const text = item.querySelector(`.${prefix}__lineweight-text`)
+        if (text) text.textContent = formatLineWeight(weight as AcGiLineWeight)
+      })
+      paintTrigger(currentWeight)
     },
     close,
     isOpen: () => open,
@@ -733,6 +748,7 @@ export class AcApDrawStyleToolbar {
   private relabel(): void {
     this.swatch.title = AcApI18n.t('main.drawStyle.color')
     this.lineWeightPicker.setTitle(AcApI18n.t('main.drawStyle.lineWeight'))
+    this.lineWeightPicker.refreshLabels()
     this.fontSizeSelect.title = AcApI18n.t('main.drawStyle.fontSize')
   }
 

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
@@ -8,8 +8,16 @@ import {
 
 import { acCmColorToCssHex, parseCssToAcCmColor } from './AcApCssColor'
 
+/**
+ * Overlay line weight meaning "no CAD lineweight" (hairline).
+ *
+ * Drawn as 1 CSS pixel and not scaled with zoom until the user picks a
+ * numeric lineweight from the drawing-style / style toolbar.
+ */
+export const OVERLAY_HAIRLINE_LINE_WEIGHT = 0 as AcGiLineWeight
+
 /** Factory default CAD line weight for measurement geometry. */
-export const MEASUREMENT_LINE_WEIGHT = AcGiLineWeight.LineWeight070
+export const MEASUREMENT_LINE_WEIGHT = OVERLAY_HAIRLINE_LINE_WEIGHT
 
 /** Factory default screen font size (CSS px) for measurement badges. */
 export const MEASUREMENT_FONT_SIZE = 13
@@ -56,7 +64,7 @@ export function acapSetMeasurementDrawColor(color: AcCmColor): void {
 
 /** Update the session measurement draw line weight. */
 export function acapSetMeasurementDrawLineWeight(weight: AcGiLineWeight): void {
-  if (!(weight > 0)) return
+  if (!Number.isFinite(weight) || weight < 0) return
   measurementDrawLineWeight = weight
 }
 
@@ -97,12 +105,14 @@ export function acapCloneMeasurementStyle(
 
 /**
  * Map a CAD line weight to a canvas stroke width in CSS pixels.
- * {@link AcGiLineWeight.LineWeight070} (70) ≈ 2.5px, matching the previous
- * area-measurement default.
+ *
+ * Hairline ({@link OVERLAY_HAIRLINE_LINE_WEIGHT}) returns `0` so overlay
+ * painters can keep a 1px screen stroke that does not scale with zoom.
+ * {@link AcGiLineWeight.LineWeight070} (70) ≈ 2.5px.
  */
 export function acapMeasurementCanvasLineWidth(weight: AcGiLineWeight): number {
   const n = Number(weight)
-  if (!Number.isFinite(n) || n <= 0) return 2
+  if (!Number.isFinite(n) || n <= 0) return 0
   return Math.max(1, n / 28)
 }
 

--- a/packages/cad-viewer/src/component/common/MlLineWeightSelect.vue
+++ b/packages/cad-viewer/src/component/common/MlLineWeightSelect.vue
@@ -87,6 +87,11 @@ interface LineWeightSelectProps {
   /** When true, hide ByLayer / ByBlock / Default (overlay style pickers). */
   numericOnly?: boolean
   /**
+   * Prepend a hairline (no CAD lineweight) option. Used by measurement /
+   * review style pickers; other ribbon line-weight controls stay unchanged.
+   */
+  includeHairline?: boolean
+  /**
    * Narrower trigger sized for numeric weights plus a stroke preview
    * (measure / markup style pickers).
    */
@@ -94,10 +99,11 @@ interface LineWeightSelectProps {
 }
 
 const props = withDefaults(defineProps<LineWeightSelectProps>(), {
-  compact: false
+  compact: false,
+  includeHairline: false
 })
 
-const { locale } = useI18n()
+const { locale, t } = useI18n()
 
 const popperClass = computed(() =>
   props.compact
@@ -117,6 +123,9 @@ const emit = defineEmits<{
  * @returns Human-readable text for the given enum member.
  */
 function formatLabel(value: AcGiLineWeight): string {
+  if (props.includeHairline && value === 0) {
+    return t('main.ribbon.property.lineWeightHairline')
+  }
   switch (value) {
     case AcGiLineWeight.ByLayer:
       return locale.value === 'ar' ? 'حسب الطبقة' : 'ByLayer'
@@ -137,6 +146,7 @@ function formatLabel(value: AcGiLineWeight): string {
  */
 function previewPx(value: AcGiLineWeight): number | null {
   if (value < 0) return null
+  if (value === 0) return 1
   return Math.max(1, Math.min(6, value / 40))
 }
 
@@ -149,7 +159,8 @@ function previewPx(value: AcGiLineWeight): number | null {
  * @returns A sort order compatible with `Array.prototype.sort`.
  */
 function sortLineWeightValues(a: AcGiLineWeight, b: AcGiLineWeight) {
-  const specialOrder = [
+  const specialOrder: AcGiLineWeight[] = [
+    ...(props.includeHairline ? [0 as AcGiLineWeight] : []),
     AcGiLineWeight.ByLayer,
     AcGiLineWeight.ByBlock,
     AcGiLineWeight.ByLineWeightDefault
@@ -167,24 +178,28 @@ function sortLineWeightValues(a: AcGiLineWeight, b: AcGiLineWeight) {
   return a - b
 }
 
-const lineWeightItems = computed<LineWeightItem[]>(() =>
-  Array.from(
+const lineWeightItems = computed<LineWeightItem[]>(() => {
+  const values = Array.from(
     new Set(
-      Object.values(AcGiLineWeight).filter(
-        (v): v is AcGiLineWeight =>
-          typeof v === 'number' &&
-          v !== AcGiLineWeight.ByDIPs &&
-          (!props.numericOnly || v > 0)
-      )
+      Object.values(AcGiLineWeight).filter((v): v is AcGiLineWeight => {
+        if (typeof v !== 'number') return false
+        if (v === AcGiLineWeight.ByDIPs) return false
+        // Overlay hairline sentinel; added back only when includeHairline.
+        if (v === 0) return false
+        if (props.numericOnly) return v > 0
+        return true
+      })
     )
   )
-    .sort(sortLineWeightValues)
-    .map(v => ({
-      value: v,
-      label: formatLabel(v),
-      previewWidth: previewPx(v)
-    }))
-)
+  if (props.includeHairline && !values.includes(0 as AcGiLineWeight)) {
+    values.push(0 as AcGiLineWeight)
+  }
+  return values.sort(sortLineWeightValues).map(v => ({
+    value: v,
+    label: formatLabel(v),
+    previewWidth: previewPx(v)
+  }))
+})
 
 const selectedItem = computed<LineWeightItem | undefined>(() =>
   lineWeightItems.value.find(item => item.value === props.modelValue)

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -1282,6 +1282,7 @@ const buildBaseTabs = (
           modelValue: markupDrawLineWeight.value,
           placeholder: t('main.ribbon.property.lineWeight'),
           numericOnly: true,
+          includeHairline: true,
           controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMarkupDrawLineWeightChange
         }
@@ -1467,6 +1468,7 @@ const buildBaseTabs = (
           modelValue: measurementDrawLineWeight.value,
           placeholder: t('main.ribbon.property.lineWeight'),
           numericOnly: true,
+          includeHairline: true,
           controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMeasurementDrawLineWeightChange
         }
@@ -2104,6 +2106,7 @@ const buildBaseTabs = (
                     componentProps: {
                       modelValue: ribbonLineWeight.value,
                       placeholder: t('main.ribbon.property.lineWeight'),
+                      includeHairline: false,
                       'onUpdate:modelValue': handleRibbonLineWeightChange
                     }
                   }

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonPropertyLineWeightSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonPropertyLineWeightSelect.vue
@@ -10,6 +10,7 @@
       :disabled="disabled"
       :placeholder="placeholder"
       :numeric-only="numericOnly"
+      :include-hairline="includeHairline === true"
       :compact="numericOnly"
       @update:modelValue="emit('update:modelValue', $event)"
     />
@@ -36,11 +37,18 @@ interface RibbonPropertyLineWeightSelectProps {
   placeholder?: string
   /** When true, hide ByLayer / ByBlock / Default (overlay style pickers). */
   numericOnly?: boolean
+  /**
+   * Prepend a hairline option. Only measurement / review style pickers
+   * should set this; Home / entity property line-weight stays unchanged.
+   */
+  includeHairline?: boolean
   /** Optional fixed width for the embedded control; defaults narrower when `numericOnly`. */
   controlWidth?: string
 }
 
-const props = defineProps<RibbonPropertyLineWeightSelectProps>()
+const props = withDefaults(defineProps<RibbonPropertyLineWeightSelectProps>(), {
+  includeHairline: false
+})
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: AcGiLineWeight): void

--- a/packages/cad-viewer/src/composable/useIsMobile.ts
+++ b/packages/cad-viewer/src/composable/useIsMobile.ts
@@ -45,7 +45,9 @@ export function useIsMobile() {
   })
 
   const isMobileOrPad = computed(() => {
-    // Depend on these so resize / primary-pointer changes re-run the shared check.
+    // Compact (≤960) already includes the phone breakpoint (≤600). Tracking
+    // isSmallViewport would not change this value; only the desktop boundary
+    // and primary-pointer type can.
     void isCompactViewport.value
     void isCoarsePointer.value
     return acedIsMobileOrPadUi()

--- a/packages/cad-viewer/src/locale/ar/main.ts
+++ b/packages/cad-viewer/src/locale/ar/main.ts
@@ -51,7 +51,8 @@ export default {
       ...enMain.ribbon.property,
       color: 'اللون',
       lineType: 'نوع الخط',
-      lineWeight: 'سُمك الخط'
+      lineWeight: 'سُمك الخط',
+      lineWeightHairline: 'بلا سماكة'
     },
 
     layerTools: {

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -230,7 +230,8 @@ export default {
     property: {
       color: 'Barva',
       lineType: 'Typ čáry',
-      lineWeight: 'Tloušťka čáry'
+      lineWeight: 'Tloušťka čáry',
+      lineWeightHairline: 'Bez tloušťky'
     },
     layerTools: {
       select: 'Hladina',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -230,7 +230,8 @@ export default {
     property: {
       color: 'Color',
       lineType: 'Linetype',
-      lineWeight: 'Lineweight'
+      lineWeight: 'Lineweight',
+      lineWeightHairline: 'Hairline'
     },
     layerTools: {
       select: 'Layer',

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -231,7 +231,8 @@ export default {
     property: {
       color: 'Renk',
       lineType: 'Çizgi Tipi',
-      lineWeight: 'Çizgi Kalınlığı'
+      lineWeight: 'Çizgi Kalınlığı',
+      lineWeightHairline: 'Kılcal'
     },
     layerTools: {
       select: 'Katman',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -227,7 +227,8 @@ export default {
     property: {
       color: '颜色',
       lineType: '线型',
-      lineWeight: '线宽'
+      lineWeight: '线宽',
+      lineWeightHairline: '无线宽'
     },
     layerTools: {
       select: '图层',


### PR DESCRIPTION
## Summary
- Default measure/markup overlay stroke to **hairline** (1 CSS px, not zoom-scaled). Overlay lineweight pickers gain a Hairline option; Home / entity lineweight is unchanged.
- Distance measurements draw world-sized arrows at both ends so they still scale with zoom when the stroke is hairline.
- Angle dimension arcs use 30% of the shorter **world-space** arm (no 15px screen floor) so the painted arc and hit target stay aligned across zoom.
- Hairline style edits omit `strokeWidthWcs` from measurement sidecars (`undefined`, not `0`), matching markup.
- Phone drawer sheet grabber is centered on the full sheet width (HTML export and simple-viewer dock sheets).

## Test plan
- [ ] New measure/markup overlays use hairline; the overlay style picker shows Hairline; the Home ribbon lineweight list does not.
- [ ] Zoom in/out with hairline: stroke stays 1px; distance arrows and the angle arc scale with the drawing.
- [ ] Choose a numeric lineweight, then zoom: stroke and decorations both scale.
- [ ] Switch locale and confirm the Hairline label updates.
- [ ] Reload a sidecar with `lineWeight: 0` and one with `lineWeight: 70` and confirm each keeps its stroke.
- [ ] Change a numeric-weight measurement to Hairline, export the sidecar, and confirm `strokeWidthWcs` is omitted.
- [ ] On a phone-width layout, the sheet grabber pill is visually centered (not offset by the close button).
