### PR TITLE
fix: sharpen locale badge icons and sync language parent in HTML export

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExHtmlToolbarFlyout.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlToolbarFlyout.spec.ts
@@ -33,11 +33,11 @@ describe('setupAcExHtmlToolbarFlyouts', () => {
       )}
       ${stripHtml(
         'mlcad-settings-strip',
-        '<button type="button" data-action="toggle-theme"></button><button type="button" id="mlcad-settings-snap-btn" data-action="snap-menu"></button><button type="button" id="mlcad-settings-locale-btn" data-action="locale-menu"></button><button type="button" data-action="switch-bg"></button>'
+        '<button type="button" data-action="toggle-theme"></button><button type="button" id="mlcad-settings-snap-btn" data-action="snap-menu"></button><button type="button" id="mlcad-settings-locale-btn" data-action="locale-menu"><span class="mlcad-tool-btn-icon"><span class="mlcad-locale-option-badge">LANG</span></span></button><button type="button" data-action="switch-bg"></button>'
       )}
       ${stripHtml(
         'mlcad-locale-strip',
-        '<button type="button" data-locale="en"></button><button type="button" data-locale="zh"></button>'
+        '<button type="button" data-locale="en"><span class="mlcad-tool-btn-icon"><span class="mlcad-locale-option-badge">EN</span></span></button><button type="button" data-locale="zh"><span class="mlcad-tool-btn-icon"><span class="mlcad-locale-option-badge">中</span></span></button>'
       )}
     `)
   }
@@ -175,6 +175,29 @@ describe('setupAcExHtmlToolbarFlyouts', () => {
       false
     )
     expect(onStripChange).toHaveBeenCalled()
+    expect(
+      document
+        .getElementById('mlcad-settings-locale-btn')
+        ?.querySelector('.mlcad-tool-btn-icon')?.innerHTML
+    ).toBe('<span class="mlcad-locale-option-badge">EN</span>')
+  })
+
+  it('seeds the language parent with the current locale badge on setup', () => {
+    mountAllStrips()
+    setupAcExHtmlToolbarFlyouts({
+      onItemClick: jest.fn(),
+      getLocale: () => 'zh'
+    })
+    expect(
+      document
+        .getElementById('mlcad-settings-locale-btn')
+        ?.querySelector('.mlcad-tool-btn-icon')?.innerHTML
+    ).toBe('<span class="mlcad-locale-option-badge">中</span>')
+    expect(
+      document
+        .querySelector<HTMLButtonElement>('[data-locale="zh"]')
+        ?.classList.contains('active')
+    ).toBe(true)
   })
 
   it('closes a dismissible zoom strip on canvas click and tool select', () => {

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -266,9 +266,16 @@ export const ACEX_HTML_SHELL_CSS = `
     background: var(--mlcad-ui-border);
   }
   .mlcad-locale-option-badge {
-    font-size: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-size: 12px;
     font-weight: 700;
     line-height: 1;
+    letter-spacing: -0.04em;
+    user-select: none;
   }
   #mlcad-zoom-window-rect,
   #mlcad-selection-rect {

