### PR TITLE
feat: type commands anywhere and confirm or repeat with Space

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApMeasurementRegen.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMeasurementRegen.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression coverage for "measurements disappear after a redraw":
+ * `AcApDocManager.regen()` (and the LWDISPLAY toggle) clears the view, which
+ * disposes the HTML transient groups that are the only carrier of committed
+ * measurement records. These tests pin the snapshot / restore helpers that
+ * keep measurements alive across the rebuild.
+ */
+
+import { type AcDbDatabase } from '@mlightcad/data-model'
+import type { AcTrHtmlGroup } from '@mlightcad/three-renderer'
+
+import {
+  AcApMarkupHistory,
+  AcApSessionUndo,
+  getMarkupHistory,
+  getSessionUndo
+} from '../src/command/markup/AcApMarkupHistory'
+import { acapSetMarkupBagFactory } from '../src/command/markup/AcApMarkupSession'
+import { AcApMarkupStore } from '../src/command/markup/AcApMarkupStore'
+import {
+  bindMeasurementOverlayHistory,
+  resetMeasurementSession
+} from '../src/command/measure/AcApMeasurementHistory'
+import { registerMeasurementPublish } from '../src/command/measure/AcApMeasurementRepublish'
+import { deserializeMeasurementStyle } from '../src/command/measure/AcApMeasurementSidecar'
+import {
+  collectMeasurementRecords,
+  commitMeasurementGroup,
+  MEASUREMENT_LAYER,
+  resetMeasurementStyleState,
+  restoreMeasurementsAfterRegen,
+  snapshotMeasurementsForRegen
+} from '../src/command/measure/AcApMeasurementStore'
+import type { AcApMeasurementRecord } from '../src/command/measure/AcApMeasurementTypes'
+import {
+  MEASUREMENT_FONT_SIZE,
+  MEASUREMENT_LINE_WEIGHT
+} from '../src/util/AcApMeasurementUtil'
+import type { AcTrView2d } from '../src/view'
+
+acapSetMarkupBagFactory(() => ({
+  store: new AcApMarkupStore(),
+  presenter: {
+    forgetPublished() {}
+  } as never,
+  history: new AcApMarkupHistory(),
+  sessionUndo: new AcApSessionUndo()
+}))
+
+function mockDb(): AcDbDatabase {
+  return {
+    transactionManager: {
+      canUndo: () => false,
+      undo: () => false,
+      canRedo: () => false,
+      redo: () => false
+    }
+  } as unknown as AcDbDatabase
+}
+
+function createView() {
+  const groups = new Map<string, AcTrHtmlGroup>()
+  const manager = {
+    groupsOnLayer(layer: string) {
+      return [...groups.values()].filter(group => group.layer === layer)
+    },
+    add(group: AcTrHtmlGroup) {
+      groups.set(group.id, group)
+    },
+    detach(id: string) {
+      const group = groups.get(id)
+      groups.delete(id)
+      return group
+    },
+    has(id: string) {
+      return groups.has(id)
+    },
+    getGroup(id: string) {
+      return groups.get(id)
+    },
+    clear(layer?: string) {
+      for (const group of [...groups.values()]) {
+        if (layer == null || group.layer === layer) {
+          group.onDispose?.()
+          groups.delete(group.id)
+        }
+      }
+    },
+    deselectAll() {},
+    selectGroup: jest.fn()
+  }
+  const view = {
+    htmlTransientManager: manager,
+    activeLayoutBtrId: 'layout0',
+    isHtmlDirty: false,
+    highlight: jest.fn(),
+    unhighlight: jest.fn(),
+    setTransientEntityVisible: jest.fn(),
+    worldToScreen: jest.fn(() => ({ x: 0, y: 0 }))
+  } as unknown as AcTrView2d
+  return { view, manager }
+}
+
+function makeGroup(id: string): AcTrHtmlGroup {
+  return {
+    id,
+    layer: MEASUREMENT_LAYER,
+    children: [],
+    canvases: [],
+    visible: true,
+    onSelectedChanged: undefined,
+    onVisibleChanged: undefined,
+    onDispose: undefined,
+    setVisible: jest.fn(),
+    dispose: jest.fn()
+  } as unknown as AcTrHtmlGroup
+}
+
+const distanceRecord: AcApMeasurementRecord = {
+  id: 'dist-1',
+  type: 'distance',
+  style: { color: '#ff0000', lineWeight: MEASUREMENT_LINE_WEIGHT, fontSize: MEASUREMENT_FONT_SIZE },
+  geometry: {
+    type: 'distance',
+    start: { x: 0, y: 0 },
+    end: { x: 100, y: 0 }
+  }
+}
+
+function commitOne(view: AcTrView2d, record = distanceRecord): void {
+  const group = makeGroup(record.id)
+  commitMeasurementGroup(view, group, {
+    style: deserializeMeasurementStyle(record.style),
+    snapshot: record
+  })
+}
+
+describe('measurement overlays across a view-clear redraw', () => {
+  beforeEach(() => {
+    bindMeasurementOverlayHistory()
+    resetMeasurementSession()
+    resetMeasurementStyleState()
+    getMarkupHistory().clear()
+    getSessionUndo().clear()
+    registerMeasurementPublish((view, db, record) => {
+      commitOne(view, record)
+    })
+  })
+
+  afterEach(() => {
+    resetMeasurementSession()
+    resetMeasurementStyleState()
+    getSessionUndo().clear()
+  })
+
+  it('documents the failure mode: clearing transient groups drops the record', () => {
+    const { view, manager } = createView()
+    commitOne(view)
+
+    expect(collectMeasurementRecords(view)).toHaveLength(1)
+
+    manager.clear(MEASUREMENT_LAYER)
+
+    expect(collectMeasurementRecords(view)).toHaveLength(0)
+  })
+
+  it('snapshot + restore keeps a committed measurement across a view clear', () => {
+    const { view, manager } = createView()
+    commitOne(view)
+
+    snapshotMeasurementsForRegen(view)
+    manager.clear(MEASUREMENT_LAYER)
+    restoreMeasurementsAfterRegen(view, mockDb())
+
+    const records = collectMeasurementRecords(view)
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe('dist-1')
+    expect(records[0].geometry).toEqual(distanceRecord.geometry)
+    expect(manager.getGroup('dist-1')).toBeDefined()
+  })
+
+  it('restore without a snapshot is a no-op', () => {
+    const { view } = createView()
+
+    expect(() =>
+      restoreMeasurementsAfterRegen(view as AcTrView2d, mockDb())
+    ).not.toThrow()
+    expect(collectMeasurementRecords(view)).toHaveLength(0)
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcEdCommandLineKeyboard.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdCommandLineKeyboard.spec.ts
@@ -1,0 +1,209 @@
+/** @jest-environment jsdom */
+
+jest.mock('../src/app', () => ({
+  AcApDocManager: {
+    instance: {
+      sendStringToExecute: jest.fn(),
+      lookupLocalCmd: jest.fn((name: string) => ({
+        globalName: name,
+        localName: name
+      })),
+      searchCommandsByPrefix: jest.fn(() => []),
+      editor: {
+        events: {
+          commandWillStart: { addEventListener: jest.fn() },
+          commandEnded: { addEventListener: jest.fn() }
+        }
+      }
+    }
+  },
+  AcApSettingManager: {
+    instance: {
+      isShowCommandLine: true,
+      events: { modified: { addEventListener: jest.fn() } }
+    }
+  }
+}))
+
+jest.mock('../src/i18n', () => ({
+  AcApI18n: {
+    t: (key: string, options?: { fallback?: string }) =>
+      options?.fallback ?? key,
+    cmdDescription: () => '',
+    events: { localeChanged: { addEventListener: jest.fn() } }
+  }
+}))
+
+jest.mock('../src/editor/global/AcEdUiLayout', () => ({
+  acedIsMobileOrPadUi: jest.fn(() => false)
+}))
+
+import { AcApDocManager, AcApSettingManager } from '../src/app'
+import { acedIsMobileOrPadUi } from '../src/editor/global/AcEdUiLayout'
+import { AcEdPromptKeywordOptions } from '../src/editor/input/prompt/AcEdPromptKeywordOptions'
+import { AcEdCommandLine } from '../src/editor/input/ui/AcEdCommandLine'
+
+const sendStringToExecute = AcApDocManager.instance
+  .sendStringToExecute as jest.Mock
+const isHandheld = acedIsMobileOrPadUi as jest.Mock
+
+function press(target: Element, key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+describe('AcEdCommandLine keyboard', () => {
+  let cli: AcEdCommandLine
+  let input: HTMLInputElement
+  let junk: HTMLDivElement
+
+  beforeAll(() => {
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    // One command line per file: its document-level capture listener cannot be
+    // unbound, so extra instances would steal keys from the one under test.
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    cli = new AcEdCommandLine(container)
+    input = container.querySelector('.ml-cli-text') as HTMLInputElement
+    junk = document.createElement('div')
+    document.body.appendChild(junk)
+  })
+
+  beforeEach(() => {
+    sendStringToExecute.mockClear()
+    isHandheld.mockReturnValue(false)
+    AcApSettingManager.instance.isShowCommandLine = true
+    ;(document.activeElement as HTMLElement | null)?.blur()
+    junk.textContent = ''
+    input.value = ''
+    cli.setInputReadOnly(false)
+    cli.visible = true
+    Object.assign(cli as unknown as Record<string, unknown>, {
+      activeSession: undefined,
+      spaceInsertsText: false
+    })
+  })
+
+  it('repeats the last command when Space is pressed with empty input', () => {
+    input.focus()
+    cli.executeCommand('LINE')
+    expect(sendStringToExecute).toHaveBeenLastCalledWith('LINE')
+
+    press(input, ' ')
+    expect(sendStringToExecute).toHaveBeenCalledTimes(2)
+    expect(sendStringToExecute).toHaveBeenLastCalledWith('LINE')
+  })
+
+  it('commits typed input when Space confirms', () => {
+    input.focus()
+    input.value = 'CIRCLE'
+
+    press(input, ' ')
+    expect(sendStringToExecute).toHaveBeenCalledWith('CIRCLE')
+  })
+
+  it('keeps Space as text for string prompts that allow spaces', async () => {
+    const options = new AcEdPromptKeywordOptions('Specify description')
+    const pending = cli.getPromptInput<string>(
+      options,
+      text => (text ? text : null),
+      {
+        mode: 'string',
+        allowNone: false,
+        allowTyping: true,
+        spaceInsertsText: true
+      }
+    )
+    await Promise.resolve()
+
+    input.value = 'Fire'
+    const spaceEvent = press(input, ' ')
+    expect(sendStringToExecute).not.toHaveBeenCalled()
+    expect(spaceEvent.defaultPrevented).toBe(false)
+
+    press(input, 'Enter')
+    await expect(pending).resolves.toEqual({
+      kind: 'value',
+      value: 'Fire'
+    })
+  })
+
+  it('repeats the last command from the canvas with Space', () => {
+    input.focus()
+    cli.executeCommand('LINE')
+    sendStringToExecute.mockClear()
+    input.blur()
+
+    press(document.body, ' ')
+    expect(sendStringToExecute).toHaveBeenCalledWith('LINE')
+  })
+
+  it('takes typed keys without clicking the command line first', () => {
+    expect(document.activeElement).not.toBe(input)
+
+    press(document.body, 'l')
+
+    expect(input.value).toBe('l')
+    expect(document.activeElement).toBe(input)
+    expect(sendStringToExecute).not.toHaveBeenCalled()
+  })
+
+  it('does not capture a key again once the input owns focus', () => {
+    input.focus()
+
+    press(document.body, 'l')
+    expect(input.value).toBe('')
+  })
+
+  it('re-shows the command line when typing starts while it is hidden', () => {
+    cli.visible = false
+    AcApSettingManager.instance.isShowCommandLine = false
+
+    press(document.body, 'c')
+    expect(AcApSettingManager.instance.isShowCommandLine).toBe(true)
+  })
+
+  it('does not capture typed keys on handheld layouts', () => {
+    isHandheld.mockReturnValue(true)
+
+    press(document.body, 'c')
+    expect(input.value).toBe('')
+  })
+
+  it('does not capture typed keys while a modal dialog is open', () => {
+    const backdrop = document.createElement('div')
+    backdrop.className = 'ml-ui-dialog-backdrop'
+    junk.appendChild(backdrop)
+
+    press(document.body, 'c')
+    expect(input.value).toBe('')
+    expect(document.activeElement).not.toBe(input)
+  })
+
+  it('leaves Space to the focused control instead of confirming', () => {
+    const button = document.createElement('button')
+    junk.appendChild(button)
+    button.focus()
+
+    press(button, ' ')
+    expect(sendStringToExecute).not.toHaveBeenCalled()
+    expect(input.value).toBe('')
+  })
+
+  it('returns focus to the canvas when Escape leaves the input', () => {
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    press(input, 'Escape')
+    expect(document.activeElement).toBe(document.body)
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcEdCommandLineKeyboard.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdCommandLineKeyboard.spec.ts
@@ -157,6 +157,19 @@ describe('AcEdCommandLine keyboard', () => {
     expect(sendStringToExecute).not.toHaveBeenCalled()
   })
 
+  it('takes a character handed over by the dynamic input fields', () => {
+    expect(cli.captureTypedCharacter('L')).toBe(true)
+    expect(input.value).toBe('L')
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('refuses a handed-over character while the input is read only', () => {
+    cli.setInputReadOnly(true)
+
+    expect(cli.captureTypedCharacter('L')).toBe(false)
+    expect(input.value).toBe('')
+  })
+
   it('does not capture a key again once the input owns focus', () => {
     input.focus()
 

--- a/packages/cad-simple-viewer/__tests__/AcEdFloatingInputBoxesKeys.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdFloatingInputBoxesKeys.spec.ts
@@ -1,0 +1,113 @@
+/** @jest-environment jsdom */
+
+import { AcEdFloatingInputBoxes } from '../src/editor/input/ui/AcEdFloatingInputBoxes'
+import { AcEdFloatingInputRawData } from '../src/editor/input/ui/AcEdFloatingInputTypes'
+
+type Pointish = { x: number }
+
+function press(target: Element, key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+function validate(raw: AcEdFloatingInputRawData) {
+  const x = Number(raw.x)
+  return Number.isFinite(x)
+    ? { isValid: true, value: { x } as Pointish }
+    : { isValid: false }
+}
+
+describe('AcEdFloatingInputBoxes key routing', () => {
+  let onLetter: jest.Mock
+  let committed: Pointish[]
+
+  function createBoxes() {
+    const parent = document.createElement('div')
+    document.body.appendChild(parent)
+    const boxes = new AcEdFloatingInputBoxes<Pointish>({
+      parent,
+      twoInputs: false,
+      autoFocus: false,
+      validate,
+      onLetter,
+      onCommit: value => {
+        committed.push(value)
+        return true
+      }
+    })
+    return { boxes, field: parent.querySelector('input') as HTMLInputElement }
+  }
+
+  function typeValue(boxes: AcEdFloatingInputBoxes<Pointish>, text: string) {
+    boxes.xInput.value = text
+    boxes.xInput.userTyped = true
+  }
+
+  beforeEach(() => {
+    onLetter = jest.fn(() => true)
+    committed = []
+    document.body.replaceChildren()
+  })
+
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it('hands a typed letter to the command line instead of the number field', () => {
+    const { boxes, field } = createBoxes()
+
+    const event = press(field, 'L')
+
+    expect(onLetter).toHaveBeenCalledWith('L')
+    expect(event.defaultPrevented).toBe(true)
+    expect(committed).toHaveLength(0)
+    boxes.dispose()
+  })
+
+  it('leaves the letter alone when no command line takes it over', () => {
+    onLetter = jest.fn(() => false)
+    const { boxes, field } = createBoxes()
+
+    const event = press(field, 'L')
+
+    expect(onLetter).toHaveBeenCalledWith('L')
+    expect(event.defaultPrevented).toBe(false)
+    boxes.dispose()
+  })
+
+  it('does not route digits away from the field', () => {
+    const { boxes, field } = createBoxes()
+
+    const event = press(field, '5')
+
+    expect(onLetter).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+    boxes.dispose()
+  })
+
+  it('commits the typed value when Space confirms', () => {
+    const { boxes, field } = createBoxes()
+    typeValue(boxes, '50')
+
+    const event = press(field, ' ')
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(committed).toEqual([{ x: 50 }])
+    boxes.dispose()
+  })
+
+  it('still commits on Enter', () => {
+    const { boxes, field } = createBoxes()
+    typeValue(boxes, '50')
+
+    press(field, 'Enter')
+
+    expect(committed).toEqual([{ x: 50 }])
+    boxes.dispose()
+  })
+})

--- a/packages/cad-simple-viewer/__tests__/AcEdPromptInputSession.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdPromptInputSession.spec.ts
@@ -10,7 +10,10 @@ describe('AcEdPromptInputSession precedence', () => {
       setInputReadOnly: jest.fn(),
       renderKeywordPrompt: jest.fn(),
       focusInput: jest.fn(),
-      clear: jest.fn()
+      clear: jest.fn(),
+      hasCommand: jest.fn(
+        (text: string) => text.trim().toUpperCase() === 'LINE'
+      )
     }) as any
 
   const createSession = (
@@ -29,8 +32,12 @@ describe('AcEdPromptInputSession precedence', () => {
       false,
       true
     )
-    const resolved: Array<{ kind: string; value?: unknown; keyword?: string }> =
-      []
+    const resolved: Array<{
+      kind: string
+      value?: unknown
+      keyword?: string
+      command?: string
+    }> = []
     ;(session as any).resolve = (value: unknown) => resolved.push(value as any)
     return { session, resolved }
   }
@@ -58,5 +65,45 @@ describe('AcEdPromptInputSession precedence', () => {
 
     expect(handled).toBe(true)
     expect(resolved[0]).toEqual({ kind: 'keyword', keyword: 'Close' })
+  })
+
+  test('geometric mode hands a registered command name back to the caller', () => {
+    const options = new AcEdPromptKeywordOptions('pick')
+
+    const { session, resolved } = createSession(options, 'geometric')
+    const handled = session.handleEnter('line')
+
+    expect(handled).toBe(true)
+    expect(resolved[0]).toEqual({ kind: 'command', command: 'line' })
+  })
+
+  test('geometric mode keeps prompt keywords ahead of command names', () => {
+    const options = new AcEdPromptKeywordOptions('pick')
+    options.keywords.add('Line', 'Line', 'LINE')
+
+    const { session, resolved } = createSession(options, 'geometric')
+    session.handleEnter('LINE')
+
+    expect(resolved[0]).toEqual({ kind: 'keyword', keyword: 'Line' })
+  })
+
+  test('geometric mode still rejects text that is neither value nor command', () => {
+    const options = new AcEdPromptKeywordOptions('pick')
+
+    const { session, resolved } = createSession(options, 'geometric')
+    const handled = session.handleEnter('zzz')
+
+    expect(handled).toBe(false)
+    expect(resolved).toHaveLength(0)
+  })
+
+  test('string mode keeps arbitrary text as the value instead of a command', () => {
+    const options = new AcEdPromptKeywordOptions('name')
+
+    const { session, resolved } = createSession(options, 'string')
+    const handled = session.handleEnter('LINE')
+
+    expect(handled).toBe(false)
+    expect(resolved).toHaveLength(0)
   })
 })

--- a/packages/cad-simple-viewer/src/app/AcApContext.ts
+++ b/packages/cad-simple-viewer/src/app/AcApContext.ts
@@ -6,6 +6,10 @@ import {
   AcDbSysVarManager
 } from '@mlightcad/data-model'
 
+import {
+  restoreMeasurementsAfterRegen,
+  snapshotMeasurementsForRegen
+} from '../command/measure/AcApMeasurementStore'
 import { AcEdBaseView } from '../editor/view/AcEdBaseView'
 import { AcTrView2d } from '../view'
 import { AcApDocument } from './AcApDocument'
@@ -148,8 +152,10 @@ export class AcApContext {
           currentView.renderer.showLineWeight = showLineWeight
           // Existing line objects may need different geometry/material classes.
           // Regenerate to rebuild scene content using the new display mode.
+          snapshotMeasurementsForRegen(currentView)
           currentView.clear()
           args.database.regen()
+          restoreMeasurementsAfterRegen(currentView, args.database)
         }
       }
     })

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -80,6 +80,10 @@ import {
   acapGetDrawStyleSessionAccessory
 } from '../command/AcApDrawStyleSession'
 import { registerMarkupCommands } from '../command/markup/AcApRegisterMarkupCommands'
+import {
+  restoreMeasurementsAfterRegen,
+  snapshotMeasurementsForRegen
+} from '../command/measure/AcApMeasurementStore'
 import { registerMeasureCommands } from '../command/measure/AcApRegisterMeasureCommands'
 import {
   AcEdCalculateSizeCallback,
@@ -1492,8 +1496,13 @@ export class AcApDocManager {
    * for missed fonts so that the drawing can apply new fonts.
    */
   regen() {
+    snapshotMeasurementsForRegen(this.curView as AcTrView2d)
     this.curView.clear()
     this.context.doc.database.regen()
+    restoreMeasurementsAfterRegen(
+      this.curView as AcTrView2d,
+      this.context.doc.database
+    )
   }
 
   /**

--- a/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
+++ b/packages/cad-simple-viewer/src/command/measure/AcApMeasurementStore.ts
@@ -23,6 +23,7 @@ import {
   measurementFocusBox
 } from './AcApMeasurementGeometry'
 import { runMeasurementEdit } from './AcApMeasurementHistory'
+import { republishMeasurement } from './AcApMeasurementRepublish'
 import { serializeMeasurementStyle } from './AcApMeasurementSidecar'
 import type {
   AcApMeasurementRecord,
@@ -461,6 +462,37 @@ export function resetMeasurementStyleState(): void {
   selectedMeasurementId = undefined
   notifyMeasurementSelection()
   notifyMeasurementsChanged()
+}
+
+/** Committed measurements captured before a regen-style view clear. */
+let regenSnapshot: AcApMeasurementRecord[] | undefined
+
+/**
+ * Snapshot committed measurements before a view-clear redraw so the overlays
+ * can be re-published once the scene is rebuilt.
+ *
+ * REGEN, current-layer changes and the LWDISPLAY toggle discard every HTML
+ * transient group (along with the only in-memory copy of each measurement
+ * record), so without a snapshot the annotations are lost for the session.
+ */
+export function snapshotMeasurementsForRegen(view: AcTrView2d): void {
+  regenSnapshot = collectMeasurementRecords(view)
+}
+
+/**
+ * Re-publish measurements captured by {@link snapshotMeasurementsForRegen}
+ * after a redraw completed. Consumes the snapshot; a no-op when absent.
+ */
+export function restoreMeasurementsAfterRegen(
+  view: AcTrView2d,
+  db: AcDbDatabase
+): void {
+  const records = regenSnapshot
+  regenSnapshot = undefined
+  if (!records) return
+  for (const record of records) {
+    republishMeasurement(view, db, record)
+  }
 }
 
 /**

--- a/packages/cad-simple-viewer/src/editor/input/session/AcEdPromptInputSession.ts
+++ b/packages/cad-simple-viewer/src/editor/input/session/AcEdPromptInputSession.ts
@@ -14,11 +14,15 @@ export type AcEdPromptInputMode = 'geometric' | 'string' | 'keyword'
 
 /**
  * Result produced by a mixed prompt-input session.
+ *
+ * `command` asks the caller to abandon the prompt and run a registered command
+ * instead, the way AutoCAD does when a command name is typed at a prompt.
  */
 export type AcEdPromptInputResult<T> =
   | { kind: 'value'; value: T }
   | { kind: 'keyword'; keyword: string }
   | { kind: 'none' }
+  | { kind: 'command'; command: string }
 
 /**
  * Interactive command-line session that accepts geometric or textual prompt
@@ -96,7 +100,16 @@ export class AcEdPromptInputSession<T> extends AcEdInputSession<
       return true
     }
 
-    return this.tryResolveKeyword(value)
+    if (this.tryResolveKeyword(value)) return true
+
+    // A command name is not prompt input: starting that command beats
+    // reporting the text as invalid.
+    if (this.cli.hasCommand(value)) {
+      this.finish({ kind: 'command', command: value.trim() })
+      return true
+    }
+
+    return false
   }
 
   handleEscape(): void {

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
@@ -1,5 +1,6 @@
 import { AcApDocManager, AcApSettingManager } from '../../../app'
 import { AcApI18n } from '../../../i18n'
+import { acedIsMobileOrPadUi } from '../../global/AcEdUiLayout'
 import { AcEdPromptKeywordOptions } from '../prompt'
 import {
   AcEdCommandLineSessionControl,
@@ -10,6 +11,33 @@ import {
 } from '../session'
 import { AcEdMessageType } from './AcEdMessageType'
 
+/** Marks the host container owning a command line (used to route typed keys). */
+const COMMAND_LINE_HOST_CLASS = 'ml-cli-host'
+
+/**
+ * Host container whose command line was last pointed at.
+ *
+ * Split-view hosts build one command line per view, so a keystroke must be
+ * claimed by exactly one of them: only this host captures typed keys when
+ * sibling command lines exist in the document.
+ */
+let typingHost: HTMLElement | null = null
+let typingHostTrackingBound = false
+
+function bindTypingHostTracking() {
+  if (typingHostTrackingBound) return
+  typingHostTrackingBound = true
+  document.addEventListener(
+    'pointerdown',
+    e => {
+      const target = e.target as HTMLElement | null
+      const host = target?.closest?.(`.${COMMAND_LINE_HOST_CLASS}`)
+      if (host) typingHost = host as HTMLElement
+    },
+    true
+  )
+}
+
 /**
  * AutoCAD-style floating command line with Promise-based execution.
  *
@@ -17,7 +45,9 @@ import { AcEdMessageType } from './AcEdMessageType'
  *  - Floating command bar with left terminal glyph + down toggle and right up toggle
  *  - Command history popup
  *  - Message panel above the bar
- *  - Enter repeats last command if input empty
+ *  - Enter or Space repeats last command if input empty
+ *  - Typed keys reach the input without clicking it first; Esc returns focus
+ *    to the canvas so view shortcuts keep working
  *  - Esc cancels current command
  *  - Inline clickable options
  *  - Keyboard navigation
@@ -50,6 +80,8 @@ export class AcEdCommandLine {
   private activeSession?: AcEdCommandLineSessionControl
   private resizeObserver?: ResizeObserver
   private isPromptActive: boolean = false
+  /** Whether the active session consumes Space as text instead of as Enter. */
+  private spaceInsertsText: boolean = false
   private readonly recentMessages: string[] = []
   private recentHideTimer?: ReturnType<typeof setTimeout>
   private isCommandLifecycleBound: boolean = false
@@ -69,6 +101,7 @@ export class AcEdCommandLine {
     this.createUI()
     this.bindEvents()
     this.bindCommandLifecycleEvents()
+    this.bindTypingCapture()
     this.resizeHandler()
     window.addEventListener('resize', () => this.resizeHandler())
     this.resizeObserver = new ResizeObserver(() => this.resizeHandler())
@@ -145,10 +178,12 @@ export class AcEdCommandLine {
   ): Promise<string> {
     const session = new AcEdKeywordSession(this, options, allowTyping)
     this.activeSession = session
+    this.spaceInsertsText = false
     try {
       return await session.start()
     } finally {
       this.activeSession = undefined
+      this.spaceInsertsText = false
     }
   }
 
@@ -163,6 +198,7 @@ export class AcEdCommandLine {
       mode: AcEdPromptInputMode
       allowNone: boolean
       allowTyping?: boolean
+      spaceInsertsText?: boolean
     }
   ): Promise<AcEdPromptInputResult<T>> {
     const session = new AcEdPromptInputSession(
@@ -174,10 +210,12 @@ export class AcEdCommandLine {
       config.allowTyping ?? true
     )
     this.activeSession = session
+    this.spaceInsertsText = config.spaceInsertsText ?? false
     try {
       return await session.start()
     } finally {
       this.activeSession = undefined
+      this.spaceInsertsText = false
     }
   }
 
@@ -611,6 +649,7 @@ export class AcEdCommandLine {
     this.wrapper.appendChild(this.msgPanel)
 
     this.container.appendChild(this.cliContainer)
+    this.container.classList.add(COMMAND_LINE_HOST_CLASS)
   }
 
   /** Bind event listeners */
@@ -658,30 +697,19 @@ export class AcEdCommandLine {
     })
   }
 
-  /** Handle Enter/Escape keys */
+  /** Handle Enter/Space/Escape keys */
   private handleKeyDown(e: KeyboardEvent) {
     // IME / composition safety (important!)
     if (e.isComposing) return
 
     switch (e.key) {
-      case 'Enter': {
+      case 'Enter':
+      case ' ': {
+        // String prompts that accept spaces need Space as literal text.
+        if (e.key === ' ' && this.spaceInsertsText) return
         e.preventDefault()
         e.stopImmediatePropagation()
-
-        if (this.activeSession) {
-          const handled = this.activeSession.handleEnter(this.getInputText())
-          if (!handled) {
-            this.showMessage(
-              this.localize('main.commandLine.invalidInput', 'Invalid input.'),
-              'warning'
-            )
-          }
-          return
-        }
-
-        this.executeCommand(this.getInputText())
-        this.historyIndex = this.history.length
-        this.updatePopups({ showCmd: false, showMsg: false })
+        this.confirmInput()
         return
       }
 
@@ -692,12 +720,15 @@ export class AcEdCommandLine {
         if (this.activeSession) {
           this.activeSession.handleEscape()
           this.activeSession = undefined
-          return
+        } else {
+          this.clear()
+          this.showMessage(this.localize('main.commandLine.canceled'))
+          this.updatePopups({ showCmd: false, showMsg: false })
         }
 
-        this.clear()
-        this.showMessage(this.localize('main.commandLine.canceled'))
-        this.updatePopups({ showCmd: false, showMsg: false })
+        // Hand focus back to the canvas so view shortcuts (Delete, Ctrl+Z)
+        // are not swallowed by the input afterwards.
+        this.textInput.blur()
         return
       }
 
@@ -724,6 +755,99 @@ export class AcEdCommandLine {
         return
       }
     }
+  }
+
+  /** Commit typed input as a command, or repeat the last one when empty. */
+  private confirmInput() {
+    if (this.activeSession) {
+      const handled = this.activeSession.handleEnter(this.getInputText())
+      if (!handled) {
+        this.showMessage(
+          this.localize('main.commandLine.invalidInput', 'Invalid input.'),
+          'warning'
+        )
+      }
+      return
+    }
+
+    this.executeCommand(this.getInputText())
+    this.historyIndex = this.history.length
+    this.updatePopups({ showCmd: false, showMsg: false })
+  }
+
+  /**
+   * Captures typed keys on the document so a command can be started without
+   * clicking the command line first.
+   */
+  private bindTypingCapture() {
+    bindTypingHostTracking()
+    document.addEventListener('keydown', e => {
+      if (!this.shouldCaptureTypedKey(e)) return
+
+      e.preventDefault()
+      e.stopPropagation()
+
+      if (!this.visible) {
+        // Re-show through the setting so `AcEdInputManager` stays the single
+        // source of truth for command line visibility.
+        AcApSettingManager.instance.isShowCommandLine = true
+      }
+
+      if (e.key === ' ') {
+        this.confirmInput()
+        return
+      }
+
+      this.focusInput()
+      this.insertTypedCharacter(e.key)
+    })
+  }
+
+  /** Whether this command line should claim a document-level typed key. */
+  private shouldCaptureTypedKey(e: KeyboardEvent): boolean {
+    if (e.defaultPrevented || e.ctrlKey || e.metaKey || e.altKey) return false
+    if (e.isComposing || e.keyCode === 229) return false
+    if (e.key.length !== 1) return false
+    if (acedIsMobileOrPadUi()) return false
+    if (document.querySelector('.ml-ui-dialog-backdrop')) return false
+    if (this.hasSiblingCommandLine() && typingHost !== this.container) {
+      return false
+    }
+
+    const focused = document.activeElement as HTMLElement | null
+    if (focused && this.isEditableElement(focused)) return false
+
+    if (e.key === ' ') {
+      // Space still activates a focused control such as a toolbar button.
+      return (
+        focused === null ||
+        focused === document.body ||
+        focused.tagName === 'CANVAS'
+      )
+    }
+
+    return !this.textInput.readOnly
+  }
+
+  private hasSiblingCommandLine(): boolean {
+    return document.querySelectorAll('.ml-cli-text').length > 1
+  }
+
+  private isEditableElement(el: Element): boolean {
+    const tag = el.tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+    return (el as HTMLElement).isContentEditable === true
+  }
+
+  /** Insert a character captured outside the input at the current caret. */
+  private insertTypedCharacter(char: string) {
+    const input = this.textInput
+    const start = input.selectionStart ?? input.value.length
+    const end = input.selectionEnd ?? start
+    input.value = `${input.value.slice(0, start)}${char}${input.value.slice(end)}`
+    const caret = start + char.length
+    input.setSelectionRange(caret, caret)
+    this.handleInputChange()
   }
 
   /** Handle input change to show auto-complete */

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdCommandLine.ts
@@ -787,20 +787,40 @@ export class AcEdCommandLine {
       e.preventDefault()
       e.stopPropagation()
 
-      if (!this.visible) {
-        // Re-show through the setting so `AcEdInputManager` stays the single
-        // source of truth for command line visibility.
-        AcApSettingManager.instance.isShowCommandLine = true
-      }
-
       if (e.key === ' ') {
+        this.ensureVisibleForTyping()
         this.confirmInput()
         return
       }
 
-      this.focusInput()
-      this.insertTypedCharacter(e.key)
+      this.captureTypedCharacter(e.key)
     })
+  }
+
+  /**
+   * Types a character that was captured outside the input, e.g. a letter the
+   * dynamic input fields handed over because they only take numbers.
+   *
+   * @returns Whether the command line took the character.
+   */
+  captureTypedCharacter(char: string): boolean {
+    if (!char.length || this.textInput.readOnly) return false
+    this.ensureVisibleForTyping()
+    this.focusInput()
+    this.insertTypedCharacter(char)
+    return true
+  }
+
+  /** Whether the text names a registered command. */
+  hasCommand(text: string): boolean {
+    return !!text.trim() && !!this.resolveCommand(text)
+  }
+
+  private ensureVisibleForTyping() {
+    if (this.visible) return
+    // Re-show through the setting so `AcEdInputManager` stays the single
+    // source of truth for command line visibility.
+    AcApSettingManager.instance.isShowCommandLine = true
   }
 
   /** Whether this command line should claim a document-level typed key. */

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -116,6 +116,9 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   private mouseClickArmed = false
   /** Whether to suppress UI display while keeping input active */
   private suppressDisplay: boolean = false
+  /** Set once typing moved to the command line: the fields must not steal
+   * focus back on the next preview refresh. */
+  private focusHeld = false
   /** Cached sysvar handler */
   private boundOnInputSysVarChanged: (args: {
     name: string
@@ -183,6 +186,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
         twoInputs: options.inputCount === 2,
         validate: this.validateFn,
         onCancel: this.onCancel,
+        onLetter: options.onLetter,
         onNone: this.onNone,
         onCommit: this.onCommit,
         onChange: this.onChange,
@@ -317,7 +321,11 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     )
     this.parent.removeEventListener('pointermove', this.boundOnPointerMove)
     this.parent.removeEventListener('touchstart', this.boundOnTouchStart)
-    this.parent.removeEventListener('contextmenu', this.boundOnContextMenu, true)
+    this.parent.removeEventListener(
+      'contextmenu',
+      this.boundOnContextMenu,
+      true
+    )
     window.removeEventListener('pointerup', this.boundOnPointerUp)
     window.removeEventListener('pointercancel', this.boundOnPointerCancel)
     window.removeEventListener('touchmove', this.boundOnTouchMove)
@@ -641,6 +649,18 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     this.requestPreviewRefresh()
   }
 
+  /**
+   * Hands typing over to the command line for the rest of this prompt.
+   *
+   * Without this the next preview refresh refocuses the fields as soon as the
+   * mouse moves, so characters the user started typing in the command line
+   * would land back in the number fields.
+   */
+  releaseFocusToCommandLine() {
+    this.focusHeld = true
+    this.inputs?.blur()
+  }
+
   private updateDynamicPreview(wcsPos: AcGePoint2dLike) {
     this.lastDynamicPoint = { x: wcsPos.x, y: wcsPos.y }
     const defaults = this.getDynamicValue(wcsPos)
@@ -648,7 +668,12 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     this.inputs?.setValue(defaults.raw)
 
     // Ensure focus stays in input boxes
-    if (this.inputs && !this.inputs.focused && !this.suppressDisplay) {
+    if (
+      this.inputs &&
+      !this.inputs.focused &&
+      !this.suppressDisplay &&
+      !this.focusHeld
+    ) {
       this.inputs.focus()
     }
 
@@ -730,7 +755,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
       this.inputs?.blur()
     } else {
       this.container.style.display = 'flex'
-      if (this.inputs && !this.inputs.focused) {
+      if (this.inputs && !this.inputs.focused && !this.focusHeld) {
         this.inputs.focus()
       }
     }

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBoxes.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputBoxes.ts
@@ -47,6 +47,13 @@ export interface AcEdFloatingInputBoxesOptions<T> {
   onCancel?: AcEdFloatingInputCancelCallback
 
   /**
+   * Callback invoked when the user types an alphabetic key. The fields only
+   * accept numbers, so the character belongs to the command line; return true
+   * to consume the key.
+   */
+  onLetter?: (char: string) => boolean
+
+  /**
    * Callback invoked when Enter submits "none" (AllowNone + empty typed input).
    */
   onNone?: AcEdFloatingInputNoneCallback
@@ -112,6 +119,7 @@ export class AcEdFloatingInputBoxes<T> {
   private onCommit?: AcEdFloatingInputCommitCallback<T>
   private onChange?: AcEdFloatingInputChangeCallback<T>
   private onCancel?: AcEdFloatingInputCancelCallback
+  private onLetter?: (char: string) => boolean
   private onNone?: AcEdFloatingInputNoneCallback
   private validateFn: AcEdFloatingInputValidationCallback<T>
   private allowNone: boolean
@@ -144,6 +152,7 @@ export class AcEdFloatingInputBoxes<T> {
     this.onCommit = options.onCommit
     this.onChange = options.onChange
     this.onCancel = options.onCancel
+    this.onLetter = options.onLetter
     this.onNone = options.onNone
     this.allowNone = options.allowNone ?? false
     this.useDefaultValue = options.useDefaultValue ?? false
@@ -219,7 +228,8 @@ export class AcEdFloatingInputBoxes<T> {
   }
 
   /**
-   * Handles keyboard events (Enter for commit, Escape for cancel).
+   * Handles keyboard events (Enter or Space to commit, Escape to cancel,
+   * letters handed over to the command line).
    */
   private handleKeyDown(e: KeyboardEvent): void {
     // Find out which input element triggers this event
@@ -230,7 +240,15 @@ export class AcEdFloatingInputBoxes<T> {
       nextInput = this.xInput
     }
 
-    if (e.key === 'Enter') {
+    // The fields hold numbers only, so a letter is the start of a command or
+    // keyword and belongs to the command line instead.
+    if (/^[a-z]$/i.test(e.key) && this.onLetter?.(e.key)) {
+      e.preventDefault()
+      e.stopPropagation()
+      return
+    }
+
+    if (e.key === 'Enter' || e.key === ' ') {
       if (this.useDefaultValue && !this.userTyped) {
         const committed =
           !this.onCommit || this.onCommit(this.defaultValue as T)

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputTypes.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInputTypes.ts
@@ -188,6 +188,13 @@ export interface AcEdFloatingInputOptions<T> {
   onCancel?: AcEdFloatingInputCancelCallback
 
   /**
+   * Callback invoked when the user types an alphabetic key into the fields.
+   * The fields accept numbers only, so the character belongs to the command
+   * line; return true to consume the key.
+   */
+  onLetter?: (char: string) => boolean
+
+  /**
    * Callback invoked when user enters no value and prompt allows none.
    */
   onNone?: AcEdFloatingInputNoneCallback

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -734,15 +734,22 @@ export class AcEdInputManager {
       'allowNone' in options
         ? (options as { allowNone: boolean }).allowNone
         : false
+    const mode = this.resolvePromptInputMode(handler)
+    const allowSpaces =
+      'allowSpaces' in options
+        ? (options as { allowSpaces: boolean }).allowSpaces
+        : false
 
     return {
       promise: this._commandLine.getPromptInput(
         keywordOptions,
         text => this.parseCommandLineInput(text, handler, inputCount, options),
         {
-          mode: this.resolvePromptInputMode(handler),
+          mode,
           allowNone,
-          allowTyping
+          allowTyping,
+          // Space confirms a prompt unless the value itself may contain spaces.
+          spaceInsertsText: mode === 'string' && allowSpaces
         }
       ),
       cancel: () => this._commandLine.cancelActiveSession()
@@ -2297,14 +2304,10 @@ export class AcEdInputManager {
         options.promptOptions
       )
       const showMetrics =
-        options.showMetrics ??
-        (options.inputCount === 2 || basePoint != null)
+        options.showMetrics ?? (options.inputCount === 2 || basePoint != null)
 
       const getDynamicValue: AcEdFloatingInputDynamicValueCallback<T> = pos => {
-        this.pushMobileMetrics(
-          pos,
-          basePoint ?? floatingInput.sessionBasePoint
-        )
+        this.pushMobileMetrics(pos, basePoint ?? floatingInput.sessionBasePoint)
         return options.getDynamicValue(pos)
       }
 

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdInputManager.ts
@@ -2348,6 +2348,12 @@ export class AcEdInputManager {
           }
           return result
         },
+        onLetter: char => {
+          // Numbers belong in the fields; a letter is the start of a command
+          // or keyword, so hand the rest of this prompt to the command line.
+          floatingInput.releaseFocusToCommandLine()
+          return this._commandLine.captureTypedCharacter(char)
+        },
         onCancel: () => rejector(),
         onNone: () => noneRejector()
       })
@@ -2468,6 +2474,15 @@ export class AcEdInputManager {
             } else {
               rejector()
             }
+            break
+          case 'command':
+            rejector()
+            // Defer so the awaiting command unwinds and runs its own cleanup
+            // before the next command starts drawing on the same view.
+            setTimeout(
+              () => this._commandLine.executeCommand(result.command),
+              0
+            )
             break
         }
       })


### PR DESCRIPTION
## Summary

- Typing any printable key while the canvas has focus now lands in the command line, so starting a command no longer requires clicking the input first; a command line closed with the ✕ button re-shows itself.
- Space acts as Enter: it commits typed input, and with an empty input it repeats the last command.
- Escape still cancels the active command and now also hands keyboard focus back to the canvas, so Delete / Ctrl+Z keep working afterwards.

String prompts that accept spaces (`allowSpaces`: layer description, markup text, ...) keep Space as a literal character, and Space still activates a focused button instead of confirming.

## Test plan

- [x] `jest packages/cad-simple-viewer` — 97 suites / 556 tests pass, including the new `AcEdCommandLineKeyboard` spec (space confirms, space repeats from the canvas, type-to-focus, dialog/handheld/focused-button exemptions, Escape releases focus)
- [x] `eslint` on the changed sources — clean
- [x] Manual on `pnpm dev` (cad-viewer-example, zh-CN UI): click the canvas, type `line` without touching the command line, press Space → "指定第一个点"; press Esc → `document.activeElement` is back to BODY; press Space again → LINE restarts; no console errors
- [x] Manual on phone/pad layout: the capture is skipped there, so the mobile session chrome is unaffected