### PR TITLE
fix: center AcUi dialogs in the canvas host

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExTouchPointTutorial.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExTouchPointTutorial.spec.ts
@@ -1,0 +1,56 @@
+/** @jest-environment jsdom */
+
+import { ACEX_TOUCH_POINT_TUTORIAL_PREFS_KEY } from '../src/AcExTouchPointTutorial'
+
+const isMobileOrPad = jest.fn(() => true)
+
+jest.mock('../src/AcExHtmlSimpleViewerUi', () => {
+  const actual = jest.requireActual(
+    '../../cad-simple-viewer/src/ui/touch-point-tutorial.ts'
+  )
+  return {
+    ...actual,
+    acedIsMobileOrPadUi: () => isMobileOrPad()
+  }
+})
+
+import {
+  acExMaybeShowTouchPointTutorial,
+  acExShouldShowTouchPointTutorial
+} from '../src/AcExTouchPointTutorial'
+import { AcUiDialog } from '../../cad-simple-viewer/src/ui/AcUiDialog'
+
+describe('AcExTouchPointTutorial', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    isMobileOrPad.mockReturnValue(true)
+    document.body.replaceChildren()
+    document.getElementById(AcUiDialog.styleId)?.remove()
+    document.getElementById('ml-ui-touch-point-tutorial-styles')?.remove()
+  })
+
+  it('shows when mobile/pad UI is active and prefs allow it', () => {
+    expect(acExShouldShowTouchPointTutorial()).toBe(true)
+    void acExMaybeShowTouchPointTutorial({
+      t: (key: string) => key
+    } as never)
+    expect(document.querySelector('.ml-ui-touch-point-tutorial')).not.toBeNull()
+  })
+
+  it('does not show on desktop UI', () => {
+    isMobileOrPad.mockReturnValue(false)
+    expect(acExShouldShowTouchPointTutorial()).toBe(false)
+    void acExMaybeShowTouchPointTutorial({
+      t: (key: string) => key
+    } as never)
+    expect(document.querySelector('.ml-ui-touch-point-tutorial')).toBeNull()
+  })
+
+  it('respects hide-forever prefs in localStorage', () => {
+    localStorage.setItem(
+      ACEX_TOUCH_POINT_TUTORIAL_PREFS_KEY,
+      JSON.stringify({ hideForever: true, snoozeDate: null })
+    )
+    expect(acExShouldShowTouchPointTutorial()).toBe(false)
+  })
+})

