### PR TITLE
fix: close measure and review sub-toolbars after selecting a tool

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
@@ -29,8 +29,14 @@ describe('ACEX_HTML_SHELL_CSS', () => {
     expect(ACEX_HTML_SHELL_CSS).toContain('--ml-ui-accent: var(--mlcad-accent)')
   })
 
-  it('uses a narrower portrait slot for sub-toolbar buttons', () => {
-    expect(ACEX_HTML_SHELL_CSS).toContain('--mlcad-subtoolbar-btn-width: 28px')
+  it('matches pad/desktop sub-toolbar buttons to the parent toolbar size', () => {
+    expect(ACEX_HTML_SHELL_CSS).not.toContain('--mlcad-subtoolbar-btn-width')
+    expect(ACEX_HTML_SHELL_CSS).toContain(
+      'width: var(--mlcad-toolbar-width);\n    height: var(--mlcad-toolbar-width);'
+    )
+  })
+
+  it('uses a narrower portrait slot for phone sub-toolbar buttons', () => {
     expect(ACEX_HTML_SHELL_CSS).toContain(
       'calc(var(--mlcad-toolbar-phone-height) - 16px)'
     )
@@ -155,9 +161,15 @@ describe('buildAcExHtmlShellBody', () => {
     expect(toolbarHtml).toContain('title="Language"')
     expect(toolbarHtml).toContain('title="Layout"')
     expect(toolbarHtml).toContain('title="Settings"')
-    expect(toolbarHtml).toContain('data-children-ui="sticky-toolbar"')
     expect(toolbarHtml).toContain('data-children-ui="toolbar"')
+    expect(toolbarHtml).toContain('data-children-ui="sticky-toolbar"')
     expect(toolbarHtml).toContain('data-children-ui="menu"')
+    expect(toolbarHtml).toMatch(
+      /id="mlcad-measure-menu-btn"[\s\S]*?data-children-ui="toolbar"/
+    )
+    expect(toolbarHtml).toMatch(
+      /id="mlcad-markup-menu-btn"[\s\S]*?data-children-ui="toolbar"/
+    )
 
     // Zoom children order: original → extents → window
     const zoomStrip = html.match(

--- a/packages/cad-html-plugin/__tests__/AcExHtmlToolbarFlyout.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlToolbarFlyout.spec.ts
@@ -44,7 +44,7 @@ describe('setupAcExHtmlToolbarFlyouts', () => {
     `)
   }
 
-  it('toggles a sticky strip and keeps it open on canvas click', () => {
+  it('closes a dismissible measure strip on canvas click and tool select', () => {
     mountAllStrips()
     const onItemClick = jest.fn()
     const flyouts = setupAcExHtmlToolbarFlyouts({ onItemClick })
@@ -56,20 +56,35 @@ describe('setupAcExHtmlToolbarFlyouts', () => {
     expect(parent?.classList.contains('is-menu-open')).toBe(true)
 
     document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
-    expect(wrap?.hidden).toBe(false)
+    expect(wrap?.hidden).toBe(true)
 
+    parent?.click()
     document
       .querySelector<HTMLButtonElement>('[data-measure-mode="distance"]')
       ?.click()
     expect(onItemClick).toHaveBeenCalled()
-    expect(wrap?.hidden).toBe(false)
-
-    parent?.click()
     expect(wrap?.hidden).toBe(true)
+
     flyouts.close()
   })
 
-  it('closes a sticky strip when another strip parent is clicked', () => {
+  it('closes a dismissible review strip after a markup tool is selected', () => {
+    mountAllStrips()
+    const onItemClick = jest.fn()
+    setupAcExHtmlToolbarFlyouts({ onItemClick })
+    const wrap = document.getElementById('mlcad-markup-strip-wrap')
+
+    document.getElementById('mlcad-markup-menu-btn')?.click()
+    expect(wrap?.hidden).toBe(false)
+
+    document
+      .querySelector<HTMLButtonElement>('[data-markup-mode="cloud"]')
+      ?.click()
+    expect(onItemClick).toHaveBeenCalled()
+    expect(wrap?.hidden).toBe(true)
+  })
+
+  it('closes a strip when another strip parent is clicked', () => {
     mountAllStrips()
     setupAcExHtmlToolbarFlyouts({ onItemClick: jest.fn() })
 
@@ -179,6 +194,22 @@ describe('setupAcExHtmlToolbarFlyouts', () => {
 
     document.getElementById('mlcad-zoom-menu-btn')?.click()
     document.querySelector<HTMLButtonElement>('[data-action="fit"]')?.click()
+    expect(onItemClick).toHaveBeenCalled()
+    expect(wrap?.hidden).toBe(true)
+  })
+
+  it('closes a dismissible settings strip after a leaf tool is selected', () => {
+    mountAllStrips()
+    const onItemClick = jest.fn()
+    setupAcExHtmlToolbarFlyouts({ onItemClick })
+    const wrap = document.getElementById('mlcad-settings-strip-wrap')
+
+    document.getElementById('mlcad-settings-btn')?.click()
+    expect(wrap?.hidden).toBe(false)
+
+    document
+      .querySelector<HTMLButtonElement>('[data-action="toggle-theme"]')
+      ?.click()
     expect(onItemClick).toHaveBeenCalled()
     expect(wrap?.hidden).toBe(true)
   })

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -37,8 +37,6 @@ export const ACEX_HTML_SHELL_CSS = `
     --mlcad-markup-accent-border: rgba(229, 57, 53, 0.45);
     --mlcad-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
     --mlcad-toolbar-width: 44px;
-    /* Sub-toolbar icon buttons: narrower than the 44px main toolbar. */
-    --mlcad-subtoolbar-btn-width: 28px;
     --mlcad-drawer-width: 220px;
     --mlcad-drawer-gap: 8px;
     --mlcad-ui-inset: 12px;
@@ -830,13 +828,15 @@ export const ACEX_HTML_SHELL_CSS = `
     box-shadow: var(--mlcad-shadow);
     backdrop-filter: blur(12px);
   }
+  /* Pad/desktop: same button size as the parent bar so a vertical strip
+     matches its width and a horizontal strip matches its height. */
   #mlcad-snap-strip .mlcad-tool-btn,
   #mlcad-measure-strip .mlcad-tool-btn,
   #mlcad-markup-strip .mlcad-tool-btn,
   #mlcad-zoom-strip .mlcad-tool-btn,
   #mlcad-settings-strip .mlcad-tool-btn,
   #mlcad-locale-strip .mlcad-tool-btn {
-    width: var(--mlcad-subtoolbar-btn-width);
+    width: var(--mlcad-toolbar-width);
     height: var(--mlcad-toolbar-width);
   }
   #mlcad-measure-strip .mlcad-tool-separator,
@@ -1839,7 +1839,7 @@ function buildAcExMeasureMenuButton(): string {
     'data-action': 'measure-menu',
     'data-i18n-key': 'toolbar.measure',
     'data-i18n-attr': 'title aria-label',
-    'data-children-ui': 'sticky-toolbar'
+    'data-children-ui': 'toolbar'
   }).replace('class="mlcad-tool-btn"', 'class="mlcad-tool-btn has-children"')
 }
 
@@ -1851,7 +1851,7 @@ function buildAcExMarkupMenuButton(): string {
     'data-action': 'markup-menu',
     'data-i18n-key': 'toolbar.annotation',
     'data-i18n-attr': 'title aria-label',
-    'data-children-ui': 'sticky-toolbar'
+    'data-children-ui': 'toolbar'
   }).replace('class="mlcad-tool-btn"', 'class="mlcad-tool-btn has-children"')
 }
 

--- a/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
@@ -3,9 +3,10 @@
  *
  * Matches cad-simple-ui-plugin:
  * - `'sticky-toolbar'`: stays open until the parent is clicked again, or
- *   another first-level button that opens a strip is clicked. Canvas clicks
- *   do not dismiss it. The parent button acts as a toggle.
- * - `'toolbar'`: icon strip that closes on canvas / outside click.
+ *   another first-level button that opens a strip is clicked. Child and
+ *   canvas clicks do not dismiss it. The parent button acts as a toggle.
+ * - `'toolbar'`: icon strip that closes when a child button is clicked, or
+ *   on canvas / outside click.
  * - `'menu'`: popover listing items (drawing layouts).
  *
  * @module AcExHtmlToolbarFlyout
@@ -73,14 +74,14 @@ interface AcExHtmlStripConfig {
 const STRIPS: AcExHtmlStripConfig[] = [
   {
     id: 'measure',
-    sticky: true,
+    sticky: false,
     btnId: 'mlcad-measure-menu-btn',
     wrapId: 'mlcad-measure-strip-wrap',
     stripId: 'mlcad-measure-strip'
   },
   {
     id: 'review',
-    sticky: true,
+    sticky: false,
     btnId: 'mlcad-markup-menu-btn',
     wrapId: 'mlcad-markup-strip-wrap',
     stripId: 'mlcad-markup-strip'
@@ -145,10 +146,10 @@ export function setAcExHtmlParentChildIcon(
 /**
  * Wires Measurement / Review / Snap / Zoom / Settings / Language parents.
  *
- * Sticky parents toggle open/closed. Opening any other strip parent replaces
- * the current strip. On phone, language under settings replaces the settings
- * strip (only one strip level visible). Canvas clicks dismiss only non-sticky
- * strips.
+ * Parents toggle open/closed. Opening any other strip parent replaces the
+ * current strip. Clicking a child tool on a dismissible strip closes it.
+ * On phone, language under settings replaces the settings strip (only one
+ * strip level visible). Canvas clicks dismiss only non-sticky strips.
  */
 export function setupAcExHtmlToolbarFlyouts(
   options: AcExHtmlToolbarFlyoutOptions
@@ -329,10 +330,8 @@ export function setupAcExHtmlToolbarFlyouts(
           // Nested locale opener is handled above.
           if (btn.id === 'mlcad-settings-locale-btn') return
           options.onItemClick(btn)
-          if (!entry.sticky && entry.id !== 'settings') {
+          if (!entry.sticky) {
             close()
-          } else if (entry.id === 'settings') {
-            options.onStripChange?.()
           }
         })
       })

--- a/packages/cad-simple-ui-plugin/README.md
+++ b/packages/cad-simple-ui-plugin/README.md
@@ -330,7 +330,7 @@ See `cad-simple-viewer-example` (`demoToolbarPresets.ts`) for a working layout s
 | `requiresDocument` | When `false`, button stays enabled before a drawing is opened |
 | `minOpenMode` | Hide below Review/Write (`AcEdOpenMode.Review`) |
 | `children` | Nested items shown as a sub-toolbar or popover when the parent is clicked |
-| `childrenUi` | `'menu'` (popover, default), `'toolbar'` (closes on canvas click), or `'sticky-toolbar'` (stays until the parent is clicked again) |
+| `childrenUi` | `'menu'` (popover, default), `'toolbar'` (closes on child or canvas click), or `'sticky-toolbar'` (stays until the parent is clicked again) |
 | `childIcon` | `'fixed'` (default): parent keeps its own icon; `'selected'`: parent icon follows the active child item |
 | `selectedChildId` | Initial submenu selection when `childIcon` is `'selected'` |
 | `toggle` | Two-state button with `getValue`, `on`, and `off` branches |
@@ -478,14 +478,14 @@ Popover menu (default when `childrenUi` is omitted):
 }
 ```
 
-Icon sub-toolbar beside the parent (same model as the HTML export viewer). Measure and Review use `'sticky-toolbar'` so canvas clicks do not dismiss the strip; Export, Toolbar Position, and Language use `'toolbar'` so an outside click closes it:
+Icon sub-toolbar beside the parent (same model as the HTML export viewer). Measure, Review, Export, Toolbar Position, and Language use `'toolbar'` so clicking a child button or the canvas closes the strip:
 
 ```typescript
 {
   id: 'measure',
   label: 'Measure',
   icon: measureIconSvg,
-  childrenUi: 'sticky-toolbar',
+  childrenUi: 'toolbar',
   children: [
     { id: 'measure-distance', label: 'Distance', command: 'measuredistance' },
     { id: 'measure-area', label: 'Area', command: 'measurearea' }
@@ -511,7 +511,7 @@ When the parent icon should reflect the active submenu item:
 
 Built-in buttons using `childIcon: 'selected'`: `toolbar-placement` and `locale`. `export`, `annotation`, and `measure` use fixed parent icons.
 
-Built-in `childrenUi`: `measure` and `annotation` are `'sticky-toolbar'`; `export`, `toolbar-placement`, and `locale` are `'toolbar'`. Custom items default to `'menu'`.
+Built-in `childrenUi`: `measure`, `annotation`, `export`, `toolbar-placement`, and `locale` are `'toolbar'`. Custom items default to `'menu'`. Use `'sticky-toolbar'` to keep a strip open until the parent is clicked again.
 
 Submenu flyout direction follows toolbar placement (e.g. arrow points left when the toolbar is on the right).
 

--- a/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
@@ -309,13 +309,11 @@ describe('default toolbar items', () => {
     expect(items[measureIndex + 2]?.id).toBe('export')
   })
 
-  it('uses sticky sub-toolbars for measure and review, dismissible for export and placement', () => {
+  it('uses dismissible sub-toolbars for measure, review, export, and placement', () => {
     const items = acuiCreateDefaultToolbarItems()
-    expect(items.find(item => item.id === 'measure')?.childrenUi).toBe(
-      'sticky-toolbar'
-    )
+    expect(items.find(item => item.id === 'measure')?.childrenUi).toBe('toolbar')
     expect(items.find(item => item.id === 'annotation')?.childrenUi).toBe(
-      'sticky-toolbar'
+      'toolbar'
     )
     expect(items.find(item => item.id === 'export')?.childrenUi).toBe('toolbar')
     expect(items.find(item => item.id === 'layout')?.childrenUi).toBe('menu')

--- a/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
@@ -177,7 +177,7 @@ function acuiCreateMeasureToolbarItem(): AcUiToolbarItem {
     id: 'measure',
     label: 'toolbar.measure',
     icon: ICON_MEASURE,
-    childrenUi: 'sticky-toolbar',
+    childrenUi: 'toolbar',
     children: [
       {
         id: 'measure-distance',
@@ -269,7 +269,7 @@ function acuiCreateAnnotationToolbarItem(): AcUiToolbarItem {
     label: 'toolbar.annotation',
     icon: ICON_ANNOTATION,
     minOpenMode: AcEdOpenMode.Review,
-    childrenUi: 'sticky-toolbar',
+    childrenUi: 'toolbar',
     children: [
       {
         id: 'markup-cloud',

--- a/packages/cad-simple-ui-plugin/src/config/types.ts
+++ b/packages/cad-simple-ui-plugin/src/config/types.ts
@@ -131,9 +131,11 @@ export type AcUiToolbarChildIconMode = 'fixed' | 'selected'
  * How nested `children` are presented when the parent button is clicked.
  *
  * - `'menu'`: popover dropdown with icon + label (default). Closes on outside click.
- * - `'toolbar'`: icon sub-toolbar beside the parent. Closes on canvas / outside click.
+ * - `'toolbar'`: icon sub-toolbar beside the parent. Closes when a child button
+ *   is clicked, or on canvas / outside click.
  * - `'sticky-toolbar'`: icon sub-toolbar that stays open until the parent button
- *   is clicked again. Canvas clicks do not dismiss it.
+ *   is clicked again, or another parent opens a different strip. Child and
+ *   canvas clicks do not dismiss it.
  */
 export type AcUiToolbarChildrenUi = 'menu' | 'toolbar' | 'sticky-toolbar'
 
@@ -184,8 +186,8 @@ export interface AcUiToolbarItem {
   children?: AcUiToolbarItem[]
   /**
    * Presentation of {@link children}. Defaults to `'menu'` (popover dropdown).
-   * Built-in Measure / Review use `'sticky-toolbar'`; Export, Toolbar
-   * Position, and Language use `'toolbar'`.
+   * Built-in Measure, Review, Export, Toolbar Position, and Language use
+   * `'toolbar'`.
    */
   childrenUi?: AcUiToolbarChildrenUi
   /**


### PR DESCRIPTION
## Summary
- Measure and Review sub-toolbars now use `toolbar` (dismissible) instead of `sticky-toolbar`, so choosing a child tool or clicking the canvas closes the strip. Snap stays sticky.
- Pad/desktop strip buttons match the parent toolbar size (44px) so a vertical flyout lines up with the main bar; phone still uses the narrower portrait slot.
- HTML export settings strips also close after a leaf tool is selected, matching the documented `toolbar` dismiss rules.

## Test plan
- [ ] Open a drawing and click Measure: selecting Distance (or another tool) should close the strip; clicking the canvas should also close it.
- [ ] Repeat for Review/markup: selecting a markup tool should close the strip.
- [ ] Snap should stay open on canvas click until the parent is toggled or another strip parent is opened.
- [ ] On pad/desktop, measure/review/zoom/settings/locale strips should be the same width/height as the main toolbar buttons.
- [ ] On phone, sub-toolbar buttons should still use the narrower portrait slot.
- [ ] Settings: toggling theme should close the strip; Language nested from settings should still replace the settings strip.