### PR TITLE
feat: move draw-style color and font-size into the command session panel

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExCommandSessionPanel.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExCommandSessionPanel.spec.ts
@@ -307,4 +307,32 @@ describe('AcExCommandSessionPanel', () => {
     confirm.click()
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
+
+  it('mounts an accessory on the first row and unmounts when hidden', () => {
+    mockPhone(true)
+    const host = mountSessionHost()
+    const panel = new AcExCommandSessionPanel(host, new AcExHtmlI18n('en'))
+    const mount = jest.fn((slot: HTMLElement) => {
+      slot.appendChild(document.createElement('span'))
+    })
+    const unmount = jest.fn()
+    panel.setState({
+      prompt: 'Specify point',
+      confirmEnabled: true,
+      metrics: null,
+      chips: []
+    })
+    panel.setAccessory({ id: 'draw-style', mount, unmount })
+    const slot = host.querySelector('.mlcad-session-accessory') as HTMLElement
+    expect(slot.hidden).toBe(false)
+    expect(mount).toHaveBeenCalledTimes(1)
+    expect(slot.firstElementChild?.tagName).toBe('SPAN')
+
+    panel.setAccessory({ id: 'draw-style', mount, unmount })
+    expect(mount).toHaveBeenCalledTimes(1)
+
+    panel.setState(null)
+    expect(unmount).toHaveBeenCalledTimes(1)
+    expect(slot.hidden).toBe(true)
+  })
 })

--- a/packages/cad-html-plugin/__tests__/AcExHtmlDrawerSheet.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlDrawerSheet.spec.ts
@@ -1,10 +1,14 @@
 /** @jest-environment jsdom */
 
 import {
+  acExHtmlIsCompactLayout,
   acExHtmlIsPhoneLayout,
   setupAcExHtmlDrawerSheets
 } from '../src/AcExHtmlDrawerSheet'
-import { ML_UI_MOBILE_MAX_WIDTH } from '../src/AcExHtmlShell'
+import {
+  ML_UI_COMPACT_MAX_WIDTH,
+  ML_UI_MOBILE_MAX_WIDTH
+} from '../src/AcExHtmlShell'
 
 describe('setupAcExHtmlDrawerSheets', () => {
   const originalMatchMedia = window.matchMedia
@@ -29,6 +33,17 @@ describe('setupAcExHtmlDrawerSheets', () => {
     expect(acExHtmlIsPhoneLayout()).toBe(true)
     mockPhone(false)
     expect(acExHtmlIsPhoneLayout()).toBe(false)
+  })
+
+  it('detects the compact (phone or pad) breakpoint', () => {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: query.includes(`${ML_UI_COMPACT_MAX_WIDTH}`),
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn()
+      }) as unknown as MediaQueryList
+    expect(acExHtmlIsCompactLayout()).toBe(true)
   })
 
   it('parks the drawer on the sidebar and closes strips on phone', () => {

--- a/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlShell.spec.ts
@@ -60,6 +60,12 @@ describe('ACEX_HTML_SHELL_CSS', () => {
     expect(ACEX_HTML_SHELL_CSS).toContain(
       '#mlcad-command-session.is-relative .mlcad-session-group-polar {'
     )
+    expect(ACEX_HTML_SHELL_CSS).toContain('.mlcad-session-accessory {')
+    expect(ACEX_HTML_SHELL_CSS).toContain("'accessory accessory'")
+    expect(ACEX_HTML_SHELL_CSS).toContain('flex: 0 0 36px')
+    expect(ACEX_HTML_SHELL_CSS).toContain(
+      '#mlcad-command-session.is-absolute .mlcad-session-actions-shared {'
+    )
   })
 })
 
@@ -90,6 +96,7 @@ describe('buildAcExHtmlShellBody', () => {
     expect(html).not.toContain('mlcad-tool-separator')
     expect(html).toContain('id="mlcad-status-bar"')
     expect(html).toContain('id="mlcad-command-session"')
+    expect(html).toContain('mlcad-session-accessory')
     expect(html).toContain('data-session-stack="abs"')
     expect(html).toContain('data-session-stack="polar"')
     expect(html).toContain('data-session-stack="delta"')

--- a/packages/cad-html-plugin/__tests__/AcExSessionDrawStyle.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSessionDrawStyle.spec.ts
@@ -1,0 +1,66 @@
+/** @jest-environment jsdom */
+
+import { TextDecoder, TextEncoder } from 'util'
+
+import type { AcExHtmlI18n } from '../src/AcExHtmlI18n'
+
+Object.assign(globalThis, { TextDecoder, TextEncoder })
+
+// Value import after the polyfill: `@mlightcad/data-model` needs TextDecoder in jsdom.
+const { setupAcExSessionDrawStyle } =
+  require('../src/AcExSessionDrawStyle') as typeof import('../src/AcExSessionDrawStyle')
+
+function fakeI18n(): AcExHtmlI18n {
+  return {
+    t: (key: string) => key
+  } as AcExHtmlI18n
+}
+
+describe('setupAcExSessionDrawStyle', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    document.getElementById('mlcad-session-style-styles')?.remove()
+  })
+
+  it('mounts color and font-size controls into the session host, not a canvas overlay', () => {
+    const canvasRoot = document.createElement('div')
+    canvasRoot.id = 'mlcad-canvas-host'
+    document.body.appendChild(canvasRoot)
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    const applyStyle = jest.fn()
+    const controller = setupAcExSessionDrawStyle({
+      i18n: fakeI18n(),
+      getKind: () => 'measure',
+      getStyle: () => ({ color: '#ff0000', fontSize: 16 }),
+      applyStyle
+    })
+
+    const accessory = controller.createSessionAccessory()
+    expect(accessory.id).toBe('draw-style')
+    accessory.mount(host)
+
+    expect(host.querySelector('.mlcad-session-style')).toBeTruthy()
+    expect(host.querySelector('.mlcad-session-style__swatch')).toBeTruthy()
+    expect(
+      (host.querySelector('.mlcad-session-style__select') as HTMLSelectElement)
+        .value
+    ).toBe('16')
+    expect(canvasRoot.childElementCount).toBe(0)
+    expect(document.querySelector('.ml-draw-style-toolbar')).toBeNull()
+
+    const select = host.querySelector(
+      '.mlcad-session-style__select'
+    ) as HTMLSelectElement
+    select.value = '20'
+    select.dispatchEvent(new Event('change'))
+    expect(applyStyle).toHaveBeenCalledWith('measure', { fontSize: 20 })
+
+    accessory.unmount()
+    expect(host.querySelector('.mlcad-session-style')).toBeNull()
+    expect(canvasRoot.childElementCount).toBe(0)
+
+    controller.dispose()
+  })
+})

--- a/packages/cad-html-plugin/src/AcExCommandSessionPanel.ts
+++ b/packages/cad-html-plugin/src/AcExCommandSessionPanel.ts
@@ -39,6 +39,18 @@ export interface AcExCommandSessionPanelHandlers {
 }
 
 /**
+ * Widget mounted at the top of the session panel (color / font size).
+ */
+export interface AcExSessionAccessory {
+  /** Stable id so a re-show can replace rather than stack. */
+  id: string
+  /** Called when the session panel is shown. `host` is the accessory row. */
+  mount(host: HTMLElement): void
+  /** Called on hide or when a different accessory replaces this one. */
+  unmount(): void
+}
+
+/**
  * Bottom session panel for the offline HTML viewer: live length/angle/Δ
  * readouts plus on-screen Confirm / Cancel. The existing
  * `#mlcad-status-bar` remains the prompt (top message bar).
@@ -54,6 +66,7 @@ export class AcExCommandSessionPanel {
   private readonly polarActions: HTMLElement | null
   private readonly deltaActions: HTMLElement | null
   private readonly sharedActions: HTMLElement | null
+  private readonly accessoryEl: HTMLElement
   private readonly chipsEl: HTMLElement
   private readonly cancelBtn: HTMLButtonElement
   private readonly confirmBtn: HTMLButtonElement
@@ -63,6 +76,7 @@ export class AcExCommandSessionPanel {
   >
   private handlers: AcExCommandSessionPanelHandlers | null = null
   private lastState: AcExCommandSessionUiState | null = null
+  private accessory: AcExSessionAccessory | null = null
 
   constructor(host: HTMLElement, i18n: AcExHtmlI18n) {
     this.i18n = i18n
@@ -79,6 +93,15 @@ export class AcExCommandSessionPanel {
     this.polarActions = host.querySelector('[data-session-actions="polar"]')
     this.deltaActions = host.querySelector('[data-session-actions="delta"]')
     this.sharedActions = host.querySelector('[data-session-actions="shared"]')
+    this.accessoryEl =
+      (host.querySelector('.mlcad-session-accessory') as HTMLElement) ??
+      host.insertBefore(
+        Object.assign(document.createElement('div'), {
+          className: 'mlcad-session-accessory',
+          hidden: true
+        }),
+        host.firstChild
+      )
     this.chipsEl = host.querySelector('.mlcad-session-chips') as HTMLElement
     this.cancelBtn = host.querySelector(
       '.mlcad-session-cancel'
@@ -134,11 +157,31 @@ export class AcExCommandSessionPanel {
       .getElementById('mlcad-root')
       ?.classList.toggle('mlcad-session-active', active)
 
-    if (!state) return
+    if (!state) {
+      this.setAccessory(null)
+      return
+    }
 
     this.confirmBtn.disabled = !state.confirmEnabled
     this.renderMetrics(state.metrics)
     this.renderChips(state.chips)
+  }
+
+  /**
+   * Mounts widgets at the top of the session panel. Pass `null` to clear.
+   * Same `id` is a no-op so live metric updates do not remount controls.
+   */
+  setAccessory(next: AcExSessionAccessory | null): void {
+    if ((this.accessory?.id ?? null) === (next?.id ?? null)) return
+    this.accessory?.unmount()
+    this.accessoryEl.replaceChildren()
+    this.accessory = next
+    if (next) {
+      this.accessoryEl.hidden = false
+      next.mount(this.accessoryEl)
+    } else {
+      this.accessoryEl.hidden = true
+    }
   }
 
   /** Re-applies metric labels after a locale change. */