--- a/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
@@ -204,14 +204,19 @@ export function setupAcExHtmlToolbarFlyouts(
   const syncLocaleSelection = () => {
     const locale = options.getLocale?.()
     const localeStrip = find('locale')?.strip
+    let activeBtn: HTMLButtonElement | null = null
     localeStrip
       ?.querySelectorAll<HTMLButtonElement>('[data-locale]')
       .forEach(btn => {
-        btn.classList.toggle(
-          'active',
-          btn.getAttribute('data-locale') === locale
-        )
+        const isActive = btn.getAttribute('data-locale') === locale
+        btn.classList.toggle('active', isActive)
+        if (isActive) activeBtn = btn
       })
+    // Parent uses the current locale badge even before the user opens the strip
+    // (`childIcon: 'selected'` parity with cad-simple-ui-plugin).
+    if (activeBtn) {
+      setAcExHtmlParentChildIcon(NESTED_OPENER_IDS.locale, activeBtn)
+    }
   }
 
   const syncParentExpanded = () => {
@@ -399,6 +404,7 @@ export function setupAcExHtmlToolbarFlyouts(
         const locale = btn.getAttribute('data-locale') as AcExHtmlLocale | null
         if (!locale) return
         options.onLocaleSelect?.(locale)
+        setAcExHtmlParentChildIcon(NESTED_OPENER_IDS.locale, btn)
         if (nestedId === 'locale') {
           // After picking a language, return to the settings strip only.
           returnToSettingsFromNested()
@@ -441,6 +447,9 @@ export function setupAcExHtmlToolbarFlyouts(
     close()
   }
   document.addEventListener('mousedown', handleDocumentClick, true)
+
+  // Seed the language parent with the active locale badge on first paint.
+  syncLocaleSelection()
 
   return {
     close,

--- a/packages/cad-simple-ui-plugin/__tests__/AcUiToolbar.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/AcUiToolbar.spec.ts
@@ -967,6 +967,7 @@ describe('AcUiToolbar in-canvas-parent layout', () => {
       ?.click()
     const firstStrip = host.querySelector<HTMLElement>('.ml-ex-ui-subtoolbar')
     expect(firstStrip).toBeTruthy()
+    expect(firstStrip?.classList.contains('is-bottom')).toBe(true)
 
     host
       .querySelector<HTMLButtonElement>('[data-toolbar-item-id="locale"]')

--- a/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
@@ -458,6 +458,8 @@ describe('default toolbar items', () => {
       'locale-tr',
       'locale-ar'
     ])
+    expect(locale?.children?.[0]?.icon).toContain('ml-ex-ui-locale-badge')
+    expect(locale?.children?.[0]?.icon).toContain('EN')
   })
 })
 

--- a/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
@@ -121,8 +121,14 @@ const LOCALE_LABELS: Record<AcApLocale, string> = {
   ar: 'toolbar.localeAr'
 }
 
+/**
+ * Locale short-code badge for toolbar icons.
+ *
+ * Uses HTML text (not SVG `<text>`) so the glyph stays sharp at the 18px
+ * toolbar icon size. SVG text often looks soft/blurry when CSS-scaled.
+ */
 function localeBadgeIcon(badge: string): string {
-  return `<span style="font-size:10px;font-weight:700;line-height:1">${badge}</span>`
+  return `<span class="ml-ex-ui-locale-badge">${badge}</span>`
 }
 
 function acuiCreateToolbarLocaleItem(

--- a/packages/cad-simple-ui-plugin/src/ui/AcUiSubToolbar.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/AcUiSubToolbar.ts
@@ -373,11 +373,11 @@ export class AcUiSubToolbar {
   }
 
   private syncRootClasses() {
-    const vertical =
-      this.options.placement === 'left' || this.options.placement === 'right'
-    const { chrome } = this.options
+    const { chrome, placement } = this.options
+    const vertical = placement === 'left' || placement === 'right'
     const classes = [
       'ml-ex-ui-subtoolbar',
+      `is-${placement}`,
       vertical ? 'is-vertical' : 'is-horizontal'
     ]
     if (chrome.showLabels) classes.push('has-labels')

--- a/packages/cad-simple-ui-plugin/src/ui/styles.ts
+++ b/packages/cad-simple-ui-plugin/src/ui/styles.ts
@@ -185,10 +185,25 @@ export function acuiEnsureUiStyles() {
 
     /* Flyout mark: a small opaque right triangle in the corner toward the
        submenu. It sits in the icon padding so the glyph stays clear.
-       Only shown when the toolbar root has .show-children-indicator. */
-    .ml-ex-ui-toolbar.show-children-indicator
+       Only shown when the toolbar/subtoolbar root has .show-children-indicator
+       and an edge class (is-right/is-left/…). Without the edge class the
+       mark must stay hidden — otherwise an unpositioned 6×6 square appears
+       in the middle of nested parents (locale / toolbar placement). */
+    .ml-ex-ui-toolbar.show-children-indicator.is-right
       .ml-ex-ui-toolbar-btn.has-children::after,
-    .ml-ex-ui-subtoolbar.show-children-indicator
+    .ml-ex-ui-toolbar.show-children-indicator.is-left
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-toolbar.show-children-indicator.is-top
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-toolbar.show-children-indicator.is-bottom
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-subtoolbar.show-children-indicator.is-right
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-subtoolbar.show-children-indicator.is-left
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-subtoolbar.show-children-indicator.is-top
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-subtoolbar.show-children-indicator.is-bottom
       .ml-ex-ui-toolbar-btn.has-children::after {
       content: '';
       position: absolute;
@@ -199,6 +214,8 @@ export function acuiEnsureUiStyles() {
     }
 
     .ml-ex-ui-toolbar.show-children-indicator.is-right
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-subtoolbar.show-children-indicator.is-right
       .ml-ex-ui-toolbar-btn.has-children::after {
       left: 1px;
       bottom: 1px;
@@ -206,6 +223,8 @@ export function acuiEnsureUiStyles() {
     }
 
     .ml-ex-ui-toolbar.show-children-indicator.is-left
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-subtoolbar.show-children-indicator.is-left
       .ml-ex-ui-toolbar-btn.has-children::after {
       right: 1px;
       bottom: 1px;
@@ -213,6 +232,8 @@ export function acuiEnsureUiStyles() {
     }
 
     .ml-ex-ui-toolbar.show-children-indicator.is-top
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-subtoolbar.show-children-indicator.is-top
       .ml-ex-ui-toolbar-btn.has-children::after {
       right: 1px;
       bottom: 1px;
@@ -220,6 +241,8 @@ export function acuiEnsureUiStyles() {
     }
 
     .ml-ex-ui-toolbar.show-children-indicator.is-bottom
+      .ml-ex-ui-toolbar-btn.has-children::after,
+    .ml-ex-ui-subtoolbar.show-children-indicator.is-bottom
       .ml-ex-ui-toolbar-btn.has-children::after {
       right: 1px;
       top: 1px;
@@ -363,6 +386,20 @@ export function acuiEnsureUiStyles() {
     .ml-ex-ui-icon svg {
       width: 18px;
       height: 18px;
+    }
+
+    /* Locale short-code badges (EN / 中 / …): fill the icon box like SVG glyphs. */
+    .ml-ex-ui-locale-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 18px;
+      height: 18px;
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1;
+      letter-spacing: -0.04em;
+      user-select: none;
     }
 
     .ml-ex-ui-subtoolbar.is-overflow-wrap {


### PR DESCRIPTION
## Summary
- Replace inline-style locale badge with CSS class (.ml-ex-ui-locale-badge) for crisp rendering at 18px icon size in cad-simple-ui-plugin
- Add is- class to AcUiSubToolbar root so flyout mark CSS can gate on a concrete edge instead of showing an unpositioned square
- Gate .has-children::after flyout mark behind edge classes (is-right/is-left/is-top/is-bottom) for both toolbar and subtoolbar roots
- Seed the language parent button with the active locale badge on setupAcExHtmlToolbarFlyouts init and after locale selection (parity with cad-simple-ui-plugin childIcon: 'selected')
- Align .mlcad-locale-option-badge CSS in cad-html-plugin with the new badge style

## Test plan
- [x] AcExHtmlToolbarFlyout.spec.ts — 10 tests passed (incl. new seeding test)
- [x] AcUiToolbar.spec.ts — 30 tests passed (incl. new is-bottom class assertion)
- [x] esolveToolbarItems.spec.ts — 37 tests passed (incl. new badge icon assertions)
- [x] All 77 tests passed