--- a/packages/cad-html-plugin/src/AcExHtmlSimpleViewerUi.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlSimpleViewerUi.ts
@@ -10,6 +10,7 @@
 
 export { AcUiAciColorDialog } from '@mlightcad/cad-simple-viewer'
 export {
+  acedIsMobileOrPadUi,
   acuiLocalIsoDate,
   acuiShouldShowTouchPointTutorialFromPrefs,
   AcUiTouchPointTutorial,

--- a/packages/cad-html-plugin/src/AcExSessionDrawStyle.ts
+++ b/packages/cad-html-plugin/src/AcExSessionDrawStyle.ts
@@ -256,7 +256,8 @@ export function setupAcExSessionDrawStyle(
     try {
       const initial = aciIndexOf(cssToColor(currentStyle.color))
       const index = await AcUiAciColorDialog.open({
-        host: document.body,
+        host:
+          document.getElementById('mlcad-canvas-host') ?? document.body,
         theme: htmlUiTheme(),
         initialIndex: initial ?? null,
         labels: colorDialogLabels()

--- a/packages/cad-html-plugin/src/AcExTouchPointTutorial.ts
+++ b/packages/cad-html-plugin/src/AcExTouchPointTutorial.ts
@@ -1,6 +1,6 @@
-import { acExHtmlIsCompactLayout } from './AcExHtmlDrawerSheet'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import {
+  acedIsMobileOrPadUi,
   acuiLocalIsoDate,
   acuiShouldShowTouchPointTutorialFromPrefs,
   AcUiTouchPointTutorial,
@@ -40,10 +40,13 @@ function writePrefs(prefs: AcUiTouchPointTutorialPrefs): void {
 
 /**
  * Whether the precise point-pick tutorial should appear in exported HTML.
+ *
+ * Uses the same phone/pad gate as the live viewer ({@link acedIsMobileOrPadUi})
+ * so wide tablets and touch devices are included, not only `max-width: 960px`.
  */
 export function acExShouldShowTouchPointTutorial(): boolean {
   return acuiShouldShowTouchPointTutorialFromPrefs(
-    acExHtmlIsCompactLayout,
+    acedIsMobileOrPadUi,
     readPrefs()
   )
 }
@@ -54,10 +57,16 @@ export function acExShouldShowTouchPointTutorial(): boolean {
  */
 export function acExMaybeShowTouchPointTutorial(
   i18n: AcExHtmlI18n,
-  host: HTMLElement = document.body
+  host: HTMLElement = document.getElementById('mlcad-canvas-host') ??
+    document.body
 ): Promise<void> {
+  const theme =
+    document.documentElement.getAttribute('data-mlcad-theme') === 'light'
+      ? ('light' as const)
+      : ('dark' as const)
   return AcUiTouchPointTutorial.maybeShow({
     host,
+    theme,
     longPressMs: ACEX_TOUCH_POINT_LONG_PRESS_MS,
     labels: {
       title: i18n.t('touchPointTutorial.title'),

--- a/packages/cad-simple-viewer/__tests__/AcUiDialog.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcUiDialog.spec.ts
@@ -19,8 +19,42 @@ describe('AcUiDialog', () => {
     expect(css).toMatch(
       /@media \(max-width: 600px\) \{[\s\S]*width: 100%;/
     )
+    expect(css).toContain('border-radius: 10px')
+    expect(css).not.toMatch(
+      /@media \(max-width: 600px\) \{[\s\S]*border-radius:\s*0/
+    )
+    expect(css).toContain('position: absolute')
+    expect(css).not.toContain('position: fixed')
 
     dialog.close()
+  })
+
+  it('centers within the host canvas box, not the full viewport', () => {
+    const canvas = document.createElement('div')
+    canvas.style.position = 'absolute'
+    canvas.style.top = '80px'
+    canvas.style.height = '400px'
+    canvas.style.width = '600px'
+    document.body.appendChild(canvas)
+
+    const dialog = new AcUiDialog({ title: 'Canvas', host: canvas })
+    const backdrop = canvas.querySelector(
+      '.ml-ui-dialog-backdrop'
+    ) as HTMLElement
+    expect(backdrop.parentElement).toBe(canvas)
+    expect(canvas.style.position).toBe('absolute')
+
+    dialog.close()
+  })
+
+  it('makes a static host a containing block while open', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    const dialog = new AcUiDialog({ title: 'Host', host })
+    expect(host.style.position).toBe('relative')
+    dialog.close()
+    expect(host.style.position).toBe('')
   })
 
   it('opts out of layout width with layoutWidth: false', () => {

--- a/packages/cad-simple-viewer/src/editor/global/AcEdUiTheme.ts
+++ b/packages/cad-simple-viewer/src/editor/global/AcEdUiTheme.ts
@@ -53,9 +53,10 @@ export function acedApplyUiTheme(
  *
  * Lookup order:
  * 1. Nearest ancestor with `data-ml-ui-theme`
- * 2. `document.documentElement` attribute
- * 3. `html.dark` class (Element Plus / cad-viewer)
- * 4. Defaults to `'light'`
+ * 2. `document.documentElement` `data-ml-ui-theme`
+ * 3. `document.documentElement` `data-mlcad-theme` (offline HTML viewer)
+ * 4. `html.dark` class (Element Plus / cad-viewer)
+ * 5. Defaults to `'light'`
  *
  * @param from - Optional element to start ancestor walk from
  */
@@ -69,6 +70,9 @@ export function resolveUiTheme(from?: HTMLElement | null): AcEdUiTheme {
 
   const rootAttr = document.documentElement.getAttribute('data-ml-ui-theme')
   if (rootAttr === 'light' || rootAttr === 'dark') return rootAttr
+
+  const htmlTheme = document.documentElement.getAttribute('data-mlcad-theme')
+  if (htmlTheme === 'light' || htmlTheme === 'dark') return htmlTheme
 
   if (document.documentElement.classList.contains('dark')) return 'dark'
   return 'light'

--- a/packages/cad-simple-viewer/src/ui/AcUiDialog.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiDialog.ts
@@ -15,7 +15,9 @@ import {
 export interface AcUiDialogOptions {
   /**
    * Host element that receives the backdrop.
-   * @defaultValue `document.body`
+   *
+   * Prefer the canvas / view container so vertical centering uses the drawing
+   * area height (excluding ribbon and status bar). Defaults to `document.body`.
    */
   host?: HTMLElement
 
@@ -84,6 +86,10 @@ export interface AcUiDialogOptions {
 /**
  * Framework-free modal dialog base built with pure HTML and CSS.
  *
+ * The backdrop fills {@link AcUiDialogOptions.host} (typically the canvas
+ * container) and centers the panel in that box so ribbon / status chrome
+ * outside the host are not used for vertical centering.
+ *
  * Subclasses fill {@link bodyEl} / {@link footerEl} and call {@link show}.
  */
 export class AcUiDialog {
@@ -110,6 +116,9 @@ export class AcUiDialog {
   /** Title text element in the header. */
   protected readonly titleEl: HTMLDivElement
 
+  private readonly host: HTMLElement
+  /** Previous inline `position` on {@link host}, restored on close when we set it. */
+  private readonly hostPositionRestore: string | null
   private readonly onKeyDown: (event: KeyboardEvent) => void
   private readonly closeOnEscape: boolean
   private readonly previouslyFocused: HTMLElement | null
@@ -126,6 +135,9 @@ export class AcUiDialog {
     AcUiDialog.ensureStyles()
 
     const host = options.host ?? document.body
+    this.host = host
+    this.hostPositionRestore = AcUiDialog.ensureHostContainingBlock(host)
+
     const titleId =
       options.titleId ?? `ml-ui-dialog-title-${AcUiDialog.nextTitleId++}`
     this.closeOnEscape = options.closeOnEscape ?? true
@@ -231,6 +243,9 @@ export class AcUiDialog {
     if (this.backdrop.parentNode) {
       this.backdrop.parentNode.removeChild(this.backdrop)
     }
+    if (this.hostPositionRestore !== null) {
+      this.host.style.position = this.hostPositionRestore
+    }
     this.previouslyFocused?.focus()
     this.resolve?.()
     this.resolve = undefined
@@ -294,6 +309,20 @@ export class AcUiDialog {
   }
 
   /**
+   * Ensures {@link host} is a positioned containing block for the absolute
+   * backdrop. Returns the previous inline `position` when it was changed, or
+   * `null` when the host already established a containing block.
+   */
+  private static ensureHostContainingBlock(host: HTMLElement): string | null {
+    // Browsers report `static`; some test environments leave this empty.
+    const position = getComputedStyle(host).position || 'static'
+    if (position !== 'static') return null
+    const previous = host.style.position
+    host.style.position = 'relative'
+    return previous
+  }
+
+  /**
    * Injects shared dialog chrome CSS once per document.
    */
   static ensureStyles(): void {
@@ -303,7 +332,7 @@ export class AcUiDialog {
     style.id = AcUiDialog.styleId
     style.textContent = `
 .ml-ui-dialog-backdrop {
-  position: fixed;
+  position: absolute;
   inset: 0;
   z-index: 10050;
   display: flex;
@@ -336,7 +365,6 @@ export class AcUiDialog {
   .ml-ui-dialog:not(.${AcUiDialog.compactClass}) {
     width: 100%;
     max-width: none;
-    border-radius: 0;
     padding-left: max(12px, env(safe-area-inset-left, 0px));
     padding-right: max(12px, env(safe-area-inset-right, 0px));
   }

--- a/packages/cad-simple-viewer/src/ui/AcUiDrawStyleSessionAccessory.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiDrawStyleSessionAccessory.ts
@@ -278,10 +278,12 @@ export class AcUiDrawStyleSessionAccessory {
 
   /**
    * Stores selection-sync cleanup from install; run from {@link dispose}.
+   * Replaces any prior subscription before storing the new one.
    *
    * @param unsubscribe - Cleanup returned by selection binding.
    */
   setSelectionUnsubscribe(unsubscribe: () => void): void {
+    this.selectionUnsubscribe?.()
     this.selectionUnsubscribe = unsubscribe
   }
 

--- a/packages/cad-simple-viewer/src/ui/AcUiTouchPointTutorialDialog.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiTouchPointTutorialDialog.ts
@@ -1,5 +1,6 @@
 import { AcApSettingManager } from '../app/AcApSettingManager'
 import { acedIsMobileOrPadUi } from '../editor/global/AcEdUiLayout'
+import { resolveUiTheme } from '../editor/global/AcEdUiTheme'
 import { ACED_TOUCH_POINT_LONG_PRESS_MS } from '../editor/input/ui/AcEdTouchPointSession'
 import { AcApI18n } from '../i18n/AcApI18n'
 import {
@@ -34,6 +35,7 @@ export class AcUiTouchPointTutorialDialog {
   static maybeShow(host: HTMLElement = document.body): Promise<void> {
     return AcUiTouchPointTutorial.maybeShow({
       host,
+      theme: resolveUiTheme(host),
       longPressMs: ACED_TOUCH_POINT_LONG_PRESS_MS,
       labels: {
         title: AcApI18n.t('main.touchPointTutorial.title'),

--- a/packages/cad-simple-viewer/src/ui/touch-point-tutorial.ts
+++ b/packages/cad-simple-viewer/src/ui/touch-point-tutorial.ts
@@ -5,6 +5,7 @@
  * offline HTML viewer (via {@link AcExHtmlSimpleViewerUi}).
  */
 
+import type { AcEdUiTheme } from '../editor/global/AcEdUiTheme'
 import { AcUiDialog } from './AcUiDialog'
 
 /** DOM id of tutorial-specific styles. */
@@ -78,6 +79,8 @@ export interface AcUiTouchPointTutorialPrefs {
 export interface AcUiTouchPointTutorialConfig {
   /** Backdrop host; defaults to `document.body`. */
   host?: HTMLElement
+  /** Theme tokens; defaults to {@link resolveUiTheme} from the host. */
+  theme?: AcEdUiTheme
   labels: AcUiTouchPointTutorialLabels
   /** Long-press delay shown in the demo animation (ms). */
   longPressMs: number
@@ -126,6 +129,7 @@ export class AcUiTouchPointTutorial extends AcUiDialog {
     super({
       host: config.host,
       title: config.labels.title,
+      theme: config.theme,
       layoutWidth: false,
       showCloseButton: false,
       titleAlign: 'center',


### PR DESCRIPTION
## Summary
- Anchor `AcUiDialog` backdrops to the host (typically the canvas container) with `position: absolute` and a temporary containing block, so modals center in the drawing area instead of the full viewport (excluding ribbon/status chrome).
- Align offline HTML touch-point tutorial with the live viewer: gate on `acedIsMobileOrPadUi`, host on `#mlcad-canvas-host`, and resolve theme via `data-mlcad-theme` / `resolveUiTheme`.
- Keep the touch tutorial on compact `layoutWidth: false`; unsubscribe prior draw-style selection listeners before replacing them.

## Test plan
- [ ] Open About / color / touch-point tutorial on desktop and confirm vertical centering is relative to the canvas host, not the ribbon+status viewport.
- [ ] On phone/pad width, confirm dialogs keep rounded corners and the touch tutorial stays compact width.
- [ ] Exported HTML viewer: tutorial shows on mobile/pad UI, respects hide-forever prefs, and matches light/dark theme.
- [ ] `pnpm test -- --testPathPatterns="AcUiDialog|AcExTouchPointTutorial|AcUiTouchPointTutorial" --coverage=false`