### PR TITLE
feat: show confirmed pick plus marks on phone/pad

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const isMobileOrPad = jest.fn(() => true)
+
+jest.mock('../src/AcExHtmlSimpleViewerUi', () => ({
+  acedIsMobileOrPadUi: () => isMobileOrPad()
+}))
+
+import { AcExConfirmedPointMarks } from '../src/AcExConfirmedPointMarks'
+
+describe('AcExConfirmedPointMarks', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    isMobileOrPad.mockReturnValue(true)
+  })
+
+  it('renders plus marks on phone/pad and clears them on desktop', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const marks = new AcExConfirmedPointMarks(host, pos => ({
+      x: pos.x * 10,
+      y: pos.y * 10
+    }))
+
+    marks.setWorldPoints([
+      { x: 1, y: 2 },
+      { x: 3, y: 4 }
+    ])
+    const els = [...host.querySelectorAll('.mlcad-confirmed-point-mark')]
+    expect(els).toHaveLength(2)
+    expect((els[0] as HTMLElement).style.left).toBe('10px')
+    expect((els[0] as HTMLElement).style.top).toBe('20px')
+
+    isMobileOrPad.mockReturnValue(false)
+    marks.setWorldPoints([{ x: 5, y: 6 }])
+    expect(host.querySelectorAll('.mlcad-confirmed-point-mark')).toHaveLength(0)
+  })
+
+  it('repositions existing marks on sync', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    let scale = 1
+    const marks = new AcExConfirmedPointMarks(host, pos => ({
+      x: pos.x * scale,
+      y: pos.y * scale
+    }))
+    marks.setWorldPoints([{ x: 2, y: 4 }])
+    const el = host.querySelector(
+      '.mlcad-confirmed-point-mark'
+    ) as HTMLElement
+    expect(el.style.left).toBe('2px')
+
+    scale = 5
+    marks.sync()
+    expect(el.style.left).toBe('10px')
+    expect(el.style.top).toBe('20px')
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts
@@ -2,10 +2,10 @@
  * @jest-environment jsdom
  */
 
-const isMobileOrPad = jest.fn(() => true)
+const isCompactLayout = jest.fn(() => true)
 
-jest.mock('../src/AcExHtmlSimpleViewerUi', () => ({
-  acedIsMobileOrPadUi: () => isMobileOrPad()
+jest.mock('../src/AcExHtmlDrawerSheet', () => ({
+  acExHtmlIsCompactLayout: () => isCompactLayout()
 }))
 
 import { AcExConfirmedPointMarks } from '../src/AcExConfirmedPointMarks'
@@ -13,7 +13,7 @@ import { AcExConfirmedPointMarks } from '../src/AcExConfirmedPointMarks'
 describe('AcExConfirmedPointMarks', () => {
   afterEach(() => {
     document.body.replaceChildren()
-    isMobileOrPad.mockReturnValue(true)
+    isCompactLayout.mockReturnValue(true)
   })
 
   it('renders plus marks on phone/pad and clears them on desktop', () => {
@@ -33,7 +33,7 @@ describe('AcExConfirmedPointMarks', () => {
     expect((els[0] as HTMLElement).style.left).toBe('10px')
     expect((els[0] as HTMLElement).style.top).toBe('20px')
 
-    isMobileOrPad.mockReturnValue(false)
+    isCompactLayout.mockReturnValue(false)
     marks.setWorldPoints([{ x: 5, y: 6 }])
     expect(host.querySelectorAll('.mlcad-confirmed-point-mark')).toHaveLength(0)
   })

--- a/packages/cad-html-plugin/src/AcExConfirmedPointMarks.ts
+++ b/packages/cad-html-plugin/src/AcExConfirmedPointMarks.ts
@@ -1,4 +1,4 @@
-import { acedIsMobileOrPadUi } from './AcExHtmlSimpleViewerUi'
+import { acExHtmlIsCompactLayout } from './AcExHtmlDrawerSheet'
 
 /**
  * World-space point used by {@link AcExConfirmedPointMarks}.
@@ -12,9 +12,11 @@ export interface AcExConfirmedPointMarkPos {
  * Temporary plus marks at confirmed pick points during multi-step measure /
  * markup tools on phone and pad.
  *
- * Desktop never shows these marks. There is no override API in the offline
- * HTML viewer (unlike `AcEdPromptPointOptions.showConfirmedPointMark` in the
- * live CAD viewer).
+ * Desktop never shows these marks. Uses the offline HTML compact breakpoint
+ * ({@link acExHtmlIsCompactLayout}) instead of `acedIsMobileOrPadUi` so measure /
+ * markup controllers stay free of the `cad-simple-viewer` barrel. There is no
+ * override API in the offline HTML viewer (unlike
+ * `AcEdPromptPointOptions.showConfirmedPointMark` in the live CAD viewer).
  */
 export class AcExConfirmedPointMarks {
   private readonly host: HTMLElement
@@ -47,7 +49,7 @@ export class AcExConfirmedPointMarks {
    * No-ops visually on desktop (clears any existing marks).
    */
   setWorldPoints(points: readonly AcExConfirmedPointMarkPos[]): void {
-    if (!acedIsMobileOrPadUi()) {
+    if (!acExHtmlIsCompactLayout()) {
       this.clear()
       return
     }

--- a/packages/cad-html-plugin/src/AcExConfirmedPointMarks.ts
+++ b/packages/cad-html-plugin/src/AcExConfirmedPointMarks.ts
@@ -1,0 +1,136 @@
+import { acedIsMobileOrPadUi } from './AcExHtmlSimpleViewerUi'
+
+/**
+ * World-space point used by {@link AcExConfirmedPointMarks}.
+ */
+export interface AcExConfirmedPointMarkPos {
+  x: number
+  y: number
+}
+
+/**
+ * Temporary plus marks at confirmed pick points during multi-step measure /
+ * markup tools on phone and pad.
+ *
+ * Desktop never shows these marks. There is no override API in the offline
+ * HTML viewer (unlike `AcEdPromptPointOptions.showConfirmedPointMark` in the
+ * live CAD viewer).
+ */
+export class AcExConfirmedPointMarks {
+  private readonly host: HTMLElement
+  private readonly wcsToScreen: (pos: AcExConfirmedPointMarkPos) => {
+    x: number
+    y: number
+  }
+  private readonly markers: HTMLDivElement[] = []
+  private worldPoints: AcExConfirmedPointMarkPos[] = []
+
+  /**
+   * @param host - Overlay host (usually `#mlcad-root` or a measure/markup layer).
+   * @param wcsToScreen - Converts WCS to host-relative CSS pixels.
+   */
+  constructor(
+    host: HTMLElement,
+    wcsToScreen: (pos: AcExConfirmedPointMarkPos) => { x: number; y: number }
+  ) {
+    this.host = host
+    this.wcsToScreen = wcsToScreen
+    AcExConfirmedPointMarks.injectCss()
+    if (getComputedStyle(host).position === 'static') {
+      host.style.position = 'relative'
+    }
+  }
+
+  /**
+   * Replaces the mark set with the given world points.
+   *
+   * No-ops visually on desktop (clears any existing marks).
+   */
+  setWorldPoints(points: readonly AcExConfirmedPointMarkPos[]): void {
+    if (!acedIsMobileOrPadUi()) {
+      this.clear()
+      return
+    }
+
+    const next = points.map(p => ({ x: p.x, y: p.y }))
+    const reuse = Math.min(this.markers.length, next.length)
+    for (let i = 0; i < reuse; i++) {
+      this.place(this.markers[i]!, next[i]!)
+    }
+    if (next.length < this.markers.length) {
+      for (let i = next.length; i < this.markers.length; i++) {
+        this.markers[i]!.remove()
+      }
+      this.markers.length = next.length
+    } else {
+      for (let i = reuse; i < next.length; i++) {
+        const el = document.createElement('div')
+        el.className = 'mlcad-confirmed-point-mark'
+        this.host.appendChild(el)
+        this.place(el, next[i]!)
+        this.markers.push(el)
+      }
+    }
+    this.worldPoints = next
+  }
+
+  /** Repositions existing marks after pan/zoom. */
+  sync(): void {
+    for (let i = 0; i < this.markers.length; i++) {
+      const pos = this.worldPoints[i]
+      if (!pos) continue
+      this.place(this.markers[i]!, pos)
+    }
+  }
+
+  /** Removes all marks. */
+  clear(): void {
+    for (const el of this.markers) el.remove()
+    this.markers.length = 0
+    this.worldPoints = []
+  }
+
+  private place(el: HTMLDivElement, world: AcExConfirmedPointMarkPos): void {
+    const screen = this.wcsToScreen(world)
+    el.style.left = `${screen.x}px`
+    el.style.top = `${screen.y}px`
+  }
+
+  private static injectCss(): void {
+    if (document.getElementById('mlcad-confirmed-point-mark-style')) return
+    const style = document.createElement('style')
+    style.id = 'mlcad-confirmed-point-mark-style'
+    style.textContent = `
+      .mlcad-confirmed-point-mark {
+        position: absolute;
+        pointer-events: none;
+        z-index: 5;
+        width: 12px;
+        height: 12px;
+        transform: translate(-50%, -50%);
+        box-sizing: border-box;
+        color: var(--mlcad-measure-accent, #08e8de);
+      }
+      .mlcad-confirmed-point-mark::before,
+      .mlcad-confirmed-point-mark::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        background: currentColor;
+        transform-origin: center;
+      }
+      .mlcad-confirmed-point-mark::before {
+        width: 100%;
+        height: 2px;
+        transform: translate(-50%, -50%);
+      }
+      .mlcad-confirmed-point-mark::after {
+        width: 2px;
+        height: 100%;
+        transform: translate(-50%, -50%);
+      }
+    `
+    document.head.appendChild(style)
+  }
+}

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -11,6 +11,7 @@
 import * as THREE from 'three'
 
 import type { AcExCommandSessionUiState } from './AcExCommandSessionPanel'
+import { AcExConfirmedPointMarks } from './AcExConfirmedPointMarks'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import {
@@ -267,6 +268,8 @@ export class AcExMarkupController {
   private _lastSelectPointer:
     | { t: number; x: number; y: number; id: string }
     | undefined
+  /** Phone/pad plus marks at confirmed in-progress pick points. */
+  private readonly _confirmedPointMarks: AcExConfirmedPointMarks
 
   constructor(options: AcExMarkupControllerOptions) {
     this._root = options.root
@@ -300,6 +303,11 @@ export class AcExMarkupController {
       void this._handleImportFile()
     })
     this._root.appendChild(this._fileInput)
+
+    this._confirmedPointMarks = new AcExConfirmedPointMarks(
+      this._root,
+      pos => this._confirmedPointMarkScreen(pos)
+    )
     this._updateVisibilityToolbar()
   }
 
@@ -420,6 +428,29 @@ export class AcExMarkupController {
   } {
     const s = this._view.wcsToScreen(new THREE.Vector2(p.x, p.y))
     return { x: s.x, y: s.y }
+  }
+
+  /**
+   * Host-relative CSS pixels for a confirmed-point plus mark.
+   */
+  private _confirmedPointMarkScreen(p: { x: number; y: number }): {
+    x: number
+    y: number
+  } {
+    const screen = this._wcsToScreenPoint(p)
+    const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
+    return { x: screen.x - rootRect.left, y: screen.y - rootRect.top }
+  }
+
+  /**
+   * Shows or clears phone/pad plus marks for in-progress `_points`.
+   */
+  private _syncConfirmedPointMarks(): void {
+    if (!this._mode || this._points.length === 0) {
+      this._confirmedPointMarks.clear()
+      return
+    }
+    this._confirmedPointMarks.setWorldPoints(this._points)
   }
 
   private _scaledCanvasLineWidth(
@@ -544,6 +575,7 @@ export class AcExMarkupController {
     this._awaitingInlineText = false
     this._clearPreview()
     this._onOsnapMarker(null, null)
+    this._confirmedPointMarks.clear()
     this._updateToolbarActive()
     this._syncGripPointerEvents()
     this._updateIdleStatus()
@@ -667,6 +699,7 @@ export class AcExMarkupController {
         this._lastOverlaySyncKey = overlayKey
       }
       this._refreshActivePreview()
+      this._syncConfirmedPointMarks()
     } finally {
       this._inOverlaySync = false
       this._overlayRootRect = null
@@ -690,24 +723,35 @@ export class AcExMarkupController {
     this._lastPointer = { x: clientX, y: clientY }
     const point = this._resolvePointerWithOsnap(clientX, clientY)
 
+    let handled = false
     switch (this._mode) {
       case 'arrow':
-        return this._pointerTwoPoint(point, 'arrow')
+        handled = this._pointerTwoPoint(point, 'arrow')
+        break
       case 'rect':
-        return this._pointerTwoPoint(point, 'rect')
+        handled = this._pointerTwoPoint(point, 'rect')
+        break
       case 'cloud':
-        return this._pointerTwoPoint(point, 'cloud')
+        handled = this._pointerTwoPoint(point, 'cloud')
+        break
       case 'circle':
-        return this._pointerCircle(point)
+        handled = this._pointerCircle(point)
+        break
       case 'callout':
-        return this._pointerCallout(point, clientX, clientY)
+        handled = this._pointerCallout(point, clientX, clientY)
+        break
       case 'text':
-        return this._pointerText(point)
+        handled = this._pointerText(point)
+        break
       case 'stamp':
-        return this._pointerStamp(point)
+        handled = this._pointerStamp(point)
+        break
       default:
-        return false
+        handled = false
+        break
     }
+    this._syncConfirmedPointMarks()
+    return handled
   }
 
   handlePointerMove(clientX: number, clientY: number): void {

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -9,6 +9,7 @@ import { AcGeCircArc2d, AcGeMathUtil } from '@mlightcad/data-model'
 import * as THREE from 'three'
 
 import type { AcExCommandSessionUiState } from './AcExCommandSessionPanel'
+import { AcExConfirmedPointMarks } from './AcExConfirmedPointMarks'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import { acExHtmlIcons } from './AcExHtmlIcons'
 import {
@@ -1073,6 +1074,8 @@ export class AcExMeasureController {
     point: THREE.Vector2
     snap: AcExOsnapPoint | null
   } | null = null
+  /** Phone/pad plus marks at confirmed in-progress pick points. */
+  private readonly _confirmedPointMarks: AcExConfirmedPointMarks
 
   /**
    * Creates HTML overlay layers in `root` for measurement graphics.
@@ -1108,6 +1111,11 @@ export class AcExMeasureController {
       void this._handleImportFile()
     })
     this._root.appendChild(this._fileInput)
+
+    this._confirmedPointMarks = new AcExConfirmedPointMarks(
+      this._root,
+      pos => this._confirmedPointMarkScreen(pos)
+    )
 
     this._updateVisibilityToolbar()
   }
@@ -1295,6 +1303,7 @@ export class AcExMeasureController {
     this._osnapCache = null
     this._hidePreview()
     this._onOsnapMarker(null, null)
+    this._confirmedPointMarks.clear()
     this._updateToolbarActive()
     this._syncGripPointerEvents()
     this._updateIdleStatus()
@@ -1316,6 +1325,7 @@ export class AcExMeasureController {
     }
     this._refreshActivePreview()
     this._syncSessionUi()
+    this._syncConfirmedPointMarks()
     this._requestRender()
     return true
   }
@@ -1638,6 +1648,7 @@ export class AcExMeasureController {
         this._lastOverlaySyncKey = overlayKey
       }
       this._refreshActivePreview()
+      this._syncConfirmedPointMarks()
     } finally {
       this._inOverlaySync = false
       this._overlayRootRect = null
@@ -1685,6 +1696,7 @@ export class AcExMeasureController {
     }
     this._livePointer = false
     this._syncSessionUi()
+    this._syncConfirmedPointMarks()
     return handled
   }
 
@@ -3694,6 +3706,31 @@ export class AcExMeasureController {
   } {
     const s = this._view.wcsToScreen(new THREE.Vector2(p.x, p.y))
     return { x: s.x, y: s.y }
+  }
+
+  /**
+   * Host-relative CSS pixels for a confirmed-point plus mark.
+   * @internal
+   */
+  private _confirmedPointMarkScreen(p: { x: number; y: number }): {
+    x: number
+    y: number
+  } {
+    const screen = this._wcsToScreenPoint(p)
+    const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
+    return { x: screen.x - rootRect.left, y: screen.y - rootRect.top }
+  }
+
+  /**
+   * Shows or clears phone/pad plus marks for in-progress `_points`.
+   * @internal
+   */
+  private _syncConfirmedPointMarks(): void {
+    if (!this._mode || this._points.length === 0) {
+      this._confirmedPointMarks.clear()
+      return
+    }
+    this._confirmedPointMarks.setWorldPoints(this._points)
   }
 
   /** View-synced canvas stroke width for the current camera. @internal */

--- a/packages/cad-simple-viewer/__tests__/AcEdPromptPointOptionsConfirmedMark.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdPromptPointOptionsConfirmedMark.spec.ts
@@ -1,0 +1,18 @@
+import { AcEdPromptPointOptions } from '../src/editor/input/prompt/AcEdPromptPointOptions'
+
+describe('AcEdPromptPointOptions.showConfirmedPointMark', () => {
+  it('defaults to undefined so the input manager can apply phone/pad auto behavior', () => {
+    const options = new AcEdPromptPointOptions('Specify point')
+    expect(options.showConfirmedPointMark).toBeUndefined()
+  })
+
+  it('allows an explicit override', () => {
+    const options = new AcEdPromptPointOptions('Specify point')
+    options.showConfirmedPointMark = true
+    expect(options.showConfirmedPointMark).toBe(true)
+    options.showConfirmedPointMark = false
+    expect(options.showConfirmedPointMark).toBe(false)
+    options.showConfirmedPointMark = undefined
+    expect(options.showConfirmedPointMark).toBeUndefined()
+  })
+})

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptPointOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptPointOptions.ts
@@ -14,6 +14,7 @@ export class AcEdPromptPointOptions extends AcEdPromptOptions<AcGePoint3d> {
   private _useDashedLine: boolean = false
   private _allowNone: boolean = false
   private _disableOSnap: boolean = false
+  private _showConfirmedPointMark?: boolean
   private _defaultValue?: AcGePoint3d
   private _useDefaultValue: boolean = false
 
@@ -135,6 +136,25 @@ export class AcEdPromptPointOptions extends AcEdPromptOptions<AcGePoint3d> {
   set disableOSnap(flag: boolean) {
     if (!this.isReadOnly) {
       this._disableOSnap = flag
+    }
+  }
+
+  /**
+   * Gets or sets whether a plus-shaped mark should remain at each confirmed
+   * point for the rest of the command (similar to acquired center ticks).
+   *
+   * - `undefined` (default): show on phone/pad UI, hide on desktop.
+   * - `true` / `false`: override the platform default.
+   *
+   * Useful on touch devices where short taps skip the jig preview and users
+   * otherwise cannot see points they have already picked.
+   */
+  get showConfirmedPointMark(): boolean | undefined {
+    return this._showConfirmedPointMark
+  }
+  set showConfirmedPointMark(flag: boolean | undefined) {
+    if (!this.isReadOnly) {
+      this._showConfirmedPointMark = flag
     }
   }
 }

--- a/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptPointOptions.ts
+++ b/packages/cad-simple-viewer/src/editor/input/prompt/AcEdPromptPointOptions.ts
@@ -140,10 +140,12 @@ export class AcEdPromptPointOptions extends AcEdPromptOptions<AcGePoint3d> {
   }
 
   /**
-   * Gets or sets whether a plus-shaped mark should remain at each confirmed
-   * point for the rest of the command (similar to acquired center ticks).
+   * Gets or sets whether a confirmed pick should contribute a plus-shaped mark
+   * while later point prompts in the same command run (similar to acquired
+   * center ticks). Marks appear when the next interactive point prompt starts,
+   * not immediately on confirm, so single-point commands do not flash a mark.
    *
-   * - `undefined` (default): show on phone/pad UI, hide on desktop.
+   * - `undefined` (default): track on phone/pad UI, ignore on desktop.
    * - `true` / `false`: override the platform default.
    *
    * Useful on touch devices where short taps skip the jig preview and users

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -138,7 +138,9 @@ export class AcEdInputManager {
 
   /**
    * Plus marks at confirmed pick points for the active command.
-   * Lives across sequential {@link getPoint} prompts; cleared on command end.
+   * Positions accumulate across sequential {@link getPoint} prompts (including
+   * scripted ones); DOM marks appear only when a later interactive prompt
+   * starts so single-point commands do not flash a mark. Cleared on command end.
    */
   private _confirmedPointMarks: AcEdMarkerManager | null = null
   private _confirmedPointPositions: AcGePoint2dLike[] = []
@@ -1872,8 +1874,14 @@ export class AcEdInputManager {
     const scriptedValue = this.tryGetScriptedPoint(options)
     if (scriptedValue != null) {
       cleanup?.()
-      return Promise.resolve(scriptedValue)
+      // Record for later interactive prompts in the same command; no DOM yet.
+      this.recordConfirmedPointMarkIfNeeded(options, scriptedValue)
+      return scriptedValue
     }
+
+    // Show marks for points confirmed earlier in this command while picking
+    // the next one (avoids a flash when the command ends after a single pick).
+    this.showConfirmedPointMarksIfAny()
 
     const getDynamicValue = (pos: AcGePoint2dLike) => {
       return {
@@ -1895,12 +1903,12 @@ export class AcEdInputManager {
       getDynamicValue,
       drawPreview
     })
-    this.addConfirmedPointMarkIfNeeded(options, value)
+    this.recordConfirmedPointMarkIfNeeded(options, value)
     return value
   }
 
   /**
-   * Whether a confirmed-point plus mark should be shown for this prompt.
+   * Whether a confirmed-point plus mark should be tracked for this prompt.
    *
    * Explicit {@link AcEdPromptPointOptions.showConfirmedPointMark} overrides
    * the phone/pad default.
@@ -1914,15 +1922,24 @@ export class AcEdInputManager {
   }
 
   /**
-   * Appends a plus mark at a confirmed pick when enabled for the prompt.
+   * Records a confirmed pick for later display when enabled for the prompt.
+   * DOM marks are deferred until {@link showConfirmedPointMarksIfAny}.
    */
-  private addConfirmedPointMarkIfNeeded(
+  private recordConfirmedPointMarkIfNeeded(
     options: AcEdPromptPointOptions,
     point: AcGePoint3dLike
   ): void {
     if (!this.shouldShowConfirmedPointMark(options)) return
-    this._confirmedPointMarks ??= new AcEdMarkerManager(this.view)
     this._confirmedPointPositions.push({ x: point.x, y: point.y })
+  }
+
+  /**
+   * Renders plus marks for points already confirmed in this command.
+   * Called at the start of an interactive {@link getPointInternal}.
+   */
+  private showConfirmedPointMarksIfAny(): void {
+    if (this._confirmedPointPositions.length === 0) return
+    this._confirmedPointMarks ??= new AcEdMarkerManager(this.view)
     this._confirmedPointMarks.setHintMarkers(
       this._confirmedPointPositions,
       'plus'

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -37,6 +37,7 @@ import {
 } from '../handler'
 import { AcEdPointInputContext } from '../handler/AcEdInputHandler'
 import { AcEdKeywordHandler } from '../handler/AcEdKeywordHandler'
+import { AcEdMarkerManager } from '../marker'
 import {
   AcEdPromptAngleOptions,
   AcEdPromptBoxOptions,
@@ -135,6 +136,14 @@ export class AcEdInputManager {
   /** Stores last confirmed point from getPoint() or getBox() */
   private lastPoint: AcGePoint2dLike | null = null
 
+  /**
+   * Plus marks at confirmed pick points for the active command.
+   * Lives across sequential {@link getPoint} prompts; cleared on command end.
+   */
+  private _confirmedPointMarks: AcEdMarkerManager | null = null
+  private _confirmedPointPositions: AcGePoint2dLike[] = []
+  private readonly _boundRepositionConfirmedPointMarks: () => void
+
   /** Command line UI component */
   private _commandLine: AcEdCommandLine
   /** Phone/pad prompt bar + session panel (hidden on desktop). */
@@ -182,6 +191,8 @@ export class AcEdInputManager {
    */
   constructor(view: AcEdBaseView, editorEvents: AcEditor['events']) {
     this.view = view
+    this._boundRepositionConfirmedPointMarks = () =>
+      this.repositionConfirmedPointMarks()
     this.injectCSS()
     // Newly added UI overlays (command line, previews) are container-local.
     // Ensure absolute-positioned children are anchored to this view only.
@@ -210,9 +221,17 @@ export class AcEdInputManager {
       }
       this._sessionAccessoryController.remountActiveSessionAccessory()
     })
+    this.view.events.viewChanged.addEventListener(
+      this._boundRepositionConfirmedPointMarks
+    )
+    this.view.events.viewResize.addEventListener(
+      this._boundRepositionConfirmedPointMarks
+    )
     // Safety net: if a prompt failed to clean up, close the mobile session
     // panel when the command finishes so the bottom chrome cannot linger.
+    // Also clear confirmed-point plus marks for the finished command.
     editorEvents.commandEnded.addEventListener(() => {
+      this.clearConfirmedPointMarks()
       if (this._mobileChrome.isOpen) {
         this.endMobilePrompt()
       }
@@ -1867,7 +1886,7 @@ export class AcEdInputManager {
     }
 
     const handler = new AcEdPointHandler(options)
-    return this.makeFloatingInputPromise<AcGePoint3dLike>({
+    const value = await this.makeFloatingInputPromise<AcGePoint3dLike>({
       inputCount: 2,
       promptOptions: options,
       disableOSnap: options.disableOSnap,
@@ -1876,6 +1895,50 @@ export class AcEdInputManager {
       getDynamicValue,
       drawPreview
     })
+    this.addConfirmedPointMarkIfNeeded(options, value)
+    return value
+  }
+
+  /**
+   * Whether a confirmed-point plus mark should be shown for this prompt.
+   *
+   * Explicit {@link AcEdPromptPointOptions.showConfirmedPointMark} overrides
+   * the phone/pad default.
+   */
+  private shouldShowConfirmedPointMark(
+    options: AcEdPromptPointOptions
+  ): boolean {
+    const override = options.showConfirmedPointMark
+    if (override !== undefined) return override
+    return acedIsMobileOrPadUi()
+  }
+
+  /**
+   * Appends a plus mark at a confirmed pick when enabled for the prompt.
+   */
+  private addConfirmedPointMarkIfNeeded(
+    options: AcEdPromptPointOptions,
+    point: AcGePoint3dLike
+  ): void {
+    if (!this.shouldShowConfirmedPointMark(options)) return
+    this._confirmedPointMarks ??= new AcEdMarkerManager(this.view)
+    this._confirmedPointPositions.push({ x: point.x, y: point.y })
+    this._confirmedPointMarks.setHintMarkers(
+      this._confirmedPointPositions,
+      'plus'
+    )
+  }
+
+  /** Repositions confirmed-point marks after pan/zoom. */
+  private repositionConfirmedPointMarks(): void {
+    this._confirmedPointMarks?.repositionHints()
+  }
+
+  /** Clears all confirmed-point plus marks for the finished command. */
+  private clearConfirmedPointMarks(): void {
+    this._confirmedPointMarks?.clear()
+    this._confirmedPointMarks = null
+    this._confirmedPointPositions = []
   }
 
   /**

--- a/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
+++ b/packages/cad-simple-viewer/src/editor/view/AcEdBaseView.ts
@@ -1153,7 +1153,13 @@ export abstract class AcEdBaseView {
     this._osnapResolver.clearAcquiredCenters()
   }
 
-  protected onWindowResize() {
+  /**
+   * Updates {@link width} / {@link height} from the size callback or canvas
+   * client size without notifying listeners. Subclasses that must sync
+   * projection (camera frustum, renderer buffer) before notifying should call
+   * this first, then dispatch {@link events.viewResize} themselves.
+   */
+  protected refreshViewSize() {
     if (this._calculateSizeCallback) {
       const { width, height } = this._calculateSizeCallback()
       this._width = Math.max(1, Math.floor(width))
@@ -1162,6 +1168,10 @@ export abstract class AcEdBaseView {
       this._width = Math.max(1, Math.floor(this._canvas.clientWidth))
       this._height = Math.max(1, Math.floor(this._canvas.clientHeight))
     }
+  }
+
+  protected onWindowResize() {
+    this.refreshViewSize()
     this.events.viewResize.dispatch({
       width: this._width,
       height: this._height

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -2301,11 +2301,21 @@ export class AcTrView2d extends AcEdBaseView {
   }
 
   protected onWindowResize() {
-    super.onWindowResize()
+    // Refresh size first, then sync WebGL / CSS2D / frustum before notifying
+    // listeners so `worldToScreen` consumers see the new projection.
+    this.refreshViewSize()
     this._renderer.setSize(this.width, this.height)
     this._css2dRenderer.setSize(this.width, this.height)
     this._layoutViewManager.resize(this.width, this.height)
     this._isDirty = true
+    this.events.viewResize.dispatch({
+      width: this.width,
+      height: this.height
+    })
+    // CSS2D badges reproject via `_isDirty`. Canvas overlays (measure /
+    // markup strokes, live preview) paint with `worldToScreen` and listen to
+    // `viewChanged` only — resize must notify them too.
+    this.events.viewChanged.dispatch()
   }
 
   private animate = () => {


### PR DESCRIPTION
## Summary
- Add temporary plus marks at confirmed multi-step pick points on phone/pad in the live viewer (`AcEdInputManager` + `showConfirmedPointMark`) and offline HTML measure/markup overlays.
- Clear marks when a command/session ends; reposition them on pan/zoom/resize.
- Fix `AcTrView2d` resize ordering so projection is updated before `viewResize`/`viewChanged` listeners run `worldToScreen`.

## Test plan
- [ ] On phone/pad UI, start a multi-point measure (e.g. distance/polyline) and confirm each pick shows a plus mark that survives until the command ends
- [ ] Pan/zoom mid-command and verify marks stay anchored to world points
- [ ] Cancel/finish the command and verify marks clear
- [ ] On desktop, confirm no confirmed-point plus marks appear for the same tools
- [ ] Resize the canvas during an in-progress HTML measure/markup and verify strokes + marks stay aligned
- [ ] Run unit tests: `AcExConfirmedPointMarks.spec.ts` and `AcEdPromptPointOptionsConfirmedMark.spec.ts`