### PR TITLE
feat: persist overlay arrow-head size in world units independently of hairline stroke

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts
@@ -190,13 +190,16 @@ describe('AcExHtmlOverlayDom', () => {
     acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
       fontSizePx: 13,
       textHeightWcs: 1.3,
-      elements: [grip, badge]
+      arrowSizeWcs: 1.2,
+      elements: [grip, badge],
+      canvases: [grip]
     })
     expect(grip.dataset[ACEX_OVERLAY_BASE_ZOOM]).toBe('2')
     expect(badge.dataset[ACEX_OVERLAY_BASE_ZOOM]).toBe('2')
+    expect(grip.dataset[ACEX_OVERLAY_ARROW_WCS]).toBe('1.2')
   })
 
-  it('scales distance arrows in WCS independently of hairline stroke', () => {
+  it('freezes committed distance arrows as WCS on first paint', () => {
     const canvas = document.createElement('canvas')
     const at10 = (wcs: { x: number; y: number }) => ({
       x: wcs.x * 10,
@@ -209,5 +212,15 @@ describe('AcExHtmlOverlayDom', () => {
     expect(acExScaledOverlayArrowSize(canvas, at10)).toBe(12)
     expect(Number(canvas.dataset[ACEX_OVERLAY_ARROW_WCS])).toBeCloseTo(1.2)
     expect(acExScaledOverlayArrowSize(canvas, at5)).toBeCloseTo(6)
+  })
+
+  it('uses imported arrowSizeWcs instead of seeding from screen pixels', () => {
+    const canvas = document.createElement('canvas')
+    const at10 = (wcs: { x: number; y: number }) => ({
+      x: wcs.x * 10,
+      y: wcs.y * 10
+    })
+    expect(acExScaledOverlayArrowSize(canvas, at10, 2.4)).toBeCloseTo(24)
+    expect(canvas.dataset[ACEX_OVERLAY_ARROW_WCS]).toBe('2.4')
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExMarkupSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMarkupSidecar.spec.ts
@@ -63,6 +63,7 @@ describe('AcExMarkupSidecar', () => {
             color: '#e53935',
             lineWeight: 70,
             textHeightWcs: 0.6,
+            arrowSizeWcs: 0.9,
             strokeWidthWcs: 0.1
           },
           comment: '',
@@ -82,6 +83,7 @@ describe('AcExMarkupSidecar', () => {
     expect(text).not.toMatch(/"strokeWidthWcs"\s*:/)
     const parsed = parseAcExMarkupSidecar(text)
     expect(parsed.markups[0]?.style.textHeightWcs).toBe(0.6)
+    expect(parsed.markups[0]?.style.arrowSizeWcs).toBe(0.9)
     expect(parsed.markups[0]?.style.lineWeight).toBe(0)
     expect(parsed.markups[0]?.style.strokeWidthWcs).toBeUndefined()
   })

--- a/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
@@ -74,6 +74,7 @@ describe('AcExMeasurementSidecar', () => {
             lineWeight: 70,
             fontSize: 13,
             textHeightWcs: 0.65,
+            arrowSizeWcs: 1.2,
             strokeWidthWcs: 0.1
           },
           geometry: {
@@ -88,6 +89,7 @@ describe('AcExMeasurementSidecar', () => {
     expect(text).not.toMatch(/"strokeWidthWcs"\s*:/)
     const parsed = parseAcExMeasurementSidecar(text)
     expect(parsed.measurements[0]?.style.textHeightWcs).toBe(0.65)
+    expect(parsed.measurements[0]?.style.arrowSizeWcs).toBe(1.2)
     expect(parsed.measurements[0]?.style.lineWeight).toBe(0)
     expect(parsed.measurements[0]?.style.strokeWidthWcs).toBeUndefined()
   })

--- a/packages/cad-html-plugin/src/AcExHtmlOverlayDom.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlOverlayDom.ts
@@ -10,11 +10,11 @@ export const ACEX_OVERLAY_CLOUD_WCS = 'overlayCloudWcs'
 /** Target screen diameter in CSS pixels for each revision-cloud lobe at creation. */
 export const ACEX_OVERLAY_CLOUD_DIAMETER_PX = 8
 
+/** Arrow-head length in CSS pixels at the overlay's creation-scale stroke. */
+export const ACEX_OVERLAY_ARROW_SIZE_PX = 12
+
 /** Dataset key storing overlay arrow-head length in world units. */
 export const ACEX_OVERLAY_ARROW_WCS = 'overlayArrowWcs'
-
-/** Arrow-head length in CSS pixels at first paint; stored as WCS thereafter. */
-export const ACEX_OVERLAY_ARROW_SIZE_PX = 12
 
 /**
  * Scale factor for HTML measure/markup overlays relative to first layout.
@@ -76,6 +76,14 @@ export function acExSeedOverlayStrokeWcs(
   canvas.dataset[ACEX_OVERLAY_STROKE_WCS] = String(strokeWidthWcs)
 }
 
+export function acExSeedOverlayArrowWcs(
+  canvas: HTMLElement,
+  arrowSizeWcs: number
+): void {
+  if (!(arrowSizeWcs > 0) || !Number.isFinite(arrowSizeWcs)) return
+  canvas.dataset[ACEX_OVERLAY_ARROW_WCS] = String(arrowSizeWcs)
+}
+
 /**
  * View-synced canvas stroke. Prefer strokeWidthWcs; else convert baseLineWidth
  * to WCS on first paint and stash on the canvas.
@@ -113,8 +121,11 @@ export function acExScaledCanvasLineWidth(
 /**
  * Arrow-head length in CSS pixels that stays a fixed world size.
  *
- * Distance measurements use this so arrows follow zoom even when the stroke
- * is hairline. Seeds {@link ACEX_OVERLAY_ARROW_SIZE_PX} as WCS on first paint.
+ * Used by committed distance measurements and arrow markups. Seeds
+ * {@link ACEX_OVERLAY_ARROW_SIZE_PX} as WCS on first paint (the size shown
+ * during the jig) unless `arrowSizeWcs` is provided. Live previews should use
+ * `acExOverlayArrowSize` so the head stays a constant screen size
+ * while the user zooms during placement.
  */
 export function acExScaledOverlayArrowSize(
   canvas: HTMLCanvasElement,
@@ -154,6 +165,7 @@ export function acExSeedOverlaySizesFromWcs(
   options: {
     textHeightWcs?: number
     strokeWidthWcs?: number
+    arrowSizeWcs?: number
     fontSizePx?: number
     strokeScreenPx?: number
     elements?: readonly HTMLElement[]
@@ -170,6 +182,12 @@ export function acExSeedOverlaySizesFromWcs(
   } else if (options.strokeScreenPx === 0) {
     for (const canvas of canvases ?? []) {
       delete canvas.dataset[ACEX_OVERLAY_STROKE_WCS]
+    }
+  }
+
+  if (options.arrowSizeWcs != null && options.arrowSizeWcs > 0) {
+    for (const canvas of canvases ?? []) {
+      acExSeedOverlayArrowWcs(canvas, options.arrowSizeWcs)
     }
   }
 

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -13,9 +13,11 @@ import * as THREE from 'three'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import {
+  ACEX_OVERLAY_ARROW_SIZE_PX,
   acExPositionWcsOverlay,
   acExResetOverlayViewScale,
   acExScaledCanvasLineWidth,
+  acExScaledOverlayArrowSize,
   acExScreenPxToWcs,
   acExSeedOverlaySizesFromWcs
 } from './AcExHtmlOverlayDom'
@@ -382,7 +384,7 @@ export class AcExMarkupController {
     )
   }
 
-  /** Attach world-space text height from the current view. */
+  /** Attach world-space text height and arrow length from the current view. */
   private _styleWithWcs(style: AcExMarkupStyle): AcExMarkupStyle {
     const fontSize =
       style.fontSize != null && style.fontSize > 0
@@ -391,10 +393,15 @@ export class AcExMarkupController {
     const wcsToScreen = (p: { x: number; y: number }) =>
       this._wcsToScreenPoint(p)
     const { strokeWidthWcs: _omit, ...rest } = style
+    const arrowSizeWcs =
+      style.arrowSizeWcs != null && style.arrowSizeWcs > 0
+        ? style.arrowSizeWcs
+        : acExScreenPxToWcs(ACEX_OVERLAY_ARROW_SIZE_PX, wcsToScreen)
     return {
       ...rest,
       lineWeight: ACEX_MARKUP_LINE_WEIGHT,
-      textHeightWcs: acExScreenPxToWcs(fontSize, wcsToScreen)
+      textHeightWcs: acExScreenPxToWcs(fontSize, wcsToScreen),
+      arrowSizeWcs
     }
   }
 
@@ -1349,6 +1356,7 @@ export class AcExMarkupController {
       p => this._wcsToScreenPoint(p),
       {
         textHeightWcs: record.style.textHeightWcs,
+        arrowSizeWcs: record.style.arrowSizeWcs,
         fontSizePx: record.style.fontSize ?? ACEX_MARKUP_FONT_SIZE,
         strokeScreenPx: acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
         elements: parts.dom,
@@ -1381,7 +1389,10 @@ export class AcExMarkupController {
         ctx,
         live.geometry,
         live.style.color || ACEX_MARKUP_COLOR,
-        acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
+        acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
+        undefined,
+        true,
+        live.style.arrowSizeWcs
       )
     }
     this._redrawListeners.push(redraw)
@@ -1871,7 +1882,9 @@ export class AcExMarkupController {
     g: AcExMarkupGeometry,
     color: string,
     lineWidth: number,
-    strokeWidthWcs?: number
+    strokeWidthWcs?: number,
+    scaleArrowsWithView = false,
+    arrowSizeWcs?: number
   ): void {
     const strokeWidth = this._scaledCanvasLineWidth(
       lineWidth,
@@ -1899,7 +1912,13 @@ export class AcExMarkupController {
             a,
             b,
             color,
-            acExOverlayArrowSize(strokeWidth, lineWidth)
+            scaleArrowsWithView
+              ? acExScaledOverlayArrowSize(
+                  ctx.canvas,
+                  worldToScreen,
+                  arrowSizeWcs
+                )
+              : acExOverlayArrowSize(strokeWidth, lineWidth)
           )
         }
         break
@@ -1972,7 +1991,13 @@ export class AcExMarkupController {
           color,
           true,
           strokeWidth,
-          acExOverlayArrowSize(strokeWidth, lineWidth)
+          scaleArrowsWithView
+            ? acExScaledOverlayArrowSize(
+                ctx.canvas,
+                worldToScreen,
+                arrowSizeWcs
+              )
+            : acExOverlayArrowSize(strokeWidth, lineWidth)
         )
         break
       }

--- a/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
@@ -84,6 +84,11 @@ const CLOUD_HIT_EXTRA_PX = 8
 
 /**
  * Screen length of an overlay arrow head, tracking the same WCS scale as the stroke.
+ *
+ * Hairline overlays (`baseLineWidth <= 0`) keep a constant
+ * {@link ACEX_OVERLAY_ARROW_SIZE_PX}. Use this during jig / live preview so
+ * the head stays a fixed screen size while the user zooms. After commit,
+ * freeze that size in world units with `acExScaledOverlayArrowSize`.
  */
 export function acExOverlayArrowSize(
   scaledLineWidth: number,

--- a/packages/cad-html-plugin/src/AcExMarkupSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupSidecar.ts
@@ -163,7 +163,8 @@ function parseRecord(raw: unknown): AcExMarkupRecord | undefined {
         typeof raw.style.fontSize === 'number' && raw.style.fontSize > 0
           ? raw.style.fontSize
           : undefined,
-      textHeightWcs: parsePositiveNumber(raw.style.textHeightWcs)
+      textHeightWcs: parsePositiveNumber(raw.style.textHeightWcs),
+      arrowSizeWcs: parsePositiveNumber(raw.style.arrowSizeWcs)
     },
     text: typeof raw.text === 'string' ? raw.text : undefined,
     comment: typeof raw.comment === 'string' ? raw.comment : '',

--- a/packages/cad-html-plugin/src/AcExMarkupTypes.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupTypes.ts
@@ -40,6 +40,11 @@ export interface AcExMarkupStyle {
   fontSize?: number
   /** Text / callout height in world units (preferred when restoring overlays). */
   textHeightWcs?: number
+  /**
+   * Arrow-head length in world units (arrow / callout markups). Preferred
+   * when restoring overlays.
+   */
+  arrowSizeWcs?: number
   /** Legacy canvas stroke width in world units. Ignored on parse; never written. */
   strokeWidthWcs?: number
 }

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -23,6 +23,7 @@ import {
 } from './AcExHtmlOverlayDom'
 import {
   acExDrawMarkupArrowHead,
+  acExExpandExtentsByClientRects,
   acExOverlayArrowSize
 } from './AcExMarkupGeometry'
 import { acExBindMarkupPointerDrag } from './AcExMarkupGripDrag'
@@ -250,8 +251,8 @@ function isRecordOnLayout(
   return recordLayoutId == null || recordLayoutId === activeLayoutId
 }
 
-/** World AABB of a measurement's control geometry. */
-function measurementFocusExtents(
+/** World AABB of a measurement's control geometry (no overlay padding). */
+function measurementGeometryExtents(
   geometry: AcExMeasurementGeometry
 ): AcExExtents | null {
   const xs: number[] = []
@@ -290,17 +291,48 @@ function measurementFocusExtents(
       return null
   }
   if (xs.length === 0) return null
-  let minX = Math.min(...xs)
-  let minY = Math.min(...ys)
-  let maxX = Math.max(...xs)
-  let maxY = Math.max(...ys)
-  if (!(maxX - minX > 1e-8) && !(maxY - minY > 1e-8)) {
-    minX -= 1
-    minY -= 1
-    maxX += 1
-    maxY += 1
+  return {
+    minX: Math.min(...xs),
+    minY: Math.min(...ys),
+    maxX: Math.max(...xs),
+    maxY: Math.max(...ys)
   }
-  return { minX, minY, maxX, maxY }
+}
+
+function padDegenerateExtents(extents: AcExExtents): AcExExtents {
+  if (extents.maxX - extents.minX > 1e-8 || extents.maxY - extents.minY > 1e-8) {
+    return extents
+  }
+  return {
+    minX: extents.minX - 1,
+    minY: extents.minY - 1,
+    maxX: extents.maxX + 1,
+    maxY: extents.maxY + 1
+  }
+}
+
+/**
+ * Combined zoom-to extents: control geometry plus HTML overlay rectangles.
+ *
+ * Coordinate measurements are a degenerate AABB on their own. Union the
+ * badge (capsule) so the camera frames the label instead of the point.
+ */
+function measurementFocusExtents(
+  geometry: AcExMeasurementGeometry,
+  overlayRects: ReadonlyArray<{
+    left: number
+    top: number
+    right: number
+    bottom: number
+  }>,
+  clientToWorld: (clientX: number, clientY: number) => { x: number; y: number }
+): AcExExtents | null {
+  const extents = acExExpandExtentsByClientRects(
+    measurementGeometryExtents(geometry),
+    overlayRects,
+    clientToWorld
+  )
+  return extents ? padDegenerateExtents(extents) : null
 }
 
 /**
@@ -1310,14 +1342,25 @@ export class AcExMeasureController {
   }
 
   /**
-   * Zoom to a measurement and select it.
+   * Zoom to a measurement (geometry plus HTML badge) and select it.
    *
    * @returns `true` when extents were applied.
    */
   focus(id: string): boolean {
     const measure = this._committed.find(item => item.id === id)
     if (!measure) return false
-    const extents = measurementFocusExtents(measure.record.geometry)
+    const rects = measure.parts.dom
+      .filter(el => !acExIsOverlayGrip(el) && !el.hidden)
+      .map(el => el.getBoundingClientRect())
+      .filter(rect => rect.width > 0 || rect.height > 0)
+    const extents = measurementFocusExtents(
+      measure.record.geometry,
+      rects,
+      (clientX, clientY) => {
+        const p = this._view.screenToWcs(clientX, clientY)
+        return { x: p.x, y: p.y }
+      }
+    )
     if (!extents) return false
     this._view.zoomToExtents(extents)
     this.selectFromPanel(id)

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -11,6 +11,7 @@ import * as THREE from 'three'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import {
+  ACEX_OVERLAY_ARROW_SIZE_PX,
   acExPixelsPerWorldUnit,
   acExPositionClientOverlay,
   acExPositionWcsOverlay,
@@ -20,7 +21,10 @@ import {
   acExScreenPxToWcs,
   acExSeedOverlaySizesFromWcs
 } from './AcExHtmlOverlayDom'
-import { acExDrawMarkupArrowHead } from './AcExMarkupGeometry'
+import {
+  acExDrawMarkupArrowHead,
+  acExOverlayArrowSize
+} from './AcExMarkupGeometry'
 import { acExBindMarkupPointerDrag } from './AcExMarkupGripDrag'
 import {
   ACEX_MEASUREMENT_FONT_SIZE,
@@ -3097,7 +3101,9 @@ export class AcExMeasureController {
         style.color || this._measureCss(),
         acExMeasureCanvasLineWidth(style.lineWeight),
         style.strokeWidthWcs,
-        bothArrows
+        bothArrows,
+        bothArrows,
+        style.arrowSizeWcs
       )
     }
     redraw()
@@ -3186,7 +3192,9 @@ export class AcExMeasureController {
     strokeCss: string,
     lineWidth: number,
     strokeWidthWcs?: number,
-    bothArrows = false
+    bothArrows = false,
+    scaleArrowsWithView = false,
+    arrowSizeWcs?: number
   ): void {
     if (points.length < 2) return
     const synced = this._syncCanvas(canvas)
@@ -3219,9 +3227,13 @@ export class AcExMeasureController {
     if (bothArrows && screen.length === 2) {
       const a = screen[0]!
       const b = screen[1]!
-      const arrowSize = acExScaledOverlayArrowSize(canvas, p =>
-        this._wcsToScreenPoint(p)
-      )
+      const arrowSize = scaleArrowsWithView
+        ? acExScaledOverlayArrowSize(
+            canvas,
+            p => this._wcsToScreenPoint(p),
+            arrowSizeWcs
+          )
+        : acExOverlayArrowSize(scaled, lineWidth)
       if (Math.hypot(b.x - a.x, b.y - a.y) >= arrowSize) {
         acExDrawMarkupArrowHead(ctx, b, a, strokeCss, arrowSize)
         acExDrawMarkupArrowHead(ctx, a, b, strokeCss, arrowSize)
@@ -3304,7 +3316,10 @@ export class AcExMeasureController {
       this._commitStyle = null
       return
     }
-    const style = this._ensureStyleWcs(record.style)
+    const style = this._ensureStyleWcs(
+      record.style,
+      record.type === 'distance'
+    )
     const committedRecord = { ...record, id: parts.id, style }
     this._committed.push({
       id: parts.id,
@@ -3319,6 +3334,7 @@ export class AcExMeasureController {
       p => this._wcsToScreenPoint(p),
       {
         textHeightWcs: style.textHeightWcs,
+        arrowSizeWcs: style.arrowSizeWcs,
         fontSizePx: style.fontSize,
         strokeScreenPx: acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT),
         elements: parts.dom,
@@ -3342,23 +3358,31 @@ export class AcExMeasureController {
   }
 
   /**
-   * Fill any missing world-space text height without overwriting sidecar values.
+   * Fill any missing world-space sizes without overwriting sidecar values.
    * Never writes strokeWidthWcs (overlay strokes stay hairline).
    * @internal
    */
   private _ensureStyleWcs(
-    style: AcExMeasurementSidecarStyle
+    style: AcExMeasurementSidecarStyle,
+    includeArrow = false
   ): AcExMeasurementSidecarStyle {
     const wcsToScreen = (p: { x: number; y: number }) =>
       this._wcsToScreenPoint(p)
     const { strokeWidthWcs: _omit, ...rest } = style
+    const arrowSizeWcs =
+      style.arrowSizeWcs != null && style.arrowSizeWcs > 0
+        ? style.arrowSizeWcs
+        : includeArrow
+          ? acExScreenPxToWcs(ACEX_OVERLAY_ARROW_SIZE_PX, wcsToScreen)
+          : undefined
     return {
       ...rest,
       lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
       textHeightWcs:
         style.textHeightWcs != null && style.textHeightWcs > 0
           ? style.textHeightWcs
-          : acExScreenPxToWcs(style.fontSize, wcsToScreen)
+          : acExScreenPxToWcs(style.fontSize, wcsToScreen),
+      ...(arrowSizeWcs != null && arrowSizeWcs > 0 ? { arrowSizeWcs } : {})
     }
   }
 

--- a/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
@@ -73,7 +73,8 @@ function parseStyle(raw: unknown): AcExMeasurementSidecarStyle | undefined {
     color: raw.color,
     lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
     fontSize,
-    textHeightWcs: parsePositiveNumber(raw.textHeightWcs)
+    textHeightWcs: parsePositiveNumber(raw.textHeightWcs),
+    arrowSizeWcs: parsePositiveNumber(raw.arrowSizeWcs)
   }
 }
 

--- a/packages/cad-html-plugin/src/AcExMeasurementTypes.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurementTypes.ts
@@ -31,6 +31,11 @@ export interface AcExMeasurementSidecarStyle {
   fontSize: number
   /** Badge text height in world units (preferred when restoring overlays). */
   textHeightWcs?: number
+  /**
+   * Distance-measurement arrow-head length in world units (preferred when
+   * restoring overlays).
+   */
+  arrowSizeWcs?: number
   /** Legacy canvas stroke width in world units. Ignored on parse; never written. */
   strokeWidthWcs?: number
 }

--- a/packages/cad-simple-viewer/__tests__/AcApMarkupSidecar.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMarkupSidecar.spec.ts
@@ -48,6 +48,37 @@ describe('AcApMarkupSidecar', () => {
     })
   })
 
+  it('round-trips arrowSizeWcs on arrow markups', () => {
+    const file: AcApMarkupSidecarFile = {
+      version: 1,
+      markups: [
+        {
+          id: 'markup-arrow',
+          type: 'arrow',
+          style: {
+            color: '#00ff00',
+            lineWeight: 0,
+            arrowSizeWcs: 0.8
+          },
+          comment: '',
+          status: 'open',
+          author: 'alice',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          geometry: {
+            type: 'arrow',
+            start: { x: 0, y: 0 },
+            end: { x: 5, y: 0 }
+          }
+        }
+      ]
+    }
+    const text = stringifyMarkupSidecar(file)
+    expect(text).toMatch(/"arrowSizeWcs"\s*:\s*0\.8/)
+    const parsed = parseMarkupSidecar(text)
+    expect(parsed.markups[0]?.style.arrowSizeWcs).toBe(0.8)
+  })
+
   it('suggests sidecar file names', () => {
     expect(markupSidecarFileName('plan.dwg')).toBe('plan.markup.json')
     expect(markupSidecarFileName('plan.DXF')).toBe('plan.markup.json')

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementGeometry.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementGeometry.spec.ts
@@ -1,5 +1,6 @@
 import {
   hitTestMeasurementGeometry,
+  measurementFocusBox,
   measurementGeometryBounds
 } from '../src/command/measure/AcApMeasurementGeometry'
 import type { AcApMeasurementGeometry } from '../src/command/measure/AcApMeasurementTypes'
@@ -169,5 +170,38 @@ describe('measurementGeometryBounds', () => {
     expect(box!.min.y).toBe(-25)
     expect(box!.max.x).toBe(25)
     expect(box!.max.y).toBe(25)
+  })
+})
+
+describe('measurementFocusBox', () => {
+  const clientToWorld = (clientX: number, clientY: number) => ({
+    x: clientX / 10,
+    y: -clientY / 10
+  })
+
+  it('pads a coordinate point when no overlay rect is available', () => {
+    const box = measurementFocusBox(
+      { type: 'point', position: { x: 5, y: 7 } },
+      [],
+      clientToWorld
+    )
+    expect(box).toBeDefined()
+    expect(box!.min.x).toBe(4)
+    expect(box!.min.y).toBe(6)
+    expect(box!.max.x).toBe(6)
+    expect(box!.max.y).toBe(8)
+  })
+
+  it('unions the coordinate capsule so zoom frames the badge, not the point', () => {
+    const box = measurementFocusBox(
+      { type: 'point', position: { x: 5, y: 7 } },
+      [{ left: 40, top: 20, right: 120, bottom: 50 }],
+      clientToWorld
+    )
+    expect(box).toBeDefined()
+    expect(box!.min.x).toBe(4)
+    expect(box!.min.y).toBe(-5)
+    expect(box!.max.x).toBe(12)
+    expect(box!.max.y).toBe(7)
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementSidecar.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementSidecar.spec.ts
@@ -19,6 +19,7 @@ describe('AcApMeasurementSidecar', () => {
             lineWeight: 70,
             fontSize: 13,
             textHeightWcs: 2.5,
+            arrowSizeWcs: 1.2,
             strokeWidthWcs: 0.4
           },
           geometry: {
@@ -99,6 +100,7 @@ describe('AcApMeasurementSidecar', () => {
     expect(parsed.drawingName).toBe('demo.dwg')
     expect(parsed.measurements).toHaveLength(5)
     expect(parsed.measurements[0].style.textHeightWcs).toBe(2.5)
+    expect(parsed.measurements[0].style.arrowSizeWcs).toBe(1.2)
     expect(parsed.measurements[0].style.lineWeight).toBe(0)
     expect(parsed.measurements[0].style.strokeWidthWcs).toBeUndefined()
     expect(parsed.measurements[0].geometry).toEqual({

--- a/packages/cad-simple-viewer/__tests__/AcApOverlayDrawUtil.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApOverlayDrawUtil.spec.ts
@@ -86,10 +86,22 @@ describe('AcApOverlayDrawUtil WCS stroke', () => {
     acapSeedOverlaySizesFromWcs(view, {
       fontSizePx: 13,
       textHeightWcs: 1.3,
-      elements: [el as never]
+      arrowSizeWcs: 1.2,
+      elements: [el as never],
+      canvases: [canvas]
     })
     // base = (13 * 2) / (1.3 * 10) = 2
     expect(el.baseZoom).toBe(2)
+    expect(canvas.dataset[ACAP_OVERLAY_ARROW_WCS]).toBe('1.2')
+  })
+
+  it('seeds arrow WCS independently of the text screen/WCS pair', () => {
+    const canvas = document.createElement('canvas')
+    acapSeedOverlaySizesFromWcs(mockView(10), {
+      arrowSizeWcs: 1.2,
+      canvases: [canvas]
+    })
+    expect(canvas.dataset[ACAP_OVERLAY_ARROW_WCS]).toBe('1.2')
   })
 })
 
@@ -109,11 +121,17 @@ describe('AcApOverlayDrawUtil arrow and dash scale', () => {
     expect(acapOverlayArrowSize(1, 0)).toBe(12)
   })
 
-  it('scales distance arrows in WCS independently of hairline stroke', () => {
+  it('freezes committed distance arrows as WCS on first paint', () => {
     const canvas = document.createElement('canvas')
     expect(acapScaledOverlayArrowSize(canvas, mockView(10))).toBe(12)
     expect(Number(canvas.dataset[ACAP_OVERLAY_ARROW_WCS])).toBeCloseTo(1.2)
     expect(acapScaledOverlayArrowSize(canvas, mockView(5))).toBeCloseTo(6)
+  })
+
+  it('uses imported arrowSizeWcs instead of seeding from screen pixels', () => {
+    const canvas = document.createElement('canvas')
+    expect(acapScaledOverlayArrowSize(canvas, mockView(10), 2.4)).toBeCloseTo(24)
+    expect(Number(canvas.dataset[ACAP_OVERLAY_ARROW_WCS])).toBe(2.4)
   })
 
   it('seeds cloud lobe WCS from the stroke screen/WCS pair', () => {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupSidecar.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupSidecar.ts
@@ -143,7 +143,8 @@ function parseRecord(raw: unknown): AcApMarkupRecord | undefined {
         typeof raw.style.fontSize === 'number' && raw.style.fontSize > 0
           ? raw.style.fontSize
           : undefined,
-      textHeightWcs: parsePositiveNumber(raw.style.textHeightWcs)
+      textHeightWcs: parsePositiveNumber(raw.style.textHeightWcs),
+      arrowSizeWcs: parsePositiveNumber(raw.style.arrowSizeWcs)
     },
     text: typeof raw.text === 'string' ? raw.text : undefined,
     comment: typeof raw.comment === 'string' ? raw.comment : '',

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupTypes.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupTypes.ts
@@ -41,6 +41,11 @@ export interface AcApMarkupStyle {
    */
   textHeightWcs?: number
   /**
+   * Arrow-head length in world units (arrow / callout markups). Prefer this
+   * when restoring overlays so arrow size is independent of camera zoom.
+   */
+  arrowSizeWcs?: number
+  /**
    * Legacy canvas stroke width in world units. Ignored on parse; never written.
    */
   strokeWidthWcs?: number

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupUtil.ts
@@ -9,7 +9,7 @@ import {
 
 import type { AcEdBaseView } from '../../editor'
 import { acCmColorToCssHex, parseCssToAcCmColor } from '../../util/AcApCssColor'
-import { acapScreenPxToWcs } from '../overlay/AcApOverlayDrawUtil'
+import { ACAP_OVERLAY_ARROW_SIZE_PX, acapScreenPxToWcs } from '../overlay/AcApOverlayDrawUtil'
 import type { AcApMarkupStyle } from './AcApMarkupTypes'
 
 /** Factory default markup color (ACI red) used to seed the draw style. */
@@ -111,7 +111,7 @@ export function defaultMarkupStyle(): AcApMarkupStyle {
   }
 }
 
-/** Attach world-space text height from the current view (sidecar export). */
+/** Attach world-space text height (and arrow length) from the current view. */
 export function withMarkupStyleWcs(
   style: AcApMarkupStyle,
   view: AcEdBaseView
@@ -120,10 +120,15 @@ export function withMarkupStyleWcs(
     style.fontSize != null && style.fontSize > 0
       ? style.fontSize
       : MARKUP_FONT_SIZE
+  const arrowSizeWcs =
+    style.arrowSizeWcs != null && style.arrowSizeWcs > 0
+      ? style.arrowSizeWcs
+      : acapScreenPxToWcs(ACAP_OVERLAY_ARROW_SIZE_PX, view)
   return {
     ...style,
     lineWeight: MARKUP_LINE_WEIGHT,
-    textHeightWcs: acapScreenPxToWcs(fontSize, view)
+    textHeightWcs: acapScreenPxToWcs(fontSize, view),
+    arrowSizeWcs
   }
 }
 
@@ -165,7 +170,11 @@ export function patchMarkupStyleWcs(
   return {
     ...rest,
     lineWeight: MARKUP_LINE_WEIGHT,
-    textHeightWcs
+    textHeightWcs,
+    arrowSizeWcs:
+      previous.arrowSizeWcs != null && previous.arrowSizeWcs > 0
+        ? previous.arrowSizeWcs
+        : next.arrowSizeWcs
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupCalloutEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupCalloutEntity.ts
@@ -173,7 +173,8 @@ export class AcApMarkupCalloutEntity extends AcApMarkupEntity {
         true,
         canvasLineWidth,
         view,
-        this.record.style.strokeWidthWcs
+        this.record.style.strokeWidthWcs,
+        this.record.style.arrowSizeWcs
       )
     }
     redraw()

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupEntity.ts
@@ -241,6 +241,7 @@ export abstract class AcApMarkupEntity
     acapSeedOverlaySizesFromWcs(view, {
       textHeightWcs: this.record.style.textHeightWcs,
       strokeWidthWcs: this.record.style.strokeWidthWcs,
+      arrowSizeWcs: this.record.style.arrowSizeWcs,
       fontSizePx: this.record.style.fontSize ?? MARKUP_FONT_SIZE,
       strokeScreenPx: markupCanvasLineWidth(
         resolveMarkupLineWeight(this.record.style.lineWeight)

--- a/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupSegmentEntity.ts
+++ b/packages/cad-simple-viewer/src/command/markup/entity/AcApMarkupSegmentEntity.ts
@@ -12,9 +12,9 @@ import {
   acapBindOverlayPointerDrag,
   acapDrawOverlayArrowHead,
   acapFitOverlayCanvas,
-  acapOverlayArrowSize,
   type AcApOverlayWorldDrawResult,
   acapPlaceOverlayHtml,
+  acapScaledOverlayArrowSize,
   acapScaledOverlayLineWidth
 } from '../../overlay'
 import { runMarkupEdit } from '../AcApMarkupHistory'
@@ -167,7 +167,11 @@ export class AcApMarkupSegmentEntity extends AcApMarkupEntity {
           a,
           b,
           this.record.style.color,
-          acapOverlayArrowSize(strokeWidth, canvasLineWidth)
+          acapScaledOverlayArrowSize(
+            overlay.canvas,
+            view,
+            this.record.style.arrowSizeWcs
+          )
         )
       }
     }

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementGeometry.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementGeometry.ts
@@ -13,6 +13,21 @@ import type { AcApMeasurementGeometry } from './AcApMeasurementTypes'
 
 type WorldToScreen = (point: { x: number; y: number }) => AcApScreenPoint
 
+type ClientToWorld = (clientX: number, clientY: number) => {
+  x: number
+  y: number
+}
+
+type OverlayClientRect = {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+/** Fallback pad (world units) when a point measurement has no overlay size. */
+const DEGENERATE_FOCUS_PAD_WCS = 1
+
 /**
  * Axis-aligned world bounds of a measurement's control geometry.
  *
@@ -56,6 +71,42 @@ export function measurementGeometryBounds(
       return undefined
   }
   return box.isEmpty() ? undefined : box
+}
+
+function padDegenerateMeasurementBox(box: AcGeBox2d): void {
+  const width = box.max.x - box.min.x
+  const height = box.max.y - box.min.y
+  if (width > 1e-8 || height > 1e-8) return
+  const pad = DEGENERATE_FOCUS_PAD_WCS
+  box.expandByPoint({ x: box.min.x - pad, y: box.min.y - pad })
+  box.expandByPoint({ x: box.max.x + pad, y: box.max.y + pad })
+}
+
+/**
+ * Combined zoom-to box: control geometry plus HTML overlay rectangles.
+ *
+ * Point / coordinate measurements are a degenerate AABB on their own. Union
+ * the badge (capsule) client rect so the camera frames the label instead of
+ * zooming onto the point. A 1-unit pad remains only when no overlay size is
+ * available.
+ */
+export function measurementFocusBox(
+  geometry: AcApMeasurementGeometry,
+  overlayRects: ReadonlyArray<OverlayClientRect>,
+  clientToWorld: ClientToWorld
+): AcGeBox2d | undefined {
+  const geometryBox = measurementGeometryBounds(geometry)
+  const box = geometryBox
+    ? new AcGeBox2d(geometryBox.min, geometryBox.max)
+    : new AcGeBox2d()
+  for (const rect of overlayRects) {
+    if (rect.right <= rect.left && rect.bottom <= rect.top) continue
+    box.expandByPoint(clientToWorld(rect.left, rect.top))
+    box.expandByPoint(clientToWorld(rect.right, rect.bottom))
+  }
+  if (box.isEmpty()) return undefined
+  padDegenerateMeasurementBox(box)
+  return box
 }
 
 /**

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementSidecar.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementSidecar.ts
@@ -62,7 +62,8 @@ function parseStyle(raw: unknown): AcApMeasurementSidecarStyle | undefined {
     color: raw.color,
     lineWeight: MEASUREMENT_LINE_WEIGHT,
     fontSize,
-    textHeightWcs: parsePositiveNumber(raw.textHeightWcs)
+    textHeightWcs: parsePositiveNumber(raw.textHeightWcs),
+    arrowSizeWcs: parsePositiveNumber(raw.arrowSizeWcs)
   }
 }
 

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -20,7 +20,7 @@ import {
 } from '../overlay/AcApOverlayDrawUtil'
 import {
   hitTestMeasurementGeometry,
-  measurementGeometryBounds
+  measurementFocusBox
 } from './AcApMeasurementGeometry'
 import { runMeasurementEdit } from './AcApMeasurementHistory'
 import { serializeMeasurementStyle } from './AcApMeasurementSidecar'
@@ -196,25 +196,55 @@ export function getMeasurementValueText(
 }
 
 /**
- * Select a measurement and zoom the view to its geometry.
+ * Select a measurement and zoom the view to its geometry plus HTML overlays.
  *
- * Point measurements (degenerate AABB) are padded so the camera can frame them.
+ * Coordinate measurements include the badge (capsule) so the camera frames
+ * the label instead of the point. Zooming to a 1-unit pad around the point
+ * would scale the WCS-sized capsule over the canvas and steal pointer events.
  */
 export function focusMeasurement(
   view: AcTrView2d,
   record: AcApMeasurementRecord
 ): void {
-  const box = measurementGeometryBounds(record.geometry)
+  const box = measurementFocusBox(
+    record.geometry,
+    collectMeasurementOverlayRects(view, record.id),
+    (clientX, clientY) => {
+      const canvas = view.viewportToCanvas({ x: clientX, y: clientY })
+      return view.screenToWorld(canvas)
+    }
+  )
   if (!box) return
-  const width = box.max.x - box.min.x
-  const height = box.max.y - box.min.y
-  if (!(width > 1e-8) && !(height > 1e-8)) {
-    const pad = 1
-    box.expandByPoint({ x: box.min.x - pad, y: box.min.y - pad })
-    box.expandByPoint({ x: box.max.x + pad, y: box.max.y + pad })
-  }
   view.zoomTo(box, 1.5)
   view.htmlTransientManager.selectGroup(record.id)
+}
+
+/** Badge / callout client rects; skip endpoint grips that sit on geometry. */
+function collectMeasurementOverlayRects(
+  view: AcTrView2d,
+  id: string
+): Array<{ left: number; top: number; right: number; bottom: number }> {
+  const group = view.htmlTransientManager.getGroup(id)
+  if (!group) return []
+  const rects: Array<{
+    left: number
+    top: number
+    right: number
+    bottom: number
+  }> = []
+  for (const child of group.children) {
+    const el = child.element
+    if (
+      el.classList.contains('ml-html-dot') ||
+      el.classList.contains('ml-html-grip')
+    ) {
+      continue
+    }
+    const rect = el.getBoundingClientRect()
+    if (rect.width <= 0 && rect.height <= 0) continue
+    rects.push(rect)
+  }
+  return rects
 }
 
 /**

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -14,6 +14,7 @@ import {
 } from '../../util/AcApMeasurementUtil'
 import type { AcTrView2d } from '../../view'
 import {
+  ACAP_OVERLAY_ARROW_SIZE_PX,
   acapScreenPxToWcs,
   acapSeedOverlaySizesFromWcs
 } from '../overlay/AcApOverlayDrawUtil'
@@ -273,7 +274,10 @@ export function applyMeasurementStyle(
             prev?.fontSize,
             prevSnap.textHeightWcs,
             fontSizeChanged
-          )
+          ),
+          ...(prevSnap.arrowSizeWcs != null && prevSnap.arrowSizeWcs > 0
+            ? { arrowSizeWcs: prevSnap.arrowSizeWcs }
+            : {})
         }
       }
     }
@@ -389,13 +393,21 @@ export function collectMeasurementRecords(
     let style: AcApMeasurementSidecarStyle
     if (live) {
       // Keep live color / fontSize, force hairline lineWeight, preserve
-      // creation-time textHeightWcs from the snapshot. Never export strokeWidthWcs.
+      // creation-time textHeightWcs / arrowSizeWcs from the snapshot. Never
+      // export strokeWidthWcs.
       const base = serializeMeasurementStyle(live)
+      const arrowSizeWcs =
+        snapStyle.arrowSizeWcs != null && snapStyle.arrowSizeWcs > 0
+          ? snapStyle.arrowSizeWcs
+          : extras.snapshot.type === 'distance'
+            ? acapScreenPxToWcs(ACAP_OVERLAY_ARROW_SIZE_PX, view)
+            : undefined
       style = {
         ...base,
         lineWeight: MEASUREMENT_LINE_WEIGHT,
         textHeightWcs:
-          snapStyle.textHeightWcs ?? acapScreenPxToWcs(base.fontSize, view)
+          snapStyle.textHeightWcs ?? acapScreenPxToWcs(base.fontSize, view),
+        ...(arrowSizeWcs != null && arrowSizeWcs > 0 ? { arrowSizeWcs } : {})
       }
     } else {
       const { strokeWidthWcs: _omit, ...rest } = snapStyle

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementTypes.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementTypes.ts
@@ -27,6 +27,11 @@ export interface AcApMeasurementSidecarStyle {
    */
   textHeightWcs?: number
   /**
+   * Distance-measurement arrow-head length in world units. Prefer this when
+   * restoring overlays so arrow size is independent of camera zoom.
+   */
+  arrowSizeWcs?: number
+  /**
    * Legacy canvas stroke width in world units. Ignored on parse; never written.
    */
   strokeWidthWcs?: number

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDistanceEntity.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDistanceEntity.ts
@@ -11,8 +11,8 @@ import {
 } from '../../../util'
 import type { AcTrView2d } from '../../../view'
 import {
-  acapBindOverlayPointerDrag,
   ACAP_OVERLAY_ARROW_SIZE_PX,
+  acapBindOverlayPointerDrag,
   acapPlaceOverlayHtml,
   acapScreenPxToWcs
 } from '../../overlay'

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDistanceEntity.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDistanceEntity.ts
@@ -12,7 +12,9 @@ import {
 import type { AcTrView2d } from '../../../view'
 import {
   acapBindOverlayPointerDrag,
-  acapPlaceOverlayHtml
+  ACAP_OVERLAY_ARROW_SIZE_PX,
+  acapPlaceOverlayHtml,
+  acapScreenPxToWcs
 } from '../../overlay'
 import { runMeasurementEdit } from '../AcApMeasurementHistory'
 import { republishMeasurement } from '../AcApMeasurementRepublish'
@@ -73,7 +75,8 @@ export class AcApMeasureDistanceEntity extends AcApMeasureEntity {
       options.layoutId,
       options.style,
       options.textHeightWcs,
-      options.strokeWidthWcs
+      options.strokeWidthWcs,
+      options.arrowSizeWcs
     )
     this.p1 = p1
     this.p2 = p2
@@ -122,11 +125,18 @@ export class AcApMeasureDistanceEntity extends AcApMeasureEntity {
    * @returns Record with `type: 'distance'` and start/end geometry
    */
   toRecord(layoutId?: string, view?: AcTrView2d): AcApMeasurementRecord {
+    const style = this.serializeStyle(view)
+    const arrowSizeWcs =
+      this.arrowSizeWcs ??
+      (view ? acapScreenPxToWcs(ACAP_OVERLAY_ARROW_SIZE_PX, view) : undefined)
+    if (arrowSizeWcs != null && arrowSizeWcs > 0) {
+      style.arrowSizeWcs = arrowSizeWcs
+    }
     return {
       id: this.entityId,
       type: 'distance',
       layoutId,
-      style: this.serializeStyle(view),
+      style,
       geometry: {
         type: 'distance',
         start: { x: this.p1.x, y: this.p1.y },
@@ -192,7 +202,9 @@ export class AcApMeasureDistanceEntity extends AcApMeasureEntity {
         live.start,
         live.end,
         paintStyle.color,
-        acapMeasurementCanvasLineWidth(paintStyle.lineWeight)
+        acapMeasurementCanvasLineWidth(paintStyle.lineWeight),
+        this.strokeWidthWcs,
+        this.arrowSizeWcs
       )
     paintSegment()
     const redrawPersist = () =>

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDrawUtil.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureDrawUtil.ts
@@ -87,9 +87,12 @@ function prepareMeasureCanvas(
  * @param color - Stroke color
  * @param lineWidth - Stroke width in CSS pixels (default `2`)
  * @param strokeWidthWcs - Optional imported world-space stroke width
+ * @param arrowSizeWcs - Optional imported world-space arrow-head length
  *
- * Arrow heads at both endpoints are a fixed world length (seeded from 12 CSS
- * px on first paint) so they scale with camera zoom even for hairline strokes.
+ * Arrow heads at both endpoints freeze the jig's screen size as WCS on first
+ * paint (or use imported `arrowSizeWcs` from a sidecar), then scale with camera
+ * zoom. Live jigs use {@link acapOverlayArrowSize} instead so the head stays
+ * a constant CSS size while placing.
  */
 export function drawMeasureSegmentOnCanvas(
   canvas: HTMLCanvasElement,
@@ -98,7 +101,8 @@ export function drawMeasureSegmentOnCanvas(
   p2: Point2,
   color: AcCmColor,
   lineWidth = 2,
-  strokeWidthWcs?: number
+  strokeWidthWcs?: number,
+  arrowSizeWcs?: number
 ): void {
   const prepared = prepareMeasureCanvas(canvas, view)
   if (!prepared) return
@@ -118,7 +122,7 @@ export function drawMeasureSegmentOnCanvas(
   )
   ctx.lineWidth = strokeWidth
   ctx.stroke()
-  const arrowSize = acapScaledOverlayArrowSize(canvas, view)
+  const arrowSize = acapScaledOverlayArrowSize(canvas, view, arrowSizeWcs)
   if (Math.hypot(b.x - a.x, b.y - a.y) >= arrowSize) {
     acapDrawOverlayArrowHead(ctx, b, a, css, arrowSize)
     acapDrawOverlayArrowHead(ctx, a, b, css, arrowSize)

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureEntity.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureEntity.ts
@@ -47,6 +47,8 @@ export interface AcApMeasureEntityOptions {
   textHeightWcs?: number
   /** World-space stroke width from sidecar import (optional). */
   strokeWidthWcs?: number
+  /** World-space arrow-head length from sidecar import (optional). */
+  arrowSizeWcs?: number
 }
 
 /**
@@ -89,6 +91,8 @@ export abstract class AcApMeasureEntity
   protected readonly textHeightWcs?: number
   /** Imported world-space stroke width (sidecar). */
   protected readonly strokeWidthWcs?: number
+  /** Imported world-space arrow-head length (sidecar). */
+  protected readonly arrowSizeWcs?: number
 
   /**
    * Creates a measure entity with the given id, layout, and style.
@@ -98,13 +102,15 @@ export abstract class AcApMeasureEntity
    * @param style - Measurement visual style
    * @param textHeightWcs - Optional imported world-space text height
    * @param strokeWidthWcs - Optional imported world-space stroke width
+   * @param arrowSizeWcs - Optional imported world-space arrow-head length
    */
   constructor(
     id: string,
     layoutId: string | undefined,
     style: AcApMeasurementStyle,
     textHeightWcs?: number,
-    strokeWidthWcs?: number
+    strokeWidthWcs?: number,
+    arrowSizeWcs?: number
   ) {
     super()
     this.entityId = id
@@ -112,6 +118,7 @@ export abstract class AcApMeasureEntity
     this.style = style
     this.textHeightWcs = textHeightWcs
     this.strokeWidthWcs = strokeWidthWcs
+    this.arrowSizeWcs = arrowSizeWcs
   }
 
   /**
@@ -258,6 +265,7 @@ export abstract class AcApMeasureEntity
     acapSeedOverlaySizesFromWcs(view, {
       textHeightWcs: this.textHeightWcs,
       strokeWidthWcs: this.strokeWidthWcs,
+      arrowSizeWcs: this.arrowSizeWcs,
       fontSizePx: this.style.fontSize,
       strokeScreenPx: acapMeasurementCanvasLineWidth(this.style.lineWeight),
       elements,

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureEntityFactory.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureEntityFactory.ts
@@ -27,7 +27,8 @@ export function createMeasureEntityFromRecord(
     layoutId: record.layoutId,
     style,
     textHeightWcs: record.style.textHeightWcs,
-    strokeWidthWcs: record.style.strokeWidthWcs
+    strokeWidthWcs: record.style.strokeWidthWcs,
+    arrowSizeWcs: record.style.arrowSizeWcs
   }
   const geom = record.geometry
   switch (geom.type) {

--- a/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApHtmlLivePreview.ts
@@ -17,7 +17,6 @@ import {
   acapFitOverlayCanvas,
   acapOverlayArrowSize,
   acapOverlayDash,
-  acapScaledOverlayArrowSize,
   acapScaledOverlayLineWidth
 } from './AcApOverlayDrawUtil'
 
@@ -145,14 +144,13 @@ export function acapStrokeLiveSegment(
   ctx.stroke()
   if (options?.dashed) ctx.setLineDash([])
   if (options?.arrow) {
+    const size = acapOverlayArrowSize(strokeWidth, lineWidth)
     if (options.arrow === 'both') {
-      const size = acapScaledOverlayArrowSize(ctx.canvas, view)
       if (Math.hypot(sb.x - sa.x, sb.y - sa.y) >= size) {
         acapDrawOverlayArrowHead(ctx, sb, sa, css, size)
         acapDrawOverlayArrowHead(ctx, sa, sb, css, size)
       }
     } else {
-      const size = acapOverlayArrowSize(strokeWidth, lineWidth)
       acapDrawOverlayArrowHead(ctx, sa, sb, css, size)
     }
   }

--- a/packages/cad-simple-viewer/src/command/overlay/AcApOverlayDrawUtil.ts
+++ b/packages/cad-simple-viewer/src/command/overlay/AcApOverlayDrawUtil.ts
@@ -51,6 +51,15 @@ export function acapSeedOverlayStrokeWcs(
   anchor.dataset[ACAP_OVERLAY_STROKE_WCS] = String(strokeWidthWcs)
 }
 
+/** Pre-seeds overlay arrow-head length in world units (import / first layout). */
+export function acapSeedOverlayArrowWcs(
+  anchor: HTMLElement,
+  arrowSizeWcs: number
+): void {
+  if (!(arrowSizeWcs > 0) || !Number.isFinite(arrowSizeWcs)) return
+  anchor.dataset[ACAP_OVERLAY_ARROW_WCS] = String(arrowSizeWcs)
+}
+
 /**
  * View-synced canvas stroke width.
  *
@@ -90,14 +99,19 @@ export function acapScaledOverlayLineWidth(
   return Math.max(0.5, wcs * ppu)
 }
 
-/** Dataset key storing overlay arrow-head length in world units. */
-export const ACAP_OVERLAY_ARROW_WCS = 'overlayArrowWcs'
-
 /** Arrow-head length in CSS pixels at the overlay's creation-scale stroke. */
 export const ACAP_OVERLAY_ARROW_SIZE_PX = 12
 
+/** Dataset key storing overlay arrow-head length in world units. */
+export const ACAP_OVERLAY_ARROW_WCS = 'overlayArrowWcs'
+
 /**
  * Screen length of an overlay arrow head, tracking the same WCS scale as the stroke.
+ *
+ * Hairline overlays (`baseLineWidth <= 0`) keep a constant
+ * {@link ACAP_OVERLAY_ARROW_SIZE_PX}. Use this during jig / live preview so
+ * the head stays a fixed screen size while the user zooms. After commit, use
+ * {@link acapScaledOverlayArrowSize} to freeze that size in world units.
  *
  * @param scaledLineWidth - Stroke width already converted to the current view.
  * @param baseLineWidth - CSS stroke used when the overlay was authored (default `2`).
@@ -114,9 +128,9 @@ export function acapOverlayArrowSize(
 /**
  * Arrow-head length in CSS pixels that stays a fixed world size.
  *
- * Used by distance measurements so arrows shrink/grow with zoom even when
- * the stroke is hairline (1 CSS px). Seeds {@link ACAP_OVERLAY_ARROW_SIZE_PX}
- * as WCS on first paint unless `arrowSizeWcs` is provided.
+ * Used by committed distance measurements and arrow markups. Seeds
+ * {@link ACAP_OVERLAY_ARROW_SIZE_PX} as WCS on first paint (the size shown
+ * during the jig) unless `arrowSizeWcs` is provided.
  */
 export function acapScaledOverlayArrowSize(
   canvas: HTMLElement,
@@ -175,6 +189,7 @@ export function acapSeedOverlaySizesFromWcs(
   options: {
     textHeightWcs?: number
     strokeWidthWcs?: number
+    arrowSizeWcs?: number
     /** CSS font size used when the overlay was authored (badge / callout). */
     fontSizePx?: number
     /** Screen stroke width used when authored (from CAD line weight). */
@@ -193,6 +208,12 @@ export function acapSeedOverlaySizesFromWcs(
   } else if (options.strokeScreenPx === 0) {
     for (const canvas of canvases ?? []) {
       delete canvas.dataset[ACAP_OVERLAY_STROKE_WCS]
+    }
+  }
+
+  if (options.arrowSizeWcs != null && options.arrowSizeWcs > 0) {
+    for (const canvas of canvases ?? []) {
+      acapSeedOverlayArrowWcs(canvas, options.arrowSizeWcs)
     }
   }
 
@@ -314,7 +335,8 @@ export function acapDrawOverlayLeader(
   withArrow = true,
   lineWidth = 2,
   view: AcEdBaseView,
-  strokeWidthWcs?: number
+  strokeWidthWcs?: number,
+  arrowSizeWcs?: number
 ): void {
   const strokeWidth = acapScaledOverlayLineWidth(
     lineWidth,
@@ -334,7 +356,7 @@ export function acapDrawOverlayLeader(
       anchor,
       tip,
       color,
-      acapOverlayArrowSize(strokeWidth, lineWidth)
+      acapScaledOverlayArrowSize(ctx.canvas, view, arrowSizeWcs)
     )
   }
 }


### PR DESCRIPTION
## Summary
- Persist `arrowSizeWcs` on measure/markup sidecars so committed arrow heads keep a fixed world size when the camera zooms.
- Keep live jig arrows at a constant screen size; freeze that size as WCS on first paint (or use the imported sidecar value).
- Apply the same path in both `cad-simple-viewer` and `cad-html-plugin`.
- When zooming to a measurement from the list, include HTML overlay badges so coordinate labels are framed instead of exploding a 1-unit pad around the point.

## Test plan
- [ ] Place a distance measurement, then zoom in/out — arrow heads should scale with the drawing.
- [ ] Place an arrow or callout markup, then zoom — same world-size behavior.
- [ ] During placement (jig), zoom — arrow heads should stay a constant CSS size.
- [ ] Export sidecar JSON and reload at a different zoom — arrows match the original world size.
- [ ] Click a coordinate measurement in the list — camera should frame the capsule, and pan/zoom on the canvas should still work.
- [ ] Unit tests: overlay draw util, sidecar round-trip, and `measurementFocusBox`.