### PR TITLE
feat: lock overlay measure and markup strokes to hairline

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExMarkupSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMarkupSidecar.spec.ts
@@ -40,17 +40,19 @@ describe('AcExMarkupSidecar', () => {
     ]
   }
 
-  it('round-trips sidecar JSON', () => {
+  it('round-trips sidecar JSON as hairline', () => {
     const text = stringifyAcExMarkupSidecar(sample)
+    expect(text).not.toMatch(/"strokeWidthWcs"\s*:/)
     const parsed = parseAcExMarkupSidecar(text)
     expect(parsed.version).toBe(1)
     expect(parsed.drawingName).toBe('plan.dwg')
     expect(parsed.markups).toHaveLength(2)
     expect(parsed.markups[0]?.type).toBe('arrow')
+    expect(parsed.markups[0]?.style.lineWeight).toBe(0)
     expect(parsed.markups[1]?.text).toBe('Note')
   })
 
-  it('round-trips WCS style fields', () => {
+  it('keeps textHeightWcs and ignores legacy strokeWidthWcs', () => {
     const withWcs: AcExMarkupSidecarFile = {
       version: 1,
       markups: [
@@ -76,9 +78,12 @@ describe('AcExMarkupSidecar', () => {
         }
       ]
     }
-    const parsed = parseAcExMarkupSidecar(stringifyAcExMarkupSidecar(withWcs))
+    const text = stringifyAcExMarkupSidecar(withWcs)
+    expect(text).not.toMatch(/"strokeWidthWcs"\s*:/)
+    const parsed = parseAcExMarkupSidecar(text)
     expect(parsed.markups[0]?.style.textHeightWcs).toBe(0.6)
-    expect(parsed.markups[0]?.style.strokeWidthWcs).toBe(0.1)
+    expect(parsed.markups[0]?.style.lineWeight).toBe(0)
+    expect(parsed.markups[0]?.style.strokeWidthWcs).toBeUndefined()
   })
 
   it('rejects invalid payloads', () => {
@@ -88,7 +93,7 @@ describe('AcExMarkupSidecar', () => {
     )
   })
 
-  it('drops non-finite world-space style sizes', () => {
+  it('ignores legacy strokeWidthWcs and non-finite textHeightWcs', () => {
     const parsed = parseAcExMarkupSidecar(
       JSON.stringify({
         version: 1,
@@ -100,7 +105,7 @@ describe('AcExMarkupSidecar', () => {
               color: '#ff0000',
               fontSize: 12,
               textHeightWcs: Number.POSITIVE_INFINITY,
-              strokeWidthWcs: Number.NaN
+              strokeWidthWcs: 0.5
             },
             comment: '',
             status: 'open',
@@ -112,6 +117,7 @@ describe('AcExMarkupSidecar', () => {
         ]
       })
     )
+    expect(parsed.markups[0]?.style.lineWeight).toBe(0)
     expect(parsed.markups[0]?.style.textHeightWcs).toBeUndefined()
     expect(parsed.markups[0]?.style.strokeWidthWcs).toBeUndefined()
   })

--- a/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
@@ -42,13 +42,15 @@ describe('AcExMeasurementSidecar', () => {
     ]
   }
 
-  it('round-trips sidecar JSON', () => {
+  it('round-trips sidecar JSON as hairline', () => {
     const text = stringifyAcExMeasurementSidecar(sample)
+    expect(text).not.toMatch(/"strokeWidthWcs"\s*:/)
     const parsed = parseAcExMeasurementSidecar(text)
     expect(parsed.version).toBe(1)
     expect(parsed.drawingName).toBe('plan.dwg')
     expect(parsed.measurements).toHaveLength(3)
     expect(parsed.measurements[0]?.type).toBe('distance')
+    expect(parsed.measurements[0]?.style.lineWeight).toBe(0)
     expect(parsed.measurements[1]?.type).toBe('point')
     expect(parsed.measurements[2]?.geometry).toEqual({
       type: 'arc',
@@ -60,7 +62,7 @@ describe('AcExMeasurementSidecar', () => {
     })
   })
 
-  it('round-trips WCS style fields', () => {
+  it('keeps textHeightWcs and ignores legacy strokeWidthWcs', () => {
     const withWcs: AcExMeasurementSidecarFile = {
       version: 1,
       measurements: [
@@ -82,11 +84,35 @@ describe('AcExMeasurementSidecar', () => {
         }
       ]
     }
-    const parsed = parseAcExMeasurementSidecar(
-      stringifyAcExMeasurementSidecar(withWcs)
-    )
+    const text = stringifyAcExMeasurementSidecar(withWcs)
+    expect(text).not.toMatch(/"strokeWidthWcs"\s*:/)
+    const parsed = parseAcExMeasurementSidecar(text)
     expect(parsed.measurements[0]?.style.textHeightWcs).toBe(0.65)
-    expect(parsed.measurements[0]?.style.strokeWidthWcs).toBe(0.1)
+    expect(parsed.measurements[0]?.style.lineWeight).toBe(0)
+    expect(parsed.measurements[0]?.style.strokeWidthWcs).toBeUndefined()
+  })
+
+  it('normalizes legacy thick styles to hairline on parse', () => {
+    const parsed = parseAcExMeasurementSidecar(
+      JSON.stringify({
+        version: 1,
+        measurements: [
+          {
+            id: 'thick',
+            type: 'point',
+            style: {
+              color: '#08e8de',
+              lineWeight: 70,
+              fontSize: 13,
+              strokeWidthWcs: 0.2
+            },
+            geometry: { type: 'point', position: { x: 1, y: 2 } }
+          }
+        ]
+      })
+    )
+    expect(parsed.measurements[0]?.style.lineWeight).toBe(0)
+    expect(parsed.measurements[0]?.style.strokeWidthWcs).toBeUndefined()
   })
 
   it('keeps hairline line weight 0 in sidecar styles', () => {
@@ -145,6 +171,7 @@ describe('AcExMeasurementSidecar', () => {
       })
     )
     expect(parsed.measurements).toHaveLength(1)
+    expect(parsed.measurements[0]?.style.lineWeight).toBe(0)
     expect(parsed.measurements[0]?.geometry).toEqual({
       type: 'arc',
       center: { x: 0, y: 0 },

--- a/packages/cad-html-plugin/src/AcExDrawStyleToolbar.ts
+++ b/packages/cad-html-plugin/src/AcExDrawStyleToolbar.ts
@@ -1,12 +1,12 @@
 /**
- * Canvas-top drawing style overlay (color / line weight / font size).
+ * Canvas-top drawing style overlay (color / font size).
  * Mirrors `@mlightcad/cad-simple-viewer` {@link AcApDrawStyleToolbar}.
  *
  * @module AcExDrawStyleToolbar
  * @packageDocumentation
  */
 
-import { AcCmColor, AcCmColorUtil, AcGiLineWeight } from '@mlightcad/data-model'
+import { AcCmColor, AcCmColorUtil } from '@mlightcad/data-model'
 
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 
@@ -17,8 +17,6 @@ export type AcExDrawStyleKind = 'measure' | 'markup'
 export interface AcExDrawStyleValues {
   /** CSS color string. */
   color: string
-  /** CAD line weight in hundredths of a millimeter (e.g. 70 = 0.70 mm). */
-  lineWeight: number
   /** Badge / text font size in CSS pixels. */
   fontSize: number
 }
@@ -26,7 +24,6 @@ export interface AcExDrawStyleValues {
 /** Partial style update from the overlay controls. */
 export interface AcExDrawStylePatch {
   color?: string
-  lineWeight?: number
   fontSize?: number
 }
 
@@ -98,107 +95,6 @@ const TOOLBAR_CSS = `
   color: inherit;
   font-size: 12px;
   padding: 0 6px;
-}
-.mlcad-draw-style-toolbar__lineweight {
-  position: relative;
-  width: 120px;
-  flex: 0 0 120px;
-}
-.mlcad-draw-style-toolbar__lineweight-trigger {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  height: 28px;
-  box-sizing: border-box;
-  padding: 0 6px;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  border-radius: 4px;
-  background: rgba(18, 22, 28, 0.95);
-  color: inherit;
-  font-family: inherit;
-  font-size: 12px;
-  line-height: 1;
-  text-align: left;
-  cursor: pointer;
-}
-.mlcad-draw-style-toolbar__lineweight-label {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: left;
-}
-.mlcad-draw-style-toolbar__lineweight-caret {
-  flex: 0 0 auto;
-  margin-left: auto;
-  width: 0;
-  height: 0;
-  border-left: 3.5px solid transparent;
-  border-right: 3.5px solid transparent;
-  border-top: 4px solid currentColor;
-  opacity: 0.55;
-}
-.mlcad-draw-style-toolbar__lineweight-preview {
-  position: relative;
-  display: inline-flex;
-  width: 36px;
-  height: 14px;
-  flex: 0 0 36px;
-}
-.mlcad-draw-style-toolbar__lineweight-preview::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 50%;
-  height: var(--ml-lineweight-height, 2px);
-  transform: translateY(-50%);
-  background-color: currentColor;
-  border-radius: 999px;
-}
-.mlcad-draw-style-toolbar__lineweight-menu {
-  display: none;
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  z-index: 2;
-  min-width: 148px;
-  max-height: 260px;
-  overflow-y: auto;
-  padding: 4px 0;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 6px;
-  background: rgba(28, 32, 40, 0.98);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
-}
-.mlcad-draw-style-toolbar__lineweight-menu.is-open {
-  display: block;
-}
-.mlcad-draw-style-toolbar__lineweight-item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  box-sizing: border-box;
-  padding: 4px 10px;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  font-family: inherit;
-  font-size: 12px;
-  cursor: pointer;
-}
-.mlcad-draw-style-toolbar__lineweight-item:hover,
-.mlcad-draw-style-toolbar__lineweight-item.is-selected {
-  background: rgba(255, 255, 255, 0.1);
-}
-.mlcad-draw-style-toolbar__lineweight-text {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: left;
 }
 .mlcad-draw-style-toolbar__color {
   position: relative;
@@ -283,8 +179,11 @@ function preferExactAciColor(color: AcCmColor): AcCmColor {
 
 function cssToColor(css: string): AcCmColor {
   const trimmed = css.trim()
-  const isFunctional = /^(rgb|rgba|hsl|hsla)\(/i.test(trimmed)
-  if (!isFunctional) {
+  // fromString does not accept CSS hex (`#rrggbb`) or rgb()/hsl(); those
+  // log "Unknown color name" (e.g. `#d51572`) if passed as named colors.
+  const skipFromString =
+    trimmed.startsWith('#') || /^(rgb|rgba|hsl|hsla)\(/i.test(trimmed)
+  if (!skipFromString) {
     try {
       const fromString = AcCmColor.fromString(trimmed)
       if (fromString) return preferExactAciColor(fromString)
@@ -306,169 +205,6 @@ function aciIndexOf(color: AcCmColor): number | undefined {
     return color.colorIndex
   }
   return undefined
-}
-
-function numericLineWeights(): number[] {
-  const weights = Array.from(
-    new Set(
-      Object.values(AcGiLineWeight).filter(
-        (value): value is number => typeof value === 'number' && value > 0
-      )
-    )
-  ).sort((a, b) => a - b)
-  return [0, ...weights]
-}
-
-function formatLineWeight(value: number, hairlineLabel: string): string {
-  if (!(value > 0)) return hairlineLabel
-  return `${(value / 100).toFixed(2)} mm`
-}
-
-function previewLineHeightPx(value: number): number {
-  return Math.max(1, Math.min(6, value / 40))
-}
-
-interface AcExLineWeightPicker {
-  root: HTMLDivElement
-  setValue: (weight: number) => void
-  setTitle: (title: string) => void
-  refreshLabels: () => void
-  close: () => void
-  isOpen: () => boolean
-  contains: (node: Node | null) => boolean
-}
-
-function createLineWeightPicker(
-  onChange: (weight: number) => void,
-  onOpen: () => void,
-  hairlineLabel: () => string
-): AcExLineWeightPicker {
-  const prefix = 'mlcad-draw-style-toolbar'
-  const weights = numericLineWeights()
-  let open = false
-  let currentWeight = weights[0] ?? 0
-
-  const root = document.createElement('div')
-  root.className = `${prefix}__lineweight`
-
-  const trigger = document.createElement('button')
-  trigger.type = 'button'
-  trigger.className = `${prefix}__lineweight-trigger`
-  trigger.setAttribute('aria-haspopup', 'listbox')
-  trigger.setAttribute('aria-expanded', 'false')
-
-  const preview = document.createElement('span')
-  preview.className = `${prefix}__lineweight-preview`
-
-  const label = document.createElement('span')
-  label.className = `${prefix}__lineweight-label`
-
-  const caret = document.createElement('span')
-  caret.className = `${prefix}__lineweight-caret`
-  caret.setAttribute('aria-hidden', 'true')
-
-  trigger.append(preview, label, caret)
-
-  const menu = document.createElement('div')
-  menu.className = `${prefix}__lineweight-menu`
-  menu.setAttribute('role', 'listbox')
-
-  const paintTrigger = (weight: number) => {
-    currentWeight = weight
-    preview.style.setProperty(
-      '--ml-lineweight-height',
-      `${previewLineHeightPx(weight > 0 ? weight : 1)}px`
-    )
-    label.textContent = formatLineWeight(weight, hairlineLabel())
-  }
-
-  const markSelected = (weight: number) => {
-    menu.querySelectorAll(`.${prefix}__lineweight-item`).forEach(node => {
-      const item = node as HTMLElement
-      item.classList.toggle('is-selected', item.dataset.value === String(weight))
-    })
-  }
-
-  const close = () => {
-    open = false
-    menu.classList.remove('is-open')
-    trigger.setAttribute('aria-expanded', 'false')
-  }
-
-  const openMenu = () => {
-    onOpen()
-    open = true
-    menu.classList.add('is-open')
-    trigger.setAttribute('aria-expanded', 'true')
-  }
-
-  const addItem = (weight: number) => {
-    const item = document.createElement('button')
-    item.type = 'button'
-    item.className = `${prefix}__lineweight-item`
-    item.dataset.value = String(weight)
-    item.setAttribute('role', 'option')
-
-    const itemPreview = document.createElement('span')
-    itemPreview.className = `${prefix}__lineweight-preview`
-    itemPreview.style.setProperty(
-      '--ml-lineweight-height',
-      `${previewLineHeightPx(weight > 0 ? weight : 1)}px`
-    )
-
-    const itemLabel = document.createElement('span')
-    itemLabel.className = `${prefix}__lineweight-text`
-    itemLabel.textContent = formatLineWeight(weight, hairlineLabel())
-
-    item.append(itemPreview, itemLabel)
-    item.addEventListener('click', event => {
-      event.preventDefault()
-      event.stopPropagation()
-      paintTrigger(weight)
-      markSelected(weight)
-      close()
-      onChange(weight)
-    })
-    menu.appendChild(item)
-  }
-
-  for (const weight of weights) addItem(weight)
-
-  trigger.addEventListener('click', event => {
-    event.preventDefault()
-    event.stopPropagation()
-    if (open) close()
-    else openMenu()
-  })
-
-  root.append(trigger, menu)
-  paintTrigger(currentWeight)
-  markSelected(currentWeight)
-
-  return {
-    root,
-    setValue: weight => {
-      if (!Number.isFinite(weight) || weight < 0) return
-      if (!menu.querySelector(`[data-value="${weight}"]`)) addItem(weight)
-      paintTrigger(weight)
-      markSelected(weight)
-    },
-    setTitle: title => {
-      trigger.title = title
-    },
-    refreshLabels: () => {
-      menu.querySelectorAll(`.${prefix}__lineweight-item`).forEach(node => {
-        const item = node as HTMLElement
-        const weight = Number(item.dataset.value)
-        const text = item.querySelector(`.${prefix}__lineweight-text`)
-        if (text) text.textContent = formatLineWeight(weight, hairlineLabel())
-      })
-      paintTrigger(currentWeight)
-    },
-    close,
-    isOpen: () => open,
-    contains: node => !!node && root.contains(node)
-  }
 }
 
 function ensureStyles(): void {
@@ -556,9 +292,6 @@ export function setupAcExDrawStyleToolbar(
   fontSizeSelect.className = 'mlcad-draw-style-toolbar__select'
   root.appendChild(fontSizeSelect)
 
-  const lineWeightUi: { picker: AcExLineWeightPicker | null } = {
-    picker: null
-  }
   let colorPanelOpen = false
   let colorLeaveTimer: number | undefined
   let currentKind: AcExDrawStyleKind | undefined
@@ -576,7 +309,6 @@ export function setupAcExDrawStyleToolbar(
   }
 
   const showColorPanel = () => {
-    lineWeightUi.picker?.close()
     clearColorLeaveTimer()
     colorPanelOpen = true
     colorPanel.classList.add('is-open')
@@ -600,7 +332,6 @@ export function setupAcExDrawStyleToolbar(
     const color = cssToColor(style.color)
     swatchFill.style.background = cssColor(color)
     markSelectedAci(aciIndexOf(color))
-    lineWeightUi.picker?.setValue(style.lineWeight)
 
     const sizes = new Set(FONT_SIZE_OPTIONS)
     if (Number.isFinite(style.fontSize) && style.fontSize > 0) {
@@ -628,11 +359,6 @@ export function setupAcExDrawStyleToolbar(
     ctx.applyStyle(currentKind, { color: css })
   }
 
-  const applyLineWeight = (weight: number) => {
-    if (!currentKind || !Number.isFinite(weight) || weight < 0) return
-    ctx.applyStyle(currentKind, { lineWeight: weight })
-  }
-
   const applyFontSize = (size: number) => {
     if (!currentKind || !(size > 0)) return
     ctx.applyStyle(currentKind, { fontSize: size })
@@ -640,8 +366,6 @@ export function setupAcExDrawStyleToolbar(
 
   const relabel = () => {
     swatch.title = ctx.i18n.t('drawStyle.color')
-    lineWeightUi.picker?.setTitle(ctx.i18n.t('drawStyle.lineWeight'))
-    lineWeightUi.picker?.refreshLabels()
     fontSizeSelect.title = ctx.i18n.t('drawStyle.fontSize')
   }
 
@@ -649,7 +373,6 @@ export function setupAcExDrawStyleToolbar(
     currentKind = ctx.getKind()
     if (!currentKind) {
       hideColorPanel()
-      lineWeightUi.picker?.close()
       root.classList.remove('is-visible')
       return
     }
@@ -666,12 +389,6 @@ export function setupAcExDrawStyleToolbar(
   })
   colorWrap.addEventListener('mouseenter', () => clearColorLeaveTimer())
   colorWrap.addEventListener('mouseleave', () => scheduleHideColorPanel())
-  lineWeightUi.picker = createLineWeightPicker(
-    applyLineWeight,
-    hideColorPanel,
-    () => ctx.i18n.t('drawStyle.lineWeightHairline')
-  )
-  root.insertBefore(lineWeightUi.picker.root, fontSizeSelect)
   fontSizeSelect.addEventListener('change', () => {
     applyFontSize(Number(fontSizeSelect.value))
   })
@@ -681,12 +398,8 @@ export function setupAcExDrawStyleToolbar(
   const onDocumentPointerDown = (event: PointerEvent) => {
     const target = event.target as Node | null
     const inColor = !!target && colorWrap.contains(target)
-    const inLineWeight = !!lineWeightUi.picker?.contains(target)
-    const colorOpen = colorPanelOpen
-    const weightOpen = !!lineWeightUi.picker?.isOpen()
-    if (!colorOpen && !weightOpen) return
-    if (colorOpen && !inColor) hideColorPanel()
-    if (weightOpen && !inLineWeight) lineWeightUi.picker?.close()
+    if (!colorPanelOpen) return
+    if (!inColor) hideColorPanel()
   }
   document.addEventListener('pointerdown', onDocumentPointerDown, true)
 
@@ -701,7 +414,6 @@ export function setupAcExDrawStyleToolbar(
     dispose: () => {
       document.removeEventListener('pointerdown', onDocumentPointerDown, true)
       clearColorLeaveTimer()
-      lineWeightUi.picker?.close()
       root.remove()
     }
   }

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -80,8 +80,6 @@ export type AcExHtmlMessageKey =
   | 'settings.polar'
   | 'settings.polarAngles'
   | 'drawStyle.color'
-  | 'drawStyle.lineWeight'
-  | 'drawStyle.lineWeightHairline'
   | 'drawStyle.fontSize'
   | 'layers.title'
   | 'layers.close'
@@ -242,8 +240,6 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
     },
     drawStyle: {
       color: 'Color',
-      lineWeight: 'Lineweight',
-      lineWeightHairline: 'Hairline',
       fontSize: 'Text height'
     },
     layers: {
@@ -418,8 +414,6 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
     },
     drawStyle: {
       color: '颜色',
-      lineWeight: '线宽',
-      lineWeightHairline: '无线宽',
       fontSize: '字高'
     },
     layers: {
@@ -586,8 +580,6 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
     },
     drawStyle: {
       color: 'Barva',
-      lineWeight: 'Tloušťka čáry',
-      lineWeightHairline: 'Bez tloušťky',
       fontSize: 'Výška textu'
     },
     layers: {
@@ -762,8 +754,6 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
     },
     drawStyle: {
       color: 'Renk',
-      lineWeight: 'Çizgi kalınlığı',
-      lineWeightHairline: 'Kılcal',
       fontSize: 'Yazı yüksekliği'
     },
     layers: {
@@ -942,8 +932,6 @@ const AR_MESSAGES: AcExMessageTree = {
   },
   'drawStyle': {
     'color': 'اللون',
-    'lineWeight': 'سُمك الخط',
-    'lineWeightHairline': 'بلا سماكة',
     'fontSize': 'ارتفاع النص'
   },
   'layers': {

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -1075,8 +1075,11 @@ async function startViewer(): Promise<void> {
         if (measure?.hasSelection) return 'measure'
         return undefined
       },
-      getStyle: kind =>
-        kind === 'measure' ? measure!.getDrawStyle() : markup!.getDrawStyle(),
+      getStyle: kind => {
+        const style =
+          kind === 'measure' ? measure!.getDrawStyle() : markup!.getDrawStyle()
+        return { color: style.color, fontSize: style.fontSize }
+      },
       applyStyle: (kind, patch) => {
         if (kind === 'measure') {
           measure!.setDrawStyle(patch)

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -175,12 +175,6 @@ function markupNow(): string {
   return new Date().toISOString()
 }
 
-function resolveMarkupLineWeight(weight?: number): number {
-  return typeof weight === 'number' && Number.isFinite(weight) && weight >= 0
-    ? weight
-    : ACEX_MARKUP_LINE_WEIGHT
-}
-
 function defaultStyle(
   color = ACEX_MARKUP_COLOR,
   lineWeight = ACEX_MARKUP_LINE_WEIGHT,
@@ -253,7 +247,6 @@ export class AcExMarkupController {
     snap: AcExOsnapPoint | null
   } | null = null
   private _drawColor = ACEX_MARKUP_COLOR
-  private _drawLineWeight = ACEX_MARKUP_LINE_WEIGHT
   private _drawFontSize = ACEX_MARKUP_FONT_SIZE
   private _placingShapeCallout: AcExPlacingShapeCallout | null = null
   /** Blocks canvas placement while an inline text session is open. */
@@ -349,14 +342,14 @@ export class AcExMarkupController {
       if (record) {
         return {
           color: record.style.color || this._drawColor,
-          lineWeight: record.style.lineWeight ?? this._drawLineWeight,
+          lineWeight: ACEX_MARKUP_LINE_WEIGHT,
           fontSize: record.style.fontSize ?? this._drawFontSize
         }
       }
     }
     return {
       color: this._drawColor,
-      lineWeight: this._drawLineWeight,
+      lineWeight: ACEX_MARKUP_LINE_WEIGHT,
       fontSize: this._drawFontSize
     }
   }
@@ -370,17 +363,13 @@ export class AcExMarkupController {
     fontSize?: number
   }): void {
     if (patch.color) this._drawColor = patch.color
-    if (
-      patch.lineWeight != null &&
-      Number.isFinite(patch.lineWeight) &&
-      patch.lineWeight >= 0
-    ) {
-      this._drawLineWeight = patch.lineWeight
-    }
     if (patch.fontSize != null && patch.fontSize > 0) {
       this._drawFontSize = patch.fontSize
     }
-    this._applyStyleToSelection(patch)
+    this._applyStyleToSelection({
+      color: patch.color,
+      fontSize: patch.fontSize
+    })
     this._refreshActivePreview()
     this._syncPlacingStyle()
     this._onStyleChange?.()
@@ -389,25 +378,23 @@ export class AcExMarkupController {
 
   private _sessionStyle(): AcExMarkupStyle {
     return this._styleWithWcs(
-      defaultStyle(this._drawColor, this._drawLineWeight, this._drawFontSize)
+      defaultStyle(this._drawColor, ACEX_MARKUP_LINE_WEIGHT, this._drawFontSize)
     )
   }
 
-  /** Attach world-space text/stroke sizes from the current view. */
+  /** Attach world-space text height from the current view. */
   private _styleWithWcs(style: AcExMarkupStyle): AcExMarkupStyle {
     const fontSize =
       style.fontSize != null && style.fontSize > 0
         ? style.fontSize
         : ACEX_MARKUP_FONT_SIZE
-    const lineWeight = resolveMarkupLineWeight(style.lineWeight)
-    const strokePx = acExMarkupCanvasLineWidth(lineWeight)
     const wcsToScreen = (p: { x: number; y: number }) =>
       this._wcsToScreenPoint(p)
+    const { strokeWidthWcs: _omit, ...rest } = style
     return {
-      ...style,
-      textHeightWcs: acExScreenPxToWcs(fontSize, wcsToScreen),
-      strokeWidthWcs:
-        strokePx > 0 ? acExScreenPxToWcs(strokePx, wcsToScreen) : undefined
+      ...rest,
+      lineWeight: ACEX_MARKUP_LINE_WEIGHT,
+      textHeightWcs: acExScreenPxToWcs(fontSize, wcsToScreen)
     }
   }
 
@@ -437,7 +424,6 @@ export class AcExMarkupController {
 
   private _applyStyleToSelection(patch: {
     color?: string
-    lineWeight?: number
     fontSize?: number
   }): void {
     if (this._selectedIds.size === 0) return
@@ -448,27 +434,8 @@ export class AcExMarkupController {
       if (!item) continue
       const style = item.record.style
       if (patch.color) style.color = patch.color
-      if (
-        patch.lineWeight != null &&
-        Number.isFinite(patch.lineWeight) &&
-        patch.lineWeight >= 0
-      ) {
-        const prevWeight = resolveMarkupLineWeight(style.lineWeight)
-        const prevPx = acExMarkupCanvasLineWidth(prevWeight)
-        const nextPx = acExMarkupCanvasLineWidth(patch.lineWeight)
-        if (!(nextPx > 0)) {
-          style.strokeWidthWcs = undefined
-        } else if (
-          style.strokeWidthWcs != null &&
-          style.strokeWidthWcs > 0 &&
-          prevPx > 0
-        ) {
-          style.strokeWidthWcs = style.strokeWidthWcs * (nextPx / prevPx)
-        } else {
-          style.strokeWidthWcs = acExScreenPxToWcs(nextPx, wcsToScreen)
-        }
-        style.lineWeight = patch.lineWeight
-      }
+      style.lineWeight = ACEX_MARKUP_LINE_WEIGHT
+      style.strokeWidthWcs = undefined
       if (patch.fontSize != null && patch.fontSize > 0) {
         const prevFont =
           style.fontSize != null && style.fontSize > 0
@@ -489,17 +456,14 @@ export class AcExMarkupController {
         }
         style.fontSize = patch.fontSize
       }
-      if (patch.fontSize != null || patch.lineWeight != null) {
+      if (patch.fontSize != null) {
         acExSeedOverlaySizesFromWcs(
           this._view.getCameraZoom(),
           wcsToScreen,
           {
             textHeightWcs: style.textHeightWcs,
-            strokeWidthWcs: style.strokeWidthWcs,
             fontSizePx: style.fontSize ?? ACEX_MARKUP_FONT_SIZE,
-            strokeScreenPx: acExMarkupCanvasLineWidth(
-              style.lineWeight ?? ACEX_MARKUP_LINE_WEIGHT
-            ),
+            strokeScreenPx: acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
             elements: item.parts.dom,
             canvases: item.parts.canvases
           }
@@ -1094,7 +1058,7 @@ export class AcExMarkupController {
       if (!ctx) return
       const tipS = this._worldToOverlay(tip)
       const anchorS = this._worldToOverlay(anchor)
-      const baseWidth = acExMarkupCanvasLineWidth(this._drawLineWeight)
+      const baseWidth = acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
       const scaled = this._scaledCanvasLineWidth(baseWidth, ctx.canvas)
       acExDrawMarkupLeader(
         ctx,
@@ -1385,11 +1349,8 @@ export class AcExMarkupController {
       p => this._wcsToScreenPoint(p),
       {
         textHeightWcs: record.style.textHeightWcs,
-        strokeWidthWcs: record.style.strokeWidthWcs,
         fontSizePx: record.style.fontSize ?? ACEX_MARKUP_FONT_SIZE,
-        strokeScreenPx: acExMarkupCanvasLineWidth(
-          record.style.lineWeight ?? ACEX_MARKUP_LINE_WEIGHT
-        ),
+        strokeScreenPx: acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
         elements: parts.dom,
         canvases: parts.canvases
       }
@@ -1420,8 +1381,7 @@ export class AcExMarkupController {
         ctx,
         live.geometry,
         live.style.color || ACEX_MARKUP_COLOR,
-        acExMarkupCanvasLineWidth(live.style.lineWeight),
-        live.style.strokeWidthWcs
+        acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
       )
     }
     this._redrawListeners.push(redraw)
@@ -2333,7 +2293,7 @@ export class AcExMarkupController {
     const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
     if (!ctx) return
     const color = this._drawColor
-    const lineWidth = acExMarkupCanvasLineWidth(this._drawLineWeight)
+    const lineWidth = acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
 
     if (this._points.length === 0) return
     const a = this._points[0]!
@@ -2393,7 +2353,7 @@ export class AcExMarkupController {
     const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
     if (!ctx) return
     const color = this._drawColor
-    const lineWidth = acExMarkupCanvasLineWidth(this._drawLineWeight)
+    const lineWidth = acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
     const outline = placing.outline
     // Existing shape is already committed; only preview the new leader.
     if (!placing.existingId) {

--- a/packages/cad-html-plugin/src/AcExMarkupSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupSidecar.ts
@@ -10,8 +10,12 @@ import type {
   AcExMarkupRecord,
   AcExMarkupSidecarFile,
   AcExMarkupStatus,
+  AcExMarkupStyle,
   AcExMarkupType
 } from './AcExMarkupTypes'
+
+/** Overlay line weight: hairline (1 CSS px, not zoom-scaled). */
+const ACEX_MARKUP_LINE_WEIGHT = 0
 
 const MARKUP_STATUSES: readonly AcExMarkupStatus[] = [
   'open',
@@ -153,16 +157,13 @@ function parseRecord(raw: unknown): AcExMarkupRecord | undefined {
     layoutId: typeof raw.layoutId === 'string' ? raw.layoutId : undefined,
     style: {
       color: raw.style.color,
-      lineWeight:
-        typeof raw.style.lineWeight === 'number'
-          ? raw.style.lineWeight
-          : undefined,
+      // Accept legacy lineWeight / strokeWidthWcs without failing, but always hairline.
+      lineWeight: ACEX_MARKUP_LINE_WEIGHT,
       fontSize:
         typeof raw.style.fontSize === 'number' && raw.style.fontSize > 0
           ? raw.style.fontSize
           : undefined,
-      textHeightWcs: parsePositiveNumber(raw.style.textHeightWcs),
-      strokeWidthWcs: parsePositiveNumber(raw.style.strokeWidthWcs)
+      textHeightWcs: parsePositiveNumber(raw.style.textHeightWcs)
     },
     text: typeof raw.text === 'string' ? raw.text : undefined,
     comment: typeof raw.comment === 'string' ? raw.comment : '',
@@ -210,11 +211,26 @@ export function parseAcExMarkupSidecar(text: string): AcExMarkupSidecarFile {
   }
 }
 
+function normalizeStyleForWrite(style: AcExMarkupStyle): AcExMarkupStyle {
+  const { strokeWidthWcs: _ignored, ...rest } = style
+  return {
+    ...rest,
+    lineWeight: ACEX_MARKUP_LINE_WEIGHT
+  }
+}
+
 /** Serialize a sidecar file to pretty-printed JSON. */
 export function stringifyAcExMarkupSidecar(
   file: AcExMarkupSidecarFile
 ): string {
-  return `${JSON.stringify(file, null, 2)}\n`
+  const normalized: AcExMarkupSidecarFile = {
+    ...file,
+    markups: file.markups.map(m => ({
+      ...m,
+      style: normalizeStyleForWrite(m.style)
+    }))
+  }
+  return `${JSON.stringify(normalized, null, 2)}\n`
 }
 
 /**

--- a/packages/cad-html-plugin/src/AcExMarkupTypes.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupTypes.ts
@@ -34,13 +34,13 @@ export interface AcExMarkupPoint2d {
 export interface AcExMarkupStyle {
   /** CSS color string, e.g. `#ff0000` or `rgb(255,0,0)`. */
   color: string
-  /** Optional AutoCAD-style line weight enum value. */
+  /** Always hairline (`0`) on write; legacy non-zero values are ignored on parse. */
   lineWeight?: number
   /** Authoring font size in CSS pixels for text / callout bubbles (legacy / UI). */
   fontSize?: number
   /** Text / callout height in world units (preferred when restoring overlays). */
   textHeightWcs?: number
-  /** Canvas stroke width in world units (preferred when restoring overlays). */
+  /** Legacy canvas stroke width in world units. Ignored on parse; never written. */
   strokeWidthWcs?: number
 }
 

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -954,8 +954,6 @@ export class AcExMeasureController {
   private readonly _getActiveLayoutId: (() => string) | null
   /** Accent color for lines, labels, and canvas overlays. */
   private _measureColor = ACEX_MEASURE_COLOR
-  /** Session line weight for new measurements. */
-  private _drawLineWeight = ACEX_MEASUREMENT_LINE_WEIGHT
   /** Session badge font size for new measurements. */
   private _drawFontSize = ACEX_MEASUREMENT_FONT_SIZE
   /** Style of the measurement currently being committed (import or interactive). */
@@ -1121,14 +1119,14 @@ export class AcExMeasureController {
       if (measure) {
         return {
           color: measure.record.style.color || this._measureCss(),
-          lineWeight: measure.record.style.lineWeight ?? this._drawLineWeight,
+          lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
           fontSize: measure.record.style.fontSize || this._drawFontSize
         }
       }
     }
     return {
       color: this._measureCss(),
-      lineWeight: this._drawLineWeight,
+      lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
       fontSize: this._drawFontSize
     }
   }
@@ -1153,13 +1151,6 @@ export class AcExMeasureController {
         colorChanged = true
       }
     }
-    if (
-      patch.lineWeight != null &&
-      Number.isFinite(patch.lineWeight) &&
-      patch.lineWeight >= 0
-    ) {
-      this._drawLineWeight = patch.lineWeight
-    }
     if (patch.fontSize != null && patch.fontSize > 0) {
       this._drawFontSize = patch.fontSize
     }
@@ -1172,18 +1163,10 @@ export class AcExMeasureController {
 
     const selectionPatch: {
       color?: string
-      lineWeight?: number
       fontSize?: number
     } = {}
     if (colorChanged || patch.colorHex != null || patch.color) {
       selectionPatch.color = this._measureCss()
-    }
-    if (
-      patch.lineWeight != null &&
-      Number.isFinite(patch.lineWeight) &&
-      patch.lineWeight >= 0
-    ) {
-      selectionPatch.lineWeight = patch.lineWeight
     }
     if (patch.fontSize != null && patch.fontSize > 0) {
       selectionPatch.fontSize = patch.fontSize
@@ -1193,9 +1176,7 @@ export class AcExMeasureController {
     // Mid-draw: keep in-progress commit style in sync with the session.
     if (this._commitStyle) {
       if (selectionPatch.color) this._commitStyle.color = selectionPatch.color
-      if (selectionPatch.lineWeight != null) {
-        this._commitStyle.lineWeight = selectionPatch.lineWeight
-      }
+      this._commitStyle.lineWeight = ACEX_MEASUREMENT_LINE_WEIGHT
       if (selectionPatch.fontSize != null) {
         this._commitStyle.fontSize = selectionPatch.fontSize
       }
@@ -1880,7 +1861,7 @@ export class AcExMeasureController {
       canvas,
       points,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(this._drawLineWeight),
+      acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT),
       undefined,
       options?.bothArrows
     )
@@ -3338,9 +3319,8 @@ export class AcExMeasureController {
       p => this._wcsToScreenPoint(p),
       {
         textHeightWcs: style.textHeightWcs,
-        strokeWidthWcs: style.strokeWidthWcs,
         fontSizePx: style.fontSize,
-        strokeScreenPx: acExMeasureCanvasLineWidth(style.lineWeight),
+        strokeScreenPx: acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT),
         elements: parts.dom,
         canvases: parts.canvases
       }
@@ -3356,13 +3336,14 @@ export class AcExMeasureController {
   private _defaultStyle(): AcExMeasurementSidecarStyle {
     return this._styleWithWcs({
       color: this._measureCss(),
-      lineWeight: this._drawLineWeight,
+      lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
       fontSize: this._drawFontSize
     })
   }
 
   /**
-   * Fill any missing world-space sizes without overwriting sidecar values.
+   * Fill any missing world-space text height without overwriting sidecar values.
+   * Never writes strokeWidthWcs (overlay strokes stay hairline).
    * @internal
    */
   private _ensureStyleWcs(
@@ -3370,34 +3351,28 @@ export class AcExMeasureController {
   ): AcExMeasurementSidecarStyle {
     const wcsToScreen = (p: { x: number; y: number }) =>
       this._wcsToScreenPoint(p)
-    const strokePx = acExMeasureCanvasLineWidth(style.lineWeight)
+    const { strokeWidthWcs: _omit, ...rest } = style
     return {
-      ...style,
+      ...rest,
+      lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
       textHeightWcs:
         style.textHeightWcs != null && style.textHeightWcs > 0
           ? style.textHeightWcs
-          : acExScreenPxToWcs(style.fontSize, wcsToScreen),
-      strokeWidthWcs:
-        style.strokeWidthWcs != null && style.strokeWidthWcs > 0
-          ? style.strokeWidthWcs
-          : strokePx > 0
-            ? acExScreenPxToWcs(strokePx, wcsToScreen)
-            : undefined
+          : acExScreenPxToWcs(style.fontSize, wcsToScreen)
     }
   }
 
-  /** Attach world-space text/stroke sizes from the current view. @internal */
+  /** Attach world-space text height from the current view. @internal */
   private _styleWithWcs(
     style: AcExMeasurementSidecarStyle
   ): AcExMeasurementSidecarStyle {
     const wcsToScreen = (p: { x: number; y: number }) =>
       this._wcsToScreenPoint(p)
-    const strokePx = acExMeasureCanvasLineWidth(style.lineWeight)
+    const { strokeWidthWcs: _omit, ...rest } = style
     return {
-      ...style,
-      textHeightWcs: acExScreenPxToWcs(style.fontSize, wcsToScreen),
-      strokeWidthWcs:
-        strokePx > 0 ? acExScreenPxToWcs(strokePx, wcsToScreen) : undefined
+      ...rest,
+      lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
+      textHeightWcs: acExScreenPxToWcs(style.fontSize, wcsToScreen)
     }
   }
 
@@ -3641,7 +3616,6 @@ export class AcExMeasureController {
   /** Apply style patch to currently selected measurements. @internal */
   private _applyStyleToSelection(patch: {
     color?: string
-    lineWeight?: number
     fontSize?: number
   }): void {
     if (this._selectedIds.size === 0) return
@@ -3652,28 +3626,8 @@ export class AcExMeasureController {
       if (!measure) continue
       const style = measure.record.style
       if (patch.color) style.color = patch.color
-      if (
-        patch.lineWeight != null &&
-        Number.isFinite(patch.lineWeight) &&
-        patch.lineWeight >= 0
-      ) {
-        const prevWeight = style.lineWeight
-        const prevPx = acExMeasureCanvasLineWidth(prevWeight)
-        const nextPx = acExMeasureCanvasLineWidth(patch.lineWeight)
-        if (!(nextPx > 0)) {
-          style.strokeWidthWcs = undefined
-        } else if (
-          style.strokeWidthWcs != null &&
-          style.strokeWidthWcs > 0 &&
-          prevPx > 0
-        ) {
-          style.strokeWidthWcs =
-            style.strokeWidthWcs * (nextPx / prevPx)
-        } else {
-          style.strokeWidthWcs = acExScreenPxToWcs(nextPx, wcsToScreen)
-        }
-        style.lineWeight = patch.lineWeight
-      }
+      style.lineWeight = ACEX_MEASUREMENT_LINE_WEIGHT
+      style.strokeWidthWcs = undefined
       if (patch.fontSize != null && patch.fontSize > 0) {
         const prevFont = style.fontSize
         if (
@@ -3691,21 +3645,22 @@ export class AcExMeasureController {
         }
         style.fontSize = patch.fontSize
       }
-      if (patch.fontSize != null || patch.lineWeight != null) {
+      if (patch.fontSize != null) {
         acExSeedOverlaySizesFromWcs(
           this._view.getCameraZoom(),
           wcsToScreen,
           {
             textHeightWcs: style.textHeightWcs,
-            strokeWidthWcs: style.strokeWidthWcs,
             fontSizePx: style.fontSize,
-            strokeScreenPx: acExMeasureCanvasLineWidth(style.lineWeight),
+            strokeScreenPx: acExMeasureCanvasLineWidth(
+              ACEX_MEASUREMENT_LINE_WEIGHT
+            ),
             elements: measure.parts.dom,
             canvases: measure.parts.canvases
           }
         )
       }
-      // Keep selection highlight on DOM; canvas redraws pick up color/weight.
+      // Keep selection highlight on DOM; canvas redraws pick up color.
       for (const el of measure.parts.dom) {
         if (el.classList.contains('mlcad-measure-badge') && style.fontSize) {
           el.style.fontSize = `${style.fontSize}px`
@@ -3836,7 +3791,7 @@ export class AcExMeasureController {
       arm1,
       arm2,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(this._drawLineWeight)
+      acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
     )
   }
 
@@ -3957,7 +3912,7 @@ export class AcExMeasureController {
       through,
       end,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(this._drawLineWeight)
+      acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
     )
   }
 
@@ -4020,7 +3975,7 @@ export class AcExMeasureController {
       canvas,
       points,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(this._drawLineWeight)
+      acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
     )
   }
 }

--- a/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
@@ -64,22 +64,16 @@ function parsePositiveNumber(value: unknown): number | undefined {
 
 function parseStyle(raw: unknown): AcExMeasurementSidecarStyle | undefined {
   if (!isPlainObject(raw) || typeof raw.color !== 'string') return undefined
-  const lineWeight =
-    typeof raw.lineWeight === 'number' &&
-    Number.isFinite(raw.lineWeight) &&
-    raw.lineWeight >= 0
-      ? raw.lineWeight
-      : ACEX_MEASUREMENT_LINE_WEIGHT
+  // Accept legacy lineWeight / strokeWidthWcs without failing, but always hairline.
   const fontSize =
     typeof raw.fontSize === 'number' && raw.fontSize > 0
       ? raw.fontSize
       : ACEX_MEASUREMENT_FONT_SIZE
   return {
     color: raw.color,
-    lineWeight,
+    lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
     fontSize,
-    textHeightWcs: parsePositiveNumber(raw.textHeightWcs),
-    strokeWidthWcs: parsePositiveNumber(raw.strokeWidthWcs)
+    textHeightWcs: parsePositiveNumber(raw.textHeightWcs)
   }
 }
 
@@ -174,11 +168,28 @@ export function parseAcExMeasurementSidecar(
   }
 }
 
+function normalizeStyleForWrite(
+  style: AcExMeasurementSidecarStyle
+): AcExMeasurementSidecarStyle {
+  const { strokeWidthWcs: _ignored, ...rest } = style
+  return {
+    ...rest,
+    lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT
+  }
+}
+
 /** Serialize a sidecar file to pretty-printed JSON. */
 export function stringifyAcExMeasurementSidecar(
   file: AcExMeasurementSidecarFile
 ): string {
-  return `${JSON.stringify(file, null, 2)}\n`
+  const normalized: AcExMeasurementSidecarFile = {
+    ...file,
+    measurements: file.measurements.map(m => ({
+      ...m,
+      style: normalizeStyleForWrite(m.style)
+    }))
+  }
+  return `${JSON.stringify(normalized, null, 2)}\n`
 }
 
 /**

--- a/packages/cad-html-plugin/src/AcExMeasurementTypes.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurementTypes.ts
@@ -25,12 +25,13 @@ export interface AcExMeasurementPoint2d {
 /** Drawing style stored in the sidecar (CSS-friendly + world-space sizes). */
 export interface AcExMeasurementSidecarStyle {
   color: string
+  /** Always hairline (`0`) on write; legacy non-zero values are ignored on parse. */
   lineWeight: number
   /** Authoring badge font size in CSS pixels (legacy / UI). */
   fontSize: number
   /** Badge text height in world units (preferred when restoring overlays). */
   textHeightWcs?: number
-  /** Canvas stroke width in world units (preferred when restoring overlays). */
+  /** Legacy canvas stroke width in world units. Ignored on parse; never written. */
   strokeWidthWcs?: number
 }
 

--- a/packages/cad-simple-viewer/__tests__/AcApDrawStyle.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDrawStyle.spec.ts
@@ -1,7 +1,6 @@
 import {
   AcCmColor,
-  AcCmColorMethod,
-  AcGiLineWeight
+  AcCmColorMethod
 } from '@mlightcad/data-model'
 
 import {
@@ -13,10 +12,8 @@ import type { AcApMarkupGeometry } from '../src/command/markup/AcApMarkupTypes'
 import {
   createDefaultMarkupColor,
   MARKUP_FONT_SIZE,
-  MARKUP_LINE_WEIGHT,
   setMarkupDrawColor,
   setMarkupDrawFontSize,
-  setMarkupDrawLineWeight,
   subscribeMarkupDrawStyle
 } from '../src/command/markup/AcApMarkupUtil'
 import {
@@ -30,17 +27,15 @@ import {
 } from '../src/ui/AcApDrawStyle'
 
 describe('subscribeMarkupDrawStyle', () => {
-  it('notifies when markup draw color, line weight, or font size change', () => {
+  it('notifies when markup draw color or font size change', () => {
     const seen: string[] = []
     const unsubscribe = subscribeMarkupDrawStyle(() => seen.push('change'))
     setMarkupDrawColor(new AcCmColor(AcCmColorMethod.ByACI, 3))
-    setMarkupDrawLineWeight(AcGiLineWeight.LineWeight013)
     setMarkupDrawFontSize(16)
     unsubscribe()
     setMarkupDrawColor(createDefaultMarkupColor())
-    setMarkupDrawLineWeight(MARKUP_LINE_WEIGHT)
     setMarkupDrawFontSize(MARKUP_FONT_SIZE)
-    expect(seen).toEqual(['change', 'change', 'change'])
+    expect(seen).toEqual(['change', 'change'])
   })
 })
 

--- a/packages/cad-simple-viewer/__tests__/AcApMarkupSidecar.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupSidecar.spec.ts
@@ -6,7 +6,7 @@ import {
 import type { AcApMarkupSidecarFile } from '../src/command/markup/AcApMarkupTypes'
 
 describe('AcApMarkupSidecar', () => {
-  it('round-trips a text markup', () => {
+  it('round-trips a text markup as hairline', () => {
     const file: AcApMarkupSidecarFile = {
       version: 1,
       drawingName: 'demo.dwg',
@@ -16,6 +16,7 @@ describe('AcApMarkupSidecar', () => {
           type: 'text',
           style: {
             color: '#ff0000',
+            lineWeight: 70,
             fontSize: 12,
             textHeightWcs: 1.5,
             strokeWidthWcs: 0.2
@@ -31,13 +32,16 @@ describe('AcApMarkupSidecar', () => {
       ]
     }
     const text = stringifyMarkupSidecar(file)
+    expect(text).not.toMatch(/"strokeWidthWcs"\s*:/)
+    expect(text).toMatch(/"lineWeight"\s*:\s*0/)
     const parsed = parseMarkupSidecar(text)
     expect(parsed.version).toBe(1)
     expect(parsed.drawingName).toBe('demo.dwg')
     expect(parsed.markups).toHaveLength(1)
     expect(parsed.markups[0].type).toBe('text')
+    expect(parsed.markups[0].style.lineWeight).toBe(0)
     expect(parsed.markups[0].style.textHeightWcs).toBe(1.5)
-    expect(parsed.markups[0].style.strokeWidthWcs).toBe(0.2)
+    expect(parsed.markups[0].style.strokeWidthWcs).toBeUndefined()
     expect(parsed.markups[0].geometry).toEqual({
       type: 'text',
       position: { x: 1, y: 2 }
@@ -56,7 +60,7 @@ describe('AcApMarkupSidecar', () => {
     )
   })
 
-  it('drops non-finite world-space style sizes', () => {
+  it('ignores legacy strokeWidthWcs and non-finite textHeightWcs', () => {
     const parsed = parseMarkupSidecar(
       JSON.stringify({
         version: 1,
@@ -68,7 +72,7 @@ describe('AcApMarkupSidecar', () => {
               color: '#ff0000',
               fontSize: 12,
               textHeightWcs: Number.POSITIVE_INFINITY,
-              strokeWidthWcs: Number.NaN
+              strokeWidthWcs: 0.5
             },
             comment: '',
             status: 'open',
@@ -80,6 +84,7 @@ describe('AcApMarkupSidecar', () => {
         ]
       })
     )
+    expect(parsed.markups[0]?.style.lineWeight).toBe(0)
     expect(parsed.markups[0]?.style.textHeightWcs).toBeUndefined()
     expect(parsed.markups[0]?.style.strokeWidthWcs).toBeUndefined()
   })

--- a/packages/cad-simple-viewer/__tests__/AcApMarkupUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupUtil.spec.ts
@@ -3,12 +3,11 @@ import { AcCmColor, AcCmColorMethod, AcGiLineWeight } from '@mlightcad/data-mode
 import {
   createDefaultMarkupColor,
   cssToMarkupColor,
+  defaultMarkupStyle,
   MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth,
   markupColorToCss,
-  resolveMarkupLineWeight,
-  setMarkupDrawLineWeight,
-  getMarkupLineWeight
+  resolveMarkupLineWeight
 } from '../src/command/markup/AcApMarkupUtil'
 
 describe('cssToMarkupColor', () => {
@@ -46,12 +45,9 @@ describe('cssToMarkupColor', () => {
 })
 
 describe('markup line weight', () => {
-  afterEach(() => {
-    setMarkupDrawLineWeight(MARKUP_LINE_WEIGHT)
-  })
-
   it('defaults to hairline and maps it to a 0 canvas width sentinel', () => {
     expect(MARKUP_LINE_WEIGHT).toBe(0)
+    expect(defaultMarkupStyle().lineWeight).toBe(0)
     expect(markupCanvasLineWidth(MARKUP_LINE_WEIGHT)).toBe(0)
     expect(markupCanvasLineWidth(AcGiLineWeight.LineWeight070)).toBeCloseTo(
       2.5
@@ -65,12 +61,5 @@ describe('markup line weight', () => {
     expect(resolveMarkupLineWeight(AcGiLineWeight.ByLayer)).toBe(
       MARKUP_LINE_WEIGHT
     )
-  })
-
-  it('accepts hairline as a session draw line weight', () => {
-    setMarkupDrawLineWeight(AcGiLineWeight.LineWeight013)
-    setMarkupDrawLineWeight(0 as AcGiLineWeight)
-    expect(getMarkupLineWeight()).toBe(0)
-    setMarkupDrawLineWeight(MARKUP_LINE_WEIGHT)
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementSidecar.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementSidecar.spec.ts
@@ -1,5 +1,3 @@
-import { AcGiLineWeight } from '@mlightcad/data-model'
-
 import {
   measurementSidecarFileName,
   parseMeasurementSidecar,
@@ -8,7 +6,7 @@ import {
 import type { AcApMeasurementSidecarFile } from '../src/command/measure/AcApMeasurementTypes'
 
 describe('AcApMeasurementSidecar', () => {
-  it('round-trips distance, angle, area, arc, and point measurements', () => {
+  it('round-trips distance, angle, area, arc, and point measurements as hairline', () => {
     const file: AcApMeasurementSidecarFile = {
       version: 1,
       drawingName: 'demo.dwg',
@@ -18,7 +16,7 @@ describe('AcApMeasurementSidecar', () => {
           type: 'distance',
           style: {
             color: '#ff0000',
-            lineWeight: AcGiLineWeight.LineWeight070,
+            lineWeight: 70,
             fontSize: 13,
             textHeightWcs: 2.5,
             strokeWidthWcs: 0.4
@@ -34,7 +32,7 @@ describe('AcApMeasurementSidecar', () => {
           type: 'angle',
           style: {
             color: '#00ff00',
-            lineWeight: AcGiLineWeight.LineWeight013,
+            lineWeight: 13,
             fontSize: 12
           },
           geometry: {
@@ -50,7 +48,7 @@ describe('AcApMeasurementSidecar', () => {
           layoutId: 'layout-a',
           style: {
             color: '#0000ff',
-            lineWeight: AcGiLineWeight.LineWeight070,
+            lineWeight: 70,
             fontSize: 14
           },
           geometry: {
@@ -67,7 +65,7 @@ describe('AcApMeasurementSidecar', () => {
           type: 'arc',
           style: {
             color: '#ffff00',
-            lineWeight: AcGiLineWeight.LineWeight070,
+            lineWeight: 70,
             fontSize: 13
           },
           geometry: {
@@ -84,7 +82,7 @@ describe('AcApMeasurementSidecar', () => {
           type: 'point',
           style: {
             color: '#ffffff',
-            lineWeight: AcGiLineWeight.LineWeight013,
+            lineWeight: 13,
             fontSize: 11
           },
           geometry: {
@@ -94,12 +92,15 @@ describe('AcApMeasurementSidecar', () => {
         }
       ]
     }
-    const parsed = parseMeasurementSidecar(stringifyMeasurementSidecar(file))
+    const text = stringifyMeasurementSidecar(file)
+    expect(text).not.toMatch(/"strokeWidthWcs"\s*:/)
+    const parsed = parseMeasurementSidecar(text)
     expect(parsed.version).toBe(1)
     expect(parsed.drawingName).toBe('demo.dwg')
     expect(parsed.measurements).toHaveLength(5)
     expect(parsed.measurements[0].style.textHeightWcs).toBe(2.5)
-    expect(parsed.measurements[0].style.strokeWidthWcs).toBe(0.4)
+    expect(parsed.measurements[0].style.lineWeight).toBe(0)
+    expect(parsed.measurements[0].style.strokeWidthWcs).toBeUndefined()
     expect(parsed.measurements[0].geometry).toEqual({
       type: 'distance',
       start: { x: 0, y: 0 },
@@ -121,7 +122,7 @@ describe('AcApMeasurementSidecar', () => {
     })
   })
 
-  it('keeps legacy styles that omit world-space sizes', () => {
+  it('ignores legacy non-zero lineWeight and strokeWidthWcs on parse', () => {
     const parsed = parseMeasurementSidecar(
       JSON.stringify({
         version: 1,
@@ -129,12 +130,18 @@ describe('AcApMeasurementSidecar', () => {
           {
             id: 'legacy',
             type: 'point',
-            style: { color: '#abcabc', lineWeight: 35, fontSize: 13 },
+            style: {
+              color: '#abcabc',
+              lineWeight: 35,
+              fontSize: 13,
+              strokeWidthWcs: 0.5
+            },
             geometry: { type: 'point', position: { x: 1, y: 2 } }
           }
         ]
       })
     )
+    expect(parsed.measurements[0].style.lineWeight).toBe(0)
     expect(parsed.measurements[0].style.textHeightWcs).toBeUndefined()
     expect(parsed.measurements[0].style.strokeWidthWcs).toBeUndefined()
   })
@@ -186,6 +193,7 @@ describe('AcApMeasurementSidecar', () => {
     )
     expect(parsed.measurements).toHaveLength(1)
     expect(parsed.measurements[0].id).toBe('ok')
+    expect(parsed.measurements[0].style.lineWeight).toBe(0)
   })
 
   it('keeps legacy arc records that omit the through point', () => {
@@ -209,6 +217,7 @@ describe('AcApMeasurementSidecar', () => {
       })
     )
     expect(parsed.measurements).toHaveLength(1)
+    expect(parsed.measurements[0].style.lineWeight).toBe(0)
     expect(parsed.measurements[0].geometry).toEqual({
       type: 'arc',
       center: { x: 0, y: 0 },

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementStore.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementStore.spec.ts
@@ -1,4 +1,4 @@
-import { AcCmColor, AcGiLineWeight } from '@mlightcad/data-model'
+import { AcCmColor } from '@mlightcad/data-model'
 import type { AcTrHtmlGroup } from '@mlightcad/three-renderer'
 
 import {
@@ -18,6 +18,7 @@ import {
 import type { AcApMeasurementRecord } from '../src/command/measure/AcApMeasurementTypes'
 import {
   MEASUREMENT_FONT_SIZE,
+  MEASUREMENT_LINE_WEIGHT,
   OVERLAY_HAIRLINE_LINE_WEIGHT
 } from '../src/util/AcApMeasurementUtil'
 import type { AcTrView2d } from '../src/view'
@@ -83,29 +84,28 @@ function makeGroup(id: string): AcTrHtmlGroup {
   } as unknown as AcTrHtmlGroup
 }
 
-function numericSnapshot(id: string): AcApMeasurementRecord {
-  const color = new AcCmColor()
-  color.setRGB(10, 20, 30)
+function hairlineSnapshot(id: string): AcApMeasurementRecord {
   return {
     id,
     type: 'point',
     style: {
       color: 'rgb(10,20,30)',
-      lineWeight: AcGiLineWeight.LineWeight070,
+      lineWeight: MEASUREMENT_LINE_WEIGHT,
       fontSize: MEASUREMENT_FONT_SIZE,
       textHeightWcs: 1.3,
+      // Legacy field ignored on export.
       strokeWidthWcs: 0.25
     },
     geometry: { type: 'point', position: { x: 1, y: 2 } }
   }
 }
 
-describe('AcApMeasurementStore hairline stroke WCS', () => {
+describe('AcApMeasurementStore hairline stroke', () => {
   afterEach(() => {
     resetMeasurementSession()
   })
 
-  it('omits strokeWidthWcs after switching a measurement to hairline', () => {
+  it('always exports hairline and omits strokeWidthWcs', () => {
     const { view, manager } = createView()
     const group = makeGroup('hairline-edit')
     const color = new AcCmColor()
@@ -113,26 +113,26 @@ describe('AcApMeasurementStore hairline stroke WCS', () => {
     commitMeasurementGroup(view, group, {
       style: {
         color,
-        lineWeight: AcGiLineWeight.LineWeight070,
+        lineWeight: OVERLAY_HAIRLINE_LINE_WEIGHT,
         fontSize: MEASUREMENT_FONT_SIZE
       },
-      snapshot: numericSnapshot(group.id)
+      snapshot: hairlineSnapshot(group.id)
     })
     expect(manager.getGroup('hairline-edit')).toBe(group)
 
-    applyMeasurementStyle(view, group, {
-      lineWeight: OVERLAY_HAIRLINE_LINE_WEIGHT
-    })
+    applyMeasurementStyle(view, group, { fontSize: 16 })
 
     const [record] = collectMeasurementRecords(view)
     expect(record?.style.lineWeight).toBe(0)
     expect(record?.style.strokeWidthWcs).toBeUndefined()
+    expect(record?.style.fontSize).toBe(16)
 
     const json = stringifyMeasurementSidecar({
       version: 1,
       measurements: collectMeasurementRecords(view)
     })
     expect(json).not.toMatch(/"strokeWidthWcs"\s*:/)
+    expect(json).toMatch(/"lineWeight"\s*:\s*0/)
   })
 
   it('does not invent a 0 WCS stroke for a hairline snapshot', () => {

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementUtil.spec.ts
@@ -10,13 +10,11 @@ import {
   acapCssToMeasurementColor,
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementFontSize,
-  acapGetMeasurementLineWeight,
   acapMeasurementCanvasLineWidth,
   acapGetMeasurementColor,
   acapResetMeasurementDrawStyle,
   acapSetMeasurementDrawColor,
   acapSetMeasurementDrawFontSize,
-  acapSetMeasurementDrawLineWeight,
   MEASUREMENT_FONT_SIZE,
   MEASUREMENT_LINE_WEIGHT
 } from '../src/util/AcApMeasurementUtil'
@@ -30,29 +28,27 @@ describe('AcApMeasurementUtil', () => {
     acapResetMeasurementDrawStyle()
   })
 
-  it('defaults to hairline until a numeric line weight is chosen', () => {
-    expect(acapGetMeasurementLineWeight()).toBe(MEASUREMENT_LINE_WEIGHT)
-    expect(acapGetMeasurementLineWeight()).toBe(0)
+  it('defaults to hairline line weight and factory font size', () => {
+    expect(MEASUREMENT_LINE_WEIGHT).toBe(0)
     expect(acapGetMeasurementFontSize()).toBe(MEASUREMENT_FONT_SIZE)
+    expect(acapGetCurrentMeasurementStyle(mockDb()).lineWeight).toBe(0)
   })
 
-  it('stores session draw color, line weight, and font size for later measurements', () => {
+  it('stores session draw color and font size for later measurements', () => {
     const color = new AcCmColor()
     color.setRGB(10, 20, 30)
     acapSetMeasurementDrawColor(color)
-    acapSetMeasurementDrawLineWeight(AcGiLineWeight.LineWeight013)
     acapSetMeasurementDrawFontSize(18)
 
     const drawn = acapGetMeasurementColor(mockDb())
     expect(drawn.red).toBe(10)
     expect(drawn.green).toBe(20)
     expect(drawn.blue).toBe(30)
-    expect(acapGetMeasurementLineWeight()).toBe(AcGiLineWeight.LineWeight013)
     expect(acapGetMeasurementFontSize()).toBe(18)
 
     const style = acapGetCurrentMeasurementStyle(mockDb())
     expect(style.fontSize).toBe(18)
-    expect(style.lineWeight).toBe(AcGiLineWeight.LineWeight013)
+    expect(style.lineWeight).toBe(MEASUREMENT_LINE_WEIGHT)
     expect(style.color.red).toBe(10)
   })
 
@@ -71,16 +67,6 @@ describe('AcApMeasurementUtil', () => {
 
   it('maps hairline to a 0 canvas width sentinel', () => {
     expect(acapMeasurementCanvasLineWidth(0 as AcGiLineWeight)).toBe(0)
-  })
-
-  it('accepts hairline and ignores negative CAD specials', () => {
-    acapSetMeasurementDrawLineWeight(AcGiLineWeight.LineWeight211)
-    acapSetMeasurementDrawLineWeight(AcGiLineWeight.ByLayer)
-    acapSetMeasurementDrawLineWeight(AcGiLineWeight.ByBlock)
-    expect(acapGetMeasurementLineWeight()).toBe(AcGiLineWeight.LineWeight211)
-
-    acapSetMeasurementDrawLineWeight(0 as AcGiLineWeight)
-    expect(acapGetMeasurementLineWeight()).toBe(0)
   })
 })
 
@@ -115,5 +101,15 @@ describe('acapCssToMeasurementColor', () => {
     expect(color.red).toBe(96)
     expect(color.green).toBe(165)
     expect(color.blue).toBe(250)
+  })
+
+  it('parses CSS hex without logging Unknown color name', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation()
+    const color = acapCssToMeasurementColor('#d51572')
+    expect(color.red).toBe(0xd5)
+    expect(color.green).toBe(0x15)
+    expect(color.blue).toBe(0x72)
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
   })
 })

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupArrowCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupArrowCmd.ts
@@ -24,7 +24,7 @@ import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight,
+  MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
@@ -56,7 +56,7 @@ class AcApMarkupArrowJig extends AcEdPreviewJig<AcGePoint3dLike> {
   update(p2: AcGePoint3dLike) {
     this._p2 = p2
     this._color = defaultMarkupColor()
-    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const lineWidth = markupCanvasLineWidth(MARKUP_LINE_WEIGHT)
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLiveSegment(ctx, view, this._p1, this._p2, this._color, lineWidth, {
         arrow: true

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
@@ -37,7 +37,7 @@ import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
   getMarkupFontSize,
-  getMarkupLineWeight,
+  MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth,
   subscribeMarkupDrawStyle
 } from './AcApMarkupUtil'
@@ -158,7 +158,7 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
   }
 
   private paintLeader(): void {
-    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const lineWidth = markupCanvasLineWidth(MARKUP_LINE_WEIGHT)
     const color = this._color
     const tip = this._tip
     const anchor = this._anchor

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCircleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCircleCmd.ts
@@ -32,7 +32,7 @@ import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight,
+  MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
@@ -63,7 +63,7 @@ class AcApMarkupCircleJig extends AcEdPreviewJig<number> {
   update(radius: number) {
     this._radius = Math.max(radius, 0)
     this._color = defaultMarkupColor()
-    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const lineWidth = markupCanvasLineWidth(MARKUP_LINE_WEIGHT)
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLiveCircle(
         ctx,

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCloudCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCloudCmd.ts
@@ -36,7 +36,7 @@ import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight,
+  MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
@@ -77,7 +77,7 @@ class AcApMarkupCloudJig extends AcEdPreviewJig<AcGePoint2dLike> {
   update(second: AcGePoint2dLike) {
     this._second = second
     this._color = defaultMarkupColor()
-    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const lineWidth = markupCanvasLineWidth(MARKUP_LINE_WEIGHT)
     const points = cloudLivePoints(this._first, this._second, this._view)
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLivePolyline(ctx, view, points, this._color, lineWidth, {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
@@ -24,7 +24,7 @@ import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight,
+  MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth,
   markupColorToCss
 } from './AcApMarkupUtil'
@@ -57,7 +57,7 @@ class AcApMarkupHighlightJig extends AcEdPreviewJig<AcGePoint3dLike> {
   update(second: AcGePoint3dLike) {
     this._second = second
     this._colorCss = markupColorToCss(defaultMarkupColor())
-    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const lineWidth = markupCanvasLineWidth(MARKUP_LINE_WEIGHT)
     this._preview.acapSetDraw((ctx, view) => {
       acapFillLiveHighlight(
         ctx,
@@ -115,7 +115,7 @@ export class AcApMarkupHighlightCmd extends AcEdCommand {
         type: 'highlight',
         style: {
           color: colorCss,
-          lineWeight: getMarkupLineWeight()
+          lineWeight: MARKUP_LINE_WEIGHT
         },
         geometry: {
           type: 'highlight',

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupLineCmd.ts
@@ -28,7 +28,7 @@ import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight,
+  MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth,
   markupColorToCss
 } from './AcApMarkupUtil'
@@ -84,7 +84,7 @@ class AcApMarkupLineJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._color = defaultMarkupColor()
     this._badge.setColor(this._color)
 
-    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const lineWidth = markupCanvasLineWidth(MARKUP_LINE_WEIGHT)
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLiveSegment(ctx, view, this._p1, this._p2, this._color, lineWidth)
     })
@@ -137,7 +137,7 @@ export class AcApMarkupLineCmd extends AcEdCommand {
         type: 'line',
         style: {
           color: markupColorToCss(color),
-          lineWeight: getMarkupLineWeight()
+          lineWeight: MARKUP_LINE_WEIGHT
         },
         geometry: {
           type: 'line',

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupPresenter.ts
@@ -351,7 +351,7 @@ export function attachCalloutToMarkup(
  */
 export function applyMarkupStyleToSelection(
   view: AcEdBaseView,
-  patch: Partial<AcApMarkupRecord['style']>
+  patch: Partial<Pick<AcApMarkupRecord['style'], 'color' | 'fontSize'>>
 ): void {
   const store = getMarkupStore()
   const id = store.selectedId

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupRectCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupRectCmd.ts
@@ -29,7 +29,7 @@ import { MARKUP_LIVE_LAYER } from './AcApMarkupStore'
 import type { AcApMarkupRecord } from './AcApMarkupTypes'
 import {
   defaultMarkupColor,
-  getMarkupLineWeight,
+  MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth
 } from './AcApMarkupUtil'
 
@@ -61,7 +61,7 @@ class AcApMarkupRectJig extends AcEdPreviewJig<AcGePoint2dLike> {
   update(second: AcGePoint2dLike) {
     this._second = second
     this._color = defaultMarkupColor()
-    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const lineWidth = markupCanvasLineWidth(MARKUP_LINE_WEIGHT)
     const corners = acapLiveRectCorners(this._first, this._second)
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLivePolyline(ctx, view, corners, this._color, lineWidth, {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeCallout.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupShapeCallout.ts
@@ -50,7 +50,7 @@ import type {
 import {
   defaultMarkupColor,
   getMarkupFontSize,
-  getMarkupLineWeight,
+  MARKUP_LINE_WEIGHT,
   markupCanvasLineWidth,
   subscribeMarkupDrawStyle
 } from './AcApMarkupUtil'
@@ -329,7 +329,7 @@ class AcApMarkupShapeCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
   private paintPreview(): void {
     const outline = this._outline
     const color = this._color
-    const lineWidth = markupCanvasLineWidth(getMarkupLineWeight())
+    const lineWidth = markupCanvasLineWidth(MARKUP_LINE_WEIGHT)
     const tip = this._tip
     const anchor = this._anchor
     const viewForCloud = this._view

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupSidecar.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupSidecar.ts
@@ -3,8 +3,10 @@ import type {
   AcApMarkupRecord,
   AcApMarkupSidecarFile,
   AcApMarkupStatus,
+  AcApMarkupStyle,
   AcApMarkupType
 } from './AcApMarkupTypes'
+import { MARKUP_LINE_WEIGHT } from './AcApMarkupUtil'
 
 const MARKUP_TYPES: readonly AcApMarkupType[] = [
   'text',
@@ -135,16 +137,13 @@ function parseRecord(raw: unknown): AcApMarkupRecord | undefined {
     layoutId: typeof raw.layoutId === 'string' ? raw.layoutId : undefined,
     style: {
       color: raw.style.color,
-      lineWeight:
-        typeof raw.style.lineWeight === 'number'
-          ? raw.style.lineWeight
-          : undefined,
+      // Accept legacy lineWeight / strokeWidthWcs without failing, but always hairline.
+      lineWeight: MARKUP_LINE_WEIGHT,
       fontSize:
         typeof raw.style.fontSize === 'number' && raw.style.fontSize > 0
           ? raw.style.fontSize
           : undefined,
-      textHeightWcs: parsePositiveNumber(raw.style.textHeightWcs),
-      strokeWidthWcs: parsePositiveNumber(raw.style.strokeWidthWcs)
+      textHeightWcs: parsePositiveNumber(raw.style.textHeightWcs)
     },
     text: typeof raw.text === 'string' ? raw.text : undefined,
     comment: typeof raw.comment === 'string' ? raw.comment : '',
@@ -192,9 +191,24 @@ export function parseMarkupSidecar(text: string): AcApMarkupSidecarFile {
   }
 }
 
+function normalizeStyleForWrite(style: AcApMarkupStyle): AcApMarkupStyle {
+  const { strokeWidthWcs: _ignored, ...rest } = style
+  return {
+    ...rest,
+    lineWeight: MARKUP_LINE_WEIGHT
+  }
+}
+
 /** Serialize a sidecar file to pretty-printed JSON. */
 export function stringifyMarkupSidecar(file: AcApMarkupSidecarFile): string {
-  return `${JSON.stringify(file, null, 2)}\n`
+  const normalized: AcApMarkupSidecarFile = {
+    ...file,
+    markups: file.markups.map(m => ({
+      ...m,
+      style: normalizeStyleForWrite(m.style)
+    }))
+  }
+  return `${JSON.stringify(normalized, null, 2)}\n`
 }
 
 /**

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupTypes.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupTypes.ts
@@ -31,7 +31,7 @@ export interface AcApMarkupPoint2d {
 export interface AcApMarkupStyle {
   /** CSS color string, e.g. `#ff0000` or `rgb(255,0,0)`. */
   color: string
-  /** Optional AutoCAD-style line weight enum value. */
+  /** Always hairline (`0`) on write; legacy non-zero values are ignored on parse. */
   lineWeight?: number
   /** Authoring font size in CSS pixels for text / callout bubbles (legacy / UI). */
   fontSize?: number
@@ -41,7 +41,7 @@ export interface AcApMarkupStyle {
    */
   textHeightWcs?: number
   /**
-   * Canvas stroke width in world units. Prefer this when restoring overlays.
+   * Legacy canvas stroke width in world units. Ignored on parse; never written.
    */
   strokeWidthWcs?: number
 }

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
@@ -20,8 +20,7 @@ export function createDefaultMarkupColor(): AcCmColor {
 /**
  * Overlay line weight meaning "no CAD lineweight" (hairline).
  *
- * Drawn as 1 CSS pixel and not scaled with zoom until the user picks a
- * numeric lineweight from the drawing-style / style toolbar.
+ * Drawn as 1 CSS pixel and not scaled with zoom.
  */
 export const MARKUP_HAIRLINE_LINE_WEIGHT = 0 as AcGiLineWeight
 
@@ -34,9 +33,6 @@ export const MARKUP_FONT_SIZE = 12
 /** Session draw color for newly created markups. */
 let markupDrawColor: AcCmColor = createDefaultMarkupColor()
 
-/** Session draw line weight for newly created markups. */
-let markupDrawLineWeight: AcGiLineWeight = MARKUP_LINE_WEIGHT
-
 /** Session draw font size for newly created text / callout markups. */
 let markupDrawFontSize = MARKUP_FONT_SIZE
 
@@ -46,7 +42,7 @@ function notifyMarkupDrawStyleChanged(): void {
   for (const listener of drawStyleListeners) listener()
 }
 
-/** Notify when session markup color / lineweight / font size changes. */
+/** Notify when session markup color / font size changes. */
 export function subscribeMarkupDrawStyle(listener: () => void): () => void {
   drawStyleListeners.add(listener)
   return () => {
@@ -57,11 +53,6 @@ export function subscribeMarkupDrawStyle(listener: () => void): () => void {
 /** Current color used when drawing markups (clone for safety). */
 export function defaultMarkupColor(): AcCmColor {
   return markupDrawColor.clone()
-}
-
-/** Current line weight used when drawing markups. */
-export function getMarkupLineWeight(): AcGiLineWeight {
-  return markupDrawLineWeight
 }
 
 /** Current font size (CSS px) used when drawing text / callout markups. */
@@ -75,13 +66,6 @@ export function setMarkupDrawColor(color: AcCmColor): void {
   notifyMarkupDrawStyleChanged()
 }
 
-/** Update the session markup draw line weight. */
-export function setMarkupDrawLineWeight(weight: AcGiLineWeight): void {
-  if (!Number.isFinite(weight) || weight < 0) return
-  markupDrawLineWeight = weight
-  notifyMarkupDrawStyleChanged()
-}
-
 /** Update the session markup draw font size (CSS px). */
 export function setMarkupDrawFontSize(size: number): void {
   if (!Number.isFinite(size) || size <= 0) return
@@ -91,7 +75,7 @@ export function setMarkupDrawFontSize(size: number): void {
 
 /**
  * Resolve a stored markup line weight, treating missing / negative CAD
- * specials as the session default. `0` is hairline and is kept.
+ * specials as the hairline default. `0` is hairline and is kept.
  */
 export function resolveMarkupLineWeight(
   weight: number | undefined | null
@@ -118,16 +102,16 @@ export function cssToMarkupColor(css: string): AcCmColor {
   return parseCssToAcCmColor(css, [255, 0, 0])
 }
 
-/** Build a style object from the current markup draw color / line weight / font size. */
+/** Build a style object from the current markup draw color / font size. */
 export function defaultMarkupStyle(): AcApMarkupStyle {
   return {
     color: markupColorToCss(defaultMarkupColor()),
-    lineWeight: getMarkupLineWeight(),
+    lineWeight: MARKUP_LINE_WEIGHT,
     fontSize: getMarkupFontSize()
   }
 }
 
-/** Attach world-space text/stroke sizes from the current view (sidecar export). */
+/** Attach world-space text height from the current view (sidecar export). */
 export function withMarkupStyleWcs(
   style: AcApMarkupStyle,
   view: AcEdBaseView
@@ -136,21 +120,19 @@ export function withMarkupStyleWcs(
     style.fontSize != null && style.fontSize > 0
       ? style.fontSize
       : MARKUP_FONT_SIZE
-  const lineWeight = resolveMarkupLineWeight(style.lineWeight)
-  const strokePx = markupCanvasLineWidth(lineWeight)
   return {
     ...style,
-    textHeightWcs: acapScreenPxToWcs(fontSize, view),
-    strokeWidthWcs:
-      strokePx > 0 ? acapScreenPxToWcs(strokePx, view) : undefined
+    lineWeight: MARKUP_LINE_WEIGHT,
+    textHeightWcs: acapScreenPxToWcs(fontSize, view)
   }
 }
 
 /**
- * Merge a style patch while keeping world-space sizes independent of color.
+ * Merge a style patch while keeping world-space text size independent of color.
  *
  * Only recomputes / scales {@link AcApMarkupStyle.textHeightWcs} when font size
- * changes, and {@link AcApMarkupStyle.strokeWidthWcs} when line weight changes.
+ * changes. Overlay strokes stay hairline; {@link AcApMarkupStyle.strokeWidthWcs}
+ * is never written.
  */
 export function patchMarkupStyleWcs(
   previous: AcApMarkupStyle,
@@ -164,13 +146,9 @@ export function patchMarkupStyleWcs(
       : MARKUP_FONT_SIZE
   const nextFont =
     next.fontSize != null && next.fontSize > 0 ? next.fontSize : MARKUP_FONT_SIZE
-  const prevWeight = resolveMarkupLineWeight(previous.lineWeight)
-  const nextWeight = resolveMarkupLineWeight(next.lineWeight)
 
   const fontSizeChanged =
     patch.fontSize != null && patch.fontSize !== previous.fontSize
-  const lineWeightChanged =
-    patch.lineWeight != null && patch.lineWeight !== previous.lineWeight
 
   let textHeightWcs = previous.textHeightWcs ?? next.textHeightWcs
   if (fontSizeChanged) {
@@ -183,25 +161,11 @@ export function patchMarkupStyleWcs(
     textHeightWcs = acapScreenPxToWcs(nextFont, view)
   }
 
-  let strokeWidthWcs = previous.strokeWidthWcs ?? next.strokeWidthWcs
-  const nextPx = markupCanvasLineWidth(nextWeight)
-  if (!(nextPx > 0)) {
-    strokeWidthWcs = undefined
-  } else if (lineWeightChanged) {
-    const prevPx = markupCanvasLineWidth(prevWeight)
-    if (strokeWidthWcs != null && strokeWidthWcs > 0 && prevPx > 0) {
-      strokeWidthWcs = strokeWidthWcs * (nextPx / prevPx)
-    } else {
-      strokeWidthWcs = acapScreenPxToWcs(nextPx, view)
-    }
-  } else if (strokeWidthWcs == null || !(strokeWidthWcs > 0)) {
-    strokeWidthWcs = acapScreenPxToWcs(nextPx, view)
-  }
-
+  const { strokeWidthWcs: _omitStroke, ...rest } = next
   return {
-    ...next,
-    textHeightWcs,
-    strokeWidthWcs
+    ...rest,
+    lineWeight: MARKUP_LINE_WEIGHT,
+    textHeightWcs
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
@@ -24,10 +24,10 @@ import {
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
-  acapGetMeasurementLineWeight,
   acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
-  formatMeasurementAngle
+  formatMeasurementAngle,
+  MEASUREMENT_LINE_WEIGHT
 } from '../../util'
 import { AcTrView2d } from '../../view'
 import {
@@ -101,7 +101,7 @@ class AcApMeasureArm1Jig extends AcEdPreviewJig<AcGePoint3dLike> {
   update(p: AcGePoint3dLike) {
     this._cursor = p
     const lineWidth = acapMeasurementCanvasLineWidth(
-      acapGetMeasurementLineWeight()
+      MEASUREMENT_LINE_WEIGHT
     )
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLiveSegment(
@@ -186,7 +186,7 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._badge.setFontSize(acapGetMeasurementFontSize())
 
     const lineWidth = acapMeasurementCanvasLineWidth(
-      acapGetMeasurementLineWeight()
+      MEASUREMENT_LINE_WEIGHT
     )
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLiveSegment(

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
@@ -28,10 +28,10 @@ import {
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
-  acapGetMeasurementLineWeight,
   acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
-  formatMeasurementLength
+  formatMeasurementLength,
+  MEASUREMENT_LINE_WEIGHT
 } from '../../util'
 import { AcTrView2d } from '../../view'
 import {
@@ -388,7 +388,7 @@ class AcApArcLockedEndJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._badge.setFontSize(acapGetMeasurementFontSize())
 
     const lineWidth = acapMeasurementCanvasLineWidth(
-      acapGetMeasurementLineWeight()
+      MEASUREMENT_LINE_WEIGHT
     )
     const sweep = lockedSweep(this._start, end, this._geom, this.clockwise)
 
@@ -453,7 +453,7 @@ class AcApMeasureArcThroughJig extends AcEdPreviewJig<AcGePoint3dLike> {
   update(p: AcGePoint3dLike) {
     this._cursor = p
     const lineWidth = acapMeasurementCanvasLineWidth(
-      acapGetMeasurementLineWeight()
+      MEASUREMENT_LINE_WEIGHT
     )
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLiveSegment(
@@ -536,7 +536,7 @@ class AcApMeasureArcEndJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._badge.setFontSize(acapGetMeasurementFontSize())
 
     const lineWidth = acapMeasurementCanvasLineWidth(
-      acapGetMeasurementLineWeight()
+      MEASUREMENT_LINE_WEIGHT
     )
     const arc = AcGeCircArc2d.tryCreateByThreePoints(
       this._start,

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
@@ -24,10 +24,10 @@ import {
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
-  acapGetMeasurementLineWeight,
   acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
-  formatMeasurementLength
+  formatMeasurementLength,
+  MEASUREMENT_LINE_WEIGHT
 } from '../../util'
 import { AcTrView2d } from '../../view'
 import {
@@ -119,9 +119,7 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
     this._badge.setFontSize(acapGetMeasurementFontSize())
 
     const dist = calcDist(this._p1, p2)
-    const lineWidth = acapMeasurementCanvasLineWidth(
-      acapGetMeasurementLineWeight()
-    )
+    const lineWidth = acapMeasurementCanvasLineWidth(MEASUREMENT_LINE_WEIGHT)
     this._preview.acapSetDraw((ctx, view) => {
       acapStrokeLiveSegment(
         ctx,

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementSidecar.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementSidecar.ts
@@ -1,10 +1,7 @@
-import { AcGiLineWeight } from '@mlightcad/data-model'
-
 import type { AcEdBaseView } from '../../editor'
 import {
   acapCssColor,
   acapCssToMeasurementColor,
-  acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
   MEASUREMENT_FONT_SIZE,
   MEASUREMENT_LINE_WEIGHT
@@ -56,22 +53,16 @@ function parsePositiveNumber(value: unknown): number | undefined {
 
 function parseStyle(raw: unknown): AcApMeasurementSidecarStyle | undefined {
   if (!isPlainObject(raw) || typeof raw.color !== 'string') return undefined
-  const lineWeight =
-    typeof raw.lineWeight === 'number' &&
-    Number.isFinite(raw.lineWeight) &&
-    raw.lineWeight >= 0
-      ? (raw.lineWeight as AcGiLineWeight)
-      : MEASUREMENT_LINE_WEIGHT
+  // Accept legacy lineWeight / strokeWidthWcs without failing, but always hairline.
   const fontSize =
     typeof raw.fontSize === 'number' && raw.fontSize > 0
       ? raw.fontSize
       : MEASUREMENT_FONT_SIZE
   return {
     color: raw.color,
-    lineWeight,
+    lineWeight: MEASUREMENT_LINE_WEIGHT,
     fontSize,
-    textHeightWcs: parsePositiveNumber(raw.textHeightWcs),
-    strokeWidthWcs: parsePositiveNumber(raw.strokeWidthWcs)
+    textHeightWcs: parsePositiveNumber(raw.textHeightWcs)
   }
 }
 
@@ -139,15 +130,11 @@ export function serializeMeasurementStyle(
 ): AcApMeasurementSidecarStyle {
   const result: AcApMeasurementSidecarStyle = {
     color: acapCssColor(style.color),
-    lineWeight: style.lineWeight,
+    lineWeight: MEASUREMENT_LINE_WEIGHT,
     fontSize: style.fontSize
   }
   if (view) {
     result.textHeightWcs = acapScreenPxToWcs(style.fontSize, view)
-    const strokePx = acapMeasurementCanvasLineWidth(style.lineWeight)
-    if (strokePx > 0) {
-      result.strokeWidthWcs = acapScreenPxToWcs(strokePx, view)
-    }
   }
   return result
 }
@@ -158,8 +145,7 @@ export function deserializeMeasurementStyle(
 ): AcApMeasurementStyle {
   return {
     color: acapCssToMeasurementColor(style.color),
-    lineWeight:
-      style.lineWeight >= 0 ? style.lineWeight : MEASUREMENT_LINE_WEIGHT,
+    lineWeight: MEASUREMENT_LINE_WEIGHT,
     fontSize: style.fontSize > 0 ? style.fontSize : MEASUREMENT_FONT_SIZE
   }
 }
@@ -196,11 +182,28 @@ export function parseMeasurementSidecar(
   }
 }
 
+function normalizeStyleForWrite(
+  style: AcApMeasurementSidecarStyle
+): AcApMeasurementSidecarStyle {
+  const { strokeWidthWcs: _ignored, ...rest } = style
+  return {
+    ...rest,
+    lineWeight: MEASUREMENT_LINE_WEIGHT
+  }
+}
+
 /** Serialize a sidecar file to pretty-printed JSON. */
 export function stringifyMeasurementSidecar(
   file: AcApMeasurementSidecarFile
 ): string {
-  return `${JSON.stringify(file, null, 2)}\n`
+  const normalized: AcApMeasurementSidecarFile = {
+    ...file,
+    measurements: file.measurements.map(m => ({
+      ...m,
+      style: normalizeStyleForWrite(m.style)
+    }))
+  }
+  return `${JSON.stringify(normalized, null, 2)}\n`
 }
 
 /**

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -235,28 +235,26 @@ function rememberStyle(id: string, style: AcApMeasurementStyle): void {
  * Apply a style patch to one measurement group (HTML badges/dots and canvases).
  * Does not record undo; wrap with {@link runMeasurementEdit} from UI.
  *
- * Color, line weight, and font size are independent: changing one does not
- * rewrite the others' world-space sizes from the current camera zoom.
+ * Color and font size are independent: changing one does not rewrite the
+ * other's world-space size from the current camera zoom. Overlay strokes stay
+ * hairline ({@link MEASUREMENT_LINE_WEIGHT}); strokeWidthWcs is never written.
  */
 export function applyMeasurementStyle(
   view: AcTrView2d,
   group: AcTrHtmlGroup,
-  patch: Partial<AcApMeasurementStyle>
+  patch: Partial<Pick<AcApMeasurementStyle, 'color' | 'fontSize'>>
 ): void {
   const prev = stylesById.get(group.id)
   const color = patch.color?.clone() ?? prev?.color.clone()
   if (!color) return
   const next: AcApMeasurementStyle = {
     color,
-    lineWeight: patch.lineWeight ?? prev?.lineWeight ?? MEASUREMENT_LINE_WEIGHT,
+    lineWeight: MEASUREMENT_LINE_WEIGHT,
     fontSize: patch.fontSize ?? prev?.fontSize ?? MEASUREMENT_FONT_SIZE
   }
   const fontSizeChanged =
     patch.fontSize != null &&
     (prev == null || patch.fontSize !== prev.fontSize)
-  const lineWeightChanged =
-    patch.lineWeight != null &&
-    (prev == null || patch.lineWeight !== prev.lineWeight)
 
   rememberStyle(group.id, next)
   const extras = extrasById.get(group.id)
@@ -275,26 +273,18 @@ export function applyMeasurementStyle(
             prev?.fontSize,
             prevSnap.textHeightWcs,
             fontSizeChanged
-          ),
-          strokeWidthWcs: resolveUpdatedStrokeWidthWcs(
-            view,
-            next.lineWeight,
-            prev?.lineWeight,
-            prevSnap.strokeWidthWcs,
-            lineWeightChanged
           )
         }
       }
     }
   }
 
-  if (fontSizeChanged || lineWeightChanged) {
+  if (fontSizeChanged) {
     const snap = extrasById.get(group.id)?.snapshot?.style
     acapSeedOverlaySizesFromWcs(view, {
       textHeightWcs: snap?.textHeightWcs,
-      strokeWidthWcs: snap?.strokeWidthWcs,
       fontSizePx: next.fontSize,
-      strokeScreenPx: acapMeasurementCanvasLineWidth(next.lineWeight),
+      strokeScreenPx: acapMeasurementCanvasLineWidth(MEASUREMENT_LINE_WEIGHT),
       elements: [...(group.children ?? [])],
       canvases: (group.canvases ?? []).map(c => c.canvas)
     })
@@ -303,7 +293,9 @@ export function applyMeasurementStyle(
   paintMeasurementGroup(view, group, next)
 }
 
-/** Scale or recompute text height WCS when font size changes; otherwise keep. */
+/**
+ * Scale or recompute text height WCS when font size changes; otherwise keep.
+ */
 function resolveUpdatedTextHeightWcs(
   view: AcTrView2d,
   nextFontSize: number,
@@ -327,45 +319,11 @@ function resolveUpdatedTextHeightWcs(
 }
 
 /**
- * Scale or recompute stroke WCS when line weight changes; otherwise keep.
- *
- * Hairline (`nextPx === 0`) returns `undefined` so sidecar serialization
- * omits world-space stroke instead of writing `0`.
- */
-function resolveUpdatedStrokeWidthWcs(
-  view: AcTrView2d,
-  nextLineWeight: AcApMeasurementStyle['lineWeight'],
-  prevLineWeight: AcApMeasurementStyle['lineWeight'] | undefined,
-  prevStrokeWidthWcs: number | undefined,
-  lineWeightChanged: boolean
-): number | undefined {
-  const nextPx = acapMeasurementCanvasLineWidth(nextLineWeight)
-  if (!(nextPx > 0)) return undefined
-  if (
-    lineWeightChanged &&
-    prevStrokeWidthWcs != null &&
-    prevStrokeWidthWcs > 0 &&
-    prevLineWeight != null
-  ) {
-    const prevPx = acapMeasurementCanvasLineWidth(prevLineWeight)
-    if (prevPx > 0) return prevStrokeWidthWcs * (nextPx / prevPx)
-  }
-  if (
-    lineWeightChanged ||
-    prevStrokeWidthWcs == null ||
-    !(prevStrokeWidthWcs > 0)
-  ) {
-    return acapScreenPxToWcs(nextPx, view)
-  }
-  return prevStrokeWidthWcs
-}
-
-/**
  * Apply a style patch to every selected measurement group (undoable).
  */
 export function applyMeasurementStyleToSelection(
   view: AcTrView2d,
-  patch: Partial<AcApMeasurementStyle>
+  patch: Partial<Pick<AcApMeasurementStyle, 'color' | 'fontSize'>>
 ): void {
   const groups = view.htmlTransientManager
     .getSelectedGroups()
@@ -426,23 +384,20 @@ export function collectMeasurementRecords(
     if (!extras?.snapshot) continue
     const live = extras.style ?? stylesById.get(group.id)
     const snapStyle = extras.snapshot.style
-    let style: AcApMeasurementSidecarStyle = snapStyle
+    let style: AcApMeasurementSidecarStyle
     if (live) {
-      // Keep live color / weights / fontSize, but preserve creation-time WCS
-      // from the snapshot (do not recompute from the current zoom).
+      // Keep live color / fontSize, force hairline lineWeight, preserve
+      // creation-time textHeightWcs from the snapshot. Never export strokeWidthWcs.
       const base = serializeMeasurementStyle(live)
-      const strokePx = acapMeasurementCanvasLineWidth(base.lineWeight)
       style = {
         ...base,
+        lineWeight: MEASUREMENT_LINE_WEIGHT,
         textHeightWcs:
-          snapStyle.textHeightWcs ?? acapScreenPxToWcs(base.fontSize, view),
-        strokeWidthWcs:
-          snapStyle.strokeWidthWcs != null && snapStyle.strokeWidthWcs > 0
-            ? snapStyle.strokeWidthWcs
-            : strokePx > 0
-              ? acapScreenPxToWcs(strokePx, view)
-              : undefined
+          snapStyle.textHeightWcs ?? acapScreenPxToWcs(base.fontSize, view)
       }
+    } else {
+      const { strokeWidthWcs: _omit, ...rest } = snapStyle
+      style = { ...rest, lineWeight: MEASUREMENT_LINE_WEIGHT }
     }
     records.push({
       ...extras.snapshot,

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementTypes.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementTypes.ts
@@ -17,6 +17,7 @@ export interface AcApMeasurementPoint2d {
 /** Drawing style stored in the sidecar (CSS-friendly + world-space sizes). */
 export interface AcApMeasurementSidecarStyle {
   color: string
+  /** Always hairline (`0`) on write; legacy non-zero values are ignored on parse. */
   lineWeight: AcGiLineWeight
   /** Authoring badge font size in CSS pixels (legacy / UI). */
   fontSize: number
@@ -26,7 +27,7 @@ export interface AcApMeasurementSidecarStyle {
    */
   textHeightWcs?: number
   /**
-   * Canvas stroke width in world units. Prefer this when restoring overlays.
+   * Legacy canvas stroke width in world units. Ignored on parse; never written.
    */
   strokeWidthWcs?: number
 }

--- a/packages/cad-simple-viewer/src/i18n/ar/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/ar/main.ts
@@ -56,8 +56,6 @@ export default {
   },
   drawStyle: {
     color: 'اللون',
-    lineWeight: 'سُمك الخط',
-    lineWeightHairline: 'بلا سماكة',
     fontSize: 'ارتفاع النص'
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/cs/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/cs/main.ts
@@ -56,8 +56,6 @@ export default {
   },
   drawStyle: {
     color: 'Barva',
-    lineWeight: 'Tloušťka čáry',
-    lineWeightHairline: 'Bez tloušťky',
     fontSize: 'Výška textu'
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/en/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/main.ts
@@ -56,8 +56,6 @@ export default {
   },
   drawStyle: {
     color: 'Color',
-    lineWeight: 'Lineweight',
-    lineWeightHairline: 'Hairline',
     fontSize: 'Text height'
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/tr/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/tr/main.ts
@@ -56,8 +56,6 @@ export default {
   },
   drawStyle: {
     color: 'Renk',
-    lineWeight: 'Çizgi kalınlığı',
-    lineWeightHairline: 'Kılcal',
     fontSize: 'Yazı yüksekliği'
   }
 }

--- a/packages/cad-simple-viewer/src/i18n/zh/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/main.ts
@@ -56,8 +56,6 @@ export default {
   },
   drawStyle: {
     color: '颜色',
-    lineWeight: '线宽',
-    lineWeightHairline: '无线宽',
     fontSize: '字号'
   }
 }

--- a/packages/cad-simple-viewer/src/ui/AcApDrawStyleToolbar.ts
+++ b/packages/cad-simple-viewer/src/ui/AcApDrawStyleToolbar.ts
@@ -1,7 +1,6 @@
 import {
   AcCmColor,
-  acdbHostApplicationServices,
-  AcGiLineWeight
+  acdbHostApplicationServices
 } from '@mlightcad/data-model'
 
 import {
@@ -14,11 +13,9 @@ import {
   cssToMarkupColor,
   defaultMarkupColor,
   getMarkupFontSize,
-  getMarkupLineWeight,
   markupColorToCss,
   setMarkupDrawColor,
-  setMarkupDrawFontSize,
-  setMarkupDrawLineWeight
+  setMarkupDrawFontSize
 } from '../command/markup/AcApMarkupUtil'
 import {
   applyMeasurementStyleToSelection,
@@ -34,10 +31,8 @@ import {
   acapCssToMeasurementColor,
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
-  acapGetMeasurementLineWeight,
   acapSetMeasurementDrawColor,
-  acapSetMeasurementDrawFontSize,
-  acapSetMeasurementDrawLineWeight
+  acapSetMeasurementDrawFontSize
 } from '../util/AcApMeasurementUtil'
 import type { AcTrView2d } from '../view'
 import {
@@ -105,107 +100,6 @@ const TOOLBAR_CSS = `
       color: inherit;
       font-size: 12px;
       padding: 0 6px;
-    }
-    .ml-draw-style-toolbar__lineweight {
-      position: relative;
-      width: 120px;
-      flex: 0 0 120px;
-    }
-    .ml-draw-style-toolbar__lineweight-trigger {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      width: 100%;
-      height: 28px;
-      box-sizing: border-box;
-      padding: 0 6px;
-      border: 1px solid var(--ml-ui-border, #dcdfe6);
-      border-radius: 4px;
-      background: var(--ml-ui-bg, #fff);
-      color: inherit;
-      font-family: inherit;
-      font-size: 12px;
-      line-height: 1;
-      text-align: left;
-      cursor: pointer;
-    }
-    .ml-draw-style-toolbar__lineweight-label {
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      text-align: left;
-    }
-    .ml-draw-style-toolbar__lineweight-caret {
-      flex: 0 0 auto;
-      margin-left: auto;
-      width: 0;
-      height: 0;
-      border-left: 3.5px solid transparent;
-      border-right: 3.5px solid transparent;
-      border-top: 4px solid currentColor;
-      opacity: 0.55;
-    }
-    .ml-draw-style-toolbar__lineweight-preview {
-      position: relative;
-      display: inline-flex;
-      width: 36px;
-      height: 14px;
-      flex: 0 0 36px;
-    }
-    .ml-draw-style-toolbar__lineweight-preview::before {
-      content: '';
-      position: absolute;
-      left: 0;
-      right: 0;
-      top: 50%;
-      height: var(--ml-lineweight-height, 2px);
-      transform: translateY(-50%);
-      background-color: currentColor;
-      border-radius: 999px;
-    }
-    .ml-draw-style-toolbar__lineweight-menu {
-      display: none;
-      position: absolute;
-      top: calc(100% + 4px);
-      left: 0;
-      z-index: 2;
-      min-width: 148px;
-      max-height: 260px;
-      overflow-y: auto;
-      padding: 4px 0;
-      border: 1px solid var(--ml-ui-border, #dcdfe6);
-      border-radius: 6px;
-      background: var(--ml-ui-bg, rgba(255, 255, 255, 0.98));
-      box-shadow: var(--ml-ui-shadow, 0 4px 12px rgba(0, 0, 0, 0.16));
-    }
-    .ml-draw-style-toolbar__lineweight-menu.is-open {
-      display: block;
-    }
-    .ml-draw-style-toolbar__lineweight-item {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      width: 100%;
-      box-sizing: border-box;
-      padding: 4px 10px;
-      border: 0;
-      background: transparent;
-      color: inherit;
-      font-family: inherit;
-      font-size: 12px;
-      cursor: pointer;
-    }
-    .ml-draw-style-toolbar__lineweight-item:hover,
-    .ml-draw-style-toolbar__lineweight-item.is-selected {
-      background: var(--ml-ui-hover, rgba(64, 158, 255, 0.12));
-    }
-    .ml-draw-style-toolbar__lineweight-text {
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      text-align: left;
     }
     .ml-draw-style-toolbar__color {
       position: relative;
@@ -304,201 +198,6 @@ const LARGE_ACI = Array.from({ length: 240 }, (_, i) => i + 10)
 const GRAY_ACI = Array.from({ length: 6 }, (_, i) => i + 250)
 
 /**
- * Unique numeric line weights from {@link AcGiLineWeight}, sorted ascending.
- *
- * @returns Positive values in hundredths of a millimeter (for example 25 = 0.25 mm).
- */
-function numericLineWeights(): AcGiLineWeight[] {
-  const weights = Array.from(
-    new Set(
-      Object.values(AcGiLineWeight).filter(
-        (value): value is AcGiLineWeight =>
-          typeof value === 'number' && value > 0
-      )
-    )
-  ).sort((a, b) => a - b)
-  return [0 as AcGiLineWeight, ...weights]
-}
-
-/**
- * Formats a line weight for the dropdown label.
- *
- * @param value - Line weight in hundredths of a millimeter, or `0` for hairline.
- * @returns Label such as `"Hairline"` or `"0.25 mm"`.
- */
-function formatLineWeight(value: AcGiLineWeight): string {
-  if (!(value > 0)) return AcApI18n.t('main.drawStyle.lineWeightHairline')
-  return `${(value / 100).toFixed(2)} mm`
-}
-
-/**
- * Converts a numeric line weight into a clamped preview stroke thickness.
- *
- * @param value - Line weight in hundredths of a millimeter.
- * @returns Stroke height in CSS pixels.
- */
-function previewLineHeightPx(value: number): number {
-  return Math.max(1, Math.min(6, value / 40))
-}
-
-/** Custom line-weight dropdown used by {@link AcApDrawStyleToolbar}. */
-interface AcApLineWeightPicker {
-  /** Root control appended to the overlay. */
-  root: HTMLDivElement
-  /** Updates the trigger and selected menu item. */
-  setValue: (weight: number) => void
-  /** Sets the localized tooltip on the trigger. */
-  setTitle: (title: string) => void
-  /** Relabels menu items after a locale change (hairline label). */
-  refreshLabels: () => void
-  /** Closes the popover menu. */
-  close: () => void
-  /** Whether the popover menu is open. */
-  isOpen: () => boolean
-  /** True when `node` is inside this control. */
-  contains: (node: Node | null) => boolean
-}
-
-/**
- * Builds a compact line-weight dropdown with a stroke preview in each row.
- *
- * @param onChange - Called when the user picks a weight.
- * @param onOpen - Called just before the menu opens (used to close other popovers).
- * @returns Picker controller.
- */
-function createLineWeightPicker(
-  onChange: (weight: AcGiLineWeight) => void,
-  onOpen: () => void
-): AcApLineWeightPicker {
-  const prefix = 'ml-draw-style-toolbar'
-  const weights = numericLineWeights()
-  let open = false
-  let currentWeight = weights[0] ?? (0 as AcGiLineWeight)
-
-  const root = document.createElement('div')
-  root.className = `${prefix}__lineweight`
-
-  const trigger = document.createElement('button')
-  trigger.type = 'button'
-  trigger.className = `${prefix}__lineweight-trigger`
-  trigger.setAttribute('aria-haspopup', 'listbox')
-  trigger.setAttribute('aria-expanded', 'false')
-
-  const preview = document.createElement('span')
-  preview.className = `${prefix}__lineweight-preview`
-
-  const label = document.createElement('span')
-  label.className = `${prefix}__lineweight-label`
-
-  const caret = document.createElement('span')
-  caret.className = `${prefix}__lineweight-caret`
-  caret.setAttribute('aria-hidden', 'true')
-
-  trigger.append(preview, label, caret)
-
-  const menu = document.createElement('div')
-  menu.className = `${prefix}__lineweight-menu`
-  menu.setAttribute('role', 'listbox')
-
-  const paintTrigger = (weight: number) => {
-    currentWeight = weight as AcGiLineWeight
-    preview.style.setProperty(
-      '--ml-lineweight-height',
-      `${previewLineHeightPx(weight > 0 ? weight : 1)}px`
-    )
-    label.textContent = formatLineWeight(weight as AcGiLineWeight)
-  }
-
-  const markSelected = (weight: number) => {
-    menu.querySelectorAll(`.${prefix}__lineweight-item`).forEach(node => {
-      const item = node as HTMLElement
-      item.classList.toggle('is-selected', item.dataset.value === String(weight))
-    })
-  }
-
-  const close = () => {
-    open = false
-    menu.classList.remove('is-open')
-    trigger.setAttribute('aria-expanded', 'false')
-  }
-
-  const openMenu = () => {
-    onOpen()
-    open = true
-    menu.classList.add('is-open')
-    trigger.setAttribute('aria-expanded', 'true')
-  }
-
-  const addItem = (weight: number) => {
-    const item = document.createElement('button')
-    item.type = 'button'
-    item.className = `${prefix}__lineweight-item`
-    item.dataset.value = String(weight)
-    item.setAttribute('role', 'option')
-
-    const itemPreview = document.createElement('span')
-    itemPreview.className = `${prefix}__lineweight-preview`
-    itemPreview.style.setProperty(
-      '--ml-lineweight-height',
-      `${previewLineHeightPx(weight > 0 ? weight : 1)}px`
-    )
-
-    const itemLabel = document.createElement('span')
-    itemLabel.className = `${prefix}__lineweight-text`
-    itemLabel.textContent = formatLineWeight(weight as AcGiLineWeight)
-
-    item.append(itemPreview, itemLabel)
-    item.addEventListener('click', event => {
-      event.preventDefault()
-      event.stopPropagation()
-      paintTrigger(weight)
-      markSelected(weight)
-      close()
-      onChange(weight as AcGiLineWeight)
-    })
-    menu.appendChild(item)
-  }
-
-  for (const weight of weights) addItem(weight)
-
-  trigger.addEventListener('click', event => {
-    event.preventDefault()
-    event.stopPropagation()
-    if (open) close()
-    else openMenu()
-  })
-
-  root.append(trigger, menu)
-  paintTrigger(currentWeight)
-  markSelected(currentWeight)
-
-  return {
-    root,
-    setValue: weight => {
-      if (!Number.isFinite(weight) || weight < 0) return
-      if (!menu.querySelector(`[data-value="${weight}"]`)) addItem(weight)
-      paintTrigger(weight)
-      markSelected(weight)
-    },
-    setTitle: title => {
-      trigger.title = title
-    },
-    refreshLabels: () => {
-      menu.querySelectorAll(`.${prefix}__lineweight-item`).forEach(node => {
-        const item = node as HTMLElement
-        const weight = Number(item.dataset.value)
-        const text = item.querySelector(`.${prefix}__lineweight-text`)
-        if (text) text.textContent = formatLineWeight(weight as AcGiLineWeight)
-      })
-      paintTrigger(currentWeight)
-    },
-    close,
-    isOpen: () => open,
-    contains: node => !!node && root.contains(node)
-  }
-}
-
-/**
  * Injects overlay CSS into `document.head` once.
  */
 function ensureStyles(): void {
@@ -513,9 +212,9 @@ function ensureStyles(): void {
 }
 
 /**
- * Compact color / lineweight / font-size overlay shown during measurement
- * and markup drawing commands, and while a measurement or markup overlay
- * is selected, when the host ribbon is hidden.
+ * Compact color / font-size overlay shown during measurement and markup
+ * drawing commands, and while a measurement or markup overlay is selected,
+ * when the host ribbon is hidden.
  */
 export class AcApDrawStyleToolbar {
   /** Root toolbar element appended to the view container. */
@@ -532,9 +231,6 @@ export class AcApDrawStyleToolbar {
 
   /** Popover containing ACI palettes. */
   private readonly colorPanel: HTMLDivElement
-
-  /** Compact line-weight dropdown with stroke previews. */
-  private readonly lineWeightPicker: AcApLineWeightPicker
 
   /** Dropdown of font sizes in CSS pixels. */
   private readonly fontSizeSelect: HTMLSelectElement
@@ -610,12 +306,6 @@ export class AcApDrawStyleToolbar {
     this.colorWrap.appendChild(this.colorPanel)
     this.root.appendChild(this.colorWrap)
 
-    this.lineWeightPicker = createLineWeightPicker(
-      weight => this.applyLineWeight(weight),
-      () => this.hideColorPanel()
-    )
-    this.root.appendChild(this.lineWeightPicker.root)
-
     this.fontSizeSelect = document.createElement('select')
     this.fontSizeSelect.className = 'ml-draw-style-toolbar__select'
     this.root.appendChild(this.fontSizeSelect)
@@ -641,13 +331,9 @@ export class AcApDrawStyleToolbar {
     this.onDocumentPointerDown = event => {
       const target = event.target as Node | null
       const inColor = !!target && this.colorWrap.contains(target)
-      const inLineWeight = this.lineWeightPicker.contains(target)
-      const colorOpen = this.colorPanelOpen
-      const weightOpen = this.lineWeightPicker.isOpen()
-      if (!colorOpen && !weightOpen) return
-      if (colorOpen && !inColor) this.hideColorPanel()
-      if (weightOpen && !inLineWeight) this.lineWeightPicker.close()
-      if (!inColor && !inLineWeight) {
+      if (!this.colorPanelOpen) return
+      if (!inColor) {
+        this.hideColorPanel()
         event.preventDefault()
         event.stopPropagation()
       }
@@ -693,7 +379,6 @@ export class AcApDrawStyleToolbar {
    */
   dispose(): void {
     this.hideColorPanel()
-    this.lineWeightPicker.close()
     document.removeEventListener(
       'pointerdown',
       this.onDocumentPointerDown,
@@ -738,17 +423,14 @@ export class AcApDrawStyleToolbar {
       this.syncFromSession()
     } else {
       this.hideColorPanel()
-      this.lineWeightPicker.close()
     }
   }
 
   /**
-   * Applies localized titles to the color, line-weight, and font-size controls.
+   * Applies localized titles to the color and font-size controls.
    */
   private relabel(): void {
     this.swatch.title = AcApI18n.t('main.drawStyle.color')
-    this.lineWeightPicker.setTitle(AcApI18n.t('main.drawStyle.lineWeight'))
-    this.lineWeightPicker.refreshLabels()
     this.fontSizeSelect.title = AcApI18n.t('main.drawStyle.fontSize')
   }
 
@@ -762,9 +444,8 @@ export class AcApDrawStyleToolbar {
       const color =
         selected?.color ??
         (db ? acapGetMeasurementColor(db) : acapCssToMeasurementColor('#7b8794'))
-      const lineWeight = selected?.lineWeight ?? acapGetMeasurementLineWeight()
       const fontSize = selected?.fontSize ?? acapGetMeasurementFontSize()
-      this.paint(color, lineWeight, fontSize)
+      this.paint(color, fontSize)
       return
     }
 
@@ -774,30 +455,20 @@ export class AcApDrawStyleToolbar {
     const color = selected
       ? cssToMarkupColor(selected.style.color)
       : defaultMarkupColor()
-    const lineWeight =
-      (selected?.style.lineWeight as AcGiLineWeight | undefined) ??
-      getMarkupLineWeight()
     const fontSize = selected?.style.fontSize ?? getMarkupFontSize()
-    this.paint(color, lineWeight, fontSize)
+    this.paint(color, fontSize)
   }
 
   /**
-   * Updates swatch, line-weight, and font-size controls to match a style.
+   * Updates swatch and font-size controls to match a style.
    *
    * @param color - Current draw color.
-   * @param lineWeight - Current line weight.
    * @param fontSize - Current font size in CSS pixels.
    */
-  private paint(
-    color: AcCmColor,
-    lineWeight: AcGiLineWeight,
-    fontSize: number
-  ): void {
+  private paint(color: AcCmColor, fontSize: number): void {
     const css = acapCssColor(color)
     this.swatchFill.style.background = css
     this.markSelectedAci(aciIndexOf(color))
-
-    this.lineWeightPicker.setValue(lineWeight)
 
     const sizes = new Set(FONT_SIZE_OPTIONS)
     if (Number.isFinite(fontSize) && fontSize > 0)
@@ -881,7 +552,6 @@ export class AcApDrawStyleToolbar {
    * Opens the ACI color popover.
    */
   private showColorPanel(): void {
-    this.lineWeightPicker.close()
     this.clearColorLeaveTimer()
     this.colorPanelOpen = true
     this.colorPanel.classList.add('is-open')
@@ -911,21 +581,6 @@ export class AcApDrawStyleToolbar {
     if (this.colorLeaveTimer == null) return
     window.clearTimeout(this.colorLeaveTimer)
     this.colorLeaveTimer = undefined
-  }
-
-  /**
-   * Applies a line weight to the current session and any selected entities.
-   *
-   * @param weight - Line weight in hundredths of a millimeter.
-   */
-  private applyLineWeight(weight: AcGiLineWeight): void {
-    if (this.kind === 'measure') {
-      acapSetMeasurementDrawLineWeight(weight)
-      applyMeasurementStyleToSelection(this.view, { lineWeight: weight })
-      return
-    }
-    setMarkupDrawLineWeight(weight)
-    applyMarkupStyleToSelection(this.view, { lineWeight: weight })
   }
 
   /**

--- a/packages/cad-simple-viewer/src/util/AcApCssColor.ts
+++ b/packages/cad-simple-viewer/src/util/AcApCssColor.ts
@@ -16,17 +16,22 @@ export function preferExactAciColor(color: AcCmColor): AcCmColor {
   return aci
 }
 
-/** CSS functional color notations that {@link AcCmColor.fromString} does not accept. */
-function isCssFunctionalColor(css: string): boolean {
-  return /^(rgb|rgba|hsl|hsla)\(/i.test(css.trim())
+/**
+ * CSS hex / functional notations that {@link AcCmColor.fromString} does not
+ * accept. Passing them to `fromString` logs "Unknown color name" (hex like
+ * `#d51572` is looked up as a named color).
+ */
+function shouldSkipFromString(css: string): boolean {
+  const s = css.trim()
+  return s.startsWith('#') || /^(rgb|rgba|hsl|hsla)\(/i.test(s)
 }
 
 /**
  * Parse a CSS color string into {@link AcCmColor}.
  *
- * Prefer {@link AcCmColor.setRGBFromCss} for `rgb()` / `hsl()` (and similar);
- * {@link AcCmColor.fromString} only understands named / hex / ACI-style values
- * and logs "Unknown color name" for functional CSS colors.
+ * Prefer {@link AcCmColor.setRGBFromCss} for `#hex` / `rgb()` / `hsl()`;
+ * {@link AcCmColor.fromString} only understands named / ACI-style / `RGB:r,g,b`
+ * values and logs "Unknown color name" for CSS hex and functional colors.
  */
 export function parseCssToAcCmColor(
   css: string,
@@ -39,7 +44,7 @@ export function parseCssToAcCmColor(
     return empty
   }
 
-  if (!isCssFunctionalColor(trimmed)) {
+  if (!shouldSkipFromString(trimmed)) {
     try {
       const fromString = AcCmColor.fromString(trimmed)
       if (fromString) return preferExactAciColor(fromString)

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUtil.ts
@@ -11,8 +11,7 @@ import { acCmColorToCssHex, parseCssToAcCmColor } from './AcApCssColor'
 /**
  * Overlay line weight meaning "no CAD lineweight" (hairline).
  *
- * Drawn as 1 CSS pixel and not scaled with zoom until the user picks a
- * numeric lineweight from the drawing-style / style toolbar.
+ * Drawn as 1 CSS pixel and not scaled with zoom.
  */
 export const OVERLAY_HAIRLINE_LINE_WEIGHT = 0 as AcGiLineWeight
 
@@ -24,9 +23,6 @@ export const MEASUREMENT_FONT_SIZE = 13
 
 /** Session draw color for newly created measurements (undefined = use sysvar). */
 let measurementDrawColor: AcCmColor | undefined
-
-/** Session draw line weight for newly created measurements. */
-let measurementDrawLineWeight: AcGiLineWeight = MEASUREMENT_LINE_WEIGHT
 
 /** Session draw font size for newly created measurement badges. */
 let measurementDrawFontSize = MEASUREMENT_FONT_SIZE
@@ -47,11 +43,6 @@ export function acapGetMeasurementColor(db: AcDbDatabase): AcCmColor {
   ) as AcCmColor
 }
 
-/** Current line weight used when drawing measurements. */
-export function acapGetMeasurementLineWeight(): AcGiLineWeight {
-  return measurementDrawLineWeight
-}
-
 /** Current font size (CSS px) used when drawing measurement badges. */
 export function acapGetMeasurementFontSize(): number {
   return measurementDrawFontSize
@@ -60,12 +51,6 @@ export function acapGetMeasurementFontSize(): number {
 /** Update the session measurement draw color (affects current/future measurements). */
 export function acapSetMeasurementDrawColor(color: AcCmColor): void {
   measurementDrawColor = color.clone()
-}
-
-/** Update the session measurement draw line weight. */
-export function acapSetMeasurementDrawLineWeight(weight: AcGiLineWeight): void {
-  if (!Number.isFinite(weight) || weight < 0) return
-  measurementDrawLineWeight = weight
 }
 
 /** Update the session measurement draw font size (CSS px). */
@@ -77,17 +62,16 @@ export function acapSetMeasurementDrawFontSize(size: number): void {
 /** Restore factory session measurement draw style (tests / document reset). */
 export function acapResetMeasurementDrawStyle(): void {
   measurementDrawColor = undefined
-  measurementDrawLineWeight = MEASUREMENT_LINE_WEIGHT
   measurementDrawFontSize = MEASUREMENT_FONT_SIZE
 }
 
-/** Build a style object from the current measurement draw color / line weight / font size. */
+/** Build a style object from the current measurement draw color / font size. */
 export function acapGetCurrentMeasurementStyle(
   db: AcDbDatabase
 ): AcApMeasurementStyle {
   return {
     color: acapGetMeasurementColor(db),
-    lineWeight: acapGetMeasurementLineWeight(),
+    lineWeight: MEASUREMENT_LINE_WEIGHT,
     fontSize: acapGetMeasurementFontSize()
   }
 }

--- a/packages/cad-viewer/src/component/common/MlLineWeightSelect.vue
+++ b/packages/cad-viewer/src/component/common/MlLineWeightSelect.vue
@@ -84,26 +84,19 @@ interface LineWeightSelectProps {
   disabled?: boolean
   /** Placeholder shown when no line weight can be resolved. */
   placeholder?: string
-  /** When true, hide ByLayer / ByBlock / Default (overlay style pickers). */
+  /** When true, hide ByLayer / ByBlock / Default. */
   numericOnly?: boolean
   /**
-   * Prepend a hairline (no CAD lineweight) option. Used by measurement /
-   * review style pickers; other ribbon line-weight controls stay unchanged.
-   */
-  includeHairline?: boolean
-  /**
-   * Narrower trigger sized for numeric weights plus a stroke preview
-   * (measure / markup style pickers).
+   * Narrower trigger sized for numeric weights plus a stroke preview.
    */
   compact?: boolean
 }
 
 const props = withDefaults(defineProps<LineWeightSelectProps>(), {
-  compact: false,
-  includeHairline: false
+  compact: false
 })
 
-const { locale, t } = useI18n()
+const { locale } = useI18n()
 
 const popperClass = computed(() =>
   props.compact
@@ -123,9 +116,6 @@ const emit = defineEmits<{
  * @returns Human-readable text for the given enum member.
  */
 function formatLabel(value: AcGiLineWeight): string {
-  if (props.includeHairline && value === 0) {
-    return t('main.ribbon.property.lineWeightHairline')
-  }
   switch (value) {
     case AcGiLineWeight.ByLayer:
       return locale.value === 'ar' ? 'حسب الطبقة' : 'ByLayer'
@@ -160,7 +150,6 @@ function previewPx(value: AcGiLineWeight): number | null {
  */
 function sortLineWeightValues(a: AcGiLineWeight, b: AcGiLineWeight) {
   const specialOrder: AcGiLineWeight[] = [
-    ...(props.includeHairline ? [0 as AcGiLineWeight] : []),
     AcGiLineWeight.ByLayer,
     AcGiLineWeight.ByBlock,
     AcGiLineWeight.ByLineWeightDefault
@@ -184,16 +173,12 @@ const lineWeightItems = computed<LineWeightItem[]>(() => {
       Object.values(AcGiLineWeight).filter((v): v is AcGiLineWeight => {
         if (typeof v !== 'number') return false
         if (v === AcGiLineWeight.ByDIPs) return false
-        // Overlay hairline sentinel; added back only when includeHairline.
         if (v === 0) return false
         if (props.numericOnly) return v > 0
         return true
       })
     )
   )
-  if (props.includeHairline && !values.includes(0 as AcGiLineWeight)) {
-    values.push(0 as AcGiLineWeight)
-  }
   return values.sort(sortLineWeightValues).map(v => ({
     value: v,
     label: formatLabel(v),

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -20,13 +20,11 @@ import {
   acapDrawStyleKindForCommand,
   acapGetMeasurementColor,
   acapGetMeasurementFontSize,
-  acapGetMeasurementLineWeight,
   AcApOpenCmd,
   AcApQNewCmd,
   acapRunDatabaseEdit,
   acapSetMeasurementDrawColor,
   acapSetMeasurementDrawFontSize,
-  acapSetMeasurementDrawLineWeight,
   type AcEdCommandEventArgs,
   AcEdOpenMode,
   type AcTrView2d,
@@ -37,7 +35,6 @@ import {
   getActiveMeasurementStyle,
   getEffectiveMeasurementUnits,
   getMarkupFontSize,
-  getMarkupLineWeight,
   getMarkupStore,
   getSelectedMeasurementId,
   isMarkupVisible,
@@ -46,7 +43,6 @@ import {
   refreshMeasurementValueLabels,
   setMarkupDrawColor,
   setMarkupDrawFontSize,
-  setMarkupDrawLineWeight,
   setMeasurementUnitOverride,
   subscribeMeasurementSelection
 } from '@mlightcad/cad-simple-viewer'
@@ -199,11 +195,9 @@ const isMarkupOverlayVisible = ref(true)
 const isMeasurementOverlayVisible = ref(true)
 const markupDrawColor = shallowRef(defaultMarkupColor())
 const markupDrawColorDisplay = ref(markupColorToCss(markupDrawColor.value))
-const markupDrawLineWeight = ref<AcGiLineWeight>(getMarkupLineWeight())
 const markupDrawFontSize = ref(getMarkupFontSize())
 const measurementDrawColor = shallowRef(new AcCmColor())
 const measurementDrawColorDisplay = ref('#7b8794')
-const measurementDrawLineWeight = ref<AcGiLineWeight>(acapGetMeasurementLineWeight())
 const measurementDrawFontSize = ref(acapGetMeasurementFontSize())
 const measurementLunits = ref(AcDbLinearUnits.Decimal)
 const measurementLuprec = ref(4)
@@ -784,9 +778,6 @@ const syncMarkupStyleControls = () => {
     const color = cssToMarkupColor(selected.style.color)
     markupDrawColor.value = color
     markupDrawColorDisplay.value = selected.style.color
-    markupDrawLineWeight.value =
-      (selected.style.lineWeight as AcGiLineWeight | undefined) ??
-      getMarkupLineWeight()
     markupDrawFontSize.value =
       selected.style.fontSize != null && selected.style.fontSize > 0
         ? selected.style.fontSize
@@ -794,7 +785,6 @@ const syncMarkupStyleControls = () => {
   } else {
     markupDrawColor.value = defaultMarkupColor()
     markupDrawColorDisplay.value = markupColorToCss(markupDrawColor.value)
-    markupDrawLineWeight.value = getMarkupLineWeight()
     markupDrawFontSize.value = getMarkupFontSize()
   }
   scheduleActivateRibbonTabForOverlaySelection()
@@ -804,7 +794,7 @@ const syncMarkupStyleControls = () => {
  * Apply a style patch to the currently selected markup and republish it.
  */
 const patchSelectedMarkupStyle = (
-  patch: Partial<{ color: string; lineWeight: number; fontSize: number }>
+  patch: Partial<{ color: string; fontSize: number }>
 ) => {
   const view = AcApDocManager.instance?.curView
   if (view) applyMarkupStyleToSelection(view, patch)
@@ -823,16 +813,6 @@ const handleMarkupDrawColorChange = (value?: AcCmColor) => {
 }
 
 /**
- * Updates the session markup draw line weight used by subsequent markup commands.
- * When a markup is selected, also updates that markup's line weight.
- */
-const handleMarkupDrawLineWeightChange = (value: AcGiLineWeight) => {
-  setMarkupDrawLineWeight(value)
-  markupDrawLineWeight.value = value
-  patchSelectedMarkupStyle({ lineWeight: value })
-}
-
-/**
  * Updates the session markup draw font size used by text / callout markups.
  * When a markup is selected, also updates that markup's font size.
  */
@@ -847,7 +827,6 @@ const syncMeasurementStyleControls = () => {
   if (selected) {
     measurementDrawColor.value = selected.color.clone()
     measurementDrawColorDisplay.value = acapCssColor(selected.color)
-    measurementDrawLineWeight.value = selected.lineWeight
     measurementDrawFontSize.value = selected.fontSize
   } else {
     const db = getCurrentDatabase()
@@ -856,7 +835,6 @@ const syncMeasurementStyleControls = () => {
       measurementDrawColor.value = color.clone()
       measurementDrawColorDisplay.value = acapCssColor(color)
     }
-    measurementDrawLineWeight.value = acapGetMeasurementLineWeight()
     measurementDrawFontSize.value = acapGetMeasurementFontSize()
   }
   scheduleActivateRibbonTabForOverlaySelection()
@@ -869,13 +847,6 @@ const handleMeasurementDrawColorChange = (value?: AcCmColor) => {
   measurementDrawColorDisplay.value = acapCssColor(value)
   const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
   if (view) applyMeasurementStyleToSelection(view, { color: value })
-}
-
-const handleMeasurementDrawLineWeightChange = (value: AcGiLineWeight) => {
-  acapSetMeasurementDrawLineWeight(value)
-  measurementDrawLineWeight.value = value
-  const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
-  if (view) applyMeasurementStyleToSelection(view, { lineWeight: value })
 }
 
 const handleMeasurementDrawFontSizeChange = (value: number) => {
@@ -1272,23 +1243,6 @@ const buildBaseTabs = (
       }
     },
     {
-      id: 'markup-draw-line-weight',
-      type: 'custom',
-      size: 'small',
-      tooltip: t('main.verticalToolbar.markupLineWeight.description'),
-      props: {
-        component: MlRibbonPropertyLineWeightSelect,
-        componentProps: {
-          modelValue: markupDrawLineWeight.value,
-          placeholder: t('main.ribbon.property.lineWeight'),
-          numericOnly: true,
-          includeHairline: true,
-          controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
-          'onUpdate:modelValue': handleMarkupDrawLineWeightChange
-        }
-      }
-    },
-    {
       id: 'markup-draw-font-size',
       type: 'custom',
       size: 'small',
@@ -1454,23 +1408,6 @@ const buildBaseTabs = (
           placeholder: t('main.ribbon.property.color'),
           controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
           'onUpdate:modelValue': handleMeasurementDrawColorChange
-        }
-      }
-    },
-    {
-      id: 'measurement-draw-line-weight',
-      type: 'custom',
-      size: 'small',
-      tooltip: t('main.verticalToolbar.measurementLineWeight.description'),
-      props: {
-        component: MlRibbonPropertyLineWeightSelect,
-        componentProps: {
-          modelValue: measurementDrawLineWeight.value,
-          placeholder: t('main.ribbon.property.lineWeight'),
-          numericOnly: true,
-          includeHairline: true,
-          controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
-          'onUpdate:modelValue': handleMeasurementDrawLineWeightChange
         }
       }
     },
@@ -2106,7 +2043,6 @@ const buildBaseTabs = (
                     componentProps: {
                       modelValue: ribbonLineWeight.value,
                       placeholder: t('main.ribbon.property.lineWeight'),
-                      includeHairline: false,
                       'onUpdate:modelValue': handleRibbonLineWeightChange
                     }
                   }
@@ -2336,15 +2272,13 @@ const ribbonData = computed(() => {
   const openMode = docOpenMode.value
   const markupVisible = isMarkupOverlayVisible.value
   const measurementVisible = isMeasurementOverlayVisible.value
-  // Track markup draw style so Review ribbon color / lineweight controls refresh.
+  // Track markup draw style so Review ribbon color / font controls refresh.
   markupDrawColor.value
   markupDrawColorDisplay.value
-  markupDrawLineWeight.value
   markupDrawFontSize.value
   // Track measurement draw style so Measurement ribbon controls refresh.
   measurementDrawColor.value
   measurementDrawColorDisplay.value
-  measurementDrawLineWeight.value
   measurementDrawFontSize.value
   measurementLunits.value
   measurementLuprec.value

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonPropertyLineWeightSelect.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonPropertyLineWeightSelect.vue
@@ -10,7 +10,6 @@
       :disabled="disabled"
       :placeholder="placeholder"
       :numeric-only="numericOnly"
-      :include-hairline="includeHairline === true"
       :compact="numericOnly"
       @update:modelValue="emit('update:modelValue', $event)"
     />
@@ -35,20 +34,13 @@ interface RibbonPropertyLineWeightSelectProps {
   disabled?: boolean
   /** Placeholder shown when no line weight can be resolved. */
   placeholder?: string
-  /** When true, hide ByLayer / ByBlock / Default (overlay style pickers). */
+  /** When true, hide ByLayer / ByBlock / Default. */
   numericOnly?: boolean
-  /**
-   * Prepend a hairline option. Only measurement / review style pickers
-   * should set this; Home / entity property line-weight stays unchanged.
-   */
-  includeHairline?: boolean
   /** Optional fixed width for the embedded control; defaults narrower when `numericOnly`. */
   controlWidth?: string
 }
 
-const props = withDefaults(defineProps<RibbonPropertyLineWeightSelectProps>(), {
-  includeHairline: false
-})
+const props = defineProps<RibbonPropertyLineWeightSelectProps>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: AcGiLineWeight): void

--- a/packages/cad-viewer/src/locale/ar/main.ts
+++ b/packages/cad-viewer/src/locale/ar/main.ts
@@ -51,8 +51,7 @@ export default {
       ...enMain.ribbon.property,
       color: 'اللون',
       lineType: 'نوع الخط',
-      lineWeight: 'سُمك الخط',
-      lineWeightHairline: 'بلا سماكة'
+      lineWeight: 'سُمك الخط'
     },
 
     layerTools: {
@@ -739,12 +738,6 @@ export default {
       description: 'تحديد لون علامات المراجعة الجديدة'
     },
 
-    markupLineWeight: {
-      ...enMain.verticalToolbar.markupLineWeight,
-      text: 'سُمك الخط',
-      description: 'تحديد سُمك خط علامات المراجعة الجديدة'
-    },
-
     markupFontSize: {
       ...enMain.verticalToolbar.markupFontSize,
       text: 'حجم الخط',
@@ -755,12 +748,6 @@ export default {
       ...enMain.verticalToolbar.measurementColor,
       text: 'اللون',
       description: 'تحديد لون القياس المحدد أو القياسات الجديدة'
-    },
-
-    measurementLineWeight: {
-      ...enMain.verticalToolbar.measurementLineWeight,
-      text: 'سُمك الخط',
-      description: 'تحديد سُمك خط القياس المحدد أو القياسات الجديدة'
     },
 
     measurementFontSize: {

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -230,8 +230,7 @@ export default {
     property: {
       color: 'Barva',
       lineType: 'Typ čáry',
-      lineWeight: 'Tloušťka čáry',
-      lineWeightHairline: 'Bez tloušťky'
+      lineWeight: 'Tloušťka čáry'
     },
     layerTools: {
       select: 'Hladina',
@@ -513,10 +512,6 @@ export default {
       text: 'Barva',
       description: 'Nastaví barvu nových poznámek'
     },
-    markupLineWeight: {
-      text: 'Tloušťka čáry',
-      description: 'Nastaví tloušťku čáry nových poznámek'
-    },
     markupFontSize: {
       text: 'Velikost písma',
       description: 'Nastaví velikost písma textových a odkazových poznámek'
@@ -525,11 +520,6 @@ export default {
       text: 'Barva',
       description:
         'Nastaví barvu vybraného měření, nebo měření, která přidáte příště'
-    },
-    measurementLineWeight: {
-      text: 'Tloušťka čáry',
-      description:
-        'Nastaví tloušťku čáry vybraného měření, nebo měření, která přidáte příště'
     },
     measurementFontSize: {
       text: 'Velikost písma',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -230,8 +230,7 @@ export default {
     property: {
       color: 'Color',
       lineType: 'Linetype',
-      lineWeight: 'Lineweight',
-      lineWeightHairline: 'Hairline'
+      lineWeight: 'Lineweight'
     },
     layerTools: {
       select: 'Layer',
@@ -521,10 +520,6 @@ export default {
       text: 'Color',
       description: 'Set the color for new markup drawings'
     },
-    markupLineWeight: {
-      text: 'Lineweight',
-      description: 'Set the lineweight for new markup drawings'
-    },
     markupFontSize: {
       text: 'Font size',
       description: 'Set the font size for text and callout markups'
@@ -533,11 +528,6 @@ export default {
       text: 'Color',
       description:
         'Set the color for the selected measurement, or for measurements you add next'
-    },
-    measurementLineWeight: {
-      text: 'Lineweight',
-      description:
-        'Set the lineweight for the selected measurement, or for measurements you add next'
     },
     measurementFontSize: {
       text: 'Font size',

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -231,8 +231,7 @@ export default {
     property: {
       color: 'Renk',
       lineType: 'Çizgi Tipi',
-      lineWeight: 'Çizgi Kalınlığı',
-      lineWeightHairline: 'Kılcal'
+      lineWeight: 'Çizgi Kalınlığı'
     },
     layerTools: {
       select: 'Katman',
@@ -524,10 +523,6 @@ export default {
       text: 'Renk',
       description: 'Yeni işaret çizimleri için rengi ayarlar'
     },
-    markupLineWeight: {
-      text: 'Çizgi Kalınlığı',
-      description: 'Yeni işaret çizimleri için çizgi kalınlığını ayarlar'
-    },
     markupFontSize: {
       text: 'Yazı Boyutu',
       description: 'Metin ve çağrı işaretleri için yazı boyutunu ayarlar'
@@ -535,11 +530,6 @@ export default {
     measurementColor: {
       text: 'Renk',
       description: 'Seçili ölçümün veya sonraki ölçümlerin rengini ayarlar'
-    },
-    measurementLineWeight: {
-      text: 'Çizgi Kalınlığı',
-      description:
-        'Seçili ölçümün veya sonraki ölçümlerin çizgi kalınlığını ayarlar'
     },
     measurementFontSize: {
       text: 'Yazı Boyutu',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -227,8 +227,7 @@ export default {
     property: {
       color: '颜色',
       lineType: '线型',
-      lineWeight: '线宽',
-      lineWeightHairline: '无线宽'
+      lineWeight: '线宽'
     },
     layerTools: {
       select: '图层',
@@ -483,10 +482,6 @@ export default {
       text: '颜色',
       description: '设置新建批注的颜色'
     },
-    markupLineWeight: {
-      text: '线宽',
-      description: '设置新建批注的线宽'
-    },
     markupFontSize: {
       text: '字号',
       description: '设置文字与标注文本框的字号'
@@ -494,10 +489,6 @@ export default {
     measurementColor: {
       text: '颜色',
       description: '有选中测量标注时修改其颜色；未选中时用于后续添加的测量标注'
-    },
-    measurementLineWeight: {
-      text: '线宽',
-      description: '有选中测量标注时修改其线宽；未选中时用于后续添加的测量标注'
     },
     measurementFontSize: {
       text: '字号',


### PR DESCRIPTION
## Summary
- Remove lineweight pickers from overlay draw-style UI (HTML export, simple viewer toolbar, and cad-viewer Review/Measurement ribbon). Overlay strokes stay hairline (1 CSS px, not zoom-scaled).
- Sidecar parse/write always normalizes `lineWeight` to `0` and drops legacy `strokeWidthWcs`, so old thick overlay files cannot reintroduce zoom-scaled strokes.
- Skip `AcCmColor.fromString` for CSS hex (and functional colors) so overlay color parsing no longer logs `Unknown color name`.

## Test plan
- [ ] Draw a measurement and a markup, then zoom in/out: strokes stay hairline; text height still scales with zoom.
- [ ] Confirm overlay style UI (ribbon + canvas overlay) only shows color and text height — no lineweight control. CAD entity Home lineweight is unchanged.
- [ ] Import a sidecar that has non-zero `lineWeight` / `strokeWidthWcs`: overlays render as hairline, and re-export omits `strokeWidthWcs` with `lineWeight: 0`.
- [ ] Change overlay color via the style toolbar using a hex color; no console `Unknown color name` warning.