### PR TITLE
feat: convert measurement length and area labels to a selected unit

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementUnits.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementUnits.spec.ts
@@ -1,4 +1,5 @@
 import type { AcDbDatabase } from '@mlightcad/data-model'
+import { AcDbLinearUnits } from '@mlightcad/data-model'
 
 import {
   formatMeasurementAngle,
@@ -12,13 +13,16 @@ import {
   setMeasurementUnitOverride
 } from '../src/util/AcApMeasurementUnits'
 
-function mockDb(): AcDbDatabase {
+function mockDb(options?: {
+  insunits?: number
+  lunits?: number
+}): AcDbDatabase {
   const db = {
-    _lunits: 2,
+    _lunits: options?.lunits ?? 2,
     _luprec: 4,
     _aunits: 0,
     _auprec: 0,
-    insunits: 4,
+    insunits: options?.insunits ?? 4,
     get lunits() {
       return this._lunits
     },
@@ -33,8 +37,12 @@ function mockDb(): AcDbDatabase {
     },
     formatter: {
       formatLength(value: number, options?: { showUnits?: boolean }) {
-        // insunits = 4 is millimeters, mirroring the real formatter's suffix.
-        const suffix = options?.showUnits === false ? '' : ' mm'
+        const suffix =
+          options?.showUnits === false
+            ? ''
+            : db.insunits === 4
+              ? ' mm'
+              : ''
         return `L${Number(value).toFixed(db._luprec)}:${db._lunits}${suffix}`
       },
       formatAngle(radians: number) {
@@ -125,5 +133,38 @@ describe('AcApMeasurementUnits', () => {
     })
 
     expect(formatMeasurementArea(db, 3125000)).toBe('L3125000.0000:2 mm²')
+  })
+
+  it('skips conversion when drawing INSUNITS is undefined (0)', () => {
+    const db = mockDb({ insunits: 0 })
+    setMeasurementUnitOverride({ lengthUnit: 6 })
+
+    expect(formatMeasurementLength(db, 1000)).toBe('L1000.0000:2')
+    expect(formatMeasurementArea(db, 1000)).toBe('L1000.0000:2²')
+  })
+
+  it('uses decimal length format when converting with architectural LUNITS', () => {
+    const db = mockDb({ lunits: AcDbLinearUnits.Architectural })
+    setMeasurementUnitOverride({ lengthUnit: 6 })
+
+    expect(formatMeasurementLength(db, 1000)).toBe('L1.0000:2 m')
+  })
+
+  it('converts from feet drawing units to millimeters', () => {
+    const db = mockDb({ insunits: 2 })
+    setMeasurementUnitOverride({ lengthUnit: 4 })
+
+    expect(formatMeasurementLength(db, 1)).toBe('L304.8000:2 mm')
+  })
+
+  it('restores follow-drawing length unit after reset', () => {
+    const db = mockDb()
+    setMeasurementUnitOverride({ lengthUnit: 6 })
+    resetMeasurementUnitOverride()
+
+    expect(getEffectiveMeasurementUnits(db).lengthUnit).toBe(
+      MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
+    )
+    expect(formatMeasurementLength(db, 1000)).toBe('L1000.0000:2 mm')
   })
 })

--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementUnits.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementUnits.spec.ts
@@ -2,10 +2,12 @@ import type { AcDbDatabase } from '@mlightcad/data-model'
 
 import {
   formatMeasurementAngle,
+  formatMeasurementArea,
   formatMeasurementLength,
   formatMeasurementValue,
   getEffectiveMeasurementUnits,
   getMeasurementUnitOverride,
+  MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING,
   resetMeasurementUnitOverride,
   setMeasurementUnitOverride
 } from '../src/util/AcApMeasurementUnits'
@@ -16,6 +18,7 @@ function mockDb(): AcDbDatabase {
     _luprec: 4,
     _aunits: 0,
     _auprec: 0,
+    insunits: 4,
     get lunits() {
       return this._lunits
     },
@@ -29,8 +32,10 @@ function mockDb(): AcDbDatabase {
       return this._auprec
     },
     formatter: {
-      formatLength(value: number) {
-        return `L${Number(value).toFixed(db._luprec)}:${db._lunits}`
+      formatLength(value: number, options?: { showUnits?: boolean }) {
+        // insunits = 4 is millimeters, mirroring the real formatter's suffix.
+        const suffix = options?.showUnits === false ? '' : ' mm'
+        return `L${Number(value).toFixed(db._luprec)}:${db._lunits}${suffix}`
       },
       formatAngle(radians: number) {
         return `A${radians}:${db._aunits}:${db._auprec}`
@@ -51,7 +56,8 @@ describe('AcApMeasurementUnits', () => {
       lunits: 2,
       luprec: 4,
       aunits: 0,
-      auprec: 0
+      auprec: 0,
+      lengthUnit: MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
     })
 
     setMeasurementUnitOverride({ luprec: 2, aunits: 3 })
@@ -59,7 +65,8 @@ describe('AcApMeasurementUnits', () => {
       lunits: 2,
       luprec: 2,
       aunits: 3,
-      auprec: 0
+      auprec: 0,
+      lengthUnit: MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
     })
     expect(getMeasurementUnitOverride()).toEqual({ luprec: 2, aunits: 3 })
   })
@@ -68,7 +75,7 @@ describe('AcApMeasurementUnits', () => {
     const db = mockDb()
     setMeasurementUnitOverride({ lunits: 1, luprec: 1 })
 
-    expect(formatMeasurementLength(db, 12.3456)).toBe('L12.3:1')
+    expect(formatMeasurementLength(db, 12.3456)).toBe('L12.3:1 mm')
     expect(db.lunits).toBe(2)
     expect(db.luprec).toBe(4)
   })
@@ -79,10 +86,44 @@ describe('AcApMeasurementUnits', () => {
 
     expect(formatMeasurementAngle(db, 1.5)).toBe('A1.5:1:2')
     expect(formatMeasurementValue(db, { kind: 'area', value: 10 })).toBe(
-      'L10.0:2²'
+      'L10.0:2 mm²'
     )
     expect(
       formatMeasurementValue(db, { kind: 'coordinate', x: 1, y: 2 })
-    ).toBe('X L1.0:2  Y L2.0:2')
+    ).toBe('X L1.0:2 mm  Y L2.0:2 mm')
+  })
+
+  it('converts length to the selected unit and appends its symbol', () => {
+    const db = mockDb() // insunits = 4 (millimeters)
+    setMeasurementUnitOverride({ lengthUnit: 6 }) // meters
+
+    expect(formatMeasurementLength(db, 1000)).toBe('L1.0000:2 m')
+    expect(db.insunits).toBe(4)
+  })
+
+  it('follows drawing units for the follow-drawing sentinel', () => {
+    const db = mockDb()
+    setMeasurementUnitOverride({
+      lengthUnit: MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
+    })
+
+    expect(formatMeasurementLength(db, 1000)).toBe('L1000.0000:2 mm')
+  })
+
+  it('converts area by the square of the selected length unit', () => {
+    const db = mockDb() // insunits = 4 (millimeters)
+    setMeasurementUnitOverride({ lengthUnit: 6 }) // meters
+
+    expect(formatMeasurementArea(db, 3125000)).toBe('L3.1250:2 m²')
+    expect(db.insunits).toBe(4)
+  })
+
+  it('keeps area in drawing units for the follow-drawing sentinel', () => {
+    const db = mockDb()
+    setMeasurementUnitOverride({
+      lengthUnit: MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
+    })
+
+    expect(formatMeasurementArea(db, 3125000)).toBe('L3125000.0000:2 mm²')
   })
 })

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasureAreaCmd.ts
@@ -16,7 +16,7 @@ import {
   acapGetMeasurementColor,
   acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
-  formatMeasurementLength
+  formatMeasurementArea
 } from '../../util'
 import { AcTrView2d } from '../../view'
 import {
@@ -270,7 +270,7 @@ export class AcApMeasureAreaCmd extends AcApMeasureDrawCmd {
               }
               const tempPts = [...points, cursor]
               const area = shoelaceArea(tempPts)
-              liveBadge.setText(`${formatMeasurementLength(db, area)}²`)
+              liveBadge.setText(formatMeasurementArea(db, area))
               liveBadge.setPosition(centroid(tempPts))
               liveBadge.object.visible = true
               drawPolygon(cursor)

--- a/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureAreaEntity.ts
+++ b/packages/cad-simple-viewer/src/command/measure/entity/AcApMeasureAreaEntity.ts
@@ -8,7 +8,7 @@ import {
 import {
   acapMeasurementCanvasLineWidth,
   type AcApMeasurementStyle,
-  formatMeasurementLength
+  formatMeasurementArea
 } from '../../../util'
 import type { AcTrView2d } from '../../../view'
 import {
@@ -153,7 +153,7 @@ export class AcApMeasureAreaEntity extends AcApMeasureEntity {
     const badge = new AcTrHtmlBadge({
       id: `${this.entityId}-badge`,
       color,
-      text: `${formatMeasurementLength(db, area)}²`,
+      text: formatMeasurementArea(db, area),
       worldPosition: measureCentroid(live),
       layer: MEASUREMENT_LAYER,
       fontSize: this.style.fontSize
@@ -197,7 +197,7 @@ export class AcApMeasureAreaEntity extends AcApMeasureEntity {
 
     const refreshLive = () => {
       area = measureShoelaceArea(live)
-      badge.setText(`${formatMeasurementLength(db, area)}²`)
+      badge.setText(formatMeasurementArea(db, area))
       acapPlaceOverlayHtml(view, badge, measureCentroid(live))
       paintArea(getMeasurementStyle(this.entityId) ?? this.style)
       view.isHtmlDirty = true

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUnits.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUnits.ts
@@ -39,9 +39,9 @@ const ACAD_UNIT_TO_MM: Readonly<Record<number, number>> = {
   17: 1000000000000,
   18: 149597870700000,
   19: 9.4607304725808e18,
-  20: 3.0856775814913673e19,
-  21: 304.80060960121924,
-  22: 25.400050800101604,
+  20: 3.085677581491367e19,
+  21: 304.80060960121926,
+  22: 25.400050800101603,
   23: 914.4018288036576,
   24: 1609347.2186944375
 }
@@ -149,7 +149,8 @@ export function getEffectiveMeasurementUnits(
     aunits: measurementUnitOverride.aunits ?? db.aunits,
     auprec: measurementUnitOverride.auprec ?? db.auprec,
     lengthUnit:
-      measurementUnitOverride.lengthUnit ?? MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
+      measurementUnitOverride.lengthUnit ??
+      MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
   }
 }
 
@@ -169,7 +170,8 @@ export function setMeasurementUnitOverride(
   if (patch.luprec != null) measurementUnitOverride.luprec = patch.luprec
   if (patch.aunits != null) measurementUnitOverride.aunits = patch.aunits
   if (patch.auprec != null) measurementUnitOverride.auprec = patch.auprec
-  if (patch.lengthUnit != null) measurementUnitOverride.lengthUnit = patch.lengthUnit
+  if (patch.lengthUnit != null)
+    measurementUnitOverride.lengthUnit = patch.lengthUnit
 }
 
 /** Clear session measurement unit overrides (document open / tests). */
@@ -270,10 +272,7 @@ export function formatMeasurementLength(
 }
 
 /** Format an area using effective measurement units (length unit squared). */
-export function formatMeasurementArea(
-  db: AcDbDatabase,
-  value: number
-): string {
+export function formatMeasurementArea(db: AcDbDatabase, value: number): string {
   const target = convertedLengthUnit(db)
   if (target == null) {
     return `${formatMeasurementLengthRaw(

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUnits.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUnits.ts
@@ -10,6 +10,82 @@ export interface AcApMeasurementUnits {
   aunits: number
   /** Angular display precision (AUPREC). */
   auprec: number
+  /** Length display unit (INSUNITS code) or {@link MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING}. */
+  lengthUnit: number
+}
+
+/** Sentinel length unit meaning "follow the drawing units" (no conversion). */
+export const MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING = -1
+
+/** AutoCAD INSUNITS code → scale factor expressed in millimeters. */
+const ACAD_UNIT_TO_MM: Readonly<Record<number, number>> = {
+  0: 1,
+  1: 25.4,
+  2: 304.8,
+  3: 1609344,
+  4: 1,
+  5: 10,
+  6: 1000,
+  7: 1000000,
+  8: 0.0000254,
+  9: 0.0254,
+  10: 914.4,
+  11: 0.0000001,
+  12: 0.000001,
+  13: 0.001,
+  14: 100,
+  15: 10000,
+  16: 100000,
+  17: 1000000000000,
+  18: 149597870700000,
+  19: 9.4607304725808e18,
+  20: 3.0856775814913673e19,
+  21: 304.80060960121924,
+  22: 25.400050800101604,
+  23: 914.4018288036576,
+  24: 1609347.2186944375
+}
+
+/** Short Latin suffixes shown after converted measurement lengths. */
+const ACAD_UNIT_SYMBOLS: Readonly<Record<number, string>> = {
+  1: 'in',
+  2: 'ft',
+  4: 'mm',
+  5: 'cm',
+  6: 'm',
+  7: 'km',
+  10: 'yd'
+}
+
+function acapUnitToMm(unit: number): number {
+  if (!Number.isFinite(unit)) return 1
+  return ACAD_UNIT_TO_MM[Math.trunc(unit)] ?? 1
+}
+
+/** Scale a value expressed in `fromUnit` so it is expressed in `toUnit`. */
+export function convertLengthValue(
+  value: number,
+  fromUnit: number,
+  toUnit: number
+): number {
+  const toMm = acapUnitToMm(toUnit)
+  if (toMm === 0) return value
+  return value * (acapUnitToMm(fromUnit) / toMm)
+}
+
+/** Scale an area expressed in `fromUnit` so it is expressed in `toUnit`. */
+export function convertAreaValue(
+  value: number,
+  fromUnit: number,
+  toUnit: number
+): number {
+  const factor = convertLengthValue(1, fromUnit, toUnit)
+  return value * factor * factor
+}
+
+/** Short symbol for a length-unit code, or empty when unknown / follow-drawing. */
+export function measurementLengthUnitSymbol(unit: number): string {
+  return ACAD_UNIT_SYMBOLS[Math.trunc(unit)] ?? ''
 }
 
 /** Numeric value stored on a committed measurement so its badge can be reformatted. */
@@ -22,6 +98,16 @@ export type AcApMeasurementValue =
 /** Display flags for length / area / coordinate measurement labels. */
 export const MEASUREMENT_LENGTH_FORMAT_OPTIONS: AcDbFormatterOptions = {
   showUnits: true,
+  showApproximate: true
+}
+
+/**
+ * Display flags for a length already rescaled to another physical unit. The
+ * formatter must not add the drawing suffix — the target unit symbol is
+ * appended by the caller.
+ */
+const MEASUREMENT_CONVERTED_LENGTH_FORMAT_OPTIONS: AcDbFormatterOptions = {
+  showUnits: false,
   showApproximate: true
 }
 
@@ -61,7 +147,9 @@ export function getEffectiveMeasurementUnits(
     lunits: measurementUnitOverride.lunits ?? db.lunits,
     luprec: measurementUnitOverride.luprec ?? db.luprec,
     aunits: measurementUnitOverride.aunits ?? db.aunits,
-    auprec: measurementUnitOverride.auprec ?? db.auprec
+    auprec: measurementUnitOverride.auprec ?? db.auprec,
+    lengthUnit:
+      measurementUnitOverride.lengthUnit ?? MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
   }
 }
 
@@ -81,6 +169,7 @@ export function setMeasurementUnitOverride(
   if (patch.luprec != null) measurementUnitOverride.luprec = patch.luprec
   if (patch.aunits != null) measurementUnitOverride.aunits = patch.aunits
   if (patch.auprec != null) measurementUnitOverride.auprec = patch.auprec
+  if (patch.lengthUnit != null) measurementUnitOverride.lengthUnit = patch.lengthUnit
 }
 
 /** Clear session measurement unit overrides (document open / tests). */
@@ -132,8 +221,8 @@ function withMeasurementFormatContext<T>(db: AcDbDatabase, fn: () => T): T {
   }
 }
 
-/** Format a linear distance using effective measurement units. */
-export function formatMeasurementLength(
+/** Format a linear value without applying a physical-unit conversion. */
+function formatMeasurementLengthRaw(
   db: AcDbDatabase,
   value: number,
   options: AcDbFormatterOptions = MEASUREMENT_LENGTH_FORMAT_OPTIONS
@@ -141,6 +230,67 @@ export function formatMeasurementLength(
   return withMeasurementFormatContext(db, () =>
     db.formatter.formatLength(value, options)
   )
+}
+
+/**
+ * Length unit code to convert measurement values to, or `undefined` when labels
+ * should stay in drawing units (no override selected, the override equals the
+ * drawing's INSUNITS, or the follow-drawing sentinel is active).
+ */
+function convertedLengthUnit(db: AcDbDatabase): number | undefined {
+  const target = measurementUnitOverride.lengthUnit
+  if (
+    target == null ||
+    target === db.insunits ||
+    target === MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
+  )
+    return undefined
+  return target
+}
+
+/** Format a linear distance using effective measurement units. */
+export function formatMeasurementLength(
+  db: AcDbDatabase,
+  value: number,
+  options: AcDbFormatterOptions = MEASUREMENT_LENGTH_FORMAT_OPTIONS
+): string {
+  const target = convertedLengthUnit(db)
+  if (target == null) {
+    return formatMeasurementLengthRaw(db, value, options)
+  }
+
+  const scaled = convertLengthValue(value, db.insunits ?? 0, target)
+  const text = formatMeasurementLengthRaw(
+    db,
+    scaled,
+    MEASUREMENT_CONVERTED_LENGTH_FORMAT_OPTIONS
+  )
+  const symbol = measurementLengthUnitSymbol(target)
+  return symbol ? `${text} ${symbol}` : text
+}
+
+/** Format an area using effective measurement units (length unit squared). */
+export function formatMeasurementArea(
+  db: AcDbDatabase,
+  value: number
+): string {
+  const target = convertedLengthUnit(db)
+  if (target == null) {
+    return `${formatMeasurementLengthRaw(
+      db,
+      value,
+      MEASUREMENT_LENGTH_FORMAT_OPTIONS
+    )}²`
+  }
+
+  const scaled = convertAreaValue(value, db.insunits ?? 0, target)
+  const text = formatMeasurementLengthRaw(
+    db,
+    scaled,
+    MEASUREMENT_CONVERTED_LENGTH_FORMAT_OPTIONS
+  )
+  const symbol = measurementLengthUnitSymbol(target)
+  return symbol ? `${text} ${symbol}²` : `${text}²`
 }
 
 /** Format an angle in radians using effective measurement units. */
@@ -163,7 +313,7 @@ export function formatMeasurementValue(
     case 'length':
       return formatMeasurementLength(db, value.value)
     case 'area':
-      return `${formatMeasurementLength(db, value.value)}²`
+      return formatMeasurementArea(db, value.value)
     case 'angle':
       return formatMeasurementAngle(db, value.radians)
     case 'coordinate': {

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUnits.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUnits.ts
@@ -1,7 +1,7 @@
 import {
-  AcDbLinearUnits,
   type AcDbDatabase,
-  type AcDbFormatterOptions
+  type AcDbFormatterOptions,
+  AcDbLinearUnits
 } from '@mlightcad/data-model'
 
 /** Linear/angular unit settings used when formatting measurement labels. */

--- a/packages/cad-simple-viewer/src/util/AcApMeasurementUnits.ts
+++ b/packages/cad-simple-viewer/src/util/AcApMeasurementUnits.ts
@@ -1,4 +1,8 @@
-import type { AcDbDatabase, AcDbFormatterOptions } from '@mlightcad/data-model'
+import {
+  AcDbLinearUnits,
+  type AcDbDatabase,
+  type AcDbFormatterOptions
+} from '@mlightcad/data-model'
 
 /** Linear/angular unit settings used when formatting measurement labels. */
 export interface AcApMeasurementUnits {
@@ -194,14 +198,34 @@ function hasEffectiveUnitOverride(db: AcDbDatabase): boolean {
   )
 }
 
+/** LUNITS values that assume drawing INSUNITS, not arbitrary physical units. */
+function isDrawingNativeLengthFormat(lunits: number): boolean {
+  return (
+    lunits === AcDbLinearUnits.Architectural ||
+    lunits === AcDbLinearUnits.Engineering
+  )
+}
+
 /**
  * Run `fn` with the formatter reading effective measurement units.
  * Drawing system variables are not changed.
  */
-function withMeasurementFormatContext<T>(db: AcDbDatabase, fn: () => T): T {
-  if (!hasEffectiveUnitOverride(db)) return fn()
-
+function withMeasurementFormatContext<T>(
+  db: AcDbDatabase,
+  fn: () => T,
+  formatPatch?: { forceDecimalLength?: boolean }
+): T {
   const units = getEffectiveMeasurementUnits(db)
+  const lunitsForFormat =
+    formatPatch?.forceDecimalLength &&
+    isDrawingNativeLengthFormat(units.lunits)
+      ? AcDbLinearUnits.Decimal
+      : units.lunits
+  const needsPatch =
+    hasEffectiveUnitOverride(db) || lunitsForFormat !== units.lunits
+
+  if (!needsPatch) return fn()
+
   const header = asUnitHeader(db)
   const prev = {
     lunits: header._lunits,
@@ -209,7 +233,7 @@ function withMeasurementFormatContext<T>(db: AcDbDatabase, fn: () => T): T {
     aunits: header._aunits,
     auprec: header._auprec
   }
-  header._lunits = units.lunits
+  header._lunits = lunitsForFormat
   header._luprec = units.luprec
   header._aunits = units.aunits
   header._auprec = units.auprec
@@ -227,23 +251,41 @@ function withMeasurementFormatContext<T>(db: AcDbDatabase, fn: () => T): T {
 function formatMeasurementLengthRaw(
   db: AcDbDatabase,
   value: number,
-  options: AcDbFormatterOptions = MEASUREMENT_LENGTH_FORMAT_OPTIONS
+  options: AcDbFormatterOptions = MEASUREMENT_LENGTH_FORMAT_OPTIONS,
+  formatPatch?: { forceDecimalLength?: boolean }
 ): string {
-  return withMeasurementFormatContext(db, () =>
-    db.formatter.formatLength(value, options)
+  return withMeasurementFormatContext(
+    db,
+    () => db.formatter.formatLength(value, options),
+    formatPatch
   )
+}
+
+/** Merge caller flags with converted-length defaults (units suffix always off). */
+function convertedLengthFormatOptions(
+  options: AcDbFormatterOptions
+): AcDbFormatterOptions {
+  return {
+    ...MEASUREMENT_CONVERTED_LENGTH_FORMAT_OPTIONS,
+    ...options,
+    showUnits: false
+  }
 }
 
 /**
  * Length unit code to convert measurement values to, or `undefined` when labels
  * should stay in drawing units (no override selected, the override equals the
- * drawing's INSUNITS, or the follow-drawing sentinel is active).
+ * drawing's INSUNITS, INSUNITS is undefined, or the follow-drawing sentinel is
+ * active).
  */
 function convertedLengthUnit(db: AcDbDatabase): number | undefined {
+  const fromUnit = db.insunits ?? 0
+  if (fromUnit === 0) return undefined
+
   const target = measurementUnitOverride.lengthUnit
   if (
     target == null ||
-    target === db.insunits ||
+    target === fromUnit ||
     target === MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
   )
     return undefined
@@ -261,32 +303,36 @@ export function formatMeasurementLength(
     return formatMeasurementLengthRaw(db, value, options)
   }
 
-  const scaled = convertLengthValue(value, db.insunits ?? 0, target)
+  const fromUnit = db.insunits ?? 0
+  const scaled = convertLengthValue(value, fromUnit, target)
   const text = formatMeasurementLengthRaw(
     db,
     scaled,
-    MEASUREMENT_CONVERTED_LENGTH_FORMAT_OPTIONS
+    convertedLengthFormatOptions(options),
+    { forceDecimalLength: true }
   )
   const symbol = measurementLengthUnitSymbol(target)
   return symbol ? `${text} ${symbol}` : text
 }
 
 /** Format an area using effective measurement units (length unit squared). */
-export function formatMeasurementArea(db: AcDbDatabase, value: number): string {
+export function formatMeasurementArea(
+  db: AcDbDatabase,
+  value: number,
+  options: AcDbFormatterOptions = MEASUREMENT_LENGTH_FORMAT_OPTIONS
+): string {
   const target = convertedLengthUnit(db)
   if (target == null) {
-    return `${formatMeasurementLengthRaw(
-      db,
-      value,
-      MEASUREMENT_LENGTH_FORMAT_OPTIONS
-    )}²`
+    return `${formatMeasurementLengthRaw(db, value, options)}²`
   }
 
-  const scaled = convertAreaValue(value, db.insunits ?? 0, target)
+  const fromUnit = db.insunits ?? 0
+  const scaled = convertAreaValue(value, fromUnit, target)
   const text = formatMeasurementLengthRaw(
     db,
     scaled,
-    MEASUREMENT_CONVERTED_LENGTH_FORMAT_OPTIONS
+    convertedLengthFormatOptions(options),
+    { forceDecimalLength: true }
   )
   const symbol = measurementLengthUnitSymbol(target)
   return symbol ? `${text} ${symbol}²` : `${text}²`

--- a/packages/cad-viewer-example/e2e/tests/measure-mobile-form.spec.ts
+++ b/packages/cad-viewer-example/e2e/tests/measure-mobile-form.spec.ts
@@ -5,6 +5,7 @@ import { expect, test } from '@playwright/test'
  * `ElementPlusError: [ElForm] unexpected width NaN` because the Measurement
  * ribbon units panel used `label-width="auto"` while overflow groups were hidden.
  *
+ * Length/angle unit controls are now one compact row per ribbon item (no ElForm).
  * Phone layouts hide the desktop command line, so the command is started through
  * `AcApDocManager` (same path as typing `measuredistance` on desktop).
  */
@@ -48,7 +49,9 @@ test('measure distance does not log ElForm unexpected width NaN', async ({
   })
   expect(started).toBe(true)
 
-  await expect(page.locator('.ml-ribbon-measure-units').first()).toBeAttached({
+  await expect(
+    page.locator('.ml-ribbon-measure-unit-field').first()
+  ).toBeAttached({
     timeout: 10_000
   })
   await page.waitForTimeout(400)

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -40,12 +40,12 @@ import {
   isMarkupVisible,
   isMeasurementVisible,
   markupColorToCss,
+  MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING,
   refreshMeasurementValueLabels,
   setMarkupDrawColor,
   setMarkupDrawFontSize,
   setMeasurementUnitOverride,
-  subscribeMeasurementSelection,
-  MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
+  subscribeMeasurementSelection
 } from '@mlightcad/cad-simple-viewer'
 import {
   AcCmColor,

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -44,7 +44,8 @@ import {
   setMarkupDrawColor,
   setMarkupDrawFontSize,
   setMeasurementUnitOverride,
-  subscribeMeasurementSelection
+  subscribeMeasurementSelection,
+  MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING
 } from '@mlightcad/cad-simple-viewer'
 import {
   AcCmColor,
@@ -205,6 +206,7 @@ const measurementLunits = ref(AcDbLinearUnits.Decimal)
 const measurementLuprec = ref(4)
 const measurementAunits = ref(AcDbAngleUnits.DecimalDegrees)
 const measurementAuprec = ref(0)
+const measurementLengthUnit = ref<number>(MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING)
 const isRibbonDisabled = computed(() => isDocumentOpening.value)
 const ribbonColor = ref<AcCmColor | undefined>(new AcCmColor())
 const ribbonColorDisplay = ref('#7b8794')
@@ -868,6 +870,7 @@ const syncMeasurementUnitControls = () => {
   measurementLuprec.value = units.luprec
   measurementAunits.value = units.aunits
   measurementAuprec.value = units.auprec
+  measurementLengthUnit.value = units.lengthUnit
 }
 
 const refreshCurrentMeasurementLabels = () => {
@@ -883,6 +886,7 @@ const applyMeasurementUnitOverride = (
     luprec: number
     aunits: number
     auprec: number
+    lengthUnit: number
   }>
 ) => {
   setMeasurementUnitOverride(patch)
@@ -904,6 +908,10 @@ const handleMeasurementAunitsChange = (value: number) => {
 
 const handleMeasurementAuprecChange = (value: number) => {
   applyMeasurementUnitOverride({ auprec: value })
+}
+
+const handleMeasurementLengthUnitChange = (value: number) => {
+  applyMeasurementUnitOverride({ lengthUnit: value })
 }
 
 /**
@@ -1499,8 +1507,10 @@ const buildBaseTabs = (
                   kind: 'length',
                   unitType: measurementLunits.value,
                   precision: measurementLuprec.value,
+                  lengthUnit: measurementLengthUnit.value,
                   'onUpdate:unitType': handleMeasurementLunitsChange,
-                  'onUpdate:precision': handleMeasurementLuprecChange
+                  'onUpdate:precision': handleMeasurementLuprecChange,
+                  'onUpdate:lengthUnit': handleMeasurementLengthUnitChange
                 }
               }
             }
@@ -2300,6 +2310,7 @@ const ribbonData = computed(() => {
   measurementLuprec.value
   measurementAunits.value
   measurementAuprec.value
+  measurementLengthUnit.value
   const commandByItemId = new Map<string, string>()
   commandByItemId.set('cmd-line', 'line')
   commandByItemId.set('cmd-polyline', 'pline')

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -1495,16 +1495,54 @@ const buildBaseTabs = (
       collections: [
         {
           id: 'measurement-length-units-main',
-          layout: 'row',
+          layout: 'column',
+          rows: 3,
           items: [
             {
-              id: 'measurement-length-units-panel',
+              id: 'measurement-length-units-type',
               type: 'custom',
               size: 'small',
               props: {
                 component: MlRibbonMeasurementUnitsPanel,
                 componentProps: {
                   kind: 'length',
+                  field: 'unitType',
+                  unitType: measurementLunits.value,
+                  precision: measurementLuprec.value,
+                  lengthUnit: measurementLengthUnit.value,
+                  'onUpdate:unitType': handleMeasurementLunitsChange,
+                  'onUpdate:precision': handleMeasurementLuprecChange,
+                  'onUpdate:lengthUnit': handleMeasurementLengthUnitChange
+                }
+              }
+            },
+            {
+              id: 'measurement-length-units-precision',
+              type: 'custom',
+              size: 'small',
+              props: {
+                component: MlRibbonMeasurementUnitsPanel,
+                componentProps: {
+                  kind: 'length',
+                  field: 'precision',
+                  unitType: measurementLunits.value,
+                  precision: measurementLuprec.value,
+                  lengthUnit: measurementLengthUnit.value,
+                  'onUpdate:unitType': handleMeasurementLunitsChange,
+                  'onUpdate:precision': handleMeasurementLuprecChange,
+                  'onUpdate:lengthUnit': handleMeasurementLengthUnitChange
+                }
+              }
+            },
+            {
+              id: 'measurement-length-units-unit',
+              type: 'custom',
+              size: 'small',
+              props: {
+                component: MlRibbonMeasurementUnitsPanel,
+                componentProps: {
+                  kind: 'length',
+                  field: 'lengthUnit',
                   unitType: measurementLunits.value,
                   precision: measurementLuprec.value,
                   lengthUnit: measurementLengthUnit.value,
@@ -1525,16 +1563,34 @@ const buildBaseTabs = (
       collections: [
         {
           id: 'measurement-angle-units-main',
-          layout: 'row',
+          layout: 'column',
+          rows: 3,
           items: [
             {
-              id: 'measurement-angle-units-panel',
+              id: 'measurement-angle-units-type',
               type: 'custom',
               size: 'small',
               props: {
                 component: MlRibbonMeasurementUnitsPanel,
                 componentProps: {
                   kind: 'angle',
+                  field: 'unitType',
+                  unitType: measurementAunits.value,
+                  precision: measurementAuprec.value,
+                  'onUpdate:unitType': handleMeasurementAunitsChange,
+                  'onUpdate:precision': handleMeasurementAuprecChange
+                }
+              }
+            },
+            {
+              id: 'measurement-angle-units-precision',
+              type: 'custom',
+              size: 'small',
+              props: {
+                component: MlRibbonMeasurementUnitsPanel,
+                componentProps: {
+                  kind: 'angle',
+                  field: 'precision',
                   unitType: measurementAunits.value,
                   precision: measurementAuprec.value,
                   'onUpdate:unitType': handleMeasurementAunitsChange,

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonMeasurementUnitsPanel.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonMeasurementUnitsPanel.vue
@@ -32,11 +32,26 @@
         />
       </el-select>
     </el-form-item>
+    <el-form-item v-if="isLength" :label="unitLabel">
+      <el-select
+        :model-value="lengthUnit"
+        class="ml-ribbon-measure-units__control"
+        @update:model-value="emit('update:lengthUnit', $event)"
+      >
+        <el-option
+          v-for="opt in lengthUnitOptions"
+          :key="opt.value"
+          :label="opt.label"
+          :value="opt.value"
+        />
+      </el-select>
+    </el-form-item>
   </el-form>
 </template>
 
 <script setup lang="ts">
-import { AcDbAngleUnits, AcDbLinearUnits } from '@mlightcad/data-model'
+import { MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING } from '@mlightcad/cad-simple-viewer'
+import { AcDbAngleUnits, AcDbLinearUnits, AcDbUnitsValue } from '@mlightcad/data-model'
 import { ElForm, ElFormItem, ElOption, ElSelect } from 'element-plus'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -53,6 +68,7 @@ interface RibbonMeasurementUnitsPanelProps {
   kind: 'length' | 'angle'
   unitType: number
   precision: number
+  lengthUnit?: number
 }
 
 const props = defineProps<RibbonMeasurementUnitsPanelProps>()
@@ -60,6 +76,7 @@ const props = defineProps<RibbonMeasurementUnitsPanelProps>()
 const emit = defineEmits<{
   (e: 'update:unitType', value: number): void
   (e: 'update:precision', value: number): void
+  (e: 'update:lengthUnit', value: number): void
 }>()
 
 const { t } = useI18n()
@@ -77,6 +94,8 @@ const precisionLabel = computed(() =>
     ? t('dialog.drawingUnitsDlg.lengthPrecision')
     : t('dialog.drawingUnitsDlg.anglePrecision')
 )
+
+const unitLabel = computed(() => t('dialog.drawingUnitsDlg.lengthUnit'))
 
 const unitOptions = computed(() =>
   isLength.value
@@ -133,6 +152,41 @@ const unitOptions = computed(() =>
 const precisionOptions = computed(() =>
   drawingUnitPrecisionOptions(props.precision)
 )
+
+const lengthUnitOptions = computed(() => [
+  {
+    value: MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING,
+    label: t('dialog.drawingUnitsDlg.lengthUnitFollowDrawing')
+  },
+  {
+    value: AcDbUnitsValue.Millimeters,
+    label: `${t('dialog.drawingUnitsDlg.insUnits._4')} (mm)`
+  },
+  {
+    value: AcDbUnitsValue.Centimeters,
+    label: `${t('dialog.drawingUnitsDlg.insUnits._5')} (cm)`
+  },
+  {
+    value: AcDbUnitsValue.Meters,
+    label: `${t('dialog.drawingUnitsDlg.insUnits._6')} (m)`
+  },
+  {
+    value: AcDbUnitsValue.Kilometers,
+    label: `${t('dialog.drawingUnitsDlg.insUnits._7')} (km)`
+  },
+  {
+    value: AcDbUnitsValue.Inches,
+    label: `${t('dialog.drawingUnitsDlg.insUnits._1')} (in)`
+  },
+  {
+    value: AcDbUnitsValue.Feet,
+    label: `${t('dialog.drawingUnitsDlg.insUnits._2')} (ft)`
+  },
+  {
+    value: AcDbUnitsValue.Yards,
+    label: `${t('dialog.drawingUnitsDlg.insUnits._10')} (yd)`
+  }
+])
 </script>
 
 <style scoped>

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonMeasurementUnitsPanel.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonMeasurementUnitsPanel.vue
@@ -1,5 +1,6 @@
 <template>
   <el-form
+    v-if="!field"
     label-position="left"
     class="ml-ribbon-measure-units"
     size="small"
@@ -47,6 +48,22 @@
       </el-select>
     </el-form-item>
   </el-form>
+  <div v-else class="ml-ribbon-measure-unit-field">
+    <span class="ml-ribbon-measure-unit-field__label">{{ activeFieldLabel }}</span>
+    <el-select
+      :model-value="activeFieldValue"
+      size="small"
+      class="ml-ribbon-measure-unit-field__control"
+      @update:model-value="onFieldChange"
+    >
+      <el-option
+        v-for="opt in activeFieldOptions"
+        :key="opt.value"
+        :label="opt.label"
+        :value="opt.value"
+      />
+    </el-select>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -63,12 +80,18 @@ import { drawingUnitPrecisionOptions } from '../../util/drawingUnitPrecision'
  *
  * Labels are aligned with CSS grid instead of `label-width="auto"`, which
  * makes ElForm report `unexpected width NaN` when overflow groups are hidden.
+ *
+ * When `field` is set, only one compact row is rendered so the ribbon can
+ * allocate one row per dropdown (same layout as the Home Properties panel).
  */
+type MeasurementUnitsField = 'unitType' | 'precision' | 'lengthUnit'
+
 interface RibbonMeasurementUnitsPanelProps {
   kind: 'length' | 'angle'
   unitType: number
   precision: number
   lengthUnit?: number
+  field?: MeasurementUnitsField
 }
 
 const props = defineProps<RibbonMeasurementUnitsPanelProps>()
@@ -187,6 +210,59 @@ const lengthUnitOptions = computed(() => [
     label: `${t('dialog.drawingUnitsDlg.insUnits._10')} (yd)`
   }
 ])
+
+const activeFieldLabel = computed(() => {
+  switch (props.field) {
+    case 'unitType':
+      return typeLabel.value
+    case 'precision':
+      return precisionLabel.value
+    case 'lengthUnit':
+      return unitLabel.value
+    default:
+      return ''
+  }
+})
+
+const activeFieldValue = computed(() => {
+  switch (props.field) {
+    case 'unitType':
+      return props.unitType
+    case 'precision':
+      return props.precision
+    case 'lengthUnit':
+      return props.lengthUnit
+    default:
+      return undefined
+  }
+})
+
+const activeFieldOptions = computed(() => {
+  switch (props.field) {
+    case 'unitType':
+      return unitOptions.value
+    case 'precision':
+      return precisionOptions.value
+    case 'lengthUnit':
+      return lengthUnitOptions.value
+    default:
+      return []
+  }
+})
+
+function onFieldChange(value: number) {
+  switch (props.field) {
+    case 'unitType':
+      emit('update:unitType', value)
+      break
+    case 'precision':
+      emit('update:precision', value)
+      break
+    case 'lengthUnit':
+      emit('update:lengthUnit', value)
+      break
+  }
+}
 </script>
 
 <style scoped>
@@ -217,5 +293,31 @@ const lengthUnitOptions = computed(() => [
 
 .ml-ribbon-measure-units__control {
   width: calc(132px * var(--ml-ribbon-measure-units-scale));
+}
+
+.ml-ribbon-measure-unit-field {
+  --ml-ribbon-measure-unit-scale: var(--ml-rb-scale, 1);
+  display: inline-flex;
+  align-items: center;
+  gap: calc(6px * var(--ml-ribbon-measure-unit-scale));
+  width: 100%;
+  min-height: var(--ml-rb-compact-height, 28px);
+}
+
+.ml-ribbon-measure-unit-field__label {
+  flex: 0 0 auto;
+  font-size: calc(11px * var(--ml-ribbon-measure-unit-scale));
+  color: var(--el-text-color-regular);
+  white-space: nowrap;
+}
+
+.ml-ribbon-measure-unit-field__control {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: calc(132px * var(--ml-ribbon-measure-unit-scale));
+}
+
+.ml-ribbon-measure-unit-field__control :deep(.el-select) {
+  width: 100%;
 }
 </style>

--- a/packages/cad-viewer/src/locale/ar/dialog.ts
+++ b/packages/cad-viewer/src/locale/ar/dialog.ts
@@ -24,6 +24,8 @@ export default {
     lengthSection: 'الطول',
     lengthType: 'النوع:',
     lengthPrecision: 'الدقة:',
+    lengthUnit: 'الوحدة:',
+    lengthUnitFollowDrawing: 'اتبع الرسم',
 
     angleSection: 'الزاوية',
     angleType: 'النوع:',

--- a/packages/cad-viewer/src/locale/cs/dialog.ts
+++ b/packages/cad-viewer/src/locale/cs/dialog.ts
@@ -13,6 +13,8 @@ export default {
     lengthSection: 'Délka',
     lengthType: 'Typ:',
     lengthPrecision: 'Přesnost:',
+    lengthUnit: 'Jednotka:',
+    lengthUnitFollowDrawing: 'Podle výkresu',
     angleSection: 'Úhel',
     angleType: 'Typ:',
     anglePrecision: 'Přesnost:',

--- a/packages/cad-viewer/src/locale/en/dialog.ts
+++ b/packages/cad-viewer/src/locale/en/dialog.ts
@@ -13,6 +13,8 @@ export default {
     lengthSection: 'Length',
     lengthType: 'Type:',
     lengthPrecision: 'Precision:',
+    lengthUnit: 'Unit:',
+    lengthUnitFollowDrawing: 'Follow drawing',
     angleSection: 'Angle',
     angleType: 'Type:',
     anglePrecision: 'Precision:',

--- a/packages/cad-viewer/src/locale/tr/dialog.ts
+++ b/packages/cad-viewer/src/locale/tr/dialog.ts
@@ -13,6 +13,8 @@ export default {
     lengthSection: 'Uzunluk',
     lengthType: 'Tür:',
     lengthPrecision: 'Hassasiyet:',
+    lengthUnit: 'Birim:',
+    lengthUnitFollowDrawing: 'Çizimi takip et',
     angleSection: 'Açı',
     angleType: 'Tür:',
     anglePrecision: 'Hassasiyet:',

--- a/packages/cad-viewer/src/locale/zh/dialog.ts
+++ b/packages/cad-viewer/src/locale/zh/dialog.ts
@@ -13,6 +13,8 @@ export default {
     lengthSection: '长度',
     lengthType: '类型:',
     lengthPrecision: '精度:',
+    lengthUnit: '单位:',
+    lengthUnitFollowDrawing: '跟随图纸',
     angleSection: '角度',
     angleType: '类型:',
     anglePrecision: '精度:',


### PR DESCRIPTION
Measurement badges can now be displayed in a physical unit the user picks (mm/cm/m/km/in/ft/yd) instead of the drawing's INSUNITS, or left following the drawing. Areas convert by the square of the selected unit so length and area labels never disagree, and converted values are formatted without the drawing suffix so a single unit symbol is emitted.

Formatting resolves the target unit in one shared guard and patches the private header fields for the duration of one formatter call, so LUNITS / LUPREC / AUNITS / AUPREC / INSUNITS sysvars are never written.