### PR TITLE
fix: ignore leftover mouse events after touch point picks

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcEdTouchPointSession.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdTouchPointSession.spec.ts
@@ -1,5 +1,18 @@
-import { AcEdTouchPointSession } from '../src/editor/input/ui/AcEdTouchPointSession'
+/**
+ * @jest-environment jsdom
+ */
 import { acedLoupeLocalFromCanvasDelta } from '../src/editor/input/ui/AcEdSnapLoupeMath'
+import {
+  ACED_TOUCH_MOUSE_GUARD_MS,
+  acedArmTouchMouseGuard,
+  acedClearFollowingClickSink,
+  acedIsGhostClientOrigin,
+  acedIsTouchDerivedMouseEvent,
+  acedResetTouchMouseGuard,
+  acedShouldIgnoreCompatMouse,
+  acedSinkFollowingClick,
+  AcEdTouchPointSession
+} from '../src/editor/input/ui/AcEdTouchPointSession'
 
 describe('AcEdTouchPointSession', () => {
   beforeEach(() => {
@@ -45,6 +58,102 @@ describe('AcEdTouchPointSession', () => {
     session.start(1, 0, 0, () => undefined, 350)
     expect(session.move(40, 0, false)).toBe('continue')
     expect(session.phase).toBe('pending')
+  })
+})
+
+describe('acedSinkFollowingClick', () => {
+  afterEach(() => {
+    acedResetTouchMouseGuard()
+    jest.useRealTimers()
+  })
+
+  it('stops the next click so a new point prompt is not auto-committed', () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const later = jest.fn()
+    target.addEventListener('click', later)
+    acedSinkFollowingClick()
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(later).not.toHaveBeenCalled()
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(later).toHaveBeenCalledTimes(1)
+    target.remove()
+  })
+
+  it('can be cleared so a later mouse click is not eaten', () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const later = jest.fn()
+    target.addEventListener('click', later)
+    acedSinkFollowingClick()
+    acedClearFollowingClickSink()
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(later).toHaveBeenCalledTimes(1)
+    target.remove()
+  })
+
+  it('expires so a later mouse click is not eaten if no leftover click arrives', () => {
+    jest.useFakeTimers()
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const later = jest.fn()
+    target.addEventListener('click', later)
+    acedSinkFollowingClick()
+    jest.advanceTimersByTime(ACED_TOUCH_MOUSE_GUARD_MS)
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(later).toHaveBeenCalledTimes(1)
+    target.remove()
+    jest.useRealTimers()
+  })
+})
+
+describe('acedShouldIgnoreCompatMouse', () => {
+  afterEach(() => {
+    acedResetTouchMouseGuard()
+  })
+
+  it('ignores mouse after a touch pick so a second nearby point is not committed', () => {
+    acedArmTouchMouseGuard(1000)
+    expect(acedShouldIgnoreCompatMouse(1000)).toBe(true)
+    expect(
+      acedShouldIgnoreCompatMouse(1000 + ACED_TOUCH_MOUSE_GUARD_MS - 1)
+    ).toBe(true)
+    expect(acedShouldIgnoreCompatMouse(1000 + ACED_TOUCH_MOUSE_GUARD_MS)).toBe(
+      false
+    )
+  })
+
+  it('stays armed while the following-click sink is still listening', () => {
+    acedSinkFollowingClick()
+    expect(acedShouldIgnoreCompatMouse(1e12)).toBe(true)
+    acedClearFollowingClickSink()
+    expect(acedShouldIgnoreCompatMouse(1e12)).toBe(false)
+  })
+})
+
+describe('acedIsGhostClientOrigin', () => {
+  it('detects the (0, 0) leftover used as a canvas top-left pick', () => {
+    expect(acedIsGhostClientOrigin({ clientX: 0, clientY: 0 })).toBe(true)
+    expect(acedIsGhostClientOrigin({ clientX: 1, clientY: 0 })).toBe(false)
+  })
+})
+
+describe('acedIsTouchDerivedMouseEvent', () => {
+  it('treats pointerType touch as touch-derived', () => {
+    expect(
+      acedIsTouchDerivedMouseEvent({ pointerType: 'touch' } as PointerEvent)
+    ).toBe(true)
+    expect(
+      acedIsTouchDerivedMouseEvent({ pointerType: 'mouse' } as PointerEvent)
+    ).toBe(false)
+  })
+
+  it('treats sourceCapabilities.firesTouchEvents as touch-derived', () => {
+    expect(
+      acedIsTouchDerivedMouseEvent({
+        sourceCapabilities: { firesTouchEvents: true }
+      } as unknown as MouseEvent)
+    ).toBe(true)
   })
 })
 

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
@@ -164,8 +164,8 @@ class AcApMeasureAngleJig extends AcEdPreviewJig<AcGePoint3dLike> {
       // Keep the label slightly above the vertex (was -30px screen offset).
       transform: 'translate(-50%, calc(-50% - 30px))'
     })
