### PR TITLE
fix: ignore leftover mouse after HTML touch picks and align confirmed-point marks with mobile nav UI

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts
@@ -2,10 +2,10 @@
  * @jest-environment jsdom
  */
 
-const isCompactLayout = jest.fn(() => true)
+const isMobileNavUi = jest.fn(() => true)
 
 jest.mock('../src/AcExHtmlDrawerSheet', () => ({
-  acExHtmlIsCompactLayout: () => isCompactLayout()
+  acExHtmlIsMobileNavUi: () => isMobileNavUi()
 }))
 
 import { AcExConfirmedPointMarks } from '../src/AcExConfirmedPointMarks'
@@ -13,7 +13,7 @@ import { AcExConfirmedPointMarks } from '../src/AcExConfirmedPointMarks'
 describe('AcExConfirmedPointMarks', () => {
   afterEach(() => {
     document.body.replaceChildren()
-    isCompactLayout.mockReturnValue(true)
+    isMobileNavUi.mockReturnValue(true)
   })
 
   it('renders plus marks on phone/pad and clears them on desktop', () => {
@@ -33,9 +33,21 @@ describe('AcExConfirmedPointMarks', () => {
     expect((els[0] as HTMLElement).style.left).toBe('10px')
     expect((els[0] as HTMLElement).style.top).toBe('20px')
 
-    isCompactLayout.mockReturnValue(false)
+    isMobileNavUi.mockReturnValue(false)
     marks.setWorldPoints([{ x: 5, y: 6 }])
     expect(host.querySelectorAll('.mlcad-confirmed-point-mark')).toHaveLength(0)
+  })
+
+  it('shows marks when mobile nav UI is on from a coarse pointer, not only compact width', () => {
+    isMobileNavUi.mockReturnValue(true)
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const marks = new AcExConfirmedPointMarks(host, pos => ({
+      x: pos.x,
+      y: pos.y
+    }))
+    marks.setWorldPoints([{ x: 8, y: 12 }])
+    expect(host.querySelectorAll('.mlcad-confirmed-point-mark')).toHaveLength(1)
   })
 
   it('repositions existing marks on sync', () => {

--- a/packages/cad-html-plugin/__tests__/AcExTouchPointSession.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExTouchPointSession.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  ACEX_TOUCH_MOUSE_GUARD_MS,
+  acExArmTouchMouseGuard,
+  acExClearFollowingClickSink,
+  acExResetTouchMouseGuard,
+  acExShouldIgnoreCompatMouse,
+  acExSinkFollowingClick,
+  AcExTouchPointSession
+} from '../src/AcExTouchPointSession'
+
+describe('AcExTouchPointSession', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+    acExResetTouchMouseGuard()
+  })
+
+  it('commits a short tap without opening the loupe', () => {
+    const onLongPress = jest.fn()
+    const session = new AcExTouchPointSession()
+    session.start(1, 10, 20, onLongPress, 350)
+    expect(session.phase).toBe('pending')
+    expect(session.end()).toBe('commit')
+    expect(onLongPress).not.toHaveBeenCalled()
+    expect(session.phase).toBe('idle')
+  })
+
+  it('opens the loupe after the long-press delay and commits on end', () => {
+    const onLongPress = jest.fn()
+    const session = new AcExTouchPointSession()
+    session.start(1, 10, 20, onLongPress, 350)
+    jest.advanceTimersByTime(350)
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+    expect(session.phase).toBe('loupe')
+    expect(session.end()).toBe('commit')
+  })
+})
+
+describe('acExShouldIgnoreCompatMouse', () => {
+  afterEach(() => {
+    acExResetTouchMouseGuard()
+  })
+
+  it('ignores mouse after a touch pick so a second nearby point is not committed', () => {
+    acExArmTouchMouseGuard(1000)
+    expect(acExShouldIgnoreCompatMouse(1000)).toBe(true)
+    expect(
+      acExShouldIgnoreCompatMouse(1000 + ACEX_TOUCH_MOUSE_GUARD_MS - 1)
+    ).toBe(true)
+    expect(acExShouldIgnoreCompatMouse(1000 + ACEX_TOUCH_MOUSE_GUARD_MS)).toBe(
+      false
+    )
+  })
+
+  it('stays armed while the following-click sink is still listening', () => {
+    acExSinkFollowingClick()
+    expect(acExShouldIgnoreCompatMouse(1e12)).toBe(true)
+    acExClearFollowingClickSink()
+    expect(acExShouldIgnoreCompatMouse(1e12)).toBe(false)
+  })
+})
+
+describe('acExSinkFollowingClick', () => {
+  afterEach(() => {
+    acExResetTouchMouseGuard()
+  })
+
+  it('eats the leftover click after a touch pick', () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const later = jest.fn()
+    target.addEventListener('click', later)
+    acExSinkFollowingClick()
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(later).not.toHaveBeenCalled()
+    target.remove()
+  })
+
+  it('expires so a later mouse click is not eaten if no leftover click arrives', () => {
+    jest.useFakeTimers()
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const later = jest.fn()
+    target.addEventListener('click', later)
+    acExSinkFollowingClick()
+    jest.advanceTimersByTime(ACEX_TOUCH_MOUSE_GUARD_MS)
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(later).toHaveBeenCalledTimes(1)
+    target.remove()
+    jest.useRealTimers()
+  })
+})

--- a/packages/cad-html-plugin/src/AcExConfirmedPointMarks.ts
+++ b/packages/cad-html-plugin/src/AcExConfirmedPointMarks.ts
@@ -1,4 +1,4 @@
-import { acExHtmlIsCompactLayout } from './AcExHtmlDrawerSheet'
+import { acExHtmlIsMobileNavUi } from './AcExHtmlDrawerSheet'
 
 /**
  * World-space point used by {@link AcExConfirmedPointMarks}.
@@ -12,10 +12,11 @@ export interface AcExConfirmedPointMarkPos {
  * Temporary plus marks at confirmed pick points during multi-step measure /
  * markup tools on phone and pad.
  *
- * Desktop never shows these marks. Uses the offline HTML compact breakpoint
- * ({@link acExHtmlIsCompactLayout}) instead of `acedIsMobileOrPadUi` so measure /
- * markup controllers stay free of the `cad-simple-viewer` barrel. There is no
- * override API in the offline HTML viewer (unlike
+ * Desktop never shows these marks. Uses {@link acExHtmlIsMobileNavUi} (compact
+ * width or coarse pointer) instead of `acedIsMobileOrPadUi` so measure /
+ * markup controllers stay free of the `cad-simple-viewer` barrel and stay
+ * aligned with HTML mobile pick chrome (snap loupe, hidden Select/Pan).
+ * There is no override API in the offline HTML viewer (unlike
  * `AcEdPromptPointOptions.showConfirmedPointMark` in the live CAD viewer).
  */
 export class AcExConfirmedPointMarks {
@@ -49,7 +50,7 @@ export class AcExConfirmedPointMarks {
    * No-ops visually on desktop (clears any existing marks).
    */
   setWorldPoints(points: readonly AcExConfirmedPointMarkPos[]): void {
-    if (!acExHtmlIsCompactLayout()) {
+    if (!acExHtmlIsMobileNavUi()) {
       this.clear()
       return
     }

--- a/packages/cad-html-plugin/src/AcExHtmlDrawerSheet.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlDrawerSheet.ts
@@ -47,8 +47,9 @@ export function acExHtmlIsCompactLayout(): boolean {
 
 /**
  * Whether idle touch should unify pan + long-press box select (and hide
- * Select / Pan). Compact width covers phone and pad; coarse pointer covers
- * wider tablets such as iPad landscape.
+ * Select / Pan), and whether confirmed-point plus marks should show.
+ * Compact width covers phone and pad; coarse pointer covers wider tablets
+ * such as iPad landscape.
  */
 export function acExHtmlIsMobileNavUi(): boolean {
   return (

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -92,7 +92,11 @@ import type {
   AcExSnapshot,
   AcExViewerMode
 } from './AcExSnapshotTypes'
-import { AcExTouchPointSession } from './AcExTouchPointSession'
+import {
+  acExShouldIgnoreCompatMouse,
+  acExSinkFollowingClick,
+  AcExTouchPointSession
+} from './AcExTouchPointSession'
 import { acExMaybeShowTouchPointTutorial } from './AcExTouchPointTutorial'
 import {
   releaseLayerGroupsGeometryCpuArrays,
@@ -2212,9 +2216,6 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     startY: number
     activated: boolean
   } | null = null
-  let ignoreMouseUntil = 0
-  const TOUCH_MOUSE_GUARD_MS = 1000
-
   const releaseBoxPointerCapture = (pointerId: number) => {
     try {
       if (domElement.hasPointerCapture(pointerId)) {
@@ -2225,9 +2226,6 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     }
   }
 
-  const armTouchMouseGuard = () => {
-    ignoreMouseUntil = performance.now() + TOUCH_MOUSE_GUARD_MS
-  }
   const selectionRect = document.createElement('div')
   selectionRect.id = 'mlcad-selection-rect'
   selectionRect.hidden = true
@@ -2421,7 +2419,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     acExSetMobileSnapLoupePreciseCapture(false)
     if (gesture) releaseBoxPointerCapture(gesture.pointerId)
     // Compat mouse after touch, not a real mouse box-select.
-    if (gesture?.pointerType === 'touch') armTouchMouseGuard()
+    if (gesture?.pointerType === 'touch') acExSinkFollowingClick()
     if (!gesture) return
     if (!commit || !gesture.activated) {
       if (gesture.kind === 'zoom-window') {
@@ -2481,7 +2479,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
         hideSelectionRect()
         acExSetMobileSnapLoupePreciseCapture(false)
         releaseBoxPointerCapture(gesture.pointerId)
-        armTouchMouseGuard()
+        acExSinkFollowingClick()
         if (gesture.kind === 'select') {
           applyClickSelect(event.clientX, event.clientY)
         }
@@ -2494,6 +2492,10 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     // Loupe moves coalesce into RAF; cancel before commit/abort so a late
     // flush cannot set live pointer and bring the OSNAP glyph back.
     cancelPendingPointerMove()
+    // Chrome synthesizes mouse pointerdown+click after touchup near the finger.
+    // Without this, a two-point tool would commit the second point immediately
+    // and clear the confirmed-point plus mark.
+    acExSinkFollowingClick()
     if (!commit) {
       touchSession.cancel()
       acExHideMobileSnapLoupe()
@@ -2511,7 +2513,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
 
   const idlePointerHost: AcExIdlePointerHost = {
     navMode: () => idleNavMode(),
-    shouldIgnoreCompatMouse: () => performance.now() < ignoreMouseUntil,
+    shouldIgnoreCompatMouse: () => acExShouldIgnoreCompatMouse(),
     startTouchBox: (kind, event) => {
       // preventDefault only: do not stopImmediatePropagation so OrbitControls
       // still receives pointerdown and can pan if the finger moves first.
@@ -2593,6 +2595,10 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     'pointerdown',
     event => {
       if (event.button !== 0) return
+      if (event.pointerType !== 'touch' && acExShouldIgnoreCompatMouse()) {
+        event.stopImmediatePropagation()
+        return
+      }
       const measure = getMeasure()
       const markup = getMarkup()
       if (event.pointerType === 'touch' && isDrawingToolActive()) {

--- a/packages/cad-html-plugin/src/AcExTouchPointSession.ts
+++ b/packages/cad-html-plugin/src/AcExTouchPointSession.ts
@@ -10,6 +10,88 @@ export const ACEX_TOUCH_POINT_LONG_PRESS_MS = 1000
 export const ACEX_TOUCH_POINT_MOVE_CANCEL_PX = 10
 
 /**
+ * Ignore compatibility mouse events this long after a touch pick ends.
+ *
+ * Chrome fires a `pointerType: 'mouse'` `pointerdown` then `click` after
+ * touch `pointerup`. Those coordinates are near the finger, so a two-point
+ * command (measure distance) would commit both points from one long-press
+ * and immediately clear the confirmed-point plus mark.
+ */
+export const ACEX_TOUCH_MOUSE_GUARD_MS = 1000
+
+let followingClickSink: ((event: Event) => void) | null = null
+let followingClickSinkTimer: ReturnType<typeof setTimeout> | null = null
+let ignoreCompatMouseUntil = 0
+
+/**
+ * Stops the next `click` in the capture phase and ignores compatibility
+ * mouse events for {@link ACEX_TOUCH_MOUSE_GUARD_MS}.
+ *
+ * Touch picking commits on `pointerup`. The browser then synthesizes a
+ * mouse `pointerdown` + `click` near the finger. A drawing tool would
+ * treat that as a real mouse pick unless this guard stays armed.
+ */
+export function acExSinkFollowingClick() {
+  acExArmTouchMouseGuard()
+  if (followingClickSink) return
+  const sink = (event: Event) => {
+    event.preventDefault()
+    event.stopImmediatePropagation()
+    acExClearFollowingClickSink()
+  }
+  followingClickSink = sink
+  window.addEventListener('click', sink, true)
+  followingClickSinkTimer = setTimeout(() => {
+    acExClearFollowingClickSink()
+  }, ACEX_TOUCH_MOUSE_GUARD_MS)
+}
+
+/**
+ * Removes {@link acExSinkFollowingClick} if it is armed.
+ */
+export function acExClearFollowingClickSink() {
+  if (followingClickSinkTimer != null) {
+    clearTimeout(followingClickSinkTimer)
+    followingClickSinkTimer = null
+  }
+  if (!followingClickSink) return
+  window.removeEventListener('click', followingClickSink, true)
+  followingClickSink = null
+}
+
+/**
+ * Arms the compatibility-mouse ignore window after a touch pick.
+ *
+ * @param now - Current time in milliseconds; defaults to `performance.now()`.
+ */
+export function acExArmTouchMouseGuard(now: number = performance.now()) {
+  ignoreCompatMouseUntil = Math.max(
+    ignoreCompatMouseUntil,
+    now + ACEX_TOUCH_MOUSE_GUARD_MS
+  )
+}
+
+/**
+ * Whether mouse `pointerdown` / `click` should be ignored as leftover from
+ * a touch pick.
+ *
+ * @param now - Current time in milliseconds; defaults to `performance.now()`.
+ */
+export function acExShouldIgnoreCompatMouse(
+  now: number = performance.now()
+): boolean {
+  return followingClickSink != null || now < ignoreCompatMouseUntil
+}
+
+/**
+ * Clears the click sink and mouse guard. Used by tests.
+ */
+export function acExResetTouchMouseGuard() {
+  acExClearFollowingClickSink()
+  ignoreCompatMouseUntil = 0
+}
+
+/**
  * Phases of a one-finger point-pick gesture.
  *
  * - `idle` — no gesture in progress.


### PR DESCRIPTION
## Summary
- Share HTML touch→mouse compatibility helpers (`acExSinkFollowingClick` / `acExShouldIgnoreCompatMouse`) and use them in the offline viewer runtime so Chrome leftover `pointerdown`/`click` after touchup cannot commit a second measure/markup point or clear confirmed-point marks.
- Drive confirmed-point plus marks from `acExHtmlIsMobileNavUi` (compact width or coarse pointer) so wide tablets match mobile pick chrome.
- Add unit tests for the touch mouse guard, click sink, and mobile-nav mark visibility.

## Test plan
- [ ] On a phone/tablet (or DevTools coarse pointer): long-press to place the first measure/markup point and confirm the plus mark stays; no immediate second point from the synthesized mouse click
- [ ] Touch box-select / short tap still works; leftover mouse events do not start a mouse rubber-band
- [ ] Wide tablet with `(pointer: coarse)` shows confirmed-point marks; desktop fine pointer does not
- [ ] `npx jest packages/cad-html-plugin/__tests__/AcExTouchPointSession.spec.ts packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts`
