### PR TITLE
fix: correct ACI loupe Y offset and bump ribbon to 0.1.13

### DIFF
--- a/packages/cad-simple-viewer/src/ui/AcApAciPaletteUi.ts
+++ b/packages/cad-simple-viewer/src/ui/AcApAciPaletteUi.ts
@@ -380,7 +380,7 @@ function bindAciCellLoupe(
     loupeSwatch.style.background = acuiAciCssColor(index)
     loupeLabel.textContent = String(index)
     loupe.style.left = `${clientX}px`
-    loupe.style.top = `${clientY - LOUPE_OFFSET_Y_PX + LOUPE_SIZE_PX}px`
+    loupe.style.top = `${clientY - LOUPE_OFFSET_Y_PX}px`
     loupe.classList.add('is-visible')
     loupeActive = true
   }
@@ -393,7 +393,7 @@ function bindAciCellLoupe(
     }
     if (previewCell) {
       loupe.style.left = `${clientX}px`
-      loupe.style.top = `${clientY - LOUPE_OFFSET_Y_PX + LOUPE_SIZE_PX}px`
+      loupe.style.top = `${clientY - LOUPE_OFFSET_Y_PX}px`
     }
   }
 

--- a/packages/cad-viewer/package.json
+++ b/packages/cad-viewer/package.json
@@ -49,7 +49,7 @@
     "@mlightcad/cad-svg-plugin": "workspace:*",
     "@mlightcad/cad-simple-viewer": "workspace:*",
     "@mlightcad/data-model": "^1.14.3",
-    "@mlightcad/ribbon": "^0.1.12",
+    "@mlightcad/ribbon": "^0.1.13",
     "@mlightcad/three-renderer": "workspace:*",
     "@mlightcad/three-viewcube": "0.0.9",
     "@mlightcad/ui-components": "^0.1.11",

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -1882,8 +1882,6 @@ const buildBaseTabs = (
           id: 'home-layer',
           title: t('main.ribbon.group.layer'),
           orientation: 'row',
-          enableGroupOverflow: true,
-          priority: 90,
           collections: [
             {
               id: 'home-layer-button',
@@ -2016,7 +2014,6 @@ const buildBaseTabs = (
           id: 'home-properties',
           title: t('main.ribbon.group.properties'),
           orientation: 'row',
-          priority: 20,
           collections: [
             {
               id: 'home-properties-button',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@mlightcad/libredwg-converter': ^3.14.3
   '@mlightcad/mtext-input-box': ^0.2.23
   '@mlightcad/mtext-renderer': ^0.12.4
-  '@mlightcad/ribbon': ^0.1.12
+  '@mlightcad/ribbon': ^0.1.13
   '@mlightcad/ui-components': ^0.1.11
   element-plus: ^2.12.0
   glob: ^13.0.6
@@ -404,8 +404,8 @@ importers:
         specifier: ^1.14.3
         version: 1.14.3
       '@mlightcad/ribbon':
-        specifier: ^0.1.12
-        version: 0.1.12(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+        specifier: ^0.1.13
+        version: 0.1.13(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -1852,8 +1852,8 @@ packages:
     peerDependencies:
       three: ^0.172.0
 
-  '@mlightcad/ribbon@0.1.12':
-    resolution: {integrity: sha512-7F88Rfu6zLSBUyPSFXl5a46sH2yZiSLXaZArfCSKjvuBszVKRwgvs7B2kqVLL/jwwarJPdJ1f5Z/dXoCKMCQBg==}
+  '@mlightcad/ribbon@0.1.13':
+    resolution: {integrity: sha512-NdGbI91HCvEDDIsVLZ/tfqMFZqazGZ1nSkQqW2XZHenGce6Rz4ecEkN1pyzxQWYZNtyrAF9xcJSjQTkiHJOmlQ==}
     peerDependencies:
       '@element-plus/icons-vue': ^2.3.2
       element-plus: ^2.12.0
@@ -7285,7 +7285,7 @@ snapshots:
       opentype.js: 2.0.0
       three: 0.172.0
 
-  '@mlightcad/ribbon@0.1.12(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
+  '@mlightcad/ribbon@0.1.13(@element-plus/icons-vue@2.3.2(vue@3.5.31(typescript@5.9.3)))(element-plus@2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@element-plus/icons-vue': 2.3.2(vue@3.5.31(typescript@5.9.3))
       element-plus: 2.13.6(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ overrides:
   '@mlightcad/libredwg-converter': '^3.14.3'
   '@mlightcad/mtext-input-box': '^0.2.23'
   '@mlightcad/mtext-renderer': '^0.12.4'
-  '@mlightcad/ribbon': '^0.1.12'
+  '@mlightcad/ribbon': '^0.1.13'
   '@mlightcad/ui-components': '^0.1.11'
   element-plus: '^2.12.0'
   glob: '^13.0.6'


### PR DESCRIPTION
## Summary
- Fix ACI color-palette loupe vertical placement: with `transform: translate(-50%, -100%)`, stop adding `LOUPE_SIZE_PX` so the loupe sits above the pointer as intended.
- Bump `@mlightcad/ribbon` from 0.1.12 to 0.1.13 (package, workspace override, lockfile).
- Drop obsolete ribbon group `enableGroupOverflow` / `priority` on Home Layer and Properties groups to match the new ribbon defaults.

## Test plan
- [ ] Long-press an ACI swatch (touch/mouse): loupe appears above the finger/cursor, not overlapping it
- [ ] Drag across ACI cells while loupe is visible: position tracks correctly
- [ ] Ribbon Home tab: Layer and Properties groups layout/overflow look correct after ribbon 0.1.13
- [ ] App builds and ribbon commands still work
