### PR TITLE
refactor: replace drawStyleSessionHost with sessionProviders registry

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApDrawCmdBase.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDrawCmdBase.spec.ts
@@ -41,11 +41,15 @@ describe('AcApMeasureDrawCmd', () => {
       unmount: jest.fn()
     }
     const setActiveKind = jest.fn()
+    const host = {
+      setActiveKind,
+      createSessionAccessory: () => accessory
+    }
+    const providers = new Map<string, unknown>([['draw-style', host]])
     const view = {
       container,
-      drawStyleSessionHost: {
-        setActiveKind,
-        createSessionAccessory: () => accessory
+      sessionProviders: {
+        get: <T,>(id: string) => providers.get(id) as T | undefined
       }
     }
     const cmd = new MeasureDrawStub()
@@ -91,11 +95,15 @@ describe('AcApMarkupDrawCmd', () => {
       unmount: jest.fn()
     }
     const setActiveKind = jest.fn()
+    const host = {
+      setActiveKind,
+      createSessionAccessory: () => accessory
+    }
+    const providers = new Map<string, unknown>([['draw-style', host]])
     const view = {
       container,
-      drawStyleSessionHost: {
-        setActiveKind,
-        createSessionAccessory: () => accessory
+      sessionProviders: {
+        get: <T,>(id: string) => providers.get(id) as T | undefined
       }
     }
     const cmd = new MarkupDrawStub()

--- a/packages/cad-simple-viewer/__tests__/AcUiDrawStyle.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcUiDrawStyle.spec.ts
@@ -202,13 +202,6 @@ describe('isMarkupDoublePointer', () => {
 describe('acuiBindDrawStyleSessionAccessory', () => {
   it('assigns a draw-style sessionAccessory that mounts the view host', () => {
     const container = { parentElement: null } as unknown as HTMLElement
-    const view = {
-      container,
-      drawStyleSessionHost: null as null | {
-        setActiveKind: jest.Mock
-        createSessionAccessory: () => typeof accessory
-      }
-    }
     const accessory = {
       id: 'draw-style',
       mount: jest.fn(),
@@ -219,8 +212,18 @@ describe('acuiBindDrawStyleSessionAccessory', () => {
       setActiveKind,
       createSessionAccessory: () => accessory
     }
-    view.drawStyleSessionHost = host
-    expect(view.drawStyleSessionHost).toBe(host)
+    const providers = new Map<string, unknown>()
+    const view = {
+      container,
+      sessionProviders: {
+        get: <T,>(id: string) => providers.get(id) as T | undefined,
+        set: (id: string, value: unknown) => {
+          providers.set(id, value)
+        },
+        delete: (id: string) => providers.delete(id)
+      }
+    }
+    view.sessionProviders.set('draw-style', host)
     const command = {
       globalName: 'measuredistance',
       sessionAccessory: null as null | typeof accessory
@@ -234,7 +237,7 @@ describe('acuiBindDrawStyleSessionAccessory', () => {
     })
     expect(setActiveKind).toHaveBeenCalledWith('measure')
     expect(accessory.mount).toHaveBeenCalled()
-    view.drawStyleSessionHost = null
+    view.sessionProviders.delete('draw-style')
     expect(() =>
       command.sessionAccessory!.mount({
         host: container,

--- a/packages/cad-simple-viewer/src/command/AcApInstallDrawStyleSessionAccessory.ts
+++ b/packages/cad-simple-viewer/src/command/AcApInstallDrawStyleSessionAccessory.ts
@@ -4,6 +4,10 @@ import {
 } from '../app/AcApSettingManager'
 import type { AcEdCommandStack } from '../editor/command/AcEdCommandStack'
 import {
+  ACED_DRAW_STYLE_SESSION_PROVIDER_ID,
+  type AcEdDrawStyleSessionHost
+} from '../editor/command/AcEdSessionAccessory'
+import {
   type AcUiDrawStyleKind,
   acuiResolveDrawStyleKind,
   acuiShouldShowDrawStyleToolbar
@@ -18,21 +22,12 @@ import {
   subscribeMeasurementSelection
 } from './measure/AcApMeasurementStore'
 
-/** Per-view install record kept in {@link installs}. */
-interface DrawStyleInstallRecord {
-  /** Draw-style controls host for the view. */
-  host: AcUiDrawStyleSessionAccessory
-  /** Tears down selection sync subscriptions. */
-  unsubscribe: () => void
-}
-
-/** Weak map of views to their one-time draw-style install records. */
-const installs = new WeakMap<object, DrawStyleInstallRecord>()
-
 /**
  * Registers draw-style controls and selection-driven session accessory for a view.
  *
  * Idempotent: safe to call from both measure and markup command registration.
+ * The provider is stored on {@link AcEdBaseView.sessionProviders} under
+ * {@link ACED_DRAW_STYLE_SESSION_PROVIDER_ID}.
  *
  * @param ctx - View and command stack for this document.
  * @returns The view's draw-style session accessory host.
@@ -40,21 +35,21 @@ const installs = new WeakMap<object, DrawStyleInstallRecord>()
 export function acapInstallDrawStyleSessionAccessory(
   ctx: AcApDrawStyleSessionInstallContext
 ): AcUiDrawStyleSessionAccessory {
-  const existing = installs.get(ctx.view)
-  if (existing) return existing.host
+  const existing = ctx.view.sessionProviders.get<AcUiDrawStyleSessionAccessory>(
+    ACED_DRAW_STYLE_SESSION_PROVIDER_ID
+  )
+  if (existing) return existing
 
   const host = new AcUiDrawStyleSessionAccessory(ctx.view)
-  const unsubscribe = bindSelectionSessionAccessory(
-    ctx.view,
-    ctx.commandManager,
-    host
+  host.setSelectionUnsubscribe(
+    bindSelectionSessionAccessory(ctx.view, ctx.commandManager, host)
   )
-  installs.set(ctx.view, { host, unsubscribe })
+  ctx.view.sessionProviders.set(ACED_DRAW_STYLE_SESSION_PROVIDER_ID, host)
   return host
 }
 
 /**
- * Returns the draw-style session accessory installed for a view, if any.
+ * Returns the draw-style session provider installed for a view, if any.
  *
  * @param view - View passed to {@link acapInstallDrawStyleSessionAccessory}.
  * @returns The installed host, or `undefined` when not yet installed.
@@ -62,7 +57,9 @@ export function acapInstallDrawStyleSessionAccessory(
 export function acapGetDrawStyleSessionAccessory(
   view: AcTrView2d
 ): AcUiDrawStyleSessionAccessory | undefined {
-  return installs.get(view)?.host
+  return view.sessionProviders.get<AcUiDrawStyleSessionAccessory>(
+    ACED_DRAW_STYLE_SESSION_PROVIDER_ID
+  )
 }
 
 /**
@@ -77,7 +74,7 @@ export function acapGetDrawStyleSessionAccessory(
 function bindSelectionSessionAccessory(
   view: AcTrView2d,
   commandManager: AcEdCommandStack,
-  host: AcUiDrawStyleSessionAccessory
+  host: AcEdDrawStyleSessionHost
 ): () => void {
   const accessory = host.createSessionAccessory()
 

--- a/packages/cad-simple-viewer/src/editor/command/AcEdSessionAccessory.ts
+++ b/packages/cad-simple-viewer/src/editor/command/AcEdSessionAccessory.ts
@@ -33,7 +33,19 @@ export interface AcEdSessionAccessoryHostInfo {
 }
 
 /**
- * Optional draw-style controls host attached to a view for session accessories.
+ * Registry id for the draw-style session provider on a view.
+ *
+ * @see {@link AcEdDrawStyleSessionHost}
+ * @see {@link AcEdSessionProviderRegistry}
+ */
+export const ACED_DRAW_STYLE_SESSION_PROVIDER_ID = 'draw-style'
+
+/**
+ * Draw-style controls provider registered under
+ * {@link ACED_DRAW_STYLE_SESSION_PROVIDER_ID}.
+ *
+ * Long-lived owner of color / font-size controls; mints mountable session
+ * accessories via {@link createSessionAccessory}.
  */
 export interface AcEdDrawStyleSessionHost {
   /**

--- a/packages/cad-simple-viewer/src/editor/command/AcEdSessionProviderRegistry.ts
+++ b/packages/cad-simple-viewer/src/editor/command/AcEdSessionProviderRegistry.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-view registry of long-lived session UI providers.
+ *
+ * A provider is not a mounted {@link AcEdSessionAccessory}; it is the object
+ * that owns controls and can mint accessories (for example draw-style color /
+ * font-size UI). Multiple features register under stable string ids.
+ */
+
+/**
+ * Map of session provider id → provider instance for one view.
+ */
+export class AcEdSessionProviderRegistry {
+  /** Installed providers keyed by stable id. */
+  private readonly providers = new Map<string, unknown>()
+
+  /**
+   * Registers or replaces a provider.
+   *
+   * @param id - Stable provider id (e.g. {@link ACED_DRAW_STYLE_SESSION_PROVIDER_ID}).
+   * @param provider - Provider instance.
+   */
+  set(id: string, provider: unknown): void {
+    this.providers.set(id, provider)
+  }
+
+  /**
+   * Returns the provider for {@link id}, if registered.
+   *
+   * @param id - Stable provider id.
+   * @returns The provider cast to {@link T}, or `undefined`.
+   */
+  get<T>(id: string): T | undefined {
+    return this.providers.get(id) as T | undefined
+  }
+
+  /**
+   * Whether a provider is registered under {@link id}.
+   *
+   * @param id - Stable provider id.
+   */
+  has(id: string): boolean {
+    return this.providers.has(id)
+  }
+
+  /**
+   * Removes the provider registered under {@link id}.
+   *
+   * @param id - Stable provider id.
+   * @returns `true` when an entry was removed.
+   */
+  delete(id: string): boolean {
+    return this.providers.delete(id)
+  }
+}

--- a/packages/cad-simple-viewer/src/editor/command/index.ts
+++ b/packages/cad-simple-viewer/src/editor/command/index.ts
@@ -8,4 +8,6 @@ export type {
   AcEdSessionAccessoryOptions,
   AcEdSessionAccessorySlot
 } from './AcEdSessionAccessory'
+export { ACED_DRAW_STYLE_SESSION_PROVIDER_ID } from './AcEdSessionAccessory'
+export { AcEdSessionProviderRegistry } from './AcEdSessionProviderRegistry'
 export { AcEdSessionAccessoryMountSkippedError } from './AcEdCommand'

--- a/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
@@ -15,10 +15,10 @@ import { debounce } from 'lodash-es'
 
 import type { AcTrSpatialSearchOptions } from '../../spatialIndex/AcTrSpatialIndex'
 import type {
-  AcEdDrawStyleSessionHost,
   AcEdSessionAccessory,
   AcEdSessionAccessoryHostInfo
 } from '../command/AcEdSessionAccessory'
+import { AcEdSessionProviderRegistry } from '../command/AcEdSessionProviderRegistry'
 import { AcEdCorsorType, AcEdSelectionSet } from '../input'
 import { AcEditor } from '../input/AcEditor'
 import { AcEdOsnapResolver } from '../input/AcEdOsnapResolver'
@@ -283,8 +283,11 @@ export abstract class AcEdBaseView {
   /** The HTML element to contain this view */
   protected _container: HTMLElement
 
-  /** Optional draw-style session accessory host for measure/markup UI. */
-  private _drawStyleSessionHost: AcEdDrawStyleSessionHost | null = null
+  /**
+   * Long-lived session UI providers for this view (draw-style, etc.).
+   * Feature installs register here; mountable accessories are minted on demand.
+   */
+  readonly sessionProviders = new AcEdSessionProviderRegistry()
 
   /** Events fired by the view for various interactions */
   public readonly events = {
@@ -403,23 +406,6 @@ export abstract class AcEdBaseView {
    */
   set selectionSessionAccessory(value: AcEdSessionAccessory | null) {
     this._editor.inputManager.selectionSessionAccessory = value
-  }
-
-  /**
-   * Draw-style controls host used by measure/markup session accessories.
-   * Set by draw-style install; cleared on dispose/unregister.
-   */
-  get drawStyleSessionHost(): AcEdDrawStyleSessionHost | null {
-    return this._drawStyleSessionHost
-  }
-
-  /**
-   * Registers or clears the draw-style session controls host for this view.
-   *
-   * @param value - Host instance, or `null` when disposed.
-   */
-  set drawStyleSessionHost(value: AcEdDrawStyleSessionHost | null) {
-    this._drawStyleSessionHost = value
   }
 
   /**

--- a/packages/cad-simple-viewer/src/ui/AcUiDrawStyle.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiDrawStyle.ts
@@ -1,8 +1,10 @@
 import { AcApSettingManager } from '../app/AcApSettingManager'
 import { AcEdSessionAccessoryMountSkippedError } from '../editor/command/AcEdCommand'
-import type {
-  AcEdSessionAccessory,
-  AcEdSessionAccessoryOptions
+import {
+  ACED_DRAW_STYLE_SESSION_PROVIDER_ID,
+  type AcEdDrawStyleSessionHost,
+  type AcEdSessionAccessory,
+  type AcEdSessionAccessoryOptions
 } from '../editor/command/AcEdSessionAccessory'
 import {
   type AcApDrawStyleKind,
@@ -93,7 +95,9 @@ export function acuiBindDrawStyleSessionAccessory(command: {
      *   desktop ribbon already covers the same UI.
      */
     mount(options: AcEdSessionAccessoryOptions) {
-      const host = options.view.drawStyleSessionHost
+      const host = options.view.sessionProviders.get<AcEdDrawStyleSessionHost>(
+        ACED_DRAW_STYLE_SESSION_PROVIDER_ID
+      )
       if (!host) {
         throw new AcEdSessionAccessoryMountSkippedError()
       }

--- a/packages/cad-simple-viewer/src/ui/AcUiDrawStyleSessionAccessory.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiDrawStyleSessionAccessory.ts
@@ -17,7 +17,10 @@ import {
   applyMeasurementStyleToSelection,
   getActiveMeasurementStyle
 } from '../command/measure/AcApMeasurementStore'
-import type { AcEdSessionAccessory } from '../editor/command/AcEdSessionAccessory'
+import {
+  ACED_DRAW_STYLE_SESSION_PROVIDER_ID,
+  type AcEdSessionAccessory
+} from '../editor/command/AcEdSessionAccessory'
 import { acedApplyUiTheme, resolveUiTheme } from '../editor/global/AcEdUiTheme'
 import { AcApI18n } from '../i18n'
 import {
@@ -191,8 +194,12 @@ export class AcUiDrawStyleSessionAccessory {
   /** Closes the palette when the user clicks outside the color control. */
   private readonly onDocumentPointerDown: (event: PointerEvent) => void
 
+  /** Tears down selection-sync subscriptions registered by install. */
+  private selectionUnsubscribe: (() => void) | null = null
+
   /**
-   * Creates controls, registers as the view's draw-style session host, and wires events.
+   * Creates controls and wires events. Install registers this on
+   * {@link AcEdBaseView.sessionProviders}.
    *
    * @param view - 2D view whose container supplies theme and dialog placement.
    */
@@ -266,8 +273,16 @@ export class AcUiDrawStyleSessionAccessory {
     }
     document.addEventListener('pointerdown', this.onDocumentPointerDown, true)
 
-    this.view.drawStyleSessionHost = this
     this.relabel()
+  }
+
+  /**
+   * Stores selection-sync cleanup from install; run from {@link dispose}.
+   *
+   * @param unsubscribe - Cleanup returned by selection binding.
+   */
+  setSelectionUnsubscribe(unsubscribe: () => void): void {
+    this.selectionUnsubscribe = unsubscribe
   }
 
   /**
@@ -282,7 +297,7 @@ export class AcUiDrawStyleSessionAccessory {
     }
   }
 
-  /** Removes listeners, unmounts controls, and clears the view session host. */
+  /** Removes listeners, unmounts controls, and clears the session provider. */
   dispose(): void {
     this.hideColorPanel()
     document.removeEventListener(
@@ -291,8 +306,13 @@ export class AcUiDrawStyleSessionAccessory {
       true
     )
     this.unmount()
-    if (this.view.drawStyleSessionHost === this) {
-      this.view.drawStyleSessionHost = null
+    this.selectionUnsubscribe?.()
+    this.selectionUnsubscribe = null
+    if (
+      this.view.sessionProviders.get(ACED_DRAW_STYLE_SESSION_PROVIDER_ID) ===
+      this
+    ) {
+      this.view.sessionProviders.delete(ACED_DRAW_STYLE_SESSION_PROVIDER_ID)
     }
     this.aciStacks.dispose()
   }


### PR DESCRIPTION
## Summary
- Replace view-specific `drawStyleSessionHost` with a generic `AcEdSessionProviderRegistry` on `AcEdBaseView.sessionProviders`.
- Register draw-style controls under `ACED_DRAW_STYLE_SESSION_PROVIDER_ID` and move selection-sync unsubscribe onto the provider dispose path.
- Update draw-style bind/install helpers and unit tests to use the registry API.

## Test plan
- [ ] Measure / markup draw commands still mount color and font-size session controls on desktop.
- [ ] Selecting a measurement or markup on desktop still shows the draw-style accessory; mobile still hides selection-driven accessory.
- [ ] Disposing the draw-style provider clears the registry entry and tears down selection subscriptions.
- [ ] Related unit tests: `AcApDrawCmdBase`, `AcUiDrawStyle`.