### PR TITLE
feat: add session-only settings overrides and per-product storage keys

### DIFF
--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -36,6 +36,11 @@ import { setupFileSidebarResize } from './fileSidebarResize'
 import { registerLazyPlugins } from './register'
 import { registerLibreDwgConverter } from './registerLibreDwg'
 
+// Isolate this example's prefs from cad-viewer-example on localhost.
+AcApSettingManager.configure({
+  storageKey: 'mlightcad.settings.simple-viewer'
+})
+
 const EXAMPLE_COMMAND_ALIASES = {
   LINE: ['LX'],
   CIRCLE: ['CI'],

--- a/packages/cad-simple-viewer/__tests__/AcApSettingManager.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApSettingManager.spec.ts
@@ -15,9 +15,6 @@ function installLocalStorageMock() {
     },
     clear: () => {
       store.clear()
-    },
-    get store() {
-      return store
     }
   }
   Object.defineProperty(globalThis, 'localStorage', {
@@ -55,11 +52,20 @@ describe('migrateStoredSettings', () => {
 })
 
 describe('AcApSettingManager layers', () => {
+  const originalLocalStorage = globalThis.localStorage
   let ls: ReturnType<typeof installLocalStorageMock>
 
   beforeEach(() => {
     ls = installLocalStorageMock()
     AcApSettingManager.resetInstanceForTesting()
+  })
+
+  afterEach(() => {
+    AcApSettingManager.resetInstanceForTesting()
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: originalLocalStorage
+    })
   })
 
   it('loads defaults when localStorage is empty', () => {

--- a/packages/cad-simple-viewer/__tests__/AcApSettingManager.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApSettingManager.spec.ts
@@ -1,4 +1,31 @@
-import { migrateStoredSettings } from '../src/app/AcApSettingManager'
+import {
+  AcApSettingManager,
+  migrateStoredSettings
+} from '../src/app/AcApSettingManager'
+
+function installLocalStorageMock() {
+  const store = new Map<string, string>()
+  const localStorageMock = {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    get store() {
+      return store
+    }
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorageMock,
+    configurable: true
+  })
+  return localStorageMock
+}
 
 describe('migrateStoredSettings', () => {
   it('copies isShowMainMenu onto isShowRibbon when the new key is missing', () => {
@@ -24,5 +51,109 @@ describe('migrateStoredSettings', () => {
       settings: { isShowRibbon: false },
       migrated: false
     })
+  })
+})
+
+describe('AcApSettingManager layers', () => {
+  let ls: ReturnType<typeof installLocalStorageMock>
+
+  beforeEach(() => {
+    ls = installLocalStorageMock()
+    AcApSettingManager.resetInstanceForTesting()
+  })
+
+  it('loads defaults when localStorage is empty', () => {
+    const settings = AcApSettingManager.instance
+    expect(settings.isShowCommandLine).toBe(true)
+    expect(settings.isShowToolbar).toBe(true)
+    expect(ls.getItem('settings')).toBeNull()
+  })
+
+  it('persist:false does not write localStorage', () => {
+    const settings = AcApSettingManager.instance
+    settings.set('isShowCommandLine', false, { persist: false })
+    expect(settings.isShowCommandLine).toBe(false)
+    expect(ls.getItem('settings')).toBeNull()
+  })
+
+  it('persist:true writes only the user layer, not session overrides', () => {
+    const settings = AcApSettingManager.instance
+    settings.set('isShowCommandLine', false, { persist: false })
+    settings.set('isShowToolbar', false)
+
+    const stored = JSON.parse(ls.getItem('settings')!) as Record<
+      string,
+      unknown
+    >
+    expect(stored.isShowToolbar).toBe(false)
+    expect(stored.isShowCommandLine).toBeUndefined()
+    expect(settings.isShowCommandLine).toBe(false)
+    expect(settings.isShowToolbar).toBe(false)
+  })
+
+  it('session override wins over stored user preference', () => {
+    ls.setItem('settings', JSON.stringify({ isShowCommandLine: true }))
+    AcApSettingManager.resetInstanceForTesting()
+    const settings = AcApSettingManager.instance
+    expect(settings.isShowCommandLine).toBe(true)
+
+    settings.apply({ isShowCommandLine: false }, { persist: false })
+    expect(settings.isShowCommandLine).toBe(false)
+    expect(JSON.parse(ls.getItem('settings')!).isShowCommandLine).toBe(true)
+  })
+
+  it('apply fires modified for each key', () => {
+    const settings = AcApSettingManager.instance
+    const keys: string[] = []
+    settings.events.modified.addEventListener(args => {
+      keys.push(String(args.key))
+    })
+    settings.apply(
+      { isShowCommandLine: false, isShowCoordinate: false },
+      { persist: false }
+    )
+    expect(keys).toEqual(['isShowCommandLine', 'isShowCoordinate'])
+  })
+
+  it('configure isolates products via storageKey', () => {
+    AcApSettingManager.configure({
+      storageKey: 'mlightcad.settings.product-a'
+    })
+    AcApSettingManager.instance.set('isShowToolbar', false)
+
+    AcApSettingManager.resetInstanceForTesting()
+    AcApSettingManager.configure({
+      storageKey: 'mlightcad.settings.product-b'
+    })
+    expect(AcApSettingManager.instance.isShowToolbar).toBe(true)
+
+    AcApSettingManager.resetInstanceForTesting()
+    AcApSettingManager.configure({
+      storageKey: 'mlightcad.settings.product-a'
+    })
+    expect(AcApSettingManager.instance.isShowToolbar).toBe(false)
+  })
+
+  it('migrates isShowMainMenu on load and rewrites storage', () => {
+    ls.setItem(
+      'settings',
+      JSON.stringify({ isShowMainMenu: false, isShowStats: true })
+    )
+    const settings = AcApSettingManager.instance
+    expect(settings.isShowRibbon).toBe(false)
+    expect(settings.isShowStats).toBe(true)
+
+    const stored = JSON.parse(ls.getItem('settings')!) as Record<
+      string,
+      unknown
+    >
+    expect(stored.isShowRibbon).toBe(false)
+    expect(stored.isShowMainMenu).toBeUndefined()
+    expect(stored.isShowStats).toBe(true)
+  })
+
+  it('property setters persist by default', () => {
+    AcApSettingManager.instance.isShowCommandLine = false
+    expect(JSON.parse(ls.getItem('settings')!).isShowCommandLine).toBe(false)
   })
 })

--- a/packages/cad-simple-viewer/src/app/AcApSettingManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApSettingManager.ts
@@ -3,7 +3,6 @@ import {
   AcDbOsnapMode,
   acdbOsnapModesToMask
 } from '@mlightcad/data-model'
-import { defaults } from 'lodash-es'
 
 /**
  * Font mappings for CAD text rendering.
@@ -52,6 +51,31 @@ export interface AcApSettings {
   osnapModes: number
 }
 
+/**
+ * Options for {@link AcApSettingManager.set} and {@link AcApSettingManager.apply}.
+ */
+export interface AcApSettingWriteOptions {
+  /**
+   * When `true` (default), the change is stored as a user preference and
+   * written to localStorage. When `false`, the change is a session-only
+   * override that does not touch localStorage (use for host layout / scene
+   * defaults such as hiding the command line on mobile).
+   */
+  persist?: boolean
+}
+
+/**
+ * Options for {@link AcApSettingManager.configure}.
+ */
+export interface AcApSettingManagerConfigureOptions {
+  /**
+   * localStorage key used for user preferences. Defaults to `'settings'`.
+   * Call before the first settings read/write so products on the same origin
+   * do not share preferences.
+   */
+  storageKey?: string
+}
+
 /** Default values for all application settings */
 const DEFAULT_VALUES: AcApSettings = {
   isDebug: false,
@@ -74,8 +98,8 @@ const DEFAULT_VALUES: AcApSettings = {
   ])
 }
 
-/** Local storage key for persisting settings */
-const SETTINGS_LS_KEY = 'settings'
+/** Default localStorage key for persisting user preferences */
+const DEFAULT_SETTINGS_LS_KEY = 'settings'
 
 /**
  * Maps the pre-ribbon `isShowMainMenu` key onto `isShowRibbon`.
@@ -120,44 +144,69 @@ export interface AcApSettingManagerEventArgs<
 /**
  * Singleton settings manager for the CAD application.
  *
- * This class manages application-wide settings with:
- * - Persistent storage using localStorage
- * - Event notification when settings change
- * - Type-safe setting access
- * - Default value fallbacks
+ * Settings resolve in three layers (later wins):
+ * 1. Built-in defaults
+ * 2. User preferences from localStorage
+ * 3. Session overrides (host layout; not persisted)
  *
- * The settings are automatically saved to localStorage and restored on application start.
+ * Only the user layer is written to localStorage. Use
+ * `{ persist: false }` for scene-specific layout so it does not leak into
+ * other products or later visits on the same origin.
  *
  * @template T - The settings interface type, defaults to AcApSettings
  *
  * @example
  * ```typescript
- * // Get the singleton instance
- * const settings = AcApSettingManager.instance;
+ * // Isolate this product's preferences on a shared origin
+ * AcApSettingManager.configure({
+ *   storageKey: 'mlightcad.settings.mobile-embed'
+ * })
  *
- * // Set a setting value
- * settings.set('isShowToolbar', false);
+ * // Host layout: hide command line for this session only
+ * AcApSettingManager.instance.apply(
+ *   { isShowCommandLine: false },
+ *   { persist: false }
+ * )
  *
- * // Get a setting value
- * const showToolbar = settings.get('isShowToolbar');
- *
- * // Toggle a boolean setting
- * settings.toggle('isDebug');
- *
- * // Listen for setting changes
- * settings.events.modified.addEventListener(args => {
- *   console.log(`Setting ${args.key} changed to:`, args.value);
- * });
+ * // User preference: persists across visits
+ * AcApSettingManager.instance.set('isShowToolbar', false)
  * ```
  */
 export class AcApSettingManager<T extends AcApSettings = AcApSettings> {
   /** Singleton instance */
   private static _instance?: AcApSettingManager
 
+  /** localStorage key for the user preference layer */
+  private static _storageKey = DEFAULT_SETTINGS_LS_KEY
+
   /** Events fired when settings are modified */
   public readonly events = {
     /** Fired when any setting is modified */
     modified: new AcCmEventManager<AcApSettingManagerEventArgs<T>>()
+  }
+
+  /** User preferences loaded from / written to localStorage */
+  private _user: Partial<T> = {}
+
+  /** Session-only overrides (host layout); never written to localStorage */
+  private _session: Partial<T> = {}
+
+  /**
+   * Configures the settings manager before the first read/write.
+   *
+   * Prefer calling this at host startup so each product on the same origin
+   * can use its own localStorage key. If an instance already exists, user
+   * prefs are reloaded from the new key and session overrides are cleared.
+   *
+   * @param options - Configuration options
+   */
+  static configure(options: AcApSettingManagerConfigureOptions): void {
+    if (options.storageKey != null && options.storageKey !== '') {
+      this._storageKey = options.storageKey
+    }
+    if (this._instance) {
+      this._instance.reloadFromStorage()
+    }
   }
 
   /**
@@ -175,24 +224,109 @@ export class AcApSettingManager<T extends AcApSettings = AcApSettings> {
   }
 
   /**
-   * Sets a setting value and persists it to localStorage.
+   * Resets singleton state for unit tests.
    *
-   * Fires a modified event after the setting is saved.
+   * @internal
+   */
+  static resetInstanceForTesting(): void {
+    this._instance = undefined
+    this._storageKey = DEFAULT_SETTINGS_LS_KEY
+  }
+
+  private constructor() {
+    this.reloadFromStorage()
+  }
+
+  /**
+   * Reloads the user preference layer from localStorage and clears session
+   * overrides.
+   */
+  private reloadFromStorage(): void {
+    this._user = this.readUserFromStorage()
+    this._session = {}
+  }
+
+  /**
+   * Reads and migrates user preferences from the configured storage key.
+   *
+   * @returns Partial user settings (may be empty)
+   */
+  private readUserFromStorage(): Partial<T> {
+    const raw = localStorage.getItem(AcApSettingManager._storageKey)
+    if (raw == null) {
+      return {}
+    }
+    let stored: Record<string, unknown>
+    try {
+      stored = JSON.parse(raw) as Record<string, unknown>
+    } catch {
+      return {}
+    }
+    const { settings: migrated, migrated: didMigrate } =
+      migrateStoredSettings(stored)
+    if (didMigrate) {
+      localStorage.setItem(
+        AcApSettingManager._storageKey,
+        JSON.stringify(migrated)
+      )
+    }
+    return migrated as Partial<T>
+  }
+
+  /**
+   * Writes only the user preference layer to localStorage.
+   */
+  private persistUser(): void {
+    localStorage.setItem(
+      AcApSettingManager._storageKey,
+      JSON.stringify(this._user)
+    )
+  }
+
+  /**
+   * Merges defaults, user prefs, and session overrides into effective settings.
+   *
+   * @returns A new effective settings object
+   */
+  private computeEffective(): T {
+    return {
+      ...DEFAULT_VALUES,
+      ...this._user,
+      ...this._session
+    } as T
+  }
+
+  /**
+   * Sets a setting value.
+   *
+   * By default the change is persisted as a user preference. Pass
+   * `{ persist: false }` for a session-only override that does not touch
+   * localStorage.
+   *
+   * Fires a modified event after the setting is updated.
    *
    * @template K - The setting key type
    * @param key - The setting key to modify
    * @param value - The new value for the setting
+   * @param options - Optional write options (`persist` defaults to `true`)
    *
    * @example
    * ```typescript
    * settings.set('isShowToolbar', false);
-   * settings.set('fontMapping', { 'Arial': 'Helvetica' });
+   * settings.set('isShowCommandLine', false, { persist: false });
    * ```
    */
-  set<K extends keyof T>(key: K, value: T[K]) {
-    const toggles = this.settings
-    toggles[key] = value
-    localStorage.setItem(SETTINGS_LS_KEY, JSON.stringify(toggles))
+  set<K extends keyof T>(
+    key: K,
+    value: T[K],
+    options?: AcApSettingWriteOptions
+  ) {
+    const persist = options?.persist !== false
+    this._session[key] = value
+    if (persist) {
+      this._user[key] = value
+      this.persistUser()
+    }
     this.events.modified.dispatch({
       key: key,
       value
@@ -200,9 +334,35 @@ export class AcApSettingManager<T extends AcApSettings = AcApSettings> {
   }
 
   /**
+   * Applies multiple setting values at once.
+   *
+   * Each changed key fires a separate `modified` event so existing listeners
+   * keep working without a batch API.
+   *
+   * @param partial - Settings to update
+   * @param options - Optional write options (`persist` defaults to `true`)
+   *
+   * @example
+   * ```typescript
+   * settings.apply(
+   *   { isShowCommandLine: false, isShowCoordinate: false },
+   *   { persist: false }
+   * )
+   * ```
+   */
+  apply(partial: Partial<T>, options?: AcApSettingWriteOptions) {
+    for (const key of Object.keys(partial) as Array<keyof T>) {
+      const value = partial[key]
+      if (value !== undefined) {
+        this.set(key, value as T[keyof T], options)
+      }
+    }
+  }
+
+  /**
    * Gets a setting value.
    *
-   * Returns the stored value or the default value if not set.
+   * Returns the effective value (defaults ← user ← session).
    *
    * @template K - The setting key type
    * @param key - The setting key to retrieve
@@ -222,6 +382,7 @@ export class AcApSettingManager<T extends AcApSettings = AcApSettings> {
    * Toggles a boolean setting value.
    *
    * Only works with boolean settings. The caller should ensure the setting is boolean.
+   * The toggle is persisted as a user preference.
    *
    * @template K - The setting key type
    * @param key - The boolean setting key to toggle
@@ -425,7 +586,9 @@ export class AcApSettingManager<T extends AcApSettings = AcApSettings> {
    * @param mappedFont - The replacement font name
    */
   setFontMapping(originalFont: string, mappedFont: string) {
-    const mapping = this.get('fontMapping') as AcApFontMapping
+    const mapping = {
+      ...(this.get('fontMapping') as AcApFontMapping)
+    }
     mapping[originalFont] = mappedFont
     this.set('fontMapping', mapping)
   }
@@ -449,24 +612,13 @@ export class AcApSettingManager<T extends AcApSettings = AcApSettings> {
   }
 
   /**
-   * Gets the current settings object.
+   * Gets the current effective settings object.
    *
-   * This method combines localStorage values with default values.
+   * Merges built-in defaults, user preferences, and session overrides.
    *
    * @returns The current settings object
    */
   get settings() {
-    const values = localStorage.getItem(SETTINGS_LS_KEY)
-    const stored = (values == null ? {} : JSON.parse(values)) as Record<
-      string,
-      unknown
-    >
-    const { settings: migrated, migrated: didMigrate } =
-      migrateStoredSettings(stored)
-    const results = defaults(migrated, DEFAULT_VALUES) as T
-    if (didMigrate) {
-      localStorage.setItem(SETTINGS_LS_KEY, JSON.stringify(results))
-    }
-    return results
+    return this.computeEffective()
   }
 }

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -27,10 +27,10 @@
 </template>
 
 <script setup lang="ts">
-// import { AcApSettingManager } from '@mlightcad/cad-simple-viewer'
 import {
   AcApDocManager,
   AcApOpenViewMode,
+  AcApSettingManager,
   AcEdCommandStack,
   AcEdOpenMode
 } from '@mlightcad/cad-simple-viewer'
@@ -42,6 +42,11 @@ import { AcApQuitCmd } from './commands'
 import FileUpload from './components/FileUpload.vue'
 import { initializeLocale } from './locale'
 import { store } from './store'
+
+// Isolate this example's prefs from cad-simple-viewer-example on localhost.
+AcApSettingManager.configure({
+  storageKey: 'mlightcad.settings.cad-viewer'
+})
 
 initializeLocale()
 
@@ -66,12 +71,16 @@ const initialize = () => {
   )
 }
 
-// Decide whether to show command line vertical toolbar at the right side,
-// performance stats, coordinates in status bar, etc.
-// AcApSettingManager.instance.isShowCommandLine = false
-// AcApSettingManager.instance.isShowToolbar = false
-// AcApSettingManager.instance.isShowStats = false
-// AcApSettingManager.instance.isShowCoordinate = false
+// Host layout overrides (session only — does not write localStorage):
+// AcApSettingManager.instance.apply(
+//   {
+//     isShowCommandLine: false,
+//     isShowToolbar: false,
+//     isShowStats: false,
+//     isShowCoordinate: false
+//   },
+//   { persist: false }
+// )
 
 const BASE_URL = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/'
 

--- a/packages/cad-viewer/README.md
+++ b/packages/cad-viewer/README.md
@@ -198,6 +198,8 @@ The `MlCadViewer` component accepts the following props:
 
 The `MlCadViewer` reads its UI visibility from the global `AcApSettingManager` (provided by `@mlightcad/cad-simple-viewer`). Configure these flags anywhere before rendering the viewer to customize the UI.
 
+Settings resolve in three layers (later wins): built-in defaults, user preferences in `localStorage`, and session overrides. Only user preferences are persisted. Use `{ persist: false }` for host layout (for example hide the command line on mobile) so the change does not leak into other products or later visits on the same origin.
+
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `isShowToolbar` | `boolean` | `true` | Controls toolbar visibility |
@@ -237,13 +239,22 @@ The `MlCadViewer` reads its UI visibility from the global `AcApSettingManager` (
 import { MlCadViewer } from '@mlightcad/cad-viewer'
 import { AcApSettingManager } from '@mlightcad/cad-simple-viewer'
 
-// Configure global UI flags before the viewer mounts
-AcApSettingManager.instance.isShowCommandLine = false
-// Optional toggles
-// AcApSettingManager.instance.isShowToolbar = false
-// AcApSettingManager.instance.isShowStats = true
-// AcApSettingManager.instance.isShowCoordinate = false
-// AcApSettingManager.instance.isShowEntityInfo = false
+// Optional: isolate this product's preferences on a shared origin
+AcApSettingManager.configure({
+  storageKey: 'mlightcad.settings.cad-viewer'
+})
+
+// Host layout before mount — session only (does not write localStorage)
+AcApSettingManager.instance.apply(
+  {
+    isShowCommandLine: false
+    // isShowToolbar: false,
+    // isShowStats: true,
+    // isShowCoordinate: false,
+    // isShowEntityInfo: false
+  },
+  { persist: false }
+)
 </script>
 ```
 
@@ -251,6 +262,8 @@ AcApSettingManager.instance.isShowCommandLine = false
 
 - Settings are global and immediately reflected by `MlCadViewer`.
 - You can change them at runtime using the same `AcApSettingManager.instance` reference.
+- Property setters (for example `isShowToolbar = false`) and the in-app settings menu persist user preferences by default.
+- On the same origin, give each product its own `storageKey` via `AcApSettingManager.configure` so preferences do not cross-contaminate. Call `configure` before the first settings read/write.
 
 ### Base URL Configuration
 


### PR DESCRIPTION
## Summary
- Split `AcApSettingManager` into three layers (defaults, persisted user prefs, session overrides) so host layout flags can use `{ persist: false }` without writing `localStorage`.
- Add `configure({ storageKey })` so products on the same origin (including the two localhost examples) do not share preferences.
- Cover the new layering, persist behavior, and storage-key isolation with unit tests, and document the host-layout pattern in the cad-viewer README.

## Test plan
- [x] `pnpm exec jest packages/cad-simple-viewer/__tests__/AcApSettingManager.spec.ts`
- [ ] Open `cad-viewer-example` and `cad-simple-viewer-example` on localhost, change a UI setting in one, confirm the other is unaffected
- [ ] Confirm `apply(..., { persist: false })` hides UI for the session but does not change `localStorage`
- [ ] Confirm in-app settings menu / property setters still persist across reload