-    this._badge.object.visible = false
     this._htManager.add(this._badge)
+    this._badge.object.visible = false
 
     this._preview = new AcApHtmlLivePreview(
       this._view,

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
@@ -319,8 +319,8 @@ class AcApArcLockedEndJig extends AcEdPreviewJig<AcGePoint3dLike> {
       layoutId: this._view.activeLayoutBtrId,
       fontSize: acapGetMeasurementFontSize()
     })
-    this._badge.object.visible = false
     this._htManager.add(this._badge)
+    this._badge.object.visible = false
 
     this._preview = new AcApHtmlLivePreview(
       this._view,
@@ -514,8 +514,8 @@ class AcApMeasureArcEndJig extends AcEdPreviewJig<AcGePoint3dLike> {
       layoutId: this._view.activeLayoutBtrId,
       fontSize: acapGetMeasurementFontSize()
     })
-    this._badge.object.visible = false
     this._htManager.add(this._badge)
+    this._badge.object.visible = false
 
     this._preview = new AcApHtmlLivePreview(
       this._view,

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
@@ -1,6 +1,7 @@
 import {
   AcCmColor,
   AcDbDatabase,
+  AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
 import {
@@ -97,8 +98,9 @@ export class AcApMeasureDistanceJig extends AcEdPreviewJig<AcGePoint3dLike> {
       layoutId: this._view.activeLayoutBtrId,
       fontSize: acapGetMeasurementFontSize()
     })
-    this._badge.object.visible = false
     this._htManager.add(this._badge)
+    // `add()` applies layout visibility and would force the empty capsule on.
+    this._badge.object.visible = false
 
     this._preview = new AcApHtmlLivePreview(
       this._view,
@@ -182,6 +184,7 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
           AcApI18n.t('jig.measureDistance.secondPoint')
         )
         p2Prompt.useBasePoint = true
+        p2Prompt.basePoint = new AcGePoint3d(p1)
         p2Prompt.jig = new AcApMeasureDistanceJig(context.view, db, p1, color)
         const p2Result = await editor.getPoint(p2Prompt)
         if (p2Result.status !== AcEdPromptStatus.OK) return

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -23,7 +23,13 @@ import {
 import { AcEdFloatingMessage } from './AcEdFloatingMessage'
 import { AcEdRubberBand } from './AcEdRubberBand'
 import { AcEdSnapLoupe } from './AcEdSnapLoupe'
-import { AcEdTouchPointSession } from './AcEdTouchPointSession'
+import {
+  acedIsGhostClientOrigin,
+  acedIsTouchDerivedMouseEvent,
+  acedShouldIgnoreCompatMouse,
+  acedSinkFollowingClick,
+  AcEdTouchPointSession
+} from './AcEdTouchPointSession'
 
 /**
  * A UI component providing a small floating input box used inside CAD editing
@@ -90,8 +96,13 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   private readonly touchSession = new AcEdTouchPointSession()
   /** Magnifier HUD shown after a long-press on touch. */
   private snapLoupe?: AcEdSnapLoupe
-  /** When true, the synthetic `click` that follows a touch `pointerup` is ignored. */
-  private ignoreNextClick = false
+  /**
+   * When true, a left-button mouse/pen `pointerdown` landed on this prompt's
+   * canvas, so the following `click` may commit. Touch never sets this:
+   * phone/pad hide dynamic input, so a leftover compatibility `click` would
+   * otherwise hit the canvas and commit the next point prompt.
+   */
+  private mouseClickArmed = false
   /** Whether to suppress UI display while keeping input active */
   private suppressDisplay: boolean = false
   /** Cached sysvar handler */
@@ -180,7 +191,11 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     this.boundOnPointerMove = e => this.handlePointerMove(e)
     this.boundOnPointerUp = e => this.handlePointerUp(e)
     this.boundOnPointerCancel = e => this.handlePointerCancel(e)
-    this.parent.addEventListener('pointerdown', this.boundOnPointerDown)
+    // `preventDefault` on touch `pointerdown` needs a non-passive listener so
+    // the browser does not synthesize a leftover `click` for this gesture.
+    this.parent.addEventListener('pointerdown', this.boundOnPointerDown, {
+      passive: false
+    })
     this.parent.addEventListener('pointermove', this.boundOnPointerMove)
     // Release can happen off-canvas; listen on window like the HTML viewer.
     window.addEventListener('pointerup', this.boundOnPointerUp)
@@ -222,16 +237,16 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     this.updateDynamicInputDisplay()
     if (!this.suppressDisplay) {
       super.showAt(pos)
-      // Seed preview so modifier toggles can refresh immediately.
-      const wcsPos = this.view.screenToWorld(this.view.viewportToCanvas(pos))
-      this.updateDynamicPreview(wcsPos)
-      return
+    } else {
+      this.visible = true
+      this.container.style.display = 'none'
+      this.setPosition(pos)
+      this.parent.addEventListener('mousemove', this.boundOnMouseMove)
     }
-
-    this.visible = true
-    this.container.style.display = 'none'
-    this.setPosition(pos)
-    this.parent.addEventListener('mousemove', this.boundOnMouseMove)
+    // Phone/pad have no hover. Do not seed the measure jig from a dummy
+    // canvas-(0,0) or leftover finger sample; wait for a real pointer.
+    if (!this.view.hasCursorPos) return
+    if (acedShouldIgnoreCompatMouse()) return
     const wcsPos = this.view.screenToWorld(this.view.viewportToCanvas(pos))
     this.updateDynamicPreview(wcsPos)
   }
@@ -298,6 +313,9 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
    */
   protected override handleMouseMove(e: MouseEvent) {
     if (!this.visible) return
+    if (this.touchSession.isPicking) return
+    if (acedShouldIgnoreCompatMouse()) return
+    if (acedIsGhostClientOrigin(e) || acedIsTouchDerivedMouseEvent(e)) return
 
     const wcsPos = this.getPosition({ x: e.clientX, y: e.clientY })
     this.updateDynamicPreview(wcsPos)
@@ -327,10 +345,15 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
 
   private handleClick(e: MouseEvent) {
     if (!this.visible) return
-    if (this.ignoreNextClick) {
-      this.ignoreNextClick = false
-      return
-    }
+    // Mouse/pen: commit only after this prompt saw a canvas pointerdown.
+    // Touch commits on pointerup. Compatibility mouse events after a long-press
+    // (including while the finger is still moving the loupe) must not commit
+    // a second nearby point on the next prompt.
+    if (this.touchSession.isPicking) return
+    if (acedShouldIgnoreCompatMouse()) return
+    if (!this.mouseClickArmed) return
+    this.mouseClickArmed = false
+    if (acedIsGhostClientOrigin(e) || acedIsTouchDerivedMouseEvent(e)) return
 
     const wcsPos = this.getPosition({ x: e.clientX, y: e.clientY })
     const defaults = this.getDynamicValue(wcsPos)
@@ -341,14 +364,28 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   }
 
   /**
-   * Starts a one-finger pick. Short taps still commit on `pointerup`; a
-   * long-press opens the snap loupe and disables navigation until release.
+   * Starts a one-finger pick on touch, or arms a mouse/pen click commit.
    *
-   * @param e - Pointer event; only `touch` with button 0 is handled.
+   * @param e - Pointer event; button 0 only. Touch is handled here; mouse and
+   *   pen arm {@link mouseClickArmed} so the following `click` can commit.
    */
   private handlePointerDown(e: PointerEvent) {
-    if (!this.visible || e.pointerType !== 'touch') return
-    if (e.button !== 0) return
+    if (!this.visible || e.button !== 0) return
+    if (e.pointerType !== 'touch') {
+      // Long-press (and finger move while the loupe is open) must not arm a
+      // mouse click. Compatibility `pointerdown` after touch `pointerup` also
+      // must not clear the click sink — that was committing a second nearby
+      // point on the next measure-distance prompt.
+      if (this.touchSession.isPicking) return
+      if (acedShouldIgnoreCompatMouse()) return
+      if (acedIsGhostClientOrigin(e) || acedIsTouchDerivedMouseEvent(e)) {
+        return
+      }
+      this.mouseClickArmed = true
+      return
+    }
+    e.preventDefault()
+    this.mouseClickArmed = false
     this.touchSession.start(e.pointerId, e.clientX, e.clientY, () => {
       this.view.setNavigationEnabled(false)
       this.applyClientSample(this.touchSession.x, this.touchSession.y)
@@ -384,11 +421,14 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     if (e.pointerType !== 'touch') return
     if (this.touchSession.phase === 'idle') return
     if (e.pointerId !== this.touchSession.pointerId) return
-    this.ignoreNextClick = true
+    this.mouseClickArmed = false
+    acedSinkFollowingClick()
     this.releaseTouchCapture()
     const action = this.touchSession.end()
     this.view.setNavigationEnabled(true)
     this.snapLoupe?.hide()
+    // Finger-up coords must not seed the next prompt's jig preview.
+    this.view.clearCursorPos()
     if (!this.visible || action !== 'commit') return
     this.applyClientSample(e.clientX, e.clientY)
     const wcsPos = this.lastDynamicPoint
@@ -410,11 +450,13 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     if (e.pointerType !== 'touch') return
     if (this.touchSession.phase === 'idle') return
     if (e.pointerId !== this.touchSession.pointerId) return
-    this.ignoreNextClick = true
+    this.mouseClickArmed = false
+    acedSinkFollowingClick()
     this.releaseTouchCapture()
     this.touchSession.cancel()
     this.view.setNavigationEnabled(true)
     this.snapLoupe?.hide()
+    this.view.clearCursorPos()
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -60,6 +60,7 @@ import {
 } from './AcEdFloatingInputTypes'
 import { AcEdFloatingMessage } from './AcEdFloatingMessage'
 import { AcEdMessageType } from './AcEdMessageType'
+import { acedShouldIgnoreCompatMouse } from './AcEdTouchPointSession'
 
 /**
  * Internal control-flow error used to propagate keyword picks out of
@@ -2096,7 +2097,14 @@ export class AcEdInputManager {
       document.addEventListener('keyup', modifierHandler)
       this.view.canvas.addEventListener('contextmenu', contextMenuHandler)
       // showAt() expects viewport coordinates; curMousePos is canvas-local.
-      floatingInput.showAt(this.view.canvasToViewport(this.view.curMousePos))
+      // On touch, skip the dummy canvas-(0,0) seed until a real pointer sample.
+      // Also skip leftover finger coords after a touch pick — those seed a
+      // short jig segment on the next measure-distance prompt.
+      if (this.view.hasCursorPos && !acedShouldIgnoreCompatMouse()) {
+        floatingInput.showAt(this.view.canvasToViewport(this.view.curMousePos))
+      } else {
+        floatingInput.showAt({ x: 0, y: 0 })
+      }
 
       promptInputSession.promise.then(result => {
         if (settled) return

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdTouchPointSession.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdTouchPointSession.ts
@@ -9,6 +9,129 @@ export const ACED_TOUCH_POINT_LONG_PRESS_MS = 350
  */
 export const ACED_TOUCH_POINT_MOVE_CANCEL_PX = 10
 
+let followingClickSink: ((event: Event) => void) | null = null
+let followingClickSinkTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Ignore compatibility mouse events this long after a touch pick ends.
+ *
+ * Chrome fires a `pointerType: 'mouse'` `pointerdown` then `click` after
+ * touch `pointerup`. Those coordinates are near the finger, so a two-point
+ * command (measure distance) would commit both points from one long-press.
+ */
+export const ACED_TOUCH_MOUSE_GUARD_MS = 1000
+
+let ignoreCompatMouseUntil = 0
+
+/**
+ * Whether a mouse/pen event is a leftover from a touch gesture.
+ *
+ * Browsers synthesize `pointerType: 'mouse'` (and `click`) after touch.
+ * Those events often have `clientX/clientY` of `0`, which maps to the
+ * canvas origin — the top-left of the view.
+ */
+export function acedIsTouchDerivedMouseEvent(
+  event: MouseEvent | PointerEvent
+): boolean {
+  if ('pointerType' in event && event.pointerType === 'touch') return true
+  const caps = (
+    event as MouseEvent & {
+      sourceCapabilities?: { firesTouchEvents?: boolean }
+    }
+  ).sourceCapabilities
+  return caps?.firesTouchEvents === true
+}
+
+/**
+ * Whether client coordinates are the document origin.
+ *
+ * Compatibility mouse events after a toolbar tap are often dispatched at
+ * `(0, 0)`, which would commit a point at the canvas top-left.
+ *
+ * @param event - Event with client coordinates.
+ * @returns True when both client axes are zero.
+ */
+export function acedIsGhostClientOrigin(event: {
+  clientX: number
+  clientY: number
+}): boolean {
+  return event.clientX === 0 && event.clientY === 0
+}
+
+/**
+ * Stops the next `click` in the capture phase and ignores compatibility
+ * mouse events for {@link ACED_TOUCH_MOUSE_GUARD_MS}.
+ *
+ * Touch picking commits on `pointerup`. The browser then synthesizes a
+ * mouse `pointerdown` + `click` near the finger. A new point prompt would
+ * treat that as a real mouse pick unless this guard stays armed across
+ * prompt instances.
+ */
+export function acedSinkFollowingClick() {
+  acedArmTouchMouseGuard()
+  if (followingClickSink) return
+  const sink = (event: Event) => {
+    event.preventDefault()
+    event.stopImmediatePropagation()
+    acedClearFollowingClickSink()
+  }
+  followingClickSink = sink
+  window.addEventListener('click', sink, true)
+  // If `preventDefault` on touch pointerdown already suppressed the leftover
+  // click, do not leave the sink armed forever — that would eat the next
+  // real mouse click on a hybrid (touch + mouse) device.
+  followingClickSinkTimer = setTimeout(() => {
+    acedClearFollowingClickSink()
+  }, ACED_TOUCH_MOUSE_GUARD_MS)
+}
+
+/**
+ * Removes {@link acedSinkFollowingClick} if it is armed.
+ */
+export function acedClearFollowingClickSink() {
+  if (followingClickSinkTimer != null) {
+    clearTimeout(followingClickSinkTimer)
+    followingClickSinkTimer = null
+  }
+  if (!followingClickSink) return
+  window.removeEventListener('click', followingClickSink, true)
+  followingClickSink = null
+}
+
+/**
+ * Arms the compatibility-mouse ignore window after a touch pick.
+ *
+ * @param now - Current time in milliseconds; defaults to `performance.now()`.
+ */
+export function acedArmTouchMouseGuard(now: number = performance.now()) {
+  ignoreCompatMouseUntil = Math.max(
+    ignoreCompatMouseUntil,
+    now + ACED_TOUCH_MOUSE_GUARD_MS
+  )
+}
+
+/**
+ * Whether mouse `pointerdown` / `click` should be ignored as leftover from
+ * a touch pick (including on a newly created prompt).
+ *
+ * @param now - Current time in milliseconds; defaults to `performance.now()`.
+ * @returns True while a following-click sink is armed or the guard window
+ *   has not expired.
+ */
+export function acedShouldIgnoreCompatMouse(
+  now: number = performance.now()
+): boolean {
+  return followingClickSink != null || now < ignoreCompatMouseUntil
+}
+
+/**
+ * Clears the click sink and mouse guard. Used by tests.
+ */
+export function acedResetTouchMouseGuard() {
+  acedClearFollowingClickSink()
+  ignoreCompatMouseUntil = 0
+}
+
 /**
  * Phases of a one-finger point-pick gesture.
  *

--- a/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
@@ -234,6 +234,12 @@ export abstract class AcEdBaseView {
    * the canvas bounding-rect origin (`viewportToCanvas`).
    */
   private _curMousePos: AcGePoint2d
+  /**
+   * True after at least one mouse or pointer sample has updated
+   * {@link curMousePos}. Touch devices never fire `mousemove` until a finger
+   * is down, so the default `(0, 0)` must not be treated as a real cursor.
+   */
+  private _hasCursorPos = false
   /** Set of currently selected entities */
   private _selectionSet: AcEdSelectionSet
   /**
@@ -307,10 +313,21 @@ export abstract class AcEdBaseView {
     this._height = rect.height
     this._curPos = new AcGePoint2d()
     this._curMousePos = new AcGePoint2d()
+    this._hasCursorPos = false
     this._selectionSet = new AcEdSelectionSet()
     this._editor = new AcEditor(this)
     this._osnapResolver = new AcEdOsnapResolver(this)
     this._canvas.addEventListener('mousemove', event => this.onMouseMove(event))
+    // Touch does not fire `mousemove`. Keep cursor (and therefore the next
+    // point-prompt preview) in sync with the finger, otherwise `curMousePos`
+    // stays at canvas (0, 0) — the top-left of the view. Mouse already has
+    // `mousemove`; do not also handle pointer events or hover runs twice.
+    this._canvas.addEventListener('pointerdown', event => {
+      if (event.pointerType === 'touch') this.onMouseMove(event)
+    })
+    this._canvas.addEventListener('pointermove', event => {
+      if (event.pointerType === 'touch') this.onMouseMove(event)
+    })
     this._canvas.addEventListener('mousedown', event => {
       if (event.button === 1) {
         // Middle mouse button (button === 1)
@@ -986,6 +1003,27 @@ export abstract class AcEdBaseView {
   }
 
   /**
+   * Whether {@link curMousePos} has been set by a real pointer sample.
+   *
+   * @returns False until the first mouse or pointer event on the canvas.
+   */
+  get hasCursorPos() {
+    return this._hasCursorPos
+  }
+
+  /**
+   * Marks {@link curMousePos} as stale so the next point prompt does not
+   * treat a leftover touch sample as a live cursor.
+   *
+   * Touch picking commits on `pointerup`. The finger position must not seed
+   * the following prompt's jig (that would draw a short segment next to the
+   * pick). The next real pointer sample sets this flag again.
+   */
+  clearCursorPos() {
+    this._hasCursorPos = false
+  }
+
+  /**
    * The selection set in current view.
    */
   get selectionSet() {
@@ -1104,11 +1142,14 @@ export abstract class AcEdBaseView {
   }
 
   /**
-   * Mouse move event handler.
-   * @param event Input mouse event argument
+   * Pointer sample handler. Updates canvas-local and world cursor from mouse
+   * or touch coordinates.
+   *
+   * @param event - Mouse or pointer event with client coordinates.
    */
-  private onMouseMove(event: MouseEvent) {
+  private onMouseMove(event: MouseEvent | PointerEvent) {
     // Keep one canonical conversion path for all view input code.
+    this._hasCursorPos = true
     this._curMousePos = this.viewportToCanvas({
       x: event.clientX,
       y: event.clientY


### PR DESCRIPTION
## Summary
- Stop Chrome leftover mouse pointerdown/click after a touch pick from committing a second nearby point on the next prompt (measure distance was the worst case).
- Do not seed the next point-prompt jig from canvas (0, 0) or leftover finger coordinates; keep the empty length capsule hidden until a real pointer sample.
- Hide measure badges after htmlTransientManager.add() so layout visibility cannot force an empty capsule on.

## Test plan
- [ ] Phone/pad: measure distance with a long-press snap on the first point, then pick the second point — only two points, no extra nearby point and no short leftover jig segment
- [ ] Phone/pad: short-tap both points of measure distance; pan between picks still works
- [ ] Desktop: measure distance with dynamic input on — jig and click-to-commit still work
- [ ] Desktop: DYNMODE off — jig still follows the mouse
- [ ] Hybrid (touch then mouse): after a touch pick, a later mouse click is not swallowed forever