--- a/packages/cad-html-plugin/src/AcExHtmlDrawerSheet.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlDrawerSheet.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import { ML_UI_MOBILE_MAX_WIDTH } from './AcExHtmlShell'
+import { ML_UI_COMPACT_MAX_WIDTH, ML_UI_MOBILE_MAX_WIDTH } from './AcExHtmlShell'
 
 const MIN_HEIGHT = 160
 const DEFAULT_HEIGHT_VH = 0.42
@@ -27,6 +27,15 @@ export function acExHtmlIsPhoneLayout(): boolean {
   return (
     typeof window !== 'undefined' &&
     window.matchMedia?.(`(max-width: ${ML_UI_MOBILE_MAX_WIDTH}px)`).matches ===
+      true
+  )
+}
+
+/** Whether the offline HTML chrome is using the phone or pad breakpoint. */
+export function acExHtmlIsCompactLayout(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia?.(`(max-width: ${ML_UI_COMPACT_MAX_WIDTH}px)`).matches ===
       true
   )
 }

--- a/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
@@ -235,7 +235,7 @@ export interface AcExHtmlMeasureSettingsController {
 /**
  * Wires ortho and polar tracking controls in the object-snap strip.
  * Strip open/close is owned by {@link setupAcExHtmlToolbarFlyouts}.
- * Drawing color / line weight / font size live on the canvas draw-style toolbar.
+ * Drawing color / font size live on the session panel accessory.
  */
 export function setupAcExHtmlMeasureSettings(
   ctx: AcExHtmlMeasureSettingsContext

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -13,6 +13,12 @@ import type { AcExViewerMode } from './AcExSnapshotTypes'
 export const ML_UI_MOBILE_MAX_WIDTH = 600
 
 /**
+ * Pad / compact breakpoint for the offline HTML chrome.
+ * Keep in sync with `ML_UI_COMPACT_MAX_WIDTH` in cad-simple-viewer.
+ */
+export const ML_UI_COMPACT_MAX_WIDTH = 960
+
+/**
  * Shared CSS for the offline HTML viewer chrome (toolbar, layer drawer, status bar).
  * Injected into the `<style>` block by {@link packHtml}.
  */
@@ -656,6 +662,12 @@ export const ACEX_HTML_SHELL_CSS = `
     align-items: center;
     justify-content: center;
   }
+  #mlcad-command-session.is-absolute .mlcad-session-group-abs {
+    align-items: center;
+  }
+  #mlcad-command-session.is-absolute .mlcad-session-actions-shared {
+    align-self: center;
+  }
   #mlcad-command-session.is-relative:not([hidden]),
   #mlcad-command-session.is-absolute:not([hidden]) {
     display: grid;
@@ -665,12 +677,14 @@ export const ACEX_HTML_SHELL_CSS = `
   }
   #mlcad-command-session.is-relative {
     grid-template-areas:
+      'accessory accessory'
       'polar shared'
       'delta shared'
       'chips chips';
   }
   #mlcad-command-session.is-absolute {
     grid-template-areas:
+      'accessory accessory'
       'abs shared'
       'chips chips';
   }
@@ -678,6 +692,7 @@ export const ACEX_HTML_SHELL_CSS = `
   .mlcad-session-group-delta { grid-area: delta; }
   .mlcad-session-group-abs { grid-area: abs; }
   .mlcad-session-actions-shared { grid-area: shared; }
+  .mlcad-session-accessory { grid-area: accessory; }
   .mlcad-session-chips { grid-area: chips; }
   #mlcad-command-session.is-actions-only:not([hidden]) {
     display: flex;
@@ -728,6 +743,18 @@ export const ACEX_HTML_SHELL_CSS = `
     font-variant-numeric: tabular-nums;
     font-size: 13px;
   }
+  .mlcad-session-accessory {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .mlcad-session-accessory:not([hidden]) {
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--mlcad-ui-border);
+  }
+  .mlcad-session-accessory[hidden] {
+    display: none;
+  }
   .mlcad-session-chips {
     display: none !important;
   }
@@ -746,11 +773,11 @@ export const ACEX_HTML_SHELL_CSS = `
   .mlcad-session-cancel,
   .mlcad-session-confirm {
     box-sizing: border-box;
-    flex: 0 0 48px;
+    flex: 0 0 36px;
     align-self: center;
-    margin-block: auto;
-    width: 48px;
-    height: 48px;
+    margin: 0;
+    width: 36px;
+    height: 36px;
     padding: 0;
     border-radius: 50%;
     border: 0;
@@ -764,6 +791,8 @@ export const ACEX_HTML_SHELL_CSS = `
   .mlcad-session-cancel svg,
   .mlcad-session-confirm svg {
     display: block;
+    width: 18px;
+    height: 18px;
   }
   .mlcad-session-cancel { background: #5c6370; }
   .mlcad-session-confirm { background: var(--mlcad-accent-active); }
@@ -1568,6 +1597,7 @@ export function buildAcExHtmlShellBody(
     <div id="mlcad-canvas-host">
       <footer id="mlcad-status-bar" aria-live="polite" hidden></footer>
       <div id="mlcad-command-session" class="mlcad-command-session" hidden aria-hidden="true">
+        <div class="mlcad-session-accessory" hidden></div>
         <div class="mlcad-session-group mlcad-session-group-abs">
           <div class="mlcad-session-metric-stack" data-session-stack="abs">
             <button type="button" class="mlcad-session-metric" data-session-metric="x" disabled>
@@ -1581,10 +1611,10 @@ export function buildAcExHtmlShellBody(
           </div>
           <div class="mlcad-session-actions" data-session-actions="abs">
             <button type="button" class="mlcad-session-cancel" data-i18n-key="session.cancel" data-i18n-attr="aria-label" aria-label="Cancel">
-              <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path fill="currentColor" d="M18.3 5.71a1 1 0 0 0-1.41 0L12 10.59 7.11 5.7a1 1 0 0 0-1.41 1.42L10.59 12l-4.9 4.89a1 1 0 1 0 1.42 1.42L12 13.41l4.89 4.9a1 1 0 0 0 1.42-1.42L13.41 12l4.9-4.89a1 1 0 0 0-.01-1.4z"/></svg>
+              <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M18.3 5.71a1 1 0 0 0-1.41 0L12 10.59 7.11 5.7a1 1 0 0 0-1.41 1.42L10.59 12l-4.9 4.89a1 1 0 1 0 1.42 1.42L12 13.41l4.89 4.9a1 1 0 0 0 1.42-1.42L13.41 12l4.9-4.89a1 1 0 0 0-.01-1.4z"/></svg>
             </button>
             <button type="button" class="mlcad-session-confirm" data-i18n-key="session.confirm" data-i18n-attr="aria-label" aria-label="Confirm" disabled>
-              <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path fill="currentColor" d="M9.55 18.2 3.8 12.45l1.4-1.4 4.35 4.36 9.25-9.26 1.4 1.41z"/></svg>
+              <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M9.55 18.2 3.8 12.45l1.4-1.4 4.35 4.36 9.25-9.26 1.4 1.41z"/></svg>
             </button>
           </div>
         </div>

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -15,7 +15,6 @@ import {
   acExIntersectCssRects,
   acExWcsBoxToCssRect
 } from './AcExCssRect'
-import { setupAcExDrawStyleToolbar } from './AcExDrawStyleToolbar'
 import {
   decryptAcExHtmlSnapshotPayload,
   isAcExHtmlAccessExpired,
@@ -65,6 +64,7 @@ import {
   createViewerMeshMaterial,
   createViewerPointsMaterial
 } from './AcExPatternSnapshot'
+import { setupAcExSessionDrawStyle } from './AcExSessionDrawStyle'
 import {
   ACEX_SNAP_LOUPE_INSET_PX,
   ACEX_SNAP_LOUPE_SIZE_PX,
@@ -717,8 +717,15 @@ async function startViewer(): Promise<void> {
   const drawerSheetsRef: {
     current: ReturnType<typeof setupAcExHtmlDrawerSheets> | null
   } = { current: null }
+  const sessionDrawStyleRef: {
+    current: ReturnType<typeof setupAcExSessionDrawStyle> | null
+  } = { current: null }
   const applySessionUi = () => {
-    sessionPanel?.setState(measureSession ?? markupSession)
+    const state = measureSession ?? markupSession
+    sessionPanel?.setState(state)
+    sessionPanel?.setAccessory(
+      state ? (sessionDrawStyleRef.current?.createSessionAccessory() ?? null) : null
+    )
     drawerSheetsRef.current?.syncInset()
   }
   sessionPanel?.setHandlers({
@@ -742,9 +749,6 @@ async function startViewer(): Promise<void> {
   const layoutMenuRef: {
     current: ReturnType<typeof setupAcExHtmlLayoutMenu> | null
   } = { current: null }
-  const drawStyleToolbarRef: {
-    current: ReturnType<typeof setupAcExDrawStyleToolbar> | null
-  } = { current: null }
   const navToolsRef: {
     current: ReturnType<typeof setupAcExHtmlNavTools> | null
   } = { current: null }
@@ -761,7 +765,7 @@ async function startViewer(): Promise<void> {
       controls,
       navToolsRef.current?.isPanEnabled() ?? !isToolActive()
     )
-    drawStyleToolbarRef.current?.refresh()
+    sessionDrawStyleRef.current?.refresh()
     navToolsRef.current?.syncButtons()
   }
 
@@ -1005,7 +1009,7 @@ async function startViewer(): Promise<void> {
         applySessionUi()
       },
       onStyleChange: () => {
-        drawStyleToolbarRef.current?.refresh()
+        sessionDrawStyleRef.current?.refresh()
       },
       getActiveLayoutId: () => layout.btrId,
       view: {
@@ -1078,7 +1082,7 @@ async function startViewer(): Promise<void> {
         applySessionUi()
       },
       onStyleChange: () => {
-        drawStyleToolbarRef.current?.refresh()
+        sessionDrawStyleRef.current?.refresh()
       },
       getTrackingOptions: () =>
         measureSettingsRef.current?.getTrackingOptions() ?? null,
@@ -1101,15 +1105,11 @@ async function startViewer(): Promise<void> {
       angdir: snapshot.meta.units.angdir
     })
 
-    drawStyleToolbarRef.current = setupAcExDrawStyleToolbar({
-      root,
+    sessionDrawStyleRef.current = setupAcExSessionDrawStyle({
       i18n,
       getKind: () => {
         if (measure?.isActive) return 'measure'
         if (markup?.isActive) return 'markup'
-        if (markup?.hasSelection && measure?.hasSelection) return undefined
-        if (markup?.hasSelection) return 'markup'
-        if (measure?.hasSelection) return 'measure'
         return undefined
       },
       getStyle: kind => {
@@ -1125,6 +1125,7 @@ async function startViewer(): Promise<void> {
         }
       }
     })
+    applySessionUi()
   }
 
   const toolbarCollapse = setupToolbarCollapse(i18n, () => {
@@ -1512,7 +1513,7 @@ async function startViewer(): Promise<void> {
     measurePanel?.refreshLabels()
     sessionPanel?.refreshLabels()
     measureSettingsRef.current?.refreshLabels()
-    drawStyleToolbarRef.current?.refreshLabels()
+    sessionDrawStyleRef.current?.refreshLabels()
     toolbarCollapse.refreshLabels()
     toolbarFlyouts?.refreshLabels()
     navToolsRef.current?.refreshLabels()
@@ -1531,7 +1532,7 @@ async function startViewer(): Promise<void> {
         | null) ?? 'dark'
     )
     i18n.applyToDocument()
-    drawStyleToolbarRef.current?.refresh()
+    sessionDrawStyleRef.current?.refresh()
   })
 
   window.addEventListener('keydown', event => {

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -132,7 +132,7 @@ export interface AcExMarkupControllerOptions {
     screen: { x: number; y: number } | null
   ) => void
   onActiveChange?: (active: boolean) => void
-  /** Called when selection or session draw style changes (draw-style toolbar). */
+  /** Called when selection or session draw style changes (session accessory). */
   onStyleChange?: () => void
   /** Called when a markup tool starts so the runtime can cancel measure mode. */
   onBeforeActivate?: () => void

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -218,7 +218,7 @@ export interface AcExMeasureControllerOptions {
    * (for example to toggle left-button pan on OrbitControls).
    */
   onActiveChange?: (active: boolean) => void
-  /** Called when selection or session draw style changes (draw-style toolbar). */
+  /** Called when selection or session draw style changes (session accessory). */
   onStyleChange?: () => void
   /** Active layout BTR id; used to stamp and filter measurement overlays. */
   getActiveLayoutId?: () => string

--- a/packages/cad-html-plugin/src/AcExSessionDrawStyle.ts
+++ b/packages/cad-html-plugin/src/AcExSessionDrawStyle.ts
@@ -1,19 +1,19 @@
 /**
- * Canvas-top drawing style overlay (color / font size).
- * Mirrors `@mlightcad/cad-simple-viewer` {@link AcApDrawStyleToolbar}.
+ * Color / font-size controls for the offline HTML session accessory slot.
  *
- * @module AcExDrawStyleToolbar
+ * @module AcExSessionDrawStyle
  * @packageDocumentation
  */
 
 import { AcCmColor, AcCmColorUtil } from '@mlightcad/data-model'
 
+import type { AcExSessionAccessory } from './AcExCommandSessionPanel'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 
-/** Active tool kind that owns the overlay. */
+/** Active drawing session that owns the accessory. */
 export type AcExDrawStyleKind = 'measure' | 'markup'
 
-/** Style snapshot shown in / written by the overlay. */
+/** Style snapshot shown in / written by the accessory. */
 export interface AcExDrawStyleValues {
   /** CSS color string. */
   color: string
@@ -21,16 +21,14 @@ export interface AcExDrawStyleValues {
   fontSize: number
 }
 
-/** Partial style update from the overlay controls. */
+/** Partial style update from the accessory controls. */
 export interface AcExDrawStylePatch {
   color?: string
   fontSize?: number
 }
 
-/** Dependencies for {@link setupAcExDrawStyleToolbar}. */
-export interface AcExDrawStyleToolbarContext {
-  /** Host element (`#mlcad-root`); must be positioned. */
-  root: HTMLElement
+/** Dependencies for {@link setupAcExSessionDrawStyle}. */
+export interface AcExSessionDrawStyleContext {
   i18n: AcExHtmlI18n
   /** Current kind, or `undefined` when no draw tool is active. */
   getKind: () => AcExDrawStyleKind | undefined
@@ -40,34 +38,18 @@ export interface AcExDrawStyleToolbarContext {
   applyStyle: (kind: AcExDrawStyleKind, patch: AcExDrawStylePatch) => void
 }
 
-/** Font-size choices shown in the overlay dropdown (CSS px). */
+/** Font-size choices shown in the dropdown (CSS px). */
 const FONT_SIZE_OPTIONS = [10, 12, 13, 14, 16, 18, 20, 24, 28, 32]
 
-const STYLE_ID = 'mlcad-draw-style-toolbar-styles'
+const STYLE_ID = 'mlcad-session-style-styles'
 
-const TOOLBAR_CSS = `
-.mlcad-draw-style-toolbar {
-  position: absolute;
-  top: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 40;
-  display: none;
+const SESSION_STYLE_CSS = `
+.mlcad-session-style {
+  display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 8px;
-  box-sizing: border-box;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 6px;
-  background: rgba(28, 32, 40, 0.92);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
-  color: #e8eaed;
-  pointer-events: auto;
 }
-.mlcad-draw-style-toolbar.is-visible {
-  display: inline-flex;
-}
-.mlcad-draw-style-toolbar__swatch {
+.mlcad-session-style__swatch {
   position: relative;
   width: 28px;
   height: 28px;
@@ -77,7 +59,7 @@ const TOOLBAR_CSS = `
   background: rgba(255, 255, 255, 0.06);
   cursor: pointer;
 }
-.mlcad-draw-style-toolbar__swatch-fill {
+.mlcad-session-style__swatch-fill {
   display: block;
   width: 14px;
   height: 14px;
@@ -85,7 +67,7 @@ const TOOLBAR_CSS = `
   border-radius: 50%;
   border: 1px solid #999;
 }
-.mlcad-draw-style-toolbar__select {
+.mlcad-session-style__select {
   height: 28px;
   min-width: 92px;
   max-width: 140px;
@@ -96,13 +78,14 @@ const TOOLBAR_CSS = `
   font-size: 12px;
   padding: 0 6px;
 }
-.mlcad-draw-style-toolbar__color {
+.mlcad-session-style__color {
   position: relative;
 }
-.mlcad-draw-style-toolbar__color-panel {
+.mlcad-session-style__color-panel {
   display: none;
   position: absolute;
-  top: calc(100% + 6px);
+  top: auto;
+  bottom: calc(100% + 6px);
   left: 0;
   z-index: 1;
   padding: 8px;
@@ -110,39 +93,39 @@ const TOOLBAR_CSS = `
   border-radius: 6px;
   background: rgba(28, 32, 40, 0.98);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
-  --mlcad-draw-style-aci-cell: 11px;
+  --mlcad-session-style-aci-cell: 11px;
 }
-.mlcad-draw-style-toolbar__color-panel.is-open {
+.mlcad-session-style__color-panel.is-open {
   display: block;
 }
-.mlcad-draw-style-toolbar__aci-large {
+.mlcad-session-style__aci-large {
   display: grid;
-  grid-template-columns: repeat(24, var(--mlcad-draw-style-aci-cell));
+  grid-template-columns: repeat(24, var(--mlcad-session-style-aci-cell));
   gap: 1px;
   margin-bottom: 6px;
 }
-.mlcad-draw-style-toolbar__aci-small {
+.mlcad-session-style__aci-small {
   display: grid;
-  grid-template-columns: repeat(9, var(--mlcad-draw-style-aci-cell));
+  grid-template-columns: repeat(9, var(--mlcad-session-style-aci-cell));
   gap: 1px;
   margin-bottom: 6px;
 }
-.mlcad-draw-style-toolbar__aci-gray {
+.mlcad-session-style__aci-gray {
   display: flex;
   gap: 4px;
 }
-.mlcad-draw-style-toolbar__aci-cell {
-  width: var(--mlcad-draw-style-aci-cell);
-  height: var(--mlcad-draw-style-aci-cell);
+.mlcad-session-style__aci-cell {
+  width: var(--mlcad-session-style-aci-cell);
+  height: var(--mlcad-session-style-aci-cell);
   padding: 0;
   border: 1px solid #666;
   box-sizing: border-box;
   cursor: pointer;
 }
-.mlcad-draw-style-toolbar__aci-cell:hover {
+.mlcad-session-style__aci-cell:hover {
   outline: 1px solid #00a8ff;
 }
-.mlcad-draw-style-toolbar__aci-cell.is-selected {
+.mlcad-session-style__aci-cell.is-selected {
   outline: 2px solid #08e8de;
   outline-offset: -1px;
 }
@@ -179,8 +162,6 @@ function preferExactAciColor(color: AcCmColor): AcCmColor {
 
 function cssToColor(css: string): AcCmColor {
   const trimmed = css.trim()
-  // fromString does not accept CSS hex (`#rrggbb`) or rgb()/hsl(); those
-  // log "Unknown color name" (e.g. `#d51572`) if passed as named colors.
   const skipFromString =
     trimmed.startsWith('#') || /^(rgb|rgba|hsl|hsla)\(/i.test(trimmed)
   if (!skipFromString) {
@@ -215,43 +196,45 @@ function ensureStyles(): void {
     style.id = STYLE_ID
     document.head.appendChild(style)
   }
-  style.textContent = TOOLBAR_CSS
+  style.textContent = SESSION_STYLE_CSS
 }
 
-/** Controller returned by {@link setupAcExDrawStyleToolbar}. */
-export interface AcExDrawStyleToolbarController {
-  /** Show/hide and sync controls from the active tool. */
+/** Controller returned by {@link setupAcExSessionDrawStyle}. */
+export interface AcExSessionDrawStyleController {
+  /** Sync controls from the active tool. */
   refresh: () => void
   /** Reapply i18n titles after locale change. */
   refreshLabels: () => void
+  /** Color / font-size widgets for the session panel accessory slot. */
+  createSessionAccessory: () => AcExSessionAccessory
   /** Tear down DOM listeners. */
   dispose: () => void
 }
 
 /**
- * Creates the drawing-style overlay on the canvas host.
+ * Builds color / font-size controls that mount into the session accessory.
  */
-export function setupAcExDrawStyleToolbar(
-  ctx: AcExDrawStyleToolbarContext
-): AcExDrawStyleToolbarController {
+export function setupAcExSessionDrawStyle(
+  ctx: AcExSessionDrawStyleContext
+): AcExSessionDrawStyleController {
   ensureStyles()
 
-  const root = document.createElement('div')
-  root.className = 'mlcad-draw-style-toolbar'
-  root.setAttribute('role', 'toolbar')
+  const controlsRow = document.createElement('div')
+  controlsRow.className = 'mlcad-session-style'
+  controlsRow.setAttribute('role', 'toolbar')
 
   const colorWrap = document.createElement('div')
-  colorWrap.className = 'mlcad-draw-style-toolbar__color'
+  colorWrap.className = 'mlcad-session-style__color'
 
   const swatch = document.createElement('button')
   swatch.type = 'button'
-  swatch.className = 'mlcad-draw-style-toolbar__swatch'
+  swatch.className = 'mlcad-session-style__swatch'
   const swatchFill = document.createElement('span')
-  swatchFill.className = 'mlcad-draw-style-toolbar__swatch-fill'
+  swatchFill.className = 'mlcad-session-style__swatch-fill'
   swatch.appendChild(swatchFill)
 
   const colorPanel = document.createElement('div')
-  colorPanel.className = 'mlcad-draw-style-toolbar__color-panel'
+  colorPanel.className = 'mlcad-session-style__color-panel'
 
   const createAciPalette = (indices: number[], className: string) => {
     const palette = document.createElement('div')
@@ -259,7 +242,7 @@ export function setupAcExDrawStyleToolbar(
     for (const index of indices) {
       const cell = document.createElement('button')
       cell.type = 'button'
-      cell.className = 'mlcad-draw-style-toolbar__aci-cell'
+      cell.className = 'mlcad-session-style__aci-cell'
       cell.dataset.aci = String(index)
       cell.style.background = aciCss(index)
       cell.title = String(index)
@@ -275,26 +258,26 @@ export function setupAcExDrawStyleToolbar(
   }
 
   colorPanel.appendChild(
-    createAciPalette(LARGE_ACI, 'mlcad-draw-style-toolbar__aci-large')
+    createAciPalette(LARGE_ACI, 'mlcad-session-style__aci-large')
   )
   colorPanel.appendChild(
-    createAciPalette(SMALL_ACI, 'mlcad-draw-style-toolbar__aci-small')
+    createAciPalette(SMALL_ACI, 'mlcad-session-style__aci-small')
   )
   colorPanel.appendChild(
-    createAciPalette(GRAY_ACI, 'mlcad-draw-style-toolbar__aci-gray')
+    createAciPalette(GRAY_ACI, 'mlcad-session-style__aci-gray')
   )
 
   colorWrap.appendChild(swatch)
   colorWrap.appendChild(colorPanel)
-  root.appendChild(colorWrap)
 
   const fontSizeSelect = document.createElement('select')
-  fontSizeSelect.className = 'mlcad-draw-style-toolbar__select'
-  root.appendChild(fontSizeSelect)
+  fontSizeSelect.className = 'mlcad-session-style__select'
+  controlsRow.append(colorWrap, fontSizeSelect)
 
   let colorPanelOpen = false
   let colorLeaveTimer: number | undefined
   let currentKind: AcExDrawStyleKind | undefined
+  let sessionMounted = false
 
   const clearColorLeaveTimer = () => {
     if (colorLeaveTimer == null) return
@@ -320,12 +303,10 @@ export function setupAcExDrawStyleToolbar(
   }
 
   const markSelectedAci = (index: number | undefined) => {
-    colorPanel
-      .querySelectorAll('.mlcad-draw-style-toolbar__aci-cell')
-      .forEach(el => {
-        const aci = Number((el as HTMLElement).dataset.aci)
-        el.classList.toggle('is-selected', index != null && aci === index)
-      })
+    colorPanel.querySelectorAll('.mlcad-session-style__aci-cell').forEach(el => {
+      const aci = Number((el as HTMLElement).dataset.aci)
+      el.classList.toggle('is-selected', index != null && aci === index)
+    })
   }
 
   const paint = (style: AcExDrawStyleValues) => {
@@ -373,12 +354,23 @@ export function setupAcExDrawStyleToolbar(
     currentKind = ctx.getKind()
     if (!currentKind) {
       hideColorPanel()
-      root.classList.remove('is-visible')
       return
     }
-    root.classList.add('is-visible')
     paint(ctx.getStyle(currentKind))
     relabel()
+  }
+
+  const mountSession = (host: HTMLElement) => {
+    sessionMounted = true
+    host.appendChild(controlsRow)
+    refresh()
+  }
+
+  const unmountSession = () => {
+    if (!sessionMounted) return
+    sessionMounted = false
+    hideColorPanel()
+    controlsRow.remove()
   }
 
   swatch.addEventListener('click', event => {
@@ -392,8 +384,8 @@ export function setupAcExDrawStyleToolbar(
   fontSizeSelect.addEventListener('change', () => {
     applyFontSize(Number(fontSizeSelect.value))
   })
-  root.addEventListener('pointerdown', event => event.stopPropagation())
-  root.addEventListener('mousedown', event => event.stopPropagation())
+  controlsRow.addEventListener('pointerdown', event => event.stopPropagation())
+  controlsRow.addEventListener('mousedown', event => event.stopPropagation())
 
   const onDocumentPointerDown = (event: PointerEvent) => {
     const target = event.target as Node | null
@@ -403,7 +395,6 @@ export function setupAcExDrawStyleToolbar(
   }
   document.addEventListener('pointerdown', onDocumentPointerDown, true)
 
-  ctx.root.appendChild(root)
   relabel()
 
   return {
@@ -411,10 +402,15 @@ export function setupAcExDrawStyleToolbar(
     refreshLabels: () => {
       relabel()
     },
+    createSessionAccessory: () => ({
+      id: 'draw-style',
+      mount: mountSession,
+      unmount: unmountSession
+    }),
     dispose: () => {
+      unmountSession()
       document.removeEventListener('pointerdown', onDocumentPointerDown, true)
       clearColorLeaveTimer()
-      root.remove()
     }
   }
 }

--- a/packages/cad-simple-viewer/__tests__/AcApDrawStyle.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDrawStyle.spec.ts
@@ -17,13 +17,16 @@ import {
   subscribeMarkupDrawStyle
 } from '../src/command/markup/AcApMarkupUtil'
 import {
+  acapBindDrawStyleSessionAccessory,
   acapDrawStyleKindForCommand,
   acapIsDrawStyleToolbarVisible,
+  acapRegisterDrawStyleSessionHost,
   acapResolveDrawStyleKind,
   acapSetDrawStyleHostHasRibbon,
   acapSetDrawStyleToolbarVisible,
   acapShouldShowDrawStyleToolbar,
-  acapSubscribeDrawStyleToolbarVisibility
+  acapSubscribeDrawStyleToolbarVisibility,
+  acapUnregisterDrawStyleSessionHost
 } from '../src/ui/AcApDrawStyle'
 
 describe('subscribeMarkupDrawStyle', () => {
@@ -215,5 +218,27 @@ describe('isMarkupDoublePointer', () => {
     expect(isMarkupDoublePointer(undefined, { t: 1000, x: 0, y: 0 })).toBe(
       false
     )
+  })
+})
+
+describe('acapBindDrawStyleSessionAccessory', () => {
+  it('returns the view toolbar accessory and clears after unregister', () => {
+    const view = {}
+    const accessory = {
+      id: 'draw-style',
+      mount: jest.fn(),
+      unmount: jest.fn()
+    }
+    acapRegisterDrawStyleSessionHost(view as never, {
+      createSessionAccessory: () => accessory
+    })
+    const command = {
+      createSessionAccessory: (_context: unknown) =>
+        null as typeof accessory | null
+    }
+    acapBindDrawStyleSessionAccessory(command)
+    expect(command.createSessionAccessory({ view })).toBe(accessory)
+    acapUnregisterDrawStyleSessionHost(view as never)
+    expect(command.createSessionAccessory({ view })).toBeNull()
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdCommandStackExclusivity.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdCommandStackExclusivity.spec.ts
@@ -102,4 +102,64 @@ describe('AcEdCommandStack — command exclusivity', () => {
 
     await expect(stack.cancelActive()).resolves.toBeUndefined()
   })
+
+  test('runActive sets activeCommand before work so the first prompt can read it', async () => {
+    const stack = new AcEdCommandStack()
+    const cmd = new DummyCommand()
+    const view = makeStubView(jest.fn())
+    let seenDuringWork: AcEdCommand | null = null
+
+    await stack.runActive(cmd, view, async () => {
+      seenDuringWork = stack.activeCommand
+    })
+
+    expect(seenDuringWork).toBe(cmd)
+    expect(stack.activeCommand).toBeNull()
+  })
+
+  test('runActive releases the slot if work throws', async () => {
+    const stack = new AcEdCommandStack()
+    const cmd = new DummyCommand()
+    const view = makeStubView(jest.fn())
+
+    await expect(
+      stack.runActive(cmd, view, async () => {
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
+    expect(stack.activeCommand).toBeNull()
+  })
+
+  test('cancelActive during runActive waits until work settles', async () => {
+    const stack = new AcEdCommandStack()
+    const cmd = new DummyCommand()
+    const cancelSpy = jest.fn()
+    const view = makeStubView(cancelSpy)
+
+    let resolveWork!: () => void
+    const workPromise = new Promise<void>(resolve => {
+      resolveWork = resolve
+    })
+    const runPromise = stack.runActive(cmd, view, () => workPromise)
+
+    let cancelSettled = false
+    const cancelPromise = stack.cancelActive().then(() => {
+      cancelSettled = true
+    })
+    expect(cancelSpy).toHaveBeenCalledTimes(1)
+    await Promise.resolve()
+    expect(cancelSettled).toBe(false)
+
+    resolveWork()
+    await runPromise
+    await cancelPromise
+    expect(cancelSettled).toBe(true)
+    expect(stack.activeCommand).toBeNull()
+  })
+})
+
+describe('AcEdCommand.createSessionAccessory', () => {
+  test('defaults to null', () => {
+    expect(new DummyCommand().createSessionAccessory({} as never)).toBeNull()
+  })
 })

--- a/packages/cad-simple-viewer/__tests__/AcEdMobileCommandChrome.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdMobileCommandChrome.spec.ts
@@ -97,7 +97,10 @@ describe('AcEdMobileCommandChrome', () => {
       'Specify next point'
     )
     const panel = host.querySelector('.ml-mobile-cmd-panel') as HTMLElement
-    expect(panel.firstElementChild?.classList.contains('ml-mobile-cmd-chips')).toBe(
+    expect(
+      panel.firstElementChild?.classList.contains('ml-mobile-cmd-accessory')
+    ).toBe(true)
+    expect(panel.children[1]?.classList.contains('ml-mobile-cmd-chips')).toBe(
       true
     )
     expect(panel.querySelector('.ml-mobile-cmd-chip')?.textContent).toBe('Undo')
@@ -308,5 +311,51 @@ describe('AcEdMobileCommandChrome', () => {
       (host.querySelector('.ml-mobile-cmd-group-polar') as HTMLElement).hidden
     ).toBe(false)
     media.restore()
+  })
+
+  it('mounts the accessory as the first panel row and unmounts on hide', () => {
+    const media = installMatchMedia(
+      query => query === ML_UI_MOBILE_MEDIA_QUERY
+    )
+    const mount = jest.fn((host: HTMLElement) => {
+      host.appendChild(document.createElement('span'))
+    })
+    const unmount = jest.fn()
+    chrome.show(
+      {
+        prompt: 'Specify point',
+        keywords: [],
+        allowNone: true,
+        showMetrics: false,
+        accessory: { id: 'draw-style', mount, unmount }
+      },
+      { onConfirm: jest.fn(), onCancel: jest.fn(), onKeyword: jest.fn() }
+    )
+    const accessory = host.querySelector(
+      '.ml-mobile-cmd-accessory'
+    ) as HTMLElement
+    expect(accessory.hidden).toBe(false)
+    expect(mount).toHaveBeenCalledTimes(1)
+    expect(mount.mock.calls[0][0]).toBe(accessory)
+    expect(accessory.firstElementChild?.tagName).toBe('SPAN')
+
+    chrome.hide()
+    expect(unmount).toHaveBeenCalledTimes(1)
+    expect(accessory.hidden).toBe(true)
+    expect(accessory.childElementCount).toBe(0)
+    media.restore()
+  })
+
+  it('uses 36px confirm/cancel buttons centered in the absolute metrics row', () => {
+    const css = document.getElementById('ml-mobile-cmd-styles')?.textContent ?? ''
+    expect(css).toContain('flex: 0 0 36px')
+    expect(css).toContain('width: 36px')
+    expect(css).toContain('height: 36px')
+    expect(css).toContain(
+      '.ml-mobile-cmd-panel.is-absolute .ml-mobile-cmd-actions-shared'
+    )
+    expect(css).toContain(
+      '.ml-mobile-cmd-panel.is-absolute .ml-mobile-cmd-group-abs'
+    )
   })
 })

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -1959,15 +1959,18 @@ export class AcApDocManager {
     // so its `commandEnded` lifecycle finishes before the new one begins.
     await this._commandManager.cancelActive()
 
-    const promise = cmd.trigger(this.context).finally(() => {
-      if (!options.preserveScriptInputs) {
-        this.editor.clearScriptInputs()
+    // markActive must run before trigger(): the first getPoint prompt is
+    // opened synchronously until the first await, and the mobile session
+    // accessory reads commandManager.activeCommand.
+    await this._commandManager.runActive(cmd, this.curView, async () => {
+      try {
+        await cmd.trigger(this.context)
+      } finally {
+        if (!options.preserveScriptInputs) {
+          this.editor.clearScriptInputs()
+        }
       }
-      this._commandManager.clearActive(cmd)
     })
-    this._commandManager.markActive(cmd, this.curView, promise)
-
-    await promise
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupArrowCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupArrowCmd.ts
@@ -15,7 +15,7 @@ import {
   acapStrokeLiveSegment
 } from '../overlay/AcApHtmlLivePreview'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
@@ -76,7 +76,7 @@ class AcApMarkupArrowJig extends AcEdPreviewJig<AcGePoint3dLike> {
 export class AcApMarkupArrowCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCalloutCmd.ts
@@ -24,7 +24,7 @@ import {
   acapStrokeLiveSegment
 } from '../overlay/AcApHtmlLivePreview'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   promptMarkupCapsuleText,
   withMarkupInput
@@ -184,7 +184,7 @@ class AcApMarkupCalloutJig extends AcEdPreviewJig<AcGePoint3dLike> {
 export class AcApMarkupCalloutCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCircleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCircleCmd.ts
@@ -19,7 +19,7 @@ import {
   acapStrokeLiveCircle
 } from '../overlay/AcApHtmlLivePreview'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
@@ -88,7 +88,7 @@ class AcApMarkupCircleJig extends AcEdPreviewJig<number> {
 export class AcApMarkupCircleCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCloudCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCloudCmd.ts
@@ -19,7 +19,7 @@ import {
   acapStrokeLivePolyline
 } from '../overlay/AcApHtmlLivePreview'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
@@ -99,7 +99,7 @@ class AcApMarkupCloudJig extends AcEdPreviewJig<AcGePoint2dLike> {
 export class AcApMarkupCloudCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupCmdUtil.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupCmdUtil.ts
@@ -1,5 +1,6 @@
 import type { AcApContext } from '../../app'
 import {
+  type AcEdCommand,
   AcEdCorsorType,
   AcEdOpenMode,
   AcEdPromptStatus,
@@ -7,6 +8,7 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { acapBindDrawStyleSessionAccessory } from '../../ui/AcApDrawStyle'
 import type { AcTrView2d } from '../../view'
 import { editMarkupHtmlText } from './AcApMarkupTextEdit'
 import type {
@@ -34,6 +36,15 @@ export function configureMarkupCommand(command: {
 }): void {
   command.mode = MARKUP_OPEN_MODE
   command.recordsUndoStack = false
+}
+
+/**
+ * Markup drawing commands: Review mode plus color / font-size in the
+ * phone/pad session panel.
+ */
+export function configureMarkupDrawCommand(command: AcEdCommand): void {
+  configureMarkupCommand(command)
+  acapBindDrawStyleSessionAccessory(command)
 }
 
 /** Create shared metadata fields for a new markup record. */

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupHighlightCmd.ts
@@ -15,7 +15,7 @@ import {
   AcApHtmlLivePreview
 } from '../overlay/AcApHtmlLivePreview'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
@@ -82,7 +82,7 @@ class AcApMarkupHighlightJig extends AcEdPreviewJig<AcGePoint3dLike> {
 export class AcApMarkupHighlightCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupLineCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupLineCmd.ts
@@ -19,7 +19,7 @@ import {
   acapStrokeLiveSegment
 } from '../overlay/AcApHtmlLivePreview'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
@@ -109,7 +109,7 @@ class AcApMarkupLineJig extends AcEdPreviewJig<AcGePoint3dLike> {
 export class AcApMarkupLineCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupRectCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupRectCmd.ts
@@ -16,7 +16,7 @@ import {
   acapStrokeLivePolyline
 } from '../overlay/AcApHtmlLivePreview'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   withMarkupInput
 } from './AcApMarkupCmdUtil'
@@ -82,7 +82,7 @@ class AcApMarkupRectJig extends AcEdPreviewJig<AcGePoint2dLike> {
 export class AcApMarkupRectCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupStampCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupStampCmd.ts
@@ -8,7 +8,7 @@ import {
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   promptMarkupText,
   withMarkupInput
@@ -31,7 +31,7 @@ const BUILTIN_STAMPS = new Set([
 export class AcApMarkupStampCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/markup/AcApMarkupTextCmd.ts
+++ b/packages/cad-simple-viewer/src/command/markup/AcApMarkupTextCmd.ts
@@ -9,7 +9,7 @@ import {
 import { AcApI18n } from '../../i18n'
 import type { AcTrView2d } from '../../view'
 import {
-  configureMarkupCommand,
+  configureMarkupDrawCommand,
   createMarkupMeta,
   promptMarkupCapsuleText,
   withMarkupInput
@@ -29,7 +29,7 @@ import {
 export class AcApMarkupTextCmd extends AcEdCommand {
   constructor() {
     super()
-    configureMarkupCommand(this)
+    configureMarkupDrawCommand(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAngleCmd.ts
@@ -20,6 +20,7 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { acapBindDrawStyleSessionAccessory } from '../../ui/AcApDrawStyle'
 import {
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
@@ -235,6 +236,7 @@ export class AcApMeasureAngleCmd extends AcEdCommand {
   constructor() {
     super()
     this.mode = AcEdOpenMode.Read
+    acapBindDrawStyleSessionAccessory(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureArcCmd.ts
@@ -24,6 +24,7 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { acapBindDrawStyleSessionAccessory } from '../../ui/AcApDrawStyle'
 import {
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
@@ -601,6 +602,7 @@ export class AcApMeasureArcCmd extends AcEdCommand {
   constructor() {
     super()
     this.mode = AcEdOpenMode.Read
+    acapBindDrawStyleSessionAccessory(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
@@ -16,6 +16,7 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { acapBindDrawStyleSessionAccessory } from '../../ui/AcApDrawStyle'
 import {
   acapColorToCssAlpha,
   acapCssColor,
@@ -131,6 +132,7 @@ export class AcApMeasureAreaCmd extends AcEdCommand {
   constructor() {
     super()
     this.mode = AcEdOpenMode.Read
+    acapBindDrawStyleSessionAccessory(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureContinuousCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureContinuousCmd.ts
@@ -21,6 +21,7 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { acapBindDrawStyleSessionAccessory } from '../../ui/AcApDrawStyle'
 import {
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
@@ -175,6 +176,7 @@ export class AcApMeasureContinuousCmd extends AcEdCommand {
   constructor() {
     super()
     this.mode = AcEdOpenMode.Read
+    acapBindDrawStyleSessionAccessory(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureDistanceCmd.ts
@@ -21,6 +21,7 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { acapBindDrawStyleSessionAccessory } from '../../ui/AcApDrawStyle'
 import {
   acapGetCurrentMeasurementStyle,
   acapGetMeasurementColor,
@@ -164,6 +165,7 @@ export class AcApMeasureDistanceCmd extends AcEdCommand {
   constructor() {
     super()
     this.mode = AcEdOpenMode.Read
+    acapBindDrawStyleSessionAccessory(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurePointCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurePointCmd.ts
@@ -10,6 +10,7 @@ import {
   AcEdViewMode
 } from '../../editor'
 import { AcApI18n } from '../../i18n'
+import { acapBindDrawStyleSessionAccessory } from '../../ui/AcApDrawStyle'
 import {
   acapGetCurrentMeasurementStyle,
   type AcApMeasurementStyle
@@ -41,6 +42,7 @@ export class AcApMeasurePointCmd extends AcEdCommand {
   constructor() {
     super()
     this.mode = AcEdOpenMode.Read
+    acapBindDrawStyleSessionAccessory(this)
   }
 
   async execute(context: AcApContext) {

--- a/packages/cad-simple-viewer/src/editor/command/AcEdCommand.ts
+++ b/packages/cad-simple-viewer/src/editor/command/AcEdCommand.ts
@@ -11,6 +11,7 @@ import { acapNotifyUndoStackChanged } from '../../util/AcApDatabaseEdit'
 import { eventBus } from '../global/eventBus'
 import { AcEdMessageType } from '../input/ui/AcEdMessageType'
 import { AcEdOpenMode } from '../view/AcEdOpenMode'
+import type { AcEdSessionAccessory } from './AcEdSessionAccessory'
 
 /**
  * Abstract base class for all CAD commands.
@@ -308,6 +309,17 @@ export abstract class AcEdCommand<TUserData extends object = {}> {
    */
   async execute(_context: AcApContext) {
     // Do nothing - subclasses should override this method
+  }
+
+  /**
+   * Optional widgets for the phone/pad session panel (top row, above chips
+   * and metrics). The default returns `null`.
+   *
+   * @param _context - The current application context
+   * @returns Accessory to mount, or `null` to leave the slot empty
+   */
+  createSessionAccessory(_context: AcApContext): AcEdSessionAccessory | null {
+    return null
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/command/AcEdCommandStack.ts
+++ b/packages/cad-simple-viewer/src/editor/command/AcEdCommandStack.ts
@@ -392,13 +392,15 @@ export class AcEdCommandStack {
   /**
    * Records the command that is about to begin executing.
    *
-   * Called by the dispatcher immediately after invoking `cmd.trigger(context)`.
+   * The dispatcher must call this **before** `cmd.trigger(context)`: `trigger()`
+   * runs the first prompt synchronously until its first `await`, and that prompt
+   * reads {@link activeCommand} (for example the session-panel accessory).
    * The supplied view is used to reach the editor's input manager when an
    * outside caller requests cancellation via {@link cancelActive}.
    *
-   * @param command - Command that just started executing
+   * @param command - Command that is about to start executing
    * @param view - View bound to the command's execution context
-   * @param promise - Promise returned by the command's `trigger()` call
+   * @param promise - Promise that settles when the command finishes
    */
   markActive(
     command: AcEdCommand,
@@ -408,6 +410,32 @@ export class AcEdCommandStack {
     this._activeCommand = command
     this._activeView = view
     this._activePromise = promise
+  }
+
+  /**
+   * Marks `command` active, then runs `work`. {@link activeCommand} is set
+   * before `work` is invoked so the first input prompt can read it.
+   *
+   * @param command - Command that is about to start executing
+   * @param view - View bound to the command's execution context
+   * @param work - Typically `() => cmd.trigger(context)`
+   */
+  async runActive(
+    command: AcEdCommand,
+    view: AcEdBaseView,
+    work: () => Promise<void>
+  ): Promise<void> {
+    let release!: () => void
+    const tracked = new Promise<void>(resolve => {
+      release = resolve
+    })
+    this.markActive(command, view, tracked)
+    try {
+      await work()
+    } finally {
+      this.clearActive(command)
+      release()
+    }
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/command/AcEdSessionAccessory.ts
+++ b/packages/cad-simple-viewer/src/editor/command/AcEdSessionAccessory.ts
@@ -1,0 +1,15 @@
+/**
+ * Widget mounted at the top of the phone/pad session panel while a command
+ * is prompting. Commands return this from
+ * {@link AcEdCommand.createSessionAccessory}.
+ *
+ * Kept as a types-only module so the command layer does not import chrome DOM.
+ */
+export interface AcEdSessionAccessory {
+  /** Stable id so a re-show can replace rather than stack. */
+  id: string
+  /** Called when the session panel is shown. `host` is the accessory row. */
+  mount(host: HTMLElement): void
+  /** Called on hide or when a different accessory replaces this one. */
+  unmount(): void
+}

--- a/packages/cad-simple-viewer/src/editor/command/index.ts
+++ b/packages/cad-simple-viewer/src/editor/command/index.ts
@@ -1,2 +1,3 @@
 export * from './AcEdCommand'
 export * from './AcEdCommandStack'
+export type { AcEdSessionAccessory } from './AcEdSessionAccessory'

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -10,6 +10,7 @@ import {
 
 import { AcApDocManager, AcApSettingManager } from '../../../app'
 import { AcApI18n } from '../../../i18n'
+import type { AcEdSessionAccessory } from '../../command/AcEdSessionAccessory'
 import {
   acedIsMobileOrPadUi,
   acedShouldHideDesktopCommandLine,
@@ -284,13 +285,26 @@ export class AcEdInputManager {
         prompt: args.prompt,
         keywords: args.keywords ?? [],
         allowNone: args.allowNone,
-        showMetrics: args.showMetrics
+        showMetrics: args.showMetrics,
+        accessory: this.resolveSessionAccessory()
       },
       {
         onConfirm: args.onConfirm,
         onCancel: args.onCancel,
         onKeyword: args.onKeyword
       }
+    )
+  }
+
+  /**
+   * Asks the active command for session-panel widgets (color / font size).
+   */
+  private resolveSessionAccessory(): AcEdSessionAccessory | null {
+    const manager = AcApDocManager.instance
+    return (
+      manager.commandManager.activeCommand?.createSessionAccessory(
+        manager.context
+      ) ?? null
     )
   }
 

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdMobileCommandChrome.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdMobileCommandChrome.ts
@@ -1,4 +1,5 @@
 import { AcApI18n } from '../../../i18n/AcApI18n'
+import type { AcEdSessionAccessory } from '../../command/AcEdSessionAccessory'
 import {
   acedIsMobileOrPadUi,
   acedIsMobileUiLayout,
@@ -52,6 +53,8 @@ export interface AcEdMobileCommandChromeState {
   allowNone: boolean
   /** When false, the metric row is hidden (typed-only numeric prompts). */
   showMetrics: boolean
+  /** Optional widgets mounted at the top of the bottom panel. */
+  accessory?: AcEdSessionAccessory | null
 }
 
 const STYLE_ID = 'ml-mobile-cmd-styles'
@@ -87,7 +90,9 @@ export class AcEdMobileCommandChrome {
   private readonly polarActions: HTMLDivElement
   private readonly deltaActions: HTMLDivElement
   private readonly sharedActions: HTMLDivElement
+  private readonly accessoryEl: HTMLDivElement
   private readonly chipsEl: HTMLDivElement
+  private accessory: AcEdSessionAccessory | null = null
   private readonly cancelBtn: HTMLButtonElement
   private readonly confirmBtn: HTMLButtonElement
   private readonly metricButtons: Record<
@@ -145,6 +150,11 @@ export class AcEdMobileCommandChrome {
     this.deltaStack.className = 'ml-mobile-cmd-metric-stack'
     this.deltaStack.append(this.metricButtons.dx, this.metricButtons.dy)
 
+    this.accessoryEl = document.createElement('div')
+    this.accessoryEl.className = 'ml-mobile-cmd-accessory'
+    this.accessoryEl.hidden = true
+    this.sinkPointer(this.accessoryEl)
+
     this.chipsEl = document.createElement('div')
     this.chipsEl.className = 'ml-mobile-cmd-chips'
 
@@ -194,6 +204,7 @@ export class AcEdMobileCommandChrome {
     this.deltaGroup.append(this.deltaStack, this.deltaActions)
 
     panel.append(
+      this.accessoryEl,
       this.chipsEl,
       this.absGroup,
       this.polarGroup,
@@ -239,6 +250,7 @@ export class AcEdMobileCommandChrome {
     this.host.style.setProperty('--ml-mobile-cmd-prompt-height', '40px')
     this.promptEl.textContent = stripPromptColon(state.prompt)
     this.confirmBtn.disabled = !state.allowNone
+    this.setAccessory(state.accessory ?? null)
     this.renderChips(state.keywords)
     if (this.frozenTexts) {
       this.setMetricTexts(this.frozenTexts, this.frozenHasBasePoint)
@@ -288,6 +300,7 @@ export class AcEdMobileCommandChrome {
   hide(): void {
     this.open = false
     this.callbacks = null
+    this.setAccessory(null)
     this.layoutUnsub?.()
     this.layoutUnsub = undefined
     this.root.hidden = true
@@ -371,6 +384,19 @@ export class AcEdMobileCommandChrome {
     }
   }
 
+  private setAccessory(next: AcEdSessionAccessory | null): void {
+    if ((this.accessory?.id ?? null) === (next?.id ?? null)) return
+    this.accessory?.unmount()
+    this.accessoryEl.replaceChildren()
+    this.accessory = next
+    if (next) {
+      this.accessoryEl.hidden = false
+      next.mount(this.accessoryEl)
+    } else {
+      this.accessoryEl.hidden = true
+    }
+  }
+
   private renderChips(keywords: AcEdMobileKeywordChip[]): void {
     this.chipsEl.replaceChildren()
     this.chipsEl.hidden = keywords.length === 0
@@ -444,11 +470,11 @@ function stripPromptColon(message: string): string {
 }
 
 function cancelIcon(): string {
-  return '<svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path fill="currentColor" d="M18.3 5.71a1 1 0 0 0-1.41 0L12 10.59 7.11 5.7a1 1 0 0 0-1.41 1.42L10.59 12l-4.9 4.89a1 1 0 1 0 1.42 1.42L12 13.41l4.89 4.9a1 1 0 0 0 1.42-1.42L13.41 12l4.9-4.89a1 1 0 0 0-.01-1.4z"/></svg>'
+  return '<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M18.3 5.71a1 1 0 0 0-1.41 0L12 10.59 7.11 5.7a1 1 0 0 0-1.41 1.42L10.59 12l-4.9 4.89a1 1 0 1 0 1.42 1.42L12 13.41l4.89 4.9a1 1 0 0 0 1.42-1.42L13.41 12l4.9-4.89a1 1 0 0 0-.01-1.4z"/></svg>'
 }
 
 function confirmIcon(): string {
-  return '<svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path fill="currentColor" d="M9.55 18.2 3.8 12.45l1.4-1.4 4.35 4.36 9.25-9.26 1.4 1.41z"/></svg>'
+  return '<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M9.55 18.2 3.8 12.45l1.4-1.4 4.35 4.36 9.25-9.26 1.4 1.41z"/></svg>'
 }
 
 const MOBILE_CMD_CSS = `
@@ -564,6 +590,18 @@ const MOBILE_CMD_CSS = `
     font-variant-numeric: tabular-nums;
     font-size: 13px;
   }
+  .ml-mobile-cmd-accessory {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .ml-mobile-cmd-accessory:not([hidden]) {
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--ml-ui-border, rgba(255, 255, 255, 0.12));
+  }
+  .ml-mobile-cmd-accessory[hidden] {
+    display: none;
+  }
   .ml-mobile-cmd-chips {
     display: flex;
     flex-wrap: wrap;
@@ -591,11 +629,11 @@ const MOBILE_CMD_CSS = `
   .ml-mobile-cmd-cancel,
   .ml-mobile-cmd-confirm {
     box-sizing: border-box;
-    flex: 0 0 48px;
+    flex: 0 0 36px;
     align-self: center;
-    margin-block: auto;
-    width: 48px;
-    height: 48px;
+    margin: 0;
+    width: 36px;
+    height: 36px;
     padding: 0;
     border-radius: 50%;
     border: 0;
@@ -609,6 +647,8 @@ const MOBILE_CMD_CSS = `
   .ml-mobile-cmd-cancel svg,
   .ml-mobile-cmd-confirm svg {
     display: block;
+    width: 18px;
+    height: 18px;
   }
   .ml-mobile-cmd-cancel {
     background: #5c6370;
@@ -652,6 +692,12 @@ const MOBILE_CMD_CSS = `
       align-items: center;
       justify-content: center;
     }
+    .ml-mobile-cmd-panel.is-absolute .ml-mobile-cmd-group-abs {
+      align-items: center;
+    }
+    .ml-mobile-cmd-panel.is-absolute .ml-mobile-cmd-actions-shared {
+      align-self: center;
+    }
     .ml-mobile-cmd-panel.is-relative:not([hidden]),
     .ml-mobile-cmd-panel.is-absolute:not([hidden]) {
       display: grid;
@@ -661,12 +707,14 @@ const MOBILE_CMD_CSS = `
     }
     .ml-mobile-cmd-panel.is-relative {
       grid-template-areas:
+        'accessory accessory'
         'chips chips'
         'polar shared'
         'delta shared';
     }
     .ml-mobile-cmd-panel.is-absolute {
       grid-template-areas:
+        'accessory accessory'
         'chips chips'
         'abs shared';
     }
@@ -674,6 +722,7 @@ const MOBILE_CMD_CSS = `
     .ml-mobile-cmd-group-delta { grid-area: delta; }
     .ml-mobile-cmd-group-abs { grid-area: abs; }
     .ml-mobile-cmd-actions-shared { grid-area: shared; }
+    .ml-mobile-cmd-accessory { grid-area: accessory; }
     .ml-mobile-cmd-chips { grid-area: chips; }
     .ml-mobile-cmd-panel.is-relative .ml-mobile-cmd-group-polar {
       padding-bottom: 6px;

--- a/packages/cad-simple-viewer/src/ui/AcApDrawStyle.ts
+++ b/packages/cad-simple-viewer/src/ui/AcApDrawStyle.ts
@@ -1,4 +1,7 @@
+import type { AcApContext } from '../app/AcApContext'
 import { AcApSettingManager } from '../app/AcApSettingManager'
+import type { AcEdSessionAccessory } from '../editor/command/AcEdSessionAccessory'
+import type { AcEdBaseView } from '../editor/view/AcEdBaseView'
 
 /**
  * Kind of drawing session served by the style overlay.
@@ -171,4 +174,49 @@ export function acapSetDrawStyleToolbarVisible(visible: boolean): void {
   if (toolbarVisible === visible) return
   toolbarVisible = visible
   for (const listener of visibilityListeners) listener(visible)
+}
+
+/**
+ * Host that can mount color / font-size controls into the session panel.
+ */
+export interface AcApDrawStyleSessionHost {
+  createSessionAccessory(): AcEdSessionAccessory
+}
+
+const sessionHosts = new WeakMap<object, AcApDrawStyleSessionHost>()
+
+/**
+ * Registers the view's draw-style toolbar as the session-panel accessory host.
+ *
+ * @param view - View whose container hosts the overlay.
+ * @param host - Toolbar that can reparent controls into the session slot.
+ */
+export function acapRegisterDrawStyleSessionHost(
+  view: AcEdBaseView,
+  host: AcApDrawStyleSessionHost
+): void {
+  sessionHosts.set(view, host)
+}
+
+/**
+ * Drops the view's draw-style session host (toolbar dispose).
+ *
+ * @param view - View previously passed to {@link acapRegisterDrawStyleSessionHost}.
+ */
+export function acapUnregisterDrawStyleSessionHost(view: AcEdBaseView): void {
+  sessionHosts.delete(view)
+}
+
+/**
+ * Makes `command.createSessionAccessory` return the view's draw-style controls.
+ *
+ * @param command - Command that should expose color / font-size on phone/pad.
+ */
+export function acapBindDrawStyleSessionAccessory(command: {
+  createSessionAccessory: (
+    context: AcApContext
+  ) => AcEdSessionAccessory | null
+}): void {
+  command.createSessionAccessory = context =>
+    sessionHosts.get(context.view)?.createSessionAccessory() ?? null
 }

--- a/packages/cad-simple-viewer/src/ui/AcApDrawStyleToolbar.ts
+++ b/packages/cad-simple-viewer/src/ui/AcApDrawStyleToolbar.ts
@@ -24,6 +24,7 @@ import {
   subscribeMeasurementSelection
 } from '../command/measure/AcApMeasurementStore'
 import type { AcEdCommandEventArgs } from '../editor'
+import type { AcEdSessionAccessory } from '../editor/command/AcEdSessionAccessory'
 import { acedApplyUiTheme, resolveUiTheme } from '../editor/global/AcEdUiTheme'
 import { AcApI18n } from '../i18n'
 import {
@@ -38,9 +39,11 @@ import type { AcTrView2d } from '../view'
 import {
   type AcApDrawStyleKind,
   acapDrawStyleKindForCommand,
+  acapRegisterDrawStyleSessionHost,
   acapResolveDrawStyleKind,
   acapSetDrawStyleToolbarVisible,
-  acapShouldShowDrawStyleToolbar
+  acapShouldShowDrawStyleToolbar,
+  acapUnregisterDrawStyleSessionHost
 } from './AcApDrawStyle'
 
 /** Font-size choices shown in the overlay dropdown, in CSS pixels. */
@@ -71,6 +74,11 @@ const TOOLBAR_CSS = `
     }
     .ml-draw-style-toolbar.is-visible {
       display: inline-flex;
+    }
+    .ml-draw-style-toolbar__controls {
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
     .ml-draw-style-toolbar__swatch {
       position: relative;
@@ -119,6 +127,10 @@ const TOOLBAR_CSS = `
     }
     .ml-draw-style-toolbar__color-panel.is-open {
       display: block;
+    }
+    .ml-draw-style-toolbar__color-panel--drop-up {
+      top: auto;
+      bottom: calc(100% + 6px);
     }
     .ml-draw-style-toolbar__aci-large {
       display: grid;
@@ -235,6 +247,12 @@ export class AcApDrawStyleToolbar {
   /** Dropdown of font sizes in CSS pixels. */
   private readonly fontSizeSelect: HTMLSelectElement
 
+  /** Color swatch + font-size row; reparented into the session panel. */
+  private readonly controlsRow: HTMLDivElement
+
+  /** True while controls live in the phone/pad session accessory slot. */
+  private sessionMounted = false
+
   /** Active overlay session, or `undefined` when hidden. */
   private kind: AcApDrawStyleKind | undefined
 
@@ -304,11 +322,14 @@ export class AcApDrawStyleToolbar {
     )
     this.colorWrap.appendChild(this.swatch)
     this.colorWrap.appendChild(this.colorPanel)
-    this.root.appendChild(this.colorWrap)
 
     this.fontSizeSelect = document.createElement('select')
     this.fontSizeSelect.className = 'ml-draw-style-toolbar__select'
-    this.root.appendChild(this.fontSizeSelect)
+
+    this.controlsRow = document.createElement('div')
+    this.controlsRow.className = 'ml-draw-style-toolbar__controls'
+    this.controlsRow.append(this.colorWrap, this.fontSizeSelect)
+    this.root.appendChild(this.controlsRow)
 
     this.swatch.addEventListener('click', event => {
       event.preventDefault()
@@ -328,6 +349,12 @@ export class AcApDrawStyleToolbar {
     })
     this.root.addEventListener('pointerdown', event => event.stopPropagation())
     this.root.addEventListener('mousedown', event => event.stopPropagation())
+    this.controlsRow.addEventListener('pointerdown', event =>
+      event.stopPropagation()
+    )
+    this.controlsRow.addEventListener('mousedown', event =>
+      event.stopPropagation()
+    )
     this.onDocumentPointerDown = event => {
       const target = event.target as Node | null
       const inColor = !!target && this.colorWrap.contains(target)
@@ -354,6 +381,7 @@ export class AcApDrawStyleToolbar {
       host.style.position = 'relative'
     }
     host.appendChild(this.root)
+    acapRegisterDrawStyleSessionHost(view, this)
 
     view.editor.events.commandWillStart.addEventListener(
       this.onCommandWillStart
@@ -395,8 +423,50 @@ export class AcApDrawStyleToolbar {
     )
     this.unsubscribeMarkupStore()
     this.unsubscribeMeasurementSelection()
+    this.unmountSession()
+    acapUnregisterDrawStyleSessionHost(this.view)
     this.root.remove()
     acapSetDrawStyleToolbarVisible(false)
+  }
+
+  /**
+   * Color / font-size controls for the phone/pad session panel.
+   *
+   * @returns Accessory that reparents {@link controlsRow} into the slot.
+   */
+  createSessionAccessory(): AcEdSessionAccessory {
+    return {
+      id: 'draw-style',
+      mount: host => this.mountSession(host),
+      unmount: () => this.unmountSession()
+    }
+  }
+
+  /**
+   * Moves the controls into the session panel and hides the canvas overlay.
+   *
+   * @param host - Accessory row in the bottom session panel.
+   */
+  private mountSession(host: HTMLElement): void {
+    this.sessionMounted = true
+    this.colorPanel.classList.add('ml-draw-style-toolbar__color-panel--drop-up')
+    host.appendChild(this.controlsRow)
+    this.refreshVisibility()
+    this.syncFromSession()
+  }
+
+  /**
+   * Restores the controls to the canvas overlay.
+   */
+  private unmountSession(): void {
+    if (!this.sessionMounted) return
+    this.sessionMounted = false
+    this.hideColorPanel()
+    this.colorPanel.classList.remove(
+      'ml-draw-style-toolbar__color-panel--drop-up'
+    )
+    this.root.appendChild(this.controlsRow)
+    this.refreshVisibility()
   }
 
   /**
@@ -413,12 +483,16 @@ export class AcApDrawStyleToolbar {
 
   /**
    * Shows or hides the overlay based on {@link acapShouldShowDrawStyleToolbar}.
+   * Hidden while the same controls are mounted in the session panel.
    */
   private refreshVisibility(): void {
-    const visible = acapShouldShowDrawStyleToolbar(this.kind)
+    const visible =
+      acapShouldShowDrawStyleToolbar(this.kind) && !this.sessionMounted
     this.root.classList.toggle('is-visible', visible)
-    acapSetDrawStyleToolbarVisible(visible)
-    if (visible) {
+    acapSetDrawStyleToolbarVisible(
+      visible || (this.sessionMounted && this.kind != null)
+    )
+    if (visible || this.sessionMounted) {
       this.relabel()
       this.syncFromSession()
     } else {


### PR DESCRIPTION
## Summary
- Move measure/markup color and font-size from the canvas overlay into the phone/pad and offline HTML session panel
- Shrink session confirm/cancel to 36px and add the compact (pad) layout breakpoint
- Mark the command active before `trigger()` so the first prompt can mount the accessory (single-step tools such as measure point and markup text)

## Test plan
- [ ] On phone/pad, start measure point and markup text: color and font-size appear on the first prompt
- [ ] On phone/pad, start measure distance: accessory stays mounted across subsequent points
- [ ] Change color/font during a live measure/markup and confirm overlays update
- [ ] Offline HTML viewer: session panel shows the same controls, not a canvas overlay
- [ ] Desktop layout is unchanged (no session accessory)