### PR TITLE
refactor: standardize global function prefixes to acex in cad-html-plugin

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExConfirmedPointMarks.spec.ts
@@ -5,7 +5,7 @@
 const isMobileNavUi = jest.fn(() => true)
 
 jest.mock('../src/AcExHtmlDrawerSheet', () => ({
-  acExHtmlIsMobileNavUi: () => isMobileNavUi()
+  acexHtmlIsMobileNavUi: () => isMobileNavUi()
 }))
 
 import { AcExConfirmedPointMarks } from '../src/AcExConfirmedPointMarks'

--- a/packages/cad-html-plugin/__tests__/AcExHtmlDrawerSheet.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlDrawerSheet.spec.ts
@@ -1,9 +1,9 @@
 /** @jest-environment jsdom */
 
 import {
-  acExHtmlIsCompactLayout,
-  acExHtmlIsMobileNavUi,
-  acExHtmlIsPhoneLayout,
+  acexHtmlIsCompactLayout,
+  acexHtmlIsMobileNavUi,
+  acexHtmlIsPhoneLayout,
   setupAcExHtmlDrawerSheets
 } from '../src/AcExHtmlDrawerSheet'
 import {
@@ -31,9 +31,9 @@ describe('setupAcExHtmlDrawerSheets', () => {
 
   it('detects the phone breakpoint', () => {
     mockPhone(true)
-    expect(acExHtmlIsPhoneLayout()).toBe(true)
+    expect(acexHtmlIsPhoneLayout()).toBe(true)
     mockPhone(false)
-    expect(acExHtmlIsPhoneLayout()).toBe(false)
+    expect(acexHtmlIsPhoneLayout()).toBe(false)
   })
 
   it('detects the compact (phone or pad) breakpoint', () => {
@@ -44,8 +44,8 @@ describe('setupAcExHtmlDrawerSheets', () => {
         addEventListener: jest.fn(),
         removeEventListener: jest.fn()
       }) as unknown as MediaQueryList
-    expect(acExHtmlIsCompactLayout()).toBe(true)
-    expect(acExHtmlIsMobileNavUi()).toBe(true)
+    expect(acexHtmlIsCompactLayout()).toBe(true)
+    expect(acexHtmlIsMobileNavUi()).toBe(true)
   })
 
   it('treats a coarse pointer as mobile nav UI', () => {
@@ -56,8 +56,8 @@ describe('setupAcExHtmlDrawerSheets', () => {
         addEventListener: jest.fn(),
         removeEventListener: jest.fn()
       }) as unknown as MediaQueryList
-    expect(acExHtmlIsCompactLayout()).toBe(false)
-    expect(acExHtmlIsMobileNavUi()).toBe(true)
+    expect(acexHtmlIsCompactLayout()).toBe(false)
+    expect(acexHtmlIsMobileNavUi()).toBe(true)
   })
 
   it('parks the drawer on the sidebar and closes strips on phone', () => {

--- a/packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlOverlayDom.spec.ts
@@ -5,14 +5,14 @@ import {
   ACEX_OVERLAY_BASE_ZOOM,
   ACEX_OVERLAY_CLOUD_WCS,
   ACEX_OVERLAY_STROKE_WCS,
-  acExOverlayTransform,
-  acExOverlayViewScale,
-  acExPixelsPerWorldUnit,
-  acExPositionWcsOverlay,
-  acExResetOverlayViewScale,
-  acExScaledCanvasLineWidth,
-  acExScaledOverlayArrowSize,
-  acExSeedOverlaySizesFromWcs
+  acexOverlayTransform,
+  acexOverlayViewScale,
+  acexPixelsPerWorldUnit,
+  acexPositionWcsOverlay,
+  acexResetOverlayViewScale,
+  acexScaledCanvasLineWidth,
+  acexScaledOverlayArrowSize,
+  acexSeedOverlaySizesFromWcs
 } from '../src/AcExHtmlOverlayDom'
 
 describe('AcExHtmlOverlayDom', () => {
@@ -20,16 +20,16 @@ describe('AcExHtmlOverlayDom', () => {
     const el = document.createElement('div')
     el.className = 'mlcad-measure-badge'
 
-    expect(acExOverlayViewScale(2, el)).toBe(1)
-    expect(acExOverlayViewScale(4, el)).toBe(2)
-    expect(acExOverlayTransform(el, 2)).toBe('translate(-50%, -50%) scale(2)')
+    expect(acexOverlayViewScale(2, el)).toBe(1)
+    expect(acexOverlayViewScale(4, el)).toBe(2)
+    expect(acexOverlayTransform(el, 2)).toBe('translate(-50%, -50%) scale(2)')
   })
 
   it('resets the zoom anchor when the overlay moves in world space', () => {
     const el = document.createElement('div')
-    acExOverlayViewScale(2, el)
-    acExResetOverlayViewScale(el)
-    expect(acExOverlayViewScale(3, el)).toBe(1)
+    acexOverlayViewScale(2, el)
+    acexResetOverlayViewScale(el)
+    expect(acexOverlayViewScale(3, el)).toBe(1)
   })
 
   it('positions WCS overlays in root-local coordinates', () => {
@@ -39,7 +39,7 @@ describe('AcExHtmlOverlayDom', () => {
     el.className = 'mlcad-markup-dot'
     root.appendChild(el)
 
-    acExPositionWcsOverlay(
+    acexPositionWcsOverlay(
       el,
       { x: 120, y: 80 },
       new DOMRect(20, 10, 400, 300),
@@ -53,8 +53,8 @@ describe('AcExHtmlOverlayDom', () => {
 
   it('scales canvas stroke width with zoom (legacy path)', () => {
     const canvas = document.createElement('canvas')
-    expect(acExScaledCanvasLineWidth(2, canvas, 2)).toBe(2)
-    expect(acExScaledCanvasLineWidth(2, canvas, 4)).toBe(4)
+    expect(acexScaledCanvasLineWidth(2, canvas, 2)).toBe(2)
+    expect(acexScaledCanvasLineWidth(2, canvas, 4)).toBe(4)
   })
 
   it('scales canvas stroke width with WCS via wcsToScreen', () => {
@@ -63,15 +63,15 @@ describe('AcExHtmlOverlayDom', () => {
       x: wcs.x * 10,
       y: wcs.y * 10
     })
-    expect(acExPixelsPerWorldUnit(wcsToScreen)).toBe(10)
+    expect(acexPixelsPerWorldUnit(wcsToScreen)).toBe(10)
 
-    const width = acExScaledCanvasLineWidth(2, canvas, 1, {
+    const width = acexScaledCanvasLineWidth(2, canvas, 1, {
       strokeWidthWcs: 0.25,
       wcsToScreen
     })
     expect(width).toBe(2.5)
 
-    const width2 = acExScaledCanvasLineWidth(2, canvas, 1, {
+    const width2 = acexScaledCanvasLineWidth(2, canvas, 1, {
       strokeWidthWcs: 0.25,
       wcsToScreen: (wcs: { x: number; y: number }) => ({
         x: wcs.x * 20,
@@ -90,7 +90,7 @@ describe('AcExHtmlOverlayDom', () => {
     })
 
     expect(
-      acExScaledCanvasLineWidth(0, canvas, 1, {
+      acexScaledCanvasLineWidth(0, canvas, 1, {
         strokeWidthWcs: 0.4,
         wcsToScreen
       })
@@ -106,7 +106,7 @@ describe('AcExHtmlOverlayDom', () => {
       y: wcs.y * 10
     })
 
-    acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
+    acexSeedOverlaySizesFromWcs(2, wcsToScreen, {
       strokeScreenPx: 0,
       canvases: [canvas]
     })
@@ -120,18 +120,18 @@ describe('AcExHtmlOverlayDom', () => {
       y: wcs.y * 10
     })
 
-    acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
+    acexSeedOverlaySizesFromWcs(2, wcsToScreen, {
       strokeWidthWcs: 0.2,
       canvases: [canvas]
     })
     expect(canvas.dataset[ACEX_OVERLAY_STROKE_WCS]).toBe('0.2')
 
     // Stale constructor WCS would overwrite; omit so dataset wins after style edit.
-    acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
+    acexSeedOverlaySizesFromWcs(2, wcsToScreen, {
       strokeWidthWcs: 0.4,
       canvases: [canvas]
     })
-    const width = acExScaledCanvasLineWidth(2, canvas, 2, { wcsToScreen })
+    const width = acexScaledCanvasLineWidth(2, canvas, 2, { wcsToScreen })
     expect(width).toBe(4)
   })
 
@@ -144,7 +144,7 @@ describe('AcExHtmlOverlayDom', () => {
     })
 
     // Font size without textHeightWcs must not pair with stroke WCS.
-    acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
+    acexSeedOverlaySizesFromWcs(2, wcsToScreen, {
       fontSizePx: 13,
       strokeWidthWcs: 0.4,
       strokeScreenPx: 2.5,
@@ -155,14 +155,14 @@ describe('AcExHtmlOverlayDom', () => {
     expect(canvas.dataset[ACEX_OVERLAY_STROKE_WCS]).toBe('0.4')
     expect(canvas.dataset[ACEX_OVERLAY_CLOUD_WCS]).toBe('1.28')
 
-    acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
+    acexSeedOverlaySizesFromWcs(2, wcsToScreen, {
       strokeWidthWcs: 0.8,
       strokeScreenPx: 2.5,
       canvases: [canvas]
     })
     expect(canvas.dataset[ACEX_OVERLAY_CLOUD_WCS]).toBe('2.56')
 
-    acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
+    acexSeedOverlaySizesFromWcs(2, wcsToScreen, {
       fontSizePx: 13,
       textHeightWcs: 1.3,
       elements: [el]
@@ -174,8 +174,8 @@ describe('AcExHtmlOverlayDom', () => {
   it('scales overlay endpoint grips with zoom', () => {
     const el = document.createElement('div')
     el.className = 'mlcad-markup-dot ml-html-grip'
-    acExPositionWcsOverlay(el, { x: 10, y: 10 }, new DOMRect(0, 0, 100, 100), 2)
-    acExPositionWcsOverlay(el, { x: 10, y: 10 }, new DOMRect(0, 0, 100, 100), 4)
+    acexPositionWcsOverlay(el, { x: 10, y: 10 }, new DOMRect(0, 0, 100, 100), 2)
+    acexPositionWcsOverlay(el, { x: 10, y: 10 }, new DOMRect(0, 0, 100, 100), 4)
     expect(el.style.transform).toBe('translate(-50%, -50%) scale(2)')
   })
 
@@ -187,7 +187,7 @@ describe('AcExHtmlOverlayDom', () => {
       x: wcs.x * 10,
       y: wcs.y * 10
     })
-    acExSeedOverlaySizesFromWcs(2, wcsToScreen, {
+    acexSeedOverlaySizesFromWcs(2, wcsToScreen, {
       fontSizePx: 13,
       textHeightWcs: 1.3,
       arrowSizeWcs: 1.2,
@@ -209,9 +209,9 @@ describe('AcExHtmlOverlayDom', () => {
       x: wcs.x * 5,
       y: wcs.y * 5
     })
-    expect(acExScaledOverlayArrowSize(canvas, at10)).toBe(12)
+    expect(acexScaledOverlayArrowSize(canvas, at10)).toBe(12)
     expect(Number(canvas.dataset[ACEX_OVERLAY_ARROW_WCS])).toBeCloseTo(1.2)
-    expect(acExScaledOverlayArrowSize(canvas, at5)).toBeCloseTo(6)
+    expect(acexScaledOverlayArrowSize(canvas, at5)).toBeCloseTo(6)
   })
 
   it('uses imported arrowSizeWcs instead of seeding from screen pixels', () => {
@@ -220,7 +220,7 @@ describe('AcExHtmlOverlayDom', () => {
       x: wcs.x * 10,
       y: wcs.y * 10
     })
-    expect(acExScaledOverlayArrowSize(canvas, at10, 2.4)).toBeCloseTo(24)
+    expect(acexScaledOverlayArrowSize(canvas, at10, 2.4)).toBeCloseTo(24)
     expect(canvas.dataset[ACEX_OVERLAY_ARROW_WCS]).toBe('2.4')
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExHtmlStripWrapPack.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlStripWrapPack.spec.ts
@@ -1,29 +1,29 @@
 /** @jest-environment jsdom */
 
 import {
-  acExHtmlComputeWrapPackSlot,
-  acExHtmlSyncStripWrapPack
+  acexHtmlComputeWrapPackSlot,
+  acexHtmlSyncStripWrapPack
 } from '../src/AcExHtmlStripWrapPack'
 import { ML_UI_MOBILE_MAX_WIDTH } from '../src/AcExHtmlShell'
 
-describe('acExHtmlComputeWrapPackSlot', () => {
+describe('AcExHtmlComputeWrapPackSlot', () => {
   it('stretches a single incomplete row across the full strip', () => {
     // preferredMax = 40 → floor(360/40) = 9; 3 buttons share 360
-    const result = acExHtmlComputeWrapPackSlot(360, 56, 3)
+    const result = acexHtmlComputeWrapPackSlot(360, 56, 3)
     expect(result.preferredMaxWidth).toBe(40)
     expect(result.perRow).toBe(9)
     expect(result.slotWidth).toBeCloseTo(120)
   })
 
   it('keeps a wrapped last row at the full-row slot width', () => {
-    const { perRow, slotWidth } = acExHtmlComputeWrapPackSlot(360, 56, 12)
+    const { perRow, slotWidth } = acexHtmlComputeWrapPackSlot(360, 56, 12)
     expect(perRow).toBe(9)
     expect(slotWidth).toBeCloseTo(40)
     expect(3 * slotWidth).toBeLessThan(360)
   })
 })
 
-describe('acExHtmlSyncStripWrapPack', () => {
+describe('AcExHtmlSyncStripWrapPack', () => {
   const originalMatchMedia = window.matchMedia
 
   afterEach(() => {
@@ -66,23 +66,23 @@ describe('acExHtmlSyncStripWrapPack', () => {
   it('spreads a short strip across equal columns', () => {
     mockPhone(true)
     const strip = mountStrip(3)
-    acExHtmlSyncStripWrapPack()
+    acexHtmlSyncStripWrapPack()
     expect(strip.style.gridTemplateColumns).toBe('repeat(3, minmax(0, 1fr))')
   })
 
   it('uses a full-row column count when buttons wrap', () => {
     mockPhone(true)
     const strip = mountStrip(12)
-    acExHtmlSyncStripWrapPack()
+    acexHtmlSyncStripWrapPack()
     expect(strip.style.gridTemplateColumns).toBe('repeat(9, minmax(0, 1fr))')
   })
 
   it('clears inline columns on desktop', () => {
     mockPhone(true)
     const strip = mountStrip(3)
-    acExHtmlSyncStripWrapPack()
+    acexHtmlSyncStripWrapPack()
     mockPhone(false)
-    acExHtmlSyncStripWrapPack()
+    acexHtmlSyncStripWrapPack()
     expect(strip.style.gridTemplateColumns).toBe('')
   })
 
@@ -93,7 +93,7 @@ describe('acExHtmlSyncStripWrapPack', () => {
       value: 0,
       configurable: true
     })
-    acExHtmlSyncStripWrapPack()
+    acexHtmlSyncStripWrapPack()
     expect(strip.style.gridTemplateColumns).toBe('')
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExMarkupGeometry.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMarkupGeometry.spec.ts
@@ -1,19 +1,19 @@
 import {
-  acExComputeLeaderTipOnShape,
-  acExHitTestMarkupShapeOutline,
-  acExIsAttachableShapeMarkup,
-  acExMarkupBounds,
-  acExMarkupFocusExtents,
-  acExMarkupShapeOutlineFromGeometry,
-  acExOverlayArrowSize
+  acexComputeLeaderTipOnShape,
+  acexHitTestMarkupShapeOutline,
+  acexIsAttachableShapeMarkup,
+  acexMarkupBounds,
+  acexMarkupFocusExtents,
+  acexMarkupShapeOutlineFromGeometry,
+  acexOverlayArrowSize
 } from '../src/AcExMarkupGeometry'
 import type { AcExMarkupGeometry } from '../src/AcExMarkupTypes'
 
 const identity = (point: { x: number; y: number }) => point
 
-describe('acExComputeLeaderTipOnShape', () => {
+describe('AcExComputeLeaderTipOnShape', () => {
   it('places tip on circle perimeter toward the cursor', () => {
-    const tip = acExComputeLeaderTipOnShape(
+    const tip = acexComputeLeaderTipOnShape(
       { kind: 'circle', center: { x: 0, y: 0 }, radius: 10 },
       { x: 100, y: 0 }
     )
@@ -22,7 +22,7 @@ describe('acExComputeLeaderTipOnShape', () => {
   })
 
   it('places tip on AABB edge for rect/cloud', () => {
-    const tip = acExComputeLeaderTipOnShape(
+    const tip = acexComputeLeaderTipOnShape(
       {
         kind: 'rect',
         corner1: { x: -5, y: -2 },
@@ -35,17 +35,17 @@ describe('acExComputeLeaderTipOnShape', () => {
   })
 })
 
-describe('acExIsAttachableShapeMarkup', () => {
+describe('AcExIsAttachableShapeMarkup', () => {
   it('is true only for cloud/rect/circle without a callout', () => {
     expect(
-      acExIsAttachableShapeMarkup({
+      acexIsAttachableShapeMarkup({
         type: 'rect',
         corner1: { x: 0, y: 0 },
         corner2: { x: 10, y: 10 }
       })
     ).toBe(true)
     expect(
-      acExIsAttachableShapeMarkup({
+      acexIsAttachableShapeMarkup({
         type: 'circle',
         center: { x: 0, y: 0 },
         radius: 4,
@@ -55,7 +55,7 @@ describe('acExIsAttachableShapeMarkup', () => {
   })
 })
 
-describe('acExHitTestMarkupShapeOutline', () => {
+describe('AcExHitTestMarkupShapeOutline', () => {
   const threshold = 4
 
   it('hits a rect outer frame but not the interior', () => {
@@ -65,10 +65,10 @@ describe('acExHitTestMarkupShapeOutline', () => {
       corner2: { x: 40, y: 20 }
     }
     expect(
-      acExHitTestMarkupShapeOutline(geometry, 20, 0, threshold, identity)
+      acexHitTestMarkupShapeOutline(geometry, 20, 0, threshold, identity)
     ).toBe(true)
     expect(
-      acExHitTestMarkupShapeOutline(geometry, 20, 10, threshold, identity)
+      acexHitTestMarkupShapeOutline(geometry, 20, 10, threshold, identity)
     ).toBe(false)
   })
 
@@ -79,18 +79,18 @@ describe('acExHitTestMarkupShapeOutline', () => {
       radius: 20
     }
     expect(
-      acExHitTestMarkupShapeOutline(geometry, 20, 0, threshold, identity)
+      acexHitTestMarkupShapeOutline(geometry, 20, 0, threshold, identity)
     ).toBe(true)
     expect(
-      acExHitTestMarkupShapeOutline(geometry, 0, 0, threshold, identity)
+      acexHitTestMarkupShapeOutline(geometry, 0, 0, threshold, identity)
     ).toBe(false)
   })
 })
 
-describe('acExMarkupShapeOutlineFromGeometry', () => {
+describe('AcExMarkupShapeOutlineFromGeometry', () => {
   it('maps cloud geometry to an AABB outline', () => {
     expect(
-      acExMarkupShapeOutlineFromGeometry({
+      acexMarkupShapeOutlineFromGeometry({
         type: 'cloud',
         corner1: { x: 1, y: 2 },
         corner2: { x: 3, y: 4 }
@@ -103,10 +103,10 @@ describe('acExMarkupShapeOutlineFromGeometry', () => {
   })
 })
 
-describe('acExMarkupBounds', () => {
+describe('AcExMarkupBounds', () => {
   it('unions a cloud AABB with its attached leader and text-box anchor', () => {
     expect(
-      acExMarkupBounds({
+      acexMarkupBounds({
         type: 'cloud',
         corner1: { x: 0, y: 0 },
         corner2: { x: 20, y: 10 },
@@ -117,7 +117,7 @@ describe('acExMarkupBounds', () => {
 
   it('includes both callout leader tip and text-box anchor', () => {
     expect(
-      acExMarkupBounds({
+      acexMarkupBounds({
         type: 'callout',
         tip: { x: 0, y: 0 },
         anchor: { x: 100, y: -30 }
@@ -126,10 +126,10 @@ describe('acExMarkupBounds', () => {
   })
 })
 
-describe('acExMarkupFocusExtents', () => {
+describe('AcExMarkupFocusExtents', () => {
   it('unions geometry with overlay client rectangles', () => {
     expect(
-      acExMarkupFocusExtents(
+      acexMarkupFocusExtents(
         {
           type: 'callout',
           tip: { x: 0, y: 0 },
@@ -142,13 +142,13 @@ describe('acExMarkupFocusExtents', () => {
   })
 })
 
-describe('acExOverlayArrowSize', () => {
+describe('AcExOverlayArrowSize', () => {
   it('scales arrow heads with stroke width', () => {
-    expect(acExOverlayArrowSize(2, 2)).toBe(12)
-    expect(acExOverlayArrowSize(4, 2)).toBe(24)
+    expect(acexOverlayArrowSize(2, 2)).toBe(12)
+    expect(acexOverlayArrowSize(4, 2)).toBe(24)
   })
 
   it('keeps a 12px arrow for hairline strokes', () => {
-    expect(acExOverlayArrowSize(1, 0)).toBe(12)
+    expect(acexOverlayArrowSize(1, 0)).toBe(12)
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExMarkupSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMarkupSidecar.spec.ts
@@ -1,5 +1,5 @@
 import {
-  acExMarkupSidecarFileName,
+  acexMarkupSidecarFileName,
   parseAcExMarkupSidecar,
   stringifyAcExMarkupSidecar
 } from '../src/AcExMarkupSidecar'
@@ -125,8 +125,8 @@ describe('AcExMarkupSidecar', () => {
   })
 
   it('suggests sidecar file names', () => {
-    expect(acExMarkupSidecarFileName('plan.dwg')).toBe('plan.markup.json')
-    expect(acExMarkupSidecarFileName('plan.html')).toBe('plan.markup.json')
-    expect(acExMarkupSidecarFileName()).toBe('drawing.markup.json')
+    expect(acexMarkupSidecarFileName('plan.dwg')).toBe('plan.markup.json')
+    expect(acexMarkupSidecarFileName('plan.html')).toBe('plan.markup.json')
+    expect(acexMarkupSidecarFileName()).toBe('drawing.markup.json')
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMeasurementSidecar.spec.ts
@@ -1,5 +1,5 @@
 import {
-  acExMeasurementSidecarFileName,
+  acexMeasurementSidecarFileName,
   parseAcExMeasurementSidecar,
   stringifyAcExMeasurementSidecar
 } from '../src/AcExMeasurementSidecar'
@@ -143,13 +143,13 @@ describe('AcExMeasurementSidecar', () => {
   })
 
   it('suggests sidecar file names', () => {
-    expect(acExMeasurementSidecarFileName('plan.dwg')).toBe(
+    expect(acexMeasurementSidecarFileName('plan.dwg')).toBe(
       'plan.measurement.json'
     )
-    expect(acExMeasurementSidecarFileName('plan.html')).toBe(
+    expect(acexMeasurementSidecarFileName('plan.html')).toBe(
       'plan.measurement.json'
     )
-    expect(acExMeasurementSidecarFileName()).toBe('drawing.measurement.json')
+    expect(acexMeasurementSidecarFileName()).toBe('drawing.measurement.json')
   })
 
   it('keeps legacy arc records that omit the through point', () => {

--- a/packages/cad-html-plugin/__tests__/AcExSelectionBox.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSelectionBox.spec.ts
@@ -1,25 +1,25 @@
 import {
-  acExExtentsMatchBox,
-  acExSelectionModeFromDrag
+  acexExtentsMatchBox,
+  acexSelectionModeFromDrag
 } from '../src/AcExSelectionBox'
 
-describe('acExSelectionModeFromDrag', () => {
+describe('AcExSelectionModeFromDrag', () => {
   it('uses window for left-to-right and crossing for right-to-left', () => {
-    expect(acExSelectionModeFromDrag(10, 40)).toBe('window')
-    expect(acExSelectionModeFromDrag(40, 10)).toBe('crossing')
-    expect(acExSelectionModeFromDrag(10, 10)).toBe('window')
+    expect(acexSelectionModeFromDrag(10, 40)).toBe('window')
+    expect(acexSelectionModeFromDrag(40, 10)).toBe('crossing')
+    expect(acexSelectionModeFromDrag(10, 10)).toBe('window')
   })
 })
 
-describe('acExExtentsMatchBox', () => {
+describe('AcExExtentsMatchBox', () => {
   const box = { minX: 0, minY: 0, maxX: 10, maxY: 10 }
 
   it('requires full containment for window selection', () => {
     expect(
-      acExExtentsMatchBox({ minX: 1, minY: 1, maxX: 9, maxY: 9 }, box, 'window')
+      acexExtentsMatchBox({ minX: 1, minY: 1, maxX: 9, maxY: 9 }, box, 'window')
     ).toBe(true)
     expect(
-      acExExtentsMatchBox(
+      acexExtentsMatchBox(
         { minX: -1, minY: 1, maxX: 9, maxY: 9 },
         box,
         'window'
@@ -29,14 +29,14 @@ describe('acExExtentsMatchBox', () => {
 
   it('requires intersection for crossing selection', () => {
     expect(
-      acExExtentsMatchBox(
+      acexExtentsMatchBox(
         { minX: 8, minY: 8, maxX: 12, maxY: 12 },
         box,
         'crossing'
       )
     ).toBe(true)
     expect(
-      acExExtentsMatchBox(
+      acexExtentsMatchBox(
         { minX: 20, minY: 20, maxX: 30, maxY: 30 },
         box,
         'crossing'

--- a/packages/cad-html-plugin/__tests__/AcExSnapLoupe.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapLoupe.spec.ts
@@ -1,23 +1,23 @@
 import {
-  acExCssRectToWcsBox,
-  acExCssTopLeftRectToGl,
-  acExIntersectCssRects,
-  acExWcsBoxToCssRect
+  acexCssRectToWcsBox,
+  acexCssTopLeftRectToGl,
+  acexIntersectCssRects,
+  acexWcsBoxToCssRect
 } from '../src/AcExCssRect'
-import { acExLoupeLocalFromCanvasDelta } from '../src/AcExSnapLoupe'
+import { acexLoupeLocalFromCanvasDelta } from '../src/AcExSnapLoupe'
 import { AcExTouchPointSession } from '../src/AcExTouchPointSession'
 
 describe('AcExCssRect', () => {
   it('converts CSS top-left rectangles to WebGL bottom-left', () => {
     expect(
-      acExCssTopLeftRectToGl({ x: 8, y: 8, width: 128, height: 128 }, 600)
+      acexCssTopLeftRectToGl({ x: 8, y: 8, width: 128, height: 128 }, 600)
     ).toEqual({ x: 8, y: 464, width: 128, height: 128 })
   })
 
   it('maps a world box onto a screen rect and back', () => {
     const viewBox = { minX: 0, minY: 0, maxX: 100, maxY: 50 }
     const screen = { x: 10, y: 20, width: 200, height: 100 }
-    const css = acExWcsBoxToCssRect(
+    const css = acexWcsBoxToCssRect(
       { minX: 25, minY: 10, maxX: 75, maxY: 40 },
       viewBox,
       screen
@@ -25,10 +25,10 @@ describe('AcExCssRect', () => {
     expect(css.x).toBeCloseTo(60)
     expect(css.width).toBeCloseTo(100)
     expect(css.height).toBeCloseTo(60)
-    const roundTrip = acExCssRectToWcsBox(css, viewBox, screen)
+    const roundTrip = acexCssRectToWcsBox(css, viewBox, screen)
     expect(roundTrip.minX).toBeCloseTo(25)
     expect(roundTrip.maxY).toBeCloseTo(40)
-    expect(acExIntersectCssRects(screen, { x: 0, y: 0, width: 5, height: 5 })).toBeNull()
+    expect(acexIntersectCssRects(screen, { x: 0, y: 0, width: 5, height: 5 })).toBeNull()
   })
 })
 
@@ -73,9 +73,9 @@ describe('AcExTouchPointSession', () => {
   })
 })
 
-describe('acExLoupeLocalFromCanvasDelta', () => {
+describe('AcExLoupeLocalFromCanvasDelta', () => {
   it('scales canvas deltas by the loupe zoom about the center', () => {
-    expect(acExLoupeLocalFromCanvasDelta(2, 4, 128, 3)).toEqual({
+    expect(acexLoupeLocalFromCanvasDelta(2, 4, 128, 3)).toEqual({
       x: 70,
       y: 76
     })

--- a/packages/cad-html-plugin/__tests__/AcExTouchPickStrategy.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExTouchPickStrategy.spec.ts
@@ -6,9 +6,9 @@ import {
   ACEX_SIMULATED_MOUSE_STORAGE_KEY,
   AcExLoupeTouchPickStrategy,
   AcExSimulatedMouseTouchPickStrategy,
-  acExIsSimulatedMouseEnabled,
-  acExSetSimulatedMouseEnabled,
-  acExTouchPickStrategy
+  acexIsSimulatedMouseEnabled,
+  acexSetSimulatedMouseEnabled,
+  acexTouchPickStrategy
 } from '../src/AcExTouchPickStrategy'
 
 describe('AcExTouchPickStrategy', () => {
@@ -17,15 +17,15 @@ describe('AcExTouchPickStrategy', () => {
   })
 
   it('defaults to simulated mouse when unset', () => {
-    expect(acExIsSimulatedMouseEnabled()).toBe(true)
-    expect(acExTouchPickStrategy()).toBeInstanceOf(
+    expect(acexIsSimulatedMouseEnabled()).toBe(true)
+    expect(acexTouchPickStrategy()).toBeInstanceOf(
       AcExSimulatedMouseTouchPickStrategy
     )
   })
 
   it('returns loupe strategy when disabled', () => {
-    acExSetSimulatedMouseEnabled(false)
-    expect(acExTouchPickStrategy()).toBeInstanceOf(AcExLoupeTouchPickStrategy)
+    acexSetSimulatedMouseEnabled(false)
+    expect(acexTouchPickStrategy()).toBeInstanceOf(AcExLoupeTouchPickStrategy)
   })
 
   it('offsets the simulated-mouse sample above the finger', () => {

--- a/packages/cad-html-plugin/__tests__/AcExTouchPointSession.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExTouchPointSession.spec.ts
@@ -3,11 +3,11 @@
  */
 import {
   ACEX_TOUCH_MOUSE_GUARD_MS,
-  acExArmTouchMouseGuard,
-  acExClearFollowingClickSink,
-  acExResetTouchMouseGuard,
-  acExShouldIgnoreCompatMouse,
-  acExSinkFollowingClick,
+  acexArmTouchMouseGuard,
+  acexClearFollowingClickSink,
+  acexResetTouchMouseGuard,
+  acexShouldIgnoreCompatMouse,
+  acexSinkFollowingClick,
   AcExTouchPointSession
 } from '../src/AcExTouchPointSession'
 
@@ -17,7 +17,7 @@ describe('AcExTouchPointSession', () => {
   })
   afterEach(() => {
     jest.useRealTimers()
-    acExResetTouchMouseGuard()
+    acexResetTouchMouseGuard()
   })
 
   it('commits a short tap without opening the loupe', () => {
@@ -41,33 +41,33 @@ describe('AcExTouchPointSession', () => {
   })
 })
 
-describe('acExShouldIgnoreCompatMouse', () => {
+describe('AcExShouldIgnoreCompatMouse', () => {
   afterEach(() => {
-    acExResetTouchMouseGuard()
+    acexResetTouchMouseGuard()
   })
 
   it('ignores mouse after a touch pick so a second nearby point is not committed', () => {
-    acExArmTouchMouseGuard(1000)
-    expect(acExShouldIgnoreCompatMouse(1000)).toBe(true)
+    acexArmTouchMouseGuard(1000)
+    expect(acexShouldIgnoreCompatMouse(1000)).toBe(true)
     expect(
-      acExShouldIgnoreCompatMouse(1000 + ACEX_TOUCH_MOUSE_GUARD_MS - 1)
+      acexShouldIgnoreCompatMouse(1000 + ACEX_TOUCH_MOUSE_GUARD_MS - 1)
     ).toBe(true)
-    expect(acExShouldIgnoreCompatMouse(1000 + ACEX_TOUCH_MOUSE_GUARD_MS)).toBe(
+    expect(acexShouldIgnoreCompatMouse(1000 + ACEX_TOUCH_MOUSE_GUARD_MS)).toBe(
       false
     )
   })
 
   it('stays armed while the following-click sink is still listening', () => {
-    acExSinkFollowingClick()
-    expect(acExShouldIgnoreCompatMouse(1e12)).toBe(true)
-    acExClearFollowingClickSink()
-    expect(acExShouldIgnoreCompatMouse(1e12)).toBe(false)
+    acexSinkFollowingClick()
+    expect(acexShouldIgnoreCompatMouse(1e12)).toBe(true)
+    acexClearFollowingClickSink()
+    expect(acexShouldIgnoreCompatMouse(1e12)).toBe(false)
   })
 })
 
-describe('acExSinkFollowingClick', () => {
+describe('AcExSinkFollowingClick', () => {
   afterEach(() => {
-    acExResetTouchMouseGuard()
+    acexResetTouchMouseGuard()
   })
 
   it('eats the leftover click after a touch pick', () => {
@@ -75,7 +75,7 @@ describe('acExSinkFollowingClick', () => {
     document.body.appendChild(target)
     const later = jest.fn()
     target.addEventListener('click', later)
-    acExSinkFollowingClick()
+    acexSinkFollowingClick()
     target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(later).not.toHaveBeenCalled()
     target.remove()
@@ -87,7 +87,7 @@ describe('acExSinkFollowingClick', () => {
     document.body.appendChild(target)
     const later = jest.fn()
     target.addEventListener('click', later)
-    acExSinkFollowingClick()
+    acexSinkFollowingClick()
     jest.advanceTimersByTime(ACEX_TOUCH_MOUSE_GUARD_MS)
     target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(later).toHaveBeenCalledTimes(1)

--- a/packages/cad-html-plugin/__tests__/AcExTouchPointTutorial.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExTouchPointTutorial.spec.ts
@@ -15,8 +15,8 @@ jest.mock('../src/AcExHtmlSimpleViewerUi', () => {
 })
 
 import {
-  acExMaybeShowTouchPointTutorial,
-  acExShouldShowTouchPointTutorial
+  acexMaybeShowTouchPointTutorial,
+  acexShouldShowTouchPointTutorial
 } from '../src/AcExTouchPointTutorial'
 import { AcUiDialog } from '../../cad-simple-viewer/src/ui/AcUiDialog'
 
@@ -30,8 +30,8 @@ describe('AcExTouchPointTutorial', () => {
   })
 
   it('shows when mobile/pad UI is active and prefs allow it', () => {
-    expect(acExShouldShowTouchPointTutorial()).toBe(true)
-    void acExMaybeShowTouchPointTutorial({
+    expect(acexShouldShowTouchPointTutorial()).toBe(true)
+    void acexMaybeShowTouchPointTutorial({
       t: (key: string) => key
     } as never)
     expect(document.querySelector('.ml-ui-touch-point-tutorial')).not.toBeNull()
@@ -39,8 +39,8 @@ describe('AcExTouchPointTutorial', () => {
 
   it('does not show on desktop UI', () => {
     isMobileOrPad.mockReturnValue(false)
-    expect(acExShouldShowTouchPointTutorial()).toBe(false)
-    void acExMaybeShowTouchPointTutorial({
+    expect(acexShouldShowTouchPointTutorial()).toBe(false)
+    void acexMaybeShowTouchPointTutorial({
       t: (key: string) => key
     } as never)
     expect(document.querySelector('.ml-ui-touch-point-tutorial')).toBeNull()
@@ -51,6 +51,6 @@ describe('AcExTouchPointTutorial', () => {
       ACEX_TOUCH_POINT_TUTORIAL_PREFS_KEY,
       JSON.stringify({ hideForever: true, snoozeDate: null })
     )
-    expect(acExShouldShowTouchPointTutorial()).toBe(false)
+    expect(acexShouldShowTouchPointTutorial()).toBe(false)
   })
 })

--- a/packages/cad-html-plugin/src/AcExCommandSessionPanel.ts
+++ b/packages/cad-html-plugin/src/AcExCommandSessionPanel.ts
@@ -1,4 +1,4 @@
-import { acExHtmlIsPhoneLayout } from './AcExHtmlDrawerSheet'
+import { acexHtmlIsPhoneLayout } from './AcExHtmlDrawerSheet'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
 import { ML_UI_MOBILE_MAX_WIDTH } from './AcExHtmlShell'
 
@@ -194,7 +194,7 @@ export class AcExCommandSessionPanel {
     const relative = metrics?.hasBasePoint === true
     // No rubber-band yet (and markup): still show X/Y labels, not an empty actions row.
     const absolute = !relative
-    const phone = acExHtmlIsPhoneLayout()
+    const phone = acexHtmlIsPhoneLayout()
     this.root.classList.toggle('is-relative', relative)
     this.root.classList.toggle('is-absolute', absolute)
     this.root.classList.remove('is-actions-only')

--- a/packages/cad-html-plugin/src/AcExConfirmedPointMarks.ts
+++ b/packages/cad-html-plugin/src/AcExConfirmedPointMarks.ts
@@ -1,4 +1,4 @@
-import { acExHtmlIsMobileNavUi } from './AcExHtmlDrawerSheet'
+import { acexHtmlIsMobileNavUi } from './AcExHtmlDrawerSheet'
 
 /**
  * World-space point used by {@link AcExConfirmedPointMarks}.
@@ -12,7 +12,7 @@ export interface AcExConfirmedPointMarkPos {
  * Temporary plus marks at confirmed pick points during multi-step measure /
  * markup tools on phone and pad.
  *
- * Desktop never shows these marks. Uses {@link acExHtmlIsMobileNavUi} (compact
+ * Desktop never shows these marks. Uses {@link acexHtmlIsMobileNavUi} (compact
  * width or coarse pointer) instead of `acedIsMobileOrPadUi` so measure /
  * markup controllers stay free of the `cad-simple-viewer` barrel and stay
  * aligned with HTML mobile pick chrome (snap loupe, hidden Select/Pan).
@@ -50,7 +50,7 @@ export class AcExConfirmedPointMarks {
    * No-ops visually on desktop (clears any existing marks).
    */
   setWorldPoints(points: readonly AcExConfirmedPointMarkPos[]): void {
-    if (!acExHtmlIsMobileNavUi()) {
+    if (!acexHtmlIsMobileNavUi()) {
       this.clear()
       return
     }

--- a/packages/cad-html-plugin/src/AcExCssRect.ts
+++ b/packages/cad-html-plugin/src/AcExCssRect.ts
@@ -22,7 +22,7 @@ export interface AcExCssRect {
  * @param canvasCssHeight - Canvas CSS height (same space as `rect.y`).
  * @returns The same rectangle with `y` measured from the canvas bottom.
  */
-export function acExCssTopLeftRectToGl(
+export function acexCssTopLeftRectToGl(
   rect: AcExCssRect,
   canvasCssHeight: number
 ): AcExCssRect {
@@ -42,7 +42,7 @@ export function acExCssTopLeftRectToGl(
  * @param b - Second rectangle.
  * @returns Overlap rectangle, or `null` when there is no usable overlap.
  */
-export function acExIntersectCssRects(
+export function acexIntersectCssRects(
   a: AcExCssRect,
   b: AcExCssRect
 ): AcExCssRect | null {
@@ -65,7 +65,7 @@ export function acExIntersectCssRects(
  * @param screen - CSS rectangle that displays `viewBox`.
  * @returns `box` in the same CSS space as `screen`.
  */
-export function acExWcsBoxToCssRect(
+export function acexWcsBoxToCssRect(
   box: { minX: number; minY: number; maxX: number; maxY: number },
   viewBox: { minX: number; minY: number; maxX: number; maxY: number },
   screen: AcExCssRect
@@ -81,14 +81,14 @@ export function acExWcsBoxToCssRect(
 }
 
 /**
- * Inverse of {@link acExWcsBoxToCssRect}: CSS rectangle → world box.
+ * Inverse of {@link acexWcsBoxToCssRect}: CSS rectangle → world box.
  *
  * @param rect - CSS rectangle inside `screen`.
  * @param viewBox - World extents currently mapped onto `screen`.
  * @param screen - CSS rectangle that displays `viewBox`.
  * @returns Axis-aligned world box corresponding to `rect`.
  */
-export function acExCssRectToWcsBox(
+export function acexCssRectToWcsBox(
   rect: AcExCssRect,
   viewBox: { minX: number; minY: number; maxX: number; maxY: number },
   screen: AcExCssRect

--- a/packages/cad-html-plugin/src/AcExHtmlDrawerSheet.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlDrawerSheet.ts
@@ -4,7 +4,7 @@
  * close arrow. Results drawers live inside tool-strip wraps; opening one
  * parks the drawer on the sidebar so dismissing the strip does not hide it.
  *
- * @module AcExHtmlDrawerSheet
+ * @module acexHtmlDrawerSheet
  * @packageDocumentation
  */
 
@@ -28,7 +28,7 @@ export interface AcExHtmlDrawerSheetController {
 }
 
 /** Whether the offline HTML chrome is using the phone breakpoint. */
-export function acExHtmlIsPhoneLayout(): boolean {
+export function acexHtmlIsPhoneLayout(): boolean {
   return (
     typeof window !== 'undefined' &&
     window.matchMedia?.(`(max-width: ${ML_UI_MOBILE_MAX_WIDTH}px)`).matches ===
@@ -37,7 +37,7 @@ export function acExHtmlIsPhoneLayout(): boolean {
 }
 
 /** Whether the offline HTML chrome is using the phone or pad breakpoint. */
-export function acExHtmlIsCompactLayout(): boolean {
+export function acexHtmlIsCompactLayout(): boolean {
   return (
     typeof window !== 'undefined' &&
     window.matchMedia?.(`(max-width: ${ML_UI_COMPACT_MAX_WIDTH}px)`).matches ===
@@ -51,9 +51,9 @@ export function acExHtmlIsCompactLayout(): boolean {
  * Compact width covers phone and pad; coarse pointer covers wider tablets
  * such as iPad landscape.
  */
-export function acExHtmlIsMobileNavUi(): boolean {
+export function acexHtmlIsMobileNavUi(): boolean {
   return (
-    acExHtmlIsCompactLayout() ||
+    acexHtmlIsCompactLayout() ||
     (typeof window !== 'undefined' &&
       window.matchMedia?.('(pointer: coarse)').matches === true)
   )
@@ -79,7 +79,7 @@ export function setupAcExHtmlDrawerSheets(options?: {
   }
 
   const restoreIfDesktop = () => {
-    if (acExHtmlIsPhoneLayout()) return
+    if (acexHtmlIsPhoneLayout()) return
     const sidebar = document.getElementById('mlcad-sidebar')
     for (const drawer of drawers) {
       drawer.style.height = ''
@@ -114,7 +114,7 @@ export function setupAcExHtmlDrawerSheets(options?: {
       inset += wrap.offsetHeight
     })
     const session = document.getElementById('mlcad-command-session')
-    if (session && !session.hidden && acExHtmlIsPhoneLayout()) {
+    if (session && !session.hidden && acexHtmlIsPhoneLayout()) {
       // Session replaces the toolbar (which stays in layout via visibility:
       // hidden). Pin the drawer to the session height only.
       inset = session.offsetHeight
@@ -136,7 +136,7 @@ export function setupAcExHtmlDrawerSheets(options?: {
     if (sidebar && drawer.parentElement !== sidebar) {
       sidebar.appendChild(drawer)
     }
-    if (acExHtmlIsPhoneLayout()) {
+    if (acexHtmlIsPhoneLayout()) {
       options?.closeStrips?.()
       syncInset()
     }

--- a/packages/cad-html-plugin/src/AcExHtmlIcons.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlIcons.ts
@@ -56,7 +56,7 @@ import {
  * Inline SVG markup keyed by toolbar / layer UI usage.
  * Each value is a complete `<svg>…</svg>` string using `currentColor`.
  */
-export const acExHtmlIcons = {
+export const AcExHtmlIcons = {
   /** Select tool toolbar icon. */
   select: ICON_SELECT,
   /** Pan tool toolbar icon. */
@@ -159,12 +159,12 @@ export const acExHtmlIcons = {
  * phone layouts can show a translated caption under the icon. Pad/desktop CSS
  * hides the label; `title` / `aria-label` remain the accessible name.
  *
- * @param icon - SVG markup from {@link acExHtmlIcons}.
+ * @param icon - SVG markup from {@link AcExHtmlIcons}.
  * @param title - Default `title`, `aria-label`, and label text before i18n.
  * @param attrs - Additional attributes (e.g. `data-action`, `data-i18n-key`).
  * @returns HTML string for one toolbar button.
  */
-export function acExToolbarButton(
+export function acexToolbarButton(
   icon: string,
   title: string,
   attrs: Record<string, string>
@@ -182,11 +182,11 @@ export function acExToolbarButton(
 /**
  * Builds a flyout menu item with icon + label (cad-simple-ui-plugin style).
  *
- * @param icon - SVG markup from {@link acExHtmlIcons}.
+ * @param icon - SVG markup from {@link AcExHtmlIcons}.
  * @param label - Default visible label before i18n overrides.
  * @param attrs - Additional attributes (e.g. `data-action`, `data-i18n-key`).
  */
-export function acExDropdownItem(
+export function acexDropdownItem(
   icon: string,
   label: string,
   attrs: Record<string, string>

--- a/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlMeasureSettings.ts
@@ -4,7 +4,7 @@ import {
   type AcExHtmlI18n,
   type AcExHtmlLocale
 } from './AcExHtmlI18n'
-import { acExHtmlIcons, acExToolbarButton } from './AcExHtmlIcons'
+import { AcExHtmlIcons, acexToolbarButton } from './AcExHtmlIcons'
 import type { AcExMeasureController } from './AcExMeasurement'
 import type { AcExTrackingOptions } from './AcExMeasureTracking'
 
@@ -193,13 +193,13 @@ export function buildAcExHtmlSnapStrip(): string {
   return `
       <div id="mlcad-snap-strip-wrap" hidden>
         <div id="mlcad-snap-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="toolbar.snap" aria-label="Object snap">
-          ${acExToolbarButton(acExHtmlIcons.orthoMode, 'Orthogonal mode', {
+          ${acexToolbarButton(AcExHtmlIcons.orthoMode, 'Orthogonal mode', {
             id: 'mlcad-ortho-btn',
             'data-toggle': 'ortho',
             'data-i18n-key': 'settings.ortho',
             'data-i18n-attr': 'title aria-label'
           })}
-          ${acExToolbarButton(acExHtmlIcons.polarTracking, 'Polar tracking', {
+          ${acexToolbarButton(AcExHtmlIcons.polarTracking, 'Polar tracking', {
             id: 'mlcad-polar-btn',
             'data-toggle': 'polar',
             'data-i18n-key': 'settings.polar',

--- a/packages/cad-html-plugin/src/AcExHtmlOverlayDom.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlOverlayDom.ts
@@ -19,7 +19,7 @@ export const ACEX_OVERLAY_ARROW_WCS = 'overlayArrowWcs'
 /**
  * Scale factor for HTML measure/markup overlays relative to first layout.
  */
-export function acExOverlayViewScale(zoom: number, el: HTMLElement): number {
+export function acexOverlayViewScale(zoom: number, el: HTMLElement): number {
   let base = Number(el.dataset[ACEX_OVERLAY_BASE_ZOOM])
   if (!Number.isFinite(base) || base === 0) {
     base = zoom
@@ -29,12 +29,12 @@ export function acExOverlayViewScale(zoom: number, el: HTMLElement): number {
 }
 
 /** Clears the zoom anchor so the next layout re-bases view scale. */
-export function acExResetOverlayViewScale(el: HTMLElement): void {
+export function acexResetOverlayViewScale(el: HTMLElement): void {
   delete el.dataset[ACEX_OVERLAY_BASE_ZOOM]
 }
 
 /** CSS transform prefix before optional view-synced `scale()`. */
-export function acExOverlayTransformPrefix(el: HTMLElement): string {
+export function acexOverlayTransformPrefix(el: HTMLElement): string {
   if (el.classList.contains('mlcad-measure-badge--coordinate')) {
     return 'translate(-50%, calc(-50% - 16px))'
   }
@@ -42,14 +42,14 @@ export function acExOverlayTransformPrefix(el: HTMLElement): string {
 }
 
 /** Composes centering transform with optional view-synced scale. */
-export function acExOverlayTransform(el: HTMLElement, scale: number): string {
-  const prefix = acExOverlayTransformPrefix(el)
+export function acexOverlayTransform(el: HTMLElement, scale: number): string {
+  const prefix = acexOverlayTransformPrefix(el)
   if (scale === 1) return prefix
   return `${prefix} scale(${scale})`
 }
 
 /** CSS px per one WCS unit along +X. */
-export function acExPixelsPerWorldUnit(
+export function acexPixelsPerWorldUnit(
   wcsToScreen: (wcs: { x: number; y: number }) => { x: number; y: number }
 ): number {
   const a = wcsToScreen({ x: 0, y: 0 })
@@ -58,14 +58,14 @@ export function acExPixelsPerWorldUnit(
   return ppu > 0 && Number.isFinite(ppu) ? ppu : 1
 }
 
-export function acExScreenPxToWcs(
+export function acexScreenPxToWcs(
   px: number,
   wcsToScreen: (wcs: { x: number; y: number }) => { x: number; y: number }
 ): number {
-  return px / acExPixelsPerWorldUnit(wcsToScreen)
+  return px / acexPixelsPerWorldUnit(wcsToScreen)
 }
 
-export function acExSeedOverlayStrokeWcs(
+export function acexSeedOverlayStrokeWcs(
   canvas: HTMLElement,
   strokeWidthWcs: number
 ): void {
@@ -73,7 +73,7 @@ export function acExSeedOverlayStrokeWcs(
   canvas.dataset[ACEX_OVERLAY_STROKE_WCS] = String(strokeWidthWcs)
 }
 
-export function acExSeedOverlayArrowWcs(
+export function acexSeedOverlayArrowWcs(
   canvas: HTMLElement,
   arrowSizeWcs: number
 ): void {
@@ -85,7 +85,7 @@ export function acExSeedOverlayArrowWcs(
  * View-synced canvas stroke. Prefer strokeWidthWcs; else convert baseLineWidth
  * to WCS on first paint and stash on the canvas.
  */
-export function acExScaledCanvasLineWidth(
+export function acexScaledCanvasLineWidth(
   baseLineWidth: number,
   canvas: HTMLCanvasElement,
   zoom: number,
@@ -99,7 +99,7 @@ export function acExScaledCanvasLineWidth(
     return 1
   }
   if (options?.wcsToScreen) {
-    const ppu = acExPixelsPerWorldUnit(options.wcsToScreen)
+    const ppu = acexPixelsPerWorldUnit(options.wcsToScreen)
     let wcs =
       options.strokeWidthWcs != null && options.strokeWidthWcs > 0
         ? options.strokeWidthWcs
@@ -112,7 +112,7 @@ export function acExScaledCanvasLineWidth(
     }
     return Math.max(0.5, wcs * ppu)
   }
-  return baseLineWidth * acExOverlayViewScale(zoom, canvas)
+  return baseLineWidth * acexOverlayViewScale(zoom, canvas)
 }
 
 /**
@@ -121,15 +121,15 @@ export function acExScaledCanvasLineWidth(
  * Used by committed distance measurements and arrow markups. Seeds
  * {@link ACEX_OVERLAY_ARROW_SIZE_PX} as WCS on first paint (the size shown
  * during the jig) unless `arrowSizeWcs` is provided. Live previews should use
- * `acExOverlayArrowSize` so the head stays a constant screen size
+ * `acexOverlayArrowSize` so the head stays a constant screen size
  * while the user zooms during placement.
  */
-export function acExScaledOverlayArrowSize(
+export function acexScaledOverlayArrowSize(
   canvas: HTMLCanvasElement,
   wcsToScreen: (wcs: { x: number; y: number }) => { x: number; y: number },
   arrowSizeWcs?: number
 ): number {
-  const ppu = acExPixelsPerWorldUnit(wcsToScreen)
+  const ppu = acexPixelsPerWorldUnit(wcsToScreen)
   let wcs =
     arrowSizeWcs != null && arrowSizeWcs > 0
       ? arrowSizeWcs
@@ -144,19 +144,19 @@ export function acExScaledOverlayArrowSize(
 }
 
 /** Seed DOM baseZoom so CSS size matches WCS at current camera. */
-export function acExBaseZoomFromWcsSize(
+export function acexBaseZoomFromWcsSize(
   screenPxAtCreate: number,
   sizeWcs: number,
   zoom: number,
   wcsToScreen: (wcs: { x: number; y: number }) => { x: number; y: number }
 ): number | null {
-  const ppu = acExPixelsPerWorldUnit(wcsToScreen)
+  const ppu = acexPixelsPerWorldUnit(wcsToScreen)
   if (!(zoom > 0) || !(screenPxAtCreate > 0) || !(sizeWcs > 0)) return null
   const base = (screenPxAtCreate * zoom) / (sizeWcs * ppu)
   return base > 0 && Number.isFinite(base) ? base : null
 }
 
-export function acExSeedOverlaySizesFromWcs(
+export function acexSeedOverlaySizesFromWcs(
   zoom: number,
   wcsToScreen: (wcs: { x: number; y: number }) => { x: number; y: number },
   options: {
@@ -174,7 +174,7 @@ export function acExSeedOverlaySizesFromWcs(
 
   if (strokeWidthWcs != null && strokeWidthWcs > 0) {
     for (const canvas of canvases ?? []) {
-      acExSeedOverlayStrokeWcs(canvas, strokeWidthWcs)
+      acexSeedOverlayStrokeWcs(canvas, strokeWidthWcs)
     }
   } else if (options.strokeScreenPx === 0) {
     for (const canvas of canvases ?? []) {
@@ -184,7 +184,7 @@ export function acExSeedOverlaySizesFromWcs(
 
   if (options.arrowSizeWcs != null && options.arrowSizeWcs > 0) {
     for (const canvas of canvases ?? []) {
-      acExSeedOverlayArrowWcs(canvas, options.arrowSizeWcs)
+      acexSeedOverlayArrowWcs(canvas, options.arrowSizeWcs)
     }
   }
 
@@ -209,7 +209,7 @@ export function acExSeedOverlaySizesFromWcs(
     return
   }
 
-  const baseZoom = acExBaseZoomFromWcsSize(
+  const baseZoom = acexBaseZoomFromWcsSize(
     fontSizePx,
     textHeightWcs,
     zoom,
@@ -225,7 +225,7 @@ export function acExSeedOverlaySizesFromWcs(
  * Positions one WCS-anchored overlay in root-local coordinates and applies
  * view-synced scale when `zoom` is provided.
  */
-export function acExPositionWcsOverlay(
+export function acexPositionWcsOverlay(
   el: HTMLElement,
   screen: { x: number; y: number },
   rootRect: DOMRect,
@@ -233,14 +233,14 @@ export function acExPositionWcsOverlay(
 ): void {
   el.style.left = `${screen.x - rootRect.left}px`
   el.style.top = `${screen.y - rootRect.top}px`
-  const scale = acExOverlayViewScale(zoom, el)
-  el.style.transform = acExOverlayTransform(el, scale)
+  const scale = acexOverlayViewScale(zoom, el)
+  el.style.transform = acexOverlayTransform(el, scale)
 }
 
 /**
  * Positions a cursor-following overlay in root-local client coordinates.
  */
-export function acExPositionClientOverlay(
+export function acexPositionClientOverlay(
   el: HTMLElement,
   clientX: number,
   clientY: number,
@@ -249,6 +249,6 @@ export function acExPositionClientOverlay(
 ): void {
   el.style.left = `${clientX - rootRect.left}px`
   el.style.top = `${clientY - rootRect.top}px`
-  const scale = acExOverlayViewScale(zoom, el)
-  el.style.transform = acExOverlayTransform(el, scale)
+  const scale = acexOverlayViewScale(zoom, el)
+  el.style.transform = acexOverlayTransform(el, scale)
 }

--- a/packages/cad-html-plugin/src/AcExHtmlShell.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShell.ts
@@ -1,4 +1,4 @@
-import { acExHtmlIcons, acExToolbarButton } from './AcExHtmlIcons'
+import { AcExHtmlIcons, acexToolbarButton } from './AcExHtmlIcons'
 import {
   buildAcExHtmlLocaleStrip,
   buildAcExHtmlSnapStrip
@@ -1661,13 +1661,13 @@ export function buildAcExHtmlShellBody(
     </div>
     <aside id="mlcad-sidebar">
       <nav id="mlcad-toolbar" data-i18n-attr="aria-label" data-i18n-key="toolbar.viewerTools" aria-label="Viewer tools">
-        ${acExToolbarButton(acExHtmlIcons.select, 'Select', {
+        ${acexToolbarButton(AcExHtmlIcons.select, 'Select', {
           'data-action': 'select',
           'aria-pressed': 'false',
           'data-i18n-key': 'toolbar.select',
           'data-i18n-attr': 'title aria-label'
         })}
-        ${acExToolbarButton(acExHtmlIcons.pan, 'Pan', {
+        ${acexToolbarButton(AcExHtmlIcons.pan, 'Pan', {
           'data-action': 'pan',
           'aria-pressed': 'true',
           'data-i18n-key': 'toolbar.pan',
@@ -1678,7 +1678,7 @@ export function buildAcExHtmlShellBody(
         ${measureToolbar}
         ${markupToolbar}
         ${viewerMode === 'measure' ? buildAcExToolbarSeparator() : ''}
-        ${acExToolbarButton(acExHtmlIcons.layer, 'Layers', {
+        ${acexToolbarButton(AcExHtmlIcons.layer, 'Layers', {
           id: 'mlcad-layers-btn',
           'aria-haspopup': 'dialog',
           'aria-expanded': 'false',
@@ -1687,7 +1687,7 @@ export function buildAcExHtmlShellBody(
         })}
         ${exportLayouts ? buildAcExLayoutMenuButton() : ''}
         ${settingsToolbar}
-        ${acExToolbarButton(acExHtmlIcons.chevronUp, 'Collapse toolbar', {
+        ${acexToolbarButton(AcExHtmlIcons.chevronUp, 'Collapse toolbar', {
           id: 'mlcad-toolbar-toggle',
           'aria-expanded': 'true',
           'data-i18n-key': 'toolbar.collapse',
@@ -1703,10 +1703,10 @@ export function buildAcExHtmlShellBody(
         </div>
         <div class="mlcad-layer-actions">
           <button type="button" class="mlcad-layer-action-btn" id="mlcad-layer-show-all">
-            ${acExHtmlIcons.layerOn}<span data-i18n-key="layers.showAll" data-i18n-text>Show all</span>
+            ${AcExHtmlIcons.layerOn}<span data-i18n-key="layers.showAll" data-i18n-text>Show all</span>
           </button>
           <button type="button" class="mlcad-layer-action-btn" id="mlcad-layer-hide-all">
-            ${acExHtmlIcons.layerOff}<span data-i18n-key="layers.hideAll" data-i18n-text>Hide all</span>
+            ${AcExHtmlIcons.layerOff}<span data-i18n-key="layers.hideAll" data-i18n-text>Hide all</span>
           </button>
         </div>
         <div id="mlcad-layer-list"></div>
@@ -1727,7 +1727,7 @@ function buildAcExDrawerSheetChrome(
 ): string {
   return `<div class="mlcad-drawer-sheet-chrome">
           <div class="mlcad-drawer-grabber" role="separator" aria-orientation="horizontal"></div>
-          <button type="button" class="mlcad-drawer-sheet-close" id="${closeId}" data-i18n-key="${closeKey}" data-i18n-attr="aria-label" aria-label="${closeLabel}">${acExHtmlIcons.chevronDown}</button>
+          <button type="button" class="mlcad-drawer-sheet-close" id="${closeId}" data-i18n-key="${closeKey}" data-i18n-attr="aria-label" aria-label="${closeLabel}">${AcExHtmlIcons.chevronDown}</button>
         </div>`
 }
 
@@ -1785,7 +1785,7 @@ function buildAcExReviewDrawer(): string {
 }
 
 function buildAcExLayoutMenuButton(): string {
-  return acExToolbarButton(acExHtmlIcons.layout, 'Layout', {
+  return acexToolbarButton(AcExHtmlIcons.layout, 'Layout', {
     id: 'mlcad-layout-menu-btn',
     'aria-haspopup': 'menu',
     'aria-expanded': 'false',
@@ -1797,7 +1797,7 @@ function buildAcExLayoutMenuButton(): string {
 }
 
 function buildAcExZoomMenuButton(): string {
-  return acExToolbarButton(acExHtmlIcons.zoomExtent, 'Zoom', {
+  return acexToolbarButton(AcExHtmlIcons.zoomExtent, 'Zoom', {
     id: 'mlcad-zoom-menu-btn',
     'aria-haspopup': 'true',
     'aria-expanded': 'false',
@@ -1811,17 +1811,17 @@ function buildAcExZoomMenuButton(): string {
 function buildAcExHtmlZoomStrip(): string {
   return `<div id="mlcad-zoom-strip-wrap" hidden>
         <div id="mlcad-zoom-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="toolbar.zoom" aria-label="Zoom">
-          ${acExToolbarButton(acExHtmlIcons.zoomOriginal, 'Original', {
+          ${acexToolbarButton(AcExHtmlIcons.zoomOriginal, 'Original', {
             'data-action': 'zoom-original',
             'data-i18n-key': 'toolbar.zoomOriginal',
             'data-i18n-attr': 'title aria-label'
           })}
-          ${acExToolbarButton(acExHtmlIcons.zoomExtent, 'Extents', {
+          ${acexToolbarButton(AcExHtmlIcons.zoomExtent, 'Extents', {
             'data-action': 'fit',
             'data-i18n-key': 'toolbar.zoomExtents',
             'data-i18n-attr': 'title aria-label'
           })}
-          ${acExToolbarButton(acExHtmlIcons.zoomWindow, 'Window', {
+          ${acexToolbarButton(AcExHtmlIcons.zoomWindow, 'Window', {
             'data-action': 'zoom-window',
             'aria-pressed': 'false',
             'data-i18n-key': 'toolbar.zoomWindow',
@@ -1832,7 +1832,7 @@ function buildAcExHtmlZoomStrip(): string {
 }
 
 function buildAcExSettingsMenuButton(): string {
-  return acExToolbarButton(acExHtmlIcons.settings, 'Settings', {
+  return acexToolbarButton(AcExHtmlIcons.settings, 'Settings', {
     id: 'mlcad-settings-btn',
     'aria-haspopup': 'true',
     'aria-expanded': 'false',
@@ -1846,7 +1846,7 @@ function buildAcExSettingsMenuButton(): string {
 function buildAcExHtmlSettingsStrip(viewerMode: AcExViewerMode): string {
   const snapBtn =
     viewerMode === 'measure'
-      ? acExToolbarButton(acExHtmlIcons.osnap, 'Object snap', {
+      ? acexToolbarButton(AcExHtmlIcons.osnap, 'Object snap', {
           id: 'mlcad-settings-snap-btn',
           'aria-haspopup': 'true',
           'aria-expanded': 'false',
@@ -1862,7 +1862,7 @@ function buildAcExHtmlSettingsStrip(viewerMode: AcExViewerMode): string {
 
   return `<div id="mlcad-settings-strip-wrap" hidden>
         <div id="mlcad-settings-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="toolbar.settings" aria-label="Settings">
-          ${acExToolbarButton(acExHtmlIcons.simulatedMouse, 'Mouse', {
+          ${acexToolbarButton(AcExHtmlIcons.simulatedMouse, 'Mouse', {
             id: 'mlcad-simulated-mouse-btn',
             'data-action': 'toggle-simulated-mouse',
             'data-i18n-key': 'toolbar.simulatedMouseOn',
@@ -1872,18 +1872,18 @@ function buildAcExHtmlSettingsStrip(viewerMode: AcExViewerMode): string {
             'class="mlcad-tool-btn active"'
           )}
           ${snapBtn}
-          ${acExToolbarButton(acExHtmlIcons.themeDark, 'Light', {
+          ${acexToolbarButton(AcExHtmlIcons.themeDark, 'Light', {
             id: 'mlcad-theme-btn',
             'data-action': 'toggle-theme',
             'data-i18n-key': 'toolbar.themeDark',
             'data-i18n-attr': 'title aria-label'
           })}
-          ${acExToolbarButton(acExHtmlIcons.switchBg, 'Background', {
+          ${acexToolbarButton(AcExHtmlIcons.switchBg, 'Background', {
             'data-action': 'switch-bg',
             'data-i18n-key': 'toolbar.switchBg',
             'data-i18n-attr': 'title aria-label'
           })}
-          ${acExToolbarButton(acExHtmlIcons.language, 'Language', {
+          ${acexToolbarButton(AcExHtmlIcons.language, 'Language', {
             id: 'mlcad-settings-locale-btn',
             'aria-haspopup': 'true',
             'aria-expanded': 'false',
@@ -1900,7 +1900,7 @@ function buildAcExHtmlSettingsStrip(viewerMode: AcExViewerMode): string {
 }
 
 function buildAcExMeasureMenuButton(): string {
-  return acExToolbarButton(acExHtmlIcons.measure, 'Measure', {
+  return acexToolbarButton(AcExHtmlIcons.measure, 'Measure', {
     id: 'mlcad-measure-menu-btn',
     'aria-haspopup': 'true',
     'aria-expanded': 'false',
@@ -1912,7 +1912,7 @@ function buildAcExMeasureMenuButton(): string {
 }
 
 function buildAcExMarkupMenuButton(): string {
-  return acExToolbarButton(acExHtmlIcons.annotation, 'Review', {
+  return acexToolbarButton(AcExHtmlIcons.annotation, 'Review', {
     id: 'mlcad-markup-menu-btn',
     'aria-haspopup': 'true',
     'aria-expanded': 'false',
@@ -1926,65 +1926,65 @@ function buildAcExMarkupMenuButton(): string {
 function buildAcExMeasureToolStrip(): string {
   return `<div id="mlcad-measure-strip-wrap" hidden>
     <div id="mlcad-measure-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="toolbar.measure" aria-label="Measure">
-      ${acExToolbarButton(acExHtmlIcons.measureDistance, 'Distance', {
+      ${acexToolbarButton(AcExHtmlIcons.measureDistance, 'Distance', {
         'data-action': 'measure',
         'data-measure-mode': 'distance',
         'data-i18n-key': 'toolbar.measureDistance',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.measureContinuous, 'Continuous', {
+      ${acexToolbarButton(AcExHtmlIcons.measureContinuous, 'Continuous', {
         'data-action': 'measure',
         'data-measure-mode': 'continuous',
         'data-i18n-key': 'toolbar.measureContinuous',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.measureAngle, 'Angle', {
+      ${acexToolbarButton(AcExHtmlIcons.measureAngle, 'Angle', {
         'data-action': 'measure',
         'data-measure-mode': 'angle',
         'data-i18n-key': 'toolbar.measureAngle',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.measureArc, 'Arc', {
+      ${acexToolbarButton(AcExHtmlIcons.measureArc, 'Arc', {
         'data-action': 'measure',
         'data-measure-mode': 'arc',
         'data-i18n-key': 'toolbar.measureArc',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.measureArea, 'Area', {
+      ${acexToolbarButton(AcExHtmlIcons.measureArea, 'Area', {
         'data-action': 'measure',
         'data-measure-mode': 'area',
         'data-i18n-key': 'toolbar.measureArea',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.measureCoordinate, 'XY', {
+      ${acexToolbarButton(AcExHtmlIcons.measureCoordinate, 'XY', {
         'data-action': 'measure',
         'data-measure-mode': 'coordinate',
         'data-i18n-key': 'toolbar.measureCoordinate',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.measurementPanel, 'Results', {
+      ${acexToolbarButton(AcExHtmlIcons.measurementPanel, 'Results', {
         'data-action': 'measure-panel',
         'aria-pressed': 'false',
         'data-i18n-key': 'toolbar.measurementPanel',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupShow, 'Hide', {
+      ${acexToolbarButton(AcExHtmlIcons.markupShow, 'Hide', {
         'data-action': 'measure-visibility',
         'data-i18n-key': 'toolbar.measureHide',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.clearMeasurements, 'Clear', {
+      ${acexToolbarButton(AcExHtmlIcons.clearMeasurements, 'Clear', {
         'data-action': 'clear-measurements',
         'data-i18n-key': 'toolbar.clearMeasurements',
         'data-i18n-attr': 'title aria-label'
       })}
       ${buildAcExToolbarSeparator()}
-      ${acExToolbarButton(acExHtmlIcons.markupImport, 'Import', {
+      ${acexToolbarButton(AcExHtmlIcons.markupImport, 'Import', {
         'data-action': 'measure-import',
         'data-i18n-key': 'toolbar.measureImport',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupExport, 'Export', {
+      ${acexToolbarButton(AcExHtmlIcons.markupExport, 'Export', {
         'data-action': 'measure-export',
         'data-i18n-key': 'toolbar.measureExport',
         'data-i18n-attr': 'title aria-label'
@@ -2028,71 +2028,71 @@ function buildAcExMeasureDrawer(): string {
 function buildAcExMarkupToolStrip(): string {
   return `<div id="mlcad-markup-strip-wrap" hidden>
     <div id="mlcad-markup-strip" role="toolbar" data-i18n-attr="aria-label" data-i18n-key="toolbar.annotation" aria-label="Review">
-      ${acExToolbarButton(acExHtmlIcons.markupCloud, 'Cloud', {
+      ${acexToolbarButton(AcExHtmlIcons.markupCloud, 'Cloud', {
         'data-action': 'markup',
         'data-markup-mode': 'cloud',
         'data-i18n-key': 'toolbar.markupCloud',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupRect, 'Rect', {
+      ${acexToolbarButton(AcExHtmlIcons.markupRect, 'Rect', {
         'data-action': 'markup',
         'data-markup-mode': 'rect',
         'data-i18n-key': 'toolbar.markupRect',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupCircle, 'Circle', {
+      ${acexToolbarButton(AcExHtmlIcons.markupCircle, 'Circle', {
         'data-action': 'markup',
         'data-markup-mode': 'circle',
         'data-i18n-key': 'toolbar.markupCircle',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupCallout, 'Callout', {
+      ${acexToolbarButton(AcExHtmlIcons.markupCallout, 'Callout', {
         'data-action': 'markup',
         'data-markup-mode': 'callout',
         'data-i18n-key': 'toolbar.markupCallout',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupArrow, 'Arrow', {
+      ${acexToolbarButton(AcExHtmlIcons.markupArrow, 'Arrow', {
         'data-action': 'markup',
         'data-markup-mode': 'arrow',
         'data-i18n-key': 'toolbar.markupArrow',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupText, 'Text', {
+      ${acexToolbarButton(AcExHtmlIcons.markupText, 'Text', {
         'data-action': 'markup',
         'data-markup-mode': 'text',
         'data-i18n-key': 'toolbar.markupText',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupStamp, 'Stamp', {
+      ${acexToolbarButton(AcExHtmlIcons.markupStamp, 'Stamp', {
         'data-action': 'markup',
         'data-markup-mode': 'stamp',
         'data-i18n-key': 'toolbar.markupStamp',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupPanel, 'Results', {
+      ${acexToolbarButton(AcExHtmlIcons.markupPanel, 'Results', {
         'data-action': 'markup-panel',
         'aria-pressed': 'false',
         'data-i18n-key': 'toolbar.markupPanel',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupShow, 'Hide', {
+      ${acexToolbarButton(AcExHtmlIcons.markupShow, 'Hide', {
         'data-action': 'markup-visibility',
         'data-i18n-key': 'toolbar.markupHide',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.clearMarkups, 'Clear', {
+      ${acexToolbarButton(AcExHtmlIcons.clearMarkups, 'Clear', {
         'data-action': 'clear-markups',
         'data-i18n-key': 'toolbar.clearMarkups',
         'data-i18n-attr': 'title aria-label'
       })}
       ${buildAcExToolbarSeparator()}
-      ${acExToolbarButton(acExHtmlIcons.markupImport, 'Import', {
+      ${acexToolbarButton(AcExHtmlIcons.markupImport, 'Import', {
         'data-action': 'markup-import',
         'data-i18n-key': 'toolbar.markupImport',
         'data-i18n-attr': 'title aria-label'
       })}
-      ${acExToolbarButton(acExHtmlIcons.markupExport, 'Export', {
+      ${acexToolbarButton(AcExHtmlIcons.markupExport, 'Export', {
         'data-action': 'markup-export',
         'data-i18n-key': 'toolbar.markupExport',
         'data-i18n-attr': 'title aria-label'

--- a/packages/cad-html-plugin/src/AcExHtmlStripWrapPack.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlStripWrapPack.ts
@@ -5,11 +5,11 @@
  * - A single incomplete row stretches so buttons share the strip evenly.
  * - Wrapped rows use a portrait slot; a short last row stays left-aligned.
  *
- * @module AcExHtmlStripWrapPack
+ * @module acexHtmlStripWrapPack
  * @packageDocumentation
  */
 
-import { acExHtmlIsPhoneLayout } from './AcExHtmlDrawerSheet'
+import { acexHtmlIsPhoneLayout } from './AcExHtmlDrawerSheet'
 
 const STRIP_IDS = [
   'mlcad-snap-strip',
@@ -35,7 +35,7 @@ export interface AcExHtmlWrapPackSlot {
  * Computes how many portrait slots fit, and whether a short strip should
  * stretch across the full row.
  */
-export function acExHtmlComputeWrapPackSlot(
+export function acexHtmlComputeWrapPackSlot(
   containerWidth: number,
   buttonHeight: number,
   buttonCount: number = 0
@@ -64,7 +64,7 @@ export function acExHtmlComputeWrapPackSlot(
  * Applies wrap-pack column counts to visible phone strips. No-ops (and
  * clears inline columns) on desktop.
  */
-export function acExHtmlSyncStripWrapPack() {
+export function acexHtmlSyncStripWrapPack() {
   for (const id of STRIP_IDS) {
     const strip = document.getElementById(id)
     if (strip) applyStripWrapPack(strip)
@@ -73,7 +73,7 @@ export function acExHtmlSyncStripWrapPack() {
 
 function applyStripWrapPack(strip: HTMLElement) {
   const wrap = strip.parentElement
-  if (!acExHtmlIsPhoneLayout() || wrap?.hidden) {
+  if (!acexHtmlIsPhoneLayout() || wrap?.hidden) {
     strip.style.removeProperty('grid-template-columns')
     return
   }
@@ -93,7 +93,7 @@ function applyStripWrapPack(strip: HTMLElement) {
     return
   }
   const height = Math.max(...buttons.map(button => button.offsetHeight), 1)
-  const { perRow } = acExHtmlComputeWrapPackSlot(
+  const { perRow } = acexHtmlComputeWrapPackSlot(
     containerWidth,
     height,
     buttons.length

--- a/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlToolbarFlyout.ts
@@ -12,12 +12,12 @@
  * Snap and language live under Settings as nested strips (same replace
  * pattern on phone/pad/desktop).
  *
- * @module AcExHtmlToolbarFlyout
+ * @module acexHtmlToolbarFlyout
  * @packageDocumentation
  */
 
 import type { AcExHtmlLocale } from './AcExHtmlI18n'
-import { acExHtmlSyncStripWrapPack } from './AcExHtmlStripWrapPack'
+import { acexHtmlSyncStripWrapPack } from './AcExHtmlStripWrapPack'
 
 /** Strip ids wired by {@link setupAcExHtmlToolbarFlyouts}. */
 export type AcExHtmlStripId =
@@ -197,8 +197,8 @@ export function setupAcExHtmlToolbarFlyouts(
     resolved.find(entry => entry.id === id)
 
   const syncLayout = () => {
-    acExHtmlSyncStripWrapPack()
-    requestAnimationFrame(() => acExHtmlSyncStripWrapPack())
+    acexHtmlSyncStripWrapPack()
+    requestAnimationFrame(() => acexHtmlSyncStripWrapPack())
   }
 
   const syncLocaleSelection = () => {

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -10,10 +10,10 @@ import {
   type AcExCommandSessionUiState
 } from './AcExCommandSessionPanel'
 import {
-  acExCssRectToWcsBox,
-  acExCssTopLeftRectToGl,
-  acExIntersectCssRects,
-  acExWcsBoxToCssRect
+  acexCssRectToWcsBox,
+  acexCssTopLeftRectToGl,
+  acexIntersectCssRects,
+  acexWcsBoxToCssRect
 } from './AcExCssRect'
 import {
   decryptAcExHtmlSnapshotPayload,
@@ -27,12 +27,12 @@ import {
   showAcExHtmlAccessExpired
 } from './AcExHtmlAccessGate'
 import {
-  acExHtmlIsPhoneLayout,
+  acexHtmlIsPhoneLayout,
   setupAcExHtmlDrawerSheets
 } from './AcExHtmlDrawerSheet'
 import { setupAcExHtmlExpiryMonitor } from './AcExHtmlExpiryUi'
 import { AcExHtmlI18n, detectAcExHtmlLocale } from './AcExHtmlI18n'
-import { acExHtmlIcons } from './AcExHtmlIcons'
+import { AcExHtmlIcons } from './AcExHtmlIcons'
 import { setupAcExHtmlLayoutMenu } from './AcExHtmlLayoutMenu'
 import { setupAcExHtmlMeasurePanel } from './AcExHtmlMeasurePanel'
 import { setupAcExHtmlMeasureSettings } from './AcExHtmlMeasureSettings'
@@ -44,7 +44,7 @@ import {
 } from './AcExHtmlToolbarFlyout'
 import {
   type AcExIdlePointerHost,
-  acExIdlePointerStrategy
+  acexIdlePointerStrategy
 } from './AcExIdlePointerStrategy'
 import {
   computeLayerExtentsMap,
@@ -53,10 +53,10 @@ import {
 import { AcExMarkupController, type AcExMarkupMode } from './AcExMarkup'
 import { AcExMeasureController, type AcExMeasureMode } from './AcExMeasurement'
 import {
-  acExBindMobileSnapLoupe,
-  acExHideMobileSnapLoupe,
-  acExRefreshMobileSnapLoupe,
-  acExSetMobileSnapLoupePreciseCapture
+  acexBindMobileSnapLoupe,
+  acexHideMobileSnapLoupe,
+  acexRefreshMobileSnapLoupe,
+  acexSetMobileSnapLoupePreciseCapture
 } from './AcExMobileSnapLoupe'
 import { AcExOsnapIndex } from './AcExOsnap'
 import { AcExOsnapMarker } from './AcExOsnapMarker'
@@ -69,16 +69,16 @@ import {
   viewportPaperToModelScale
 } from './AcExPaperViewport'
 import {
-  acexCameraZoomUniform,
+  AcExCameraZoomUniform,
   createViewerLineMaterial,
   createViewerMeshMaterial,
   createViewerPointsMaterial
 } from './AcExPatternSnapshot'
-import { acExSelectionModeFromDrag } from './AcExSelectionBox'
+import { acexSelectionModeFromDrag } from './AcExSelectionBox'
 import { setupAcExSessionDrawStyle } from './AcExSessionDrawStyle'
 import {
-  acExHideSimulatedMouseCursor,
-  acExRefreshSimulatedMouseCursor
+  acexHideSimulatedMouseCursor,
+  acexRefreshSimulatedMouseCursor
 } from './AcExSimulatedMouseCursor'
 import {
   ACEX_SNAP_LOUPE_INSET_PX,
@@ -97,17 +97,17 @@ import type {
   AcExViewerMode
 } from './AcExSnapshotTypes'
 import {
-  acExIsSimulatedMouseEnabled,
-  acExToggleSimulatedMouse,
+  acexIsSimulatedMouseEnabled,
+  acexToggleSimulatedMouse,
   type AcExTouchPickHudHost,
-  acExTouchPickStrategy
+  acexTouchPickStrategy
 } from './AcExTouchPickStrategy'
 import {
-  acExShouldIgnoreCompatMouse,
-  acExSinkFollowingClick,
+  acexShouldIgnoreCompatMouse,
+  acexSinkFollowingClick,
   AcExTouchPointSession
 } from './AcExTouchPointSession'
-import { acExMaybeShowTouchPointTutorial } from './AcExTouchPointTutorial'
+import { acexMaybeShowTouchPointTutorial } from './AcExTouchPointTutorial'
 import {
   releaseLayerGroupsGeometryCpuArrays,
   releaseSnapshotBatchBuffers,
@@ -183,7 +183,7 @@ function applyHtmlTheme(theme: AcExHtmlTheme): void {
   // action (switch to the other theme).
   const nextKey = theme === 'light' ? 'toolbar.themeLight' : 'toolbar.themeDark'
   const nextIcon =
-    theme === 'light' ? acExHtmlIcons.themeLight : acExHtmlIcons.themeDark
+    theme === 'light' ? AcExHtmlIcons.themeLight : AcExHtmlIcons.themeDark
   const nextTitle = theme === 'light' ? 'Light' : 'Dark'
   if (icon) icon.innerHTML = nextIcon
   btn.setAttribute('data-i18n-key', nextKey)
@@ -378,7 +378,7 @@ async function startViewer(): Promise<void> {
   root.style.setProperty('--ml-ui-grip-hot', grip?.hotColorCss ?? '#ff0000')
 
   applyHtmlTheme(loadStoredTheme())
-  syncSimulatedMouseButton(acExIsSimulatedMouseEnabled(), i18n)
+  syncSimulatedMouseButton(acexIsSimulatedMouseEnabled(), i18n)
   i18n.applyToDocument()
 
   const initialLayout =
@@ -570,7 +570,7 @@ async function startViewer(): Promise<void> {
     camera.top = ACEX_CAMERA_FRUSTUM
     camera.bottom = -ACEX_CAMERA_FRUSTUM
     camera.updateProjectionMatrix()
-    acexCameraZoomUniform.value = camera.zoom
+    AcExCameraZoomUniform.value = camera.zoom
     controls.update()
   }
 
@@ -582,7 +582,7 @@ async function startViewer(): Promise<void> {
     controls.target.copy(target)
     if (zoom != null) camera.zoom = zoom
     camera.updateProjectionMatrix()
-    acexCameraZoomUniform.value = camera.zoom
+    AcExCameraZoomUniform.value = camera.zoom
     controls.update()
     recomputeOsnapThresholdWcs()
     bumpSnapCacheKey()
@@ -805,7 +805,7 @@ async function startViewer(): Promise<void> {
     drawerSheetsRef.current?.syncInset()
     if (nowVisible && !sessionPanelVisible) {
       sessionChromeRef.current.hide()
-      void acExMaybeShowTouchPointTutorial(i18n)
+      void acexMaybeShowTouchPointTutorial(i18n)
     } else if (!nowVisible && sessionPanelVisible) {
       sessionChromeRef.current.restore()
     }
@@ -858,7 +858,7 @@ async function startViewer(): Promise<void> {
     const drawing = isToolActive()
     const navMode = navToolsRef.current?.getMode()
     const idleTouchPan =
-      navMode != null && acExIdlePointerStrategy().enablesIdleTouchPan(navMode)
+      navMode != null && acexIdlePointerStrategy().enablesIdleTouchPan(navMode)
     setOrbitPanButtons(controls, {
       leftMousePan: idlePan,
       oneFingerPan:
@@ -880,7 +880,7 @@ async function startViewer(): Promise<void> {
     setLeftPanForTools()
   }
 
-  acExBindMobileSnapLoupe({
+  acexBindMobileSnapLoupe({
     refresh: refreshSnapLoupeHud,
     hide: hideSnapLoupe,
     setPreciseCaptureActive
@@ -959,7 +959,7 @@ async function startViewer(): Promise<void> {
       viewportCamera.setRotationFromEuler(new THREE.Euler(0, 0, twist))
       viewportCamera.zoom = fitted.zoom
       viewportCamera.updateProjectionMatrix()
-      acexCameraZoomUniform.value = fitted.zoom
+      AcExCameraZoomUniform.value = fitted.zoom
       renderer.render(modelScene, viewportCamera)
       renderer.setScissorTest(false)
     }
@@ -971,7 +971,7 @@ async function startViewer(): Promise<void> {
       savedViewportBox.w
     )
     renderer.autoClear = autoClear
-    acexCameraZoomUniform.value = camera.zoom
+    AcExCameraZoomUniform.value = camera.zoom
   }
 
   /**
@@ -1002,7 +1002,7 @@ async function startViewer(): Promise<void> {
     target.setRotationFromEuler(new THREE.Euler(0, 0, twist))
     target.zoom = fitted.zoom
     target.updateProjectionMatrix()
-    acexCameraZoomUniform.value = fitted.zoom
+    AcExCameraZoomUniform.value = fitted.zoom
   }
 
   /**
@@ -1035,7 +1035,7 @@ async function startViewer(): Promise<void> {
       width: ACEX_SNAP_LOUPE_SIZE_PX,
       height: ACEX_SNAP_LOUPE_SIZE_PX
     }
-    const gl = acExCssTopLeftRectToGl(loupeRect, height)
+    const gl = acexCssTopLeftRectToGl(loupeRect, height)
     const autoClear = renderer.autoClear
     renderer.autoClear = false
     renderer.getViewport(savedViewportBox)
@@ -1052,10 +1052,10 @@ async function startViewer(): Promise<void> {
       modelRoot.children.length > 0
     ) {
       for (const viewport of layout.viewports) {
-        const magRect = acExWcsBoxToCssRect(viewport.paper, viewBox, loupeRect)
-        const hit = acExIntersectCssRects(magRect, loupeRect)
+        const magRect = acexWcsBoxToCssRect(viewport.paper, viewBox, loupeRect)
+        const hit = acexIntersectCssRects(magRect, loupeRect)
         if (!hit) continue
-        const paperHit = acExCssRectToWcsBox(hit, viewBox, loupeRect)
+        const paperHit = acexCssRectToWcsBox(hit, viewBox, loupeRect)
         const corners = [
           paperPointToModel(viewport, paperHit.minX, paperHit.minY),
           paperPointToModel(viewport, paperHit.maxX, paperHit.minY),
@@ -1068,7 +1068,7 @@ async function startViewer(): Promise<void> {
           maxX: Math.max(...corners.map(c => c.x)),
           maxY: Math.max(...corners.map(c => c.y))
         }
-        const nestedGl = acExCssTopLeftRectToGl(hit, height)
+        const nestedGl = acexCssTopLeftRectToGl(hit, height)
         renderer.setScissor(
           nestedGl.x,
           nestedGl.y,
@@ -1101,7 +1101,7 @@ async function startViewer(): Promise<void> {
       savedViewportBox.w
     )
     renderer.autoClear = autoClear
-    acexCameraZoomUniform.value = camera.zoom
+    AcExCameraZoomUniform.value = camera.zoom
   }
 
   const render = () => {
@@ -1455,7 +1455,7 @@ async function startViewer(): Promise<void> {
   }
 
   controls.addEventListener('change', () => {
-    acexCameraZoomUniform.value = camera.zoom
+    AcExCameraZoomUniform.value = camera.zoom
     recomputeOsnapThresholdWcs()
     bumpSnapCacheKey()
     render()
@@ -1569,7 +1569,7 @@ async function startViewer(): Promise<void> {
       applyHtmlTheme(next)
       i18n.applyToDocument()
     } else if (action === 'toggle-simulated-mouse') {
-      const enabled = acExToggleSimulatedMouse()
+      const enabled = acexToggleSimulatedMouse()
       syncSimulatedMouseButton(enabled, i18n)
     } else if (action === 'switch-bg') {
       switchDrawingBackground()
@@ -1618,7 +1618,7 @@ async function startViewer(): Promise<void> {
     },
     onOpen: (menuId, menuRoot) => {
       layoutMenuRef.current?.close()
-      if (acExHtmlIsPhoneLayout()) {
+      if (acexHtmlIsPhoneLayout()) {
         closeLayerDrawer()
         reviewPanel?.close()
         measurePanel?.close()
@@ -1654,7 +1654,7 @@ async function startViewer(): Promise<void> {
     onSelect: switchLayout,
     closeOtherFlyouts: () => {
       toolbarFlyouts.close()
-      if (acExHtmlIsPhoneLayout()) {
+      if (acexHtmlIsPhoneLayout()) {
         closeLayerDrawer()
         reviewPanel?.close()
         measurePanel?.close()
@@ -1824,8 +1824,8 @@ function setupToolbarCollapse(
   const syncToggle = () => {
     sidebar.classList.toggle('mlcad-sidebar--collapsed', collapsed)
     toggleBtn.innerHTML = collapsed
-      ? acExHtmlIcons.chevronDown
-      : acExHtmlIcons.chevronUp
+      ? AcExHtmlIcons.chevronDown
+      : AcExHtmlIcons.chevronUp
     toggleBtn.setAttribute('aria-expanded', String(!collapsed))
     toggleBtn.dataset.i18nKey = collapsed
       ? 'toolbar.expand'
@@ -1996,7 +1996,7 @@ function setupLayerPanel(
       zoomBtn.setAttribute('aria-label', label)
     }
     updateZoomLabels()
-    zoomBtn.innerHTML = acExHtmlIcons.zoomBox
+    zoomBtn.innerHTML = AcExHtmlIcons.zoomBox
     const extents = layerExtents.get(name)
     zoomBtn.disabled = !extents
     zoomBtn.addEventListener('click', event => {
@@ -2232,7 +2232,7 @@ interface AcExToolPointerInputOptions {
  * Touch drawing tools defer commit until pointerup so a long-press can open
  * the loupe; jig preview also waits until that precise-capture phase.
  *
- * The snap loupe is driven through {@link acExRefreshMobileSnapLoupe} so
+ * The snap loupe is driven through {@link acexRefreshMobileSnapLoupe} so
  * drawing picks and overlay grip drags share one implementation.
  *
  * @param options - Canvas, tool accessors, and render callback.
@@ -2252,26 +2252,26 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
   const touchSession = new AcExTouchPointSession()
   const touchPickHudHost: AcExTouchPickHudHost = {
     refreshSnapLoupe: (clientX, clientY) => {
-      acExRefreshMobileSnapLoupe(clientX, clientY)
+      acexRefreshMobileSnapLoupe(clientX, clientY)
     },
     hideSnapLoupe: () => {
-      acExHideMobileSnapLoupe()
+      acexHideMobileSnapLoupe()
     },
     refreshSimulatedCursor: (clientX, clientY) => {
-      acExRefreshSimulatedMouseCursor(root, clientX, clientY)
+      acexRefreshSimulatedMouseCursor(root, clientX, clientY)
     },
     hideSimulatedCursor: () => {
-      acExHideSimulatedMouseCursor()
+      acexHideSimulatedMouseCursor()
     }
   }
   const hideTouchPreciseHud = () => {
-    acExHideMobileSnapLoupe()
-    acExHideSimulatedMouseCursor()
+    acexHideMobileSnapLoupe()
+    acexHideSimulatedMouseCursor()
   }
   const applyTouchPreciseSample = (fingerX: number, fingerY: number) => {
-    const sample = acExTouchPickStrategy().mapFingerToSample(fingerX, fingerY)
+    const sample = acexTouchPickStrategy().mapFingerToSample(fingerX, fingerY)
     previewDrawingPoint(sample.x, sample.y)
-    acExTouchPickStrategy().showPreciseHud(
+    acexTouchPickStrategy().showPreciseHud(
       touchPickHudHost,
       sample.x,
       sample.y
@@ -2319,7 +2319,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     selectionRect.style.width = `${Math.abs(clientX - startX)}px`
     selectionRect.style.height = `${Math.abs(clientY - startY)}px`
     if (kind === 'select') {
-      selectionRect.dataset.mode = acExSelectionModeFromDrag(startX, clientX)
+      selectionRect.dataset.mode = acexSelectionModeFromDrag(startX, clientX)
     } else {
       delete selectionRect.dataset.mode
     }
@@ -2476,7 +2476,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
       maxX: Math.max(a.x, b.x),
       maxY: Math.max(a.y, b.y)
     }
-    const mode = acExSelectionModeFromDrag(startX, endX)
+    const mode = acexSelectionModeFromDrag(startX, endX)
     getMarkup()?.handleSelectionBox(box, mode)
     getMeasure()?.handleSelectionBox(box, mode)
     render()
@@ -2490,10 +2490,10 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     const gesture = boxGesture
     boxGesture = null
     hideSelectionRect()
-    acExSetMobileSnapLoupePreciseCapture(false)
+    acexSetMobileSnapLoupePreciseCapture(false)
     if (gesture) releaseBoxPointerCapture(gesture.pointerId)
     // Compat mouse after touch, not a real mouse box-select.
-    if (gesture?.pointerType === 'touch') acExSinkFollowingClick()
+    if (gesture?.pointerType === 'touch') acexSinkFollowingClick()
     if (!gesture) return
     if (!commit || !gesture.activated) {
       if (gesture.kind === 'zoom-window') {
@@ -2551,9 +2551,9 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
       if (!wasActivated) {
         boxGesture = null
         hideSelectionRect()
-        acExSetMobileSnapLoupePreciseCapture(false)
+        acexSetMobileSnapLoupePreciseCapture(false)
         releaseBoxPointerCapture(gesture.pointerId)
-        acExSinkFollowingClick()
+        acexSinkFollowingClick()
         if (gesture.kind === 'select') {
           applyClickSelect(event.clientX, event.clientY)
         }
@@ -2562,14 +2562,14 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
       finishBoxGesture(event.clientX, event.clientY, true)
       return
     }
-    acExSetMobileSnapLoupePreciseCapture(false)
+    acexSetMobileSnapLoupePreciseCapture(false)
     // Loupe moves coalesce into RAF; cancel before commit/abort so a late
     // flush cannot set live pointer and bring the OSNAP glyph back.
     cancelPendingPointerMove()
     // Chrome synthesizes mouse pointerdown+click after touchup near the finger.
     // Without this, a two-point tool would commit the second point immediately
     // and clear the confirmed-point plus mark.
-    acExSinkFollowingClick()
+    acexSinkFollowingClick()
     if (!commit) {
       touchSession.cancel()
       hideTouchPreciseHud()
@@ -2581,7 +2581,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     hideTouchPreciseHud()
     if (action === 'commit') {
       if (wasPrecise) {
-        const sample = acExTouchPickStrategy().mapFingerToSample(
+        const sample = acexTouchPickStrategy().mapFingerToSample(
           event.clientX,
           event.clientY
         )
@@ -2596,7 +2596,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
 
   const idlePointerHost: AcExIdlePointerHost = {
     navMode: () => idleNavMode(),
-    shouldIgnoreCompatMouse: () => acExShouldIgnoreCompatMouse(),
+    shouldIgnoreCompatMouse: () => acexShouldIgnoreCompatMouse(),
     startTouchBox: (kind, event) => {
       // preventDefault only: do not stopImmediatePropagation so OrbitControls
       // still receives pointerdown and can pan if the finger moves first.
@@ -2614,7 +2614,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
         boxGesture.activated = true
         boxGesture.startX = touchSession.x
         boxGesture.startY = touchSession.y
-        acExSetMobileSnapLoupePreciseCapture(true)
+        acexSetMobileSnapLoupePreciseCapture(true)
         if (kind === 'zoom-window') {
           getNavTools()?.handlePointerDown(touchSession.x, touchSession.y)
         } else {
@@ -2678,7 +2678,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     'pointerdown',
     event => {
       if (event.button !== 0) return
-      if (event.pointerType !== 'touch' && acExShouldIgnoreCompatMouse()) {
+      if (event.pointerType !== 'touch' && acexShouldIgnoreCompatMouse()) {
         event.stopImmediatePropagation()
         return
       }
@@ -2694,7 +2694,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
           event.clientY,
           () => {
             // Precise capture only: lock pan and start jig / HUD preview.
-            acExSetMobileSnapLoupePreciseCapture(true)
+            acexSetMobileSnapLoupePreciseCapture(true)
             applyTouchPreciseSample(touchSession.x, touchSession.y)
             render()
           }
@@ -2718,7 +2718,7 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
         }
         return
       }
-      acExIdlePointerStrategy().onPointerDown(event, idlePointerHost)
+      acexIdlePointerStrategy().onPointerDown(event, idlePointerHost)
     },
     true
   )
@@ -2755,11 +2755,11 @@ function setupToolPointerInput(options: AcExToolPointerInputOptions): void {
     }
   })
   window.addEventListener('pointerup', event => {
-    if (acExIdlePointerStrategy().onPointerUp(event, idlePointerHost)) return
+    if (acexIdlePointerStrategy().onPointerUp(event, idlePointerHost)) return
     endTouchPick(event, true)
   })
   window.addEventListener('pointercancel', event => {
-    if (acExIdlePointerStrategy().onPointerCancel(event, idlePointerHost)) {
+    if (acexIdlePointerStrategy().onPointerCancel(event, idlePointerHost)) {
       return
     }
     endTouchPick(event, false)

--- a/packages/cad-html-plugin/src/AcExIdlePointerStrategy.ts
+++ b/packages/cad-html-plugin/src/AcExIdlePointerStrategy.ts
@@ -1,4 +1,4 @@
-import { acExHtmlIsMobileNavUi } from './AcExHtmlDrawerSheet'
+import { acexHtmlIsMobileNavUi } from './AcExHtmlDrawerSheet'
 import type { AcExHtmlNavMode } from './AcExHtmlNavTools'
 
 /**
@@ -134,6 +134,6 @@ const mobileStrategy = new AcExMobileIdlePointerStrategy()
  * Re-evaluated each call so rotating a tablet or resizing the window
  * switches rules without rebinding listeners.
  */
-export function acExIdlePointerStrategy(): AcExIdlePointerStrategy {
-  return acExHtmlIsMobileNavUi() ? mobileStrategy : desktopStrategy
+export function acexIdlePointerStrategy(): AcExIdlePointerStrategy {
+  return acexHtmlIsMobileNavUi() ? mobileStrategy : desktopStrategy
 }

--- a/packages/cad-html-plugin/src/AcExLayerExtents.ts
+++ b/packages/cad-html-plugin/src/AcExLayerExtents.ts
@@ -101,7 +101,7 @@ export function toExtents(extents: AcExMutableExtents): AcExExtents | null {
  * Unions XY extents from every line and mesh batch in one layout.
  *
  * Used for initial zoom-to-fit in the offline viewer so hatch pattern shaders
- * receive a realistic {@link acexCameraZoomUniform} instead of zooming to the
+ * receive a realistic {@link AcExCameraZoomUniform} instead of zooming to the
  * often much larger database `EXTMIN`/`EXTMAX` header.
  */
 export function computeLayoutExtents(

--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -4,7 +4,7 @@
  * Creates Design Review–style overlays (cloud, callout, text, rect, circle,
  * arrow, stamp) with sidecar JSON import/export compatible with cad-simple-viewer.
  *
- * @module AcExMarkup
+ * @module acexMarkup
  * @packageDocumentation
  */
 
@@ -13,37 +13,37 @@ import * as THREE from 'three'
 import type { AcExCommandSessionUiState } from './AcExCommandSessionPanel'
 import { AcExConfirmedPointMarks } from './AcExConfirmedPointMarks'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
-import { acExHtmlIcons } from './AcExHtmlIcons'
+import { AcExHtmlIcons } from './AcExHtmlIcons'
 import {
   ACEX_OVERLAY_ARROW_SIZE_PX,
-  acExPositionWcsOverlay,
-  acExResetOverlayViewScale,
-  acExScaledCanvasLineWidth,
-  acExScaledOverlayArrowSize,
-  acExScreenPxToWcs,
-  acExSeedOverlaySizesFromWcs
+  acexPositionWcsOverlay,
+  acexResetOverlayViewScale,
+  acexScaledCanvasLineWidth,
+  acexScaledOverlayArrowSize,
+  acexScreenPxToWcs,
+  acexSeedOverlaySizesFromWcs
 } from './AcExHtmlOverlayDom'
 import {
-  acExComputeLeaderTipOnShape,
-  acExDrawMarkupArrowHead,
-  acExDrawMarkupLeader,
-  acExFitMarkupCanvas,
-  acExHitTestMarkup,
-  acExHitTestMarkupShapeOutline,
-  acExIsAttachableShapeMarkup,
-  acExMarkupBounds,
-  acExMarkupCanvasLineWidth,
-  acExMarkupCenter,
-  acExMarkupFocusExtents,
+  acexComputeLeaderTipOnShape,
+  acexDrawMarkupArrowHead,
+  acexDrawMarkupLeader,
+  acexFitMarkupCanvas,
+  acexHitTestMarkup,
+  acexHitTestMarkupShapeOutline,
+  acexIsAttachableShapeMarkup,
+  acexMarkupBounds,
+  acexMarkupCanvasLineWidth,
+  acexMarkupCenter,
+  acexMarkupFocusExtents,
   type AcExMarkupShapeOutline,
-  acExMarkupShapeOutlineFromGeometry,
-  acExOverlayArrowSize,
-  acExStrokeMarkupCloud,
-  acExTranslateMarkupGeometry
+  acexMarkupShapeOutlineFromGeometry,
+  acexOverlayArrowSize,
+  acexStrokeMarkupCloud,
+  acexTranslateMarkupGeometry
 } from './AcExMarkupGeometry'
-import { acExBindMarkupPointerDrag } from './AcExMarkupGripDrag'
+import { acexBindMarkupPointerDrag } from './AcExMarkupGripDrag'
 import {
-  acExMarkupSidecarFileName,
+  acexMarkupSidecarFileName,
   parseAcExMarkupSidecar,
   stringifyAcExMarkupSidecar
 } from './AcExMarkupSidecar'
@@ -65,8 +65,8 @@ import type {
 import type { AcExTrackingOptions } from './AcExMeasureTracking'
 import { constrainToAcExTracking } from './AcExMeasureTracking'
 import type { AcExOsnapPoint } from './AcExOsnap'
-import { acExIsOverlayGrip, acExOverlayGripClassName } from './AcExOverlayGrip'
-import { acExExtentsMatchBox, type AcExSelectionMode } from './AcExSelectionBox'
+import { acexIsOverlayGrip, acexOverlayGripClassName } from './AcExOverlayGrip'
+import { acexExtentsMatchBox, type AcExSelectionMode } from './AcExSelectionBox'
 import type { AcExExtents } from './AcExSnapshotTypes'
 
 export type { AcExMarkupMode } from './AcExMarkupTypes'
@@ -109,7 +109,7 @@ interface AcExResolvedPoint {
 }
 
 /**
- * View/camera callbacks supplied by {@link AcExHtmlViewerRuntime}.
+ * View/camera callbacks supplied by {@link acexHtmlViewerRuntime}.
  */
 export interface AcExMarkupViewApi {
   screenToWcs: (clientX: number, clientY: number) => THREE.Vector2
@@ -420,11 +420,11 @@ export class AcExMarkupController {
     const arrowSizeWcs =
       style.arrowSizeWcs != null && style.arrowSizeWcs > 0
         ? style.arrowSizeWcs
-        : acExScreenPxToWcs(ACEX_OVERLAY_ARROW_SIZE_PX, wcsToScreen)
+        : acexScreenPxToWcs(ACEX_OVERLAY_ARROW_SIZE_PX, wcsToScreen)
     return {
       ...rest,
       lineWeight: ACEX_MARKUP_LINE_WEIGHT,
-      textHeightWcs: acExScreenPxToWcs(fontSize, wcsToScreen),
+      textHeightWcs: acexScreenPxToWcs(fontSize, wcsToScreen),
       arrowSizeWcs
     }
   }
@@ -465,7 +465,7 @@ export class AcExMarkupController {
     canvas: HTMLCanvasElement,
     strokeWidthWcs?: number
   ): number {
-    return acExScaledCanvasLineWidth(
+    return acexScaledCanvasLineWidth(
       baseLineWidth,
       canvas,
       this._view.getCameraZoom(),
@@ -503,15 +503,15 @@ export class AcExMarkupController {
           style.textHeightWcs =
             style.textHeightWcs * (patch.fontSize / prevFont)
         } else {
-          style.textHeightWcs = acExScreenPxToWcs(patch.fontSize, wcsToScreen)
+          style.textHeightWcs = acexScreenPxToWcs(patch.fontSize, wcsToScreen)
         }
         style.fontSize = patch.fontSize
       }
       if (patch.fontSize != null) {
-        acExSeedOverlaySizesFromWcs(this._view.getCameraZoom(), wcsToScreen, {
+        acexSeedOverlaySizesFromWcs(this._view.getCameraZoom(), wcsToScreen, {
           textHeightWcs: style.textHeightWcs,
           fontSizePx: style.fontSize ?? ACEX_MARKUP_FONT_SIZE,
-          strokeScreenPx: acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
+          strokeScreenPx: acexMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
           elements: item.parts.dom,
           canvases: item.parts.canvases
         })
@@ -840,9 +840,9 @@ export class AcExMarkupController {
       ) {
         continue
       }
-      const bounds = acExMarkupBounds(item.record.geometry)
+      const bounds = acexMarkupBounds(item.record.geometry)
       if (!bounds) continue
-      if (acExExtentsMatchBox(bounds, box, mode)) {
+      if (acexExtentsMatchBox(bounds, box, mode)) {
         next.add(item.record.id)
       }
     }
@@ -903,7 +903,7 @@ export class AcExMarkupController {
       .filter(el => !el.classList.contains('mlcad-markup-dot') && !el.hidden)
       .map(el => el.getBoundingClientRect())
       .filter(rect => rect.width > 0 || rect.height > 0)
-    const extents = acExMarkupFocusExtents(
+    const extents = acexMarkupFocusExtents(
       item.record.geometry,
       rects,
       (clientX, clientY) => this._clientToWorld(clientX, clientY)
@@ -961,7 +961,7 @@ export class AcExMarkupController {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = acExMarkupSidecarFileName(this._drawingName)
+    a.download = acexMarkupSidecarFileName(this._drawingName)
     a.click()
     URL.revokeObjectURL(url)
     this._statusEl.textContent = this._i18n.t('status.markupExported', {
@@ -1051,7 +1051,7 @@ export class AcExMarkupController {
     if (this._points.length === 0) {
       const hit = this._pickAttachableShapeAt(clientX, clientY)
       if (hit) {
-        const outline = acExMarkupShapeOutlineFromGeometry(hit.record.geometry)
+        const outline = acexMarkupShapeOutlineFromGeometry(hit.record.geometry)
         if (outline) {
           this._beginPlacingShapeCallout(outline, {
             existingId: hit.record.id,
@@ -1078,9 +1078,9 @@ export class AcExMarkupController {
       ) {
         continue
       }
-      if (!acExIsAttachableShapeMarkup(item.record.geometry)) continue
+      if (!acexIsAttachableShapeMarkup(item.record.geometry)) continue
       if (
-        acExHitTestMarkupShapeOutline(
+        acexHitTestMarkupShapeOutline(
           item.record.geometry,
           clientX,
           clientY,
@@ -1171,20 +1171,20 @@ export class AcExMarkupController {
     const tipDot = this._makeTempDot(tip, this._drawColor)
     this._statusEl.textContent = this._i18n.t('status.markupTextEditHint')
     const paintLeader = () => {
-      const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
+      const ctx = acexFitMarkupCanvas(this._previewCanvas, this._root)
       if (!ctx) return
       const tipS = this._worldToOverlay(tip)
       const anchorS = this._worldToOverlay(anchor)
-      const baseWidth = acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
+      const baseWidth = acexMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
       const scaled = this._scaledCanvasLineWidth(baseWidth, ctx.canvas)
-      acExDrawMarkupLeader(
+      acexDrawMarkupLeader(
         ctx,
         tipS,
         anchorS,
         this._drawColor,
         true,
         scaled,
-        acExOverlayArrowSize(scaled, baseWidth)
+        acexOverlayArrowSize(scaled, baseWidth)
       )
     }
     paintLeader()
@@ -1220,7 +1220,7 @@ export class AcExMarkupController {
             x: Math.max(outline.corner1.x, outline.corner2.x) + 1,
             y: (outline.corner1.y + outline.corner2.y) / 2
           })
-    const tip = acExComputeLeaderTipOnShape(outline, toward)
+    const tip = acexComputeLeaderTipOnShape(outline, toward)
     const anchor = { ...toward }
     const badge = this._makeTempBadge(anchor, '', this._drawColor)
     const tipDot = this._makeTempDot(tip, this._drawColor)
@@ -1244,7 +1244,7 @@ export class AcExMarkupController {
     const placing = this._placingShapeCallout
     if (!placing || this._awaitingInlineText) return
     const anchor = point2(anchorPoint)
-    const tip = acExComputeLeaderTipOnShape(placing.outline, anchor)
+    const tip = acexComputeLeaderTipOnShape(placing.outline, anchor)
     placing.tip = tip
     placing.anchor = anchor
     placing.badge.dataset.wcsX = String(anchor.x)
@@ -1346,7 +1346,7 @@ export class AcExMarkupController {
     const item = this._committed.find(c => c.record.id === id)
     if (!item) return
     const g = item.record.geometry
-    if (!acExIsAttachableShapeMarkup(g)) return
+    if (!acexIsAttachableShapeMarkup(g)) return
     if (g.type !== 'cloud' && g.type !== 'rect' && g.type !== 'circle') return
     const next: AcExMarkupRecord = {
       ...item.record,
@@ -1433,7 +1433,7 @@ export class AcExMarkupController {
     if (!Number.isFinite(x) || !Number.isFinite(y)) return
     const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
     const screen = this._view.wcsToScreen(new THREE.Vector2(x, y))
-    acExPositionWcsOverlay(el, screen, rootRect, this._view.getCameraZoom())
+    acexPositionWcsOverlay(el, screen, rootRect, this._view.getCameraZoom())
   }
 
   private _commitGeometry(
@@ -1469,14 +1469,14 @@ export class AcExMarkupController {
     // Push before building visuals so the initial redraw can resolve the record.
     this._committed.push({ record, parts })
     this._buildVisuals(record, parts)
-    acExSeedOverlaySizesFromWcs(
+    acexSeedOverlaySizesFromWcs(
       this._view.getCameraZoom(),
       p => this._wcsToScreenPoint(p),
       {
         textHeightWcs: record.style.textHeightWcs,
         arrowSizeWcs: record.style.arrowSizeWcs,
         fontSizePx: record.style.fontSize ?? ACEX_MARKUP_FONT_SIZE,
-        strokeScreenPx: acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
+        strokeScreenPx: acexMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
         elements: parts.dom,
         canvases: parts.canvases
       }
@@ -1501,13 +1501,13 @@ export class AcExMarkupController {
 
     const redraw = () => {
       const live = this._findRecord(markupId) ?? record
-      const ctx = acExFitMarkupCanvas(canvas, this._root)
+      const ctx = acexFitMarkupCanvas(canvas, this._root)
       if (!ctx) return
       this._strokeGeometry(
         ctx,
         live.geometry,
         live.style.color || ACEX_MARKUP_COLOR,
-        acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
+        acexMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT),
         undefined,
         true,
         live.style.arrowSizeWcs
@@ -1593,7 +1593,7 @@ export class AcExMarkupController {
       g.type === 'rect' ||
       g.type === 'circle'
     ) {
-      const center = acExMarkupCenter(record)
+      const center = acexMarkupCenter(record)
       if (center) {
         centerDot = this._makeDot(center, color, markupId)
         parts.dom.push(centerDot)
@@ -1666,7 +1666,7 @@ export class AcExMarkupController {
   private _placeDomAt(el: HTMLElement, wcs: AcExMarkupPoint2d): void {
     el.dataset.wcsX = String(wcs.x)
     el.dataset.wcsY = String(wcs.y)
-    if (!acExIsOverlayGrip(el)) acExResetOverlayViewScale(el)
+    if (!acexIsOverlayGrip(el)) acexResetOverlayViewScale(el)
     this._positionTempDom(el)
   }
 
@@ -1755,7 +1755,7 @@ export class AcExMarkupController {
       if (!centerDot) return
       const record = this._findRecord(id)
       if (!record) return
-      const center = acExMarkupCenter(record)
+      const center = acexMarkupCenter(record)
       if (center) this._placeDomAt(centerDot, center)
     }
 
@@ -1776,7 +1776,7 @@ export class AcExMarkupController {
     // Text / stamp: drag badge to move position.
     if (badge && (geometryType === 'text' || geometryType === 'stamp')) {
       cleanups.push(
-        acExBindMarkupPointerDrag({
+        acexBindMarkupPointerDrag({
           el: badge,
           clientToWorld,
           showSnapLoupe: false,
@@ -1804,7 +1804,7 @@ export class AcExMarkupController {
     // Standalone callout or shape-attached callout: tip + bubble.
     if (badge && tipDot && (geometryType === 'callout' || hasAttachedCallout)) {
       cleanups.push(
-        acExBindMarkupPointerDrag({
+        acexBindMarkupPointerDrag({
           el: tipDot,
           clientToWorld: clientToWorldOsnap,
           isEnabled,
@@ -1821,7 +1821,7 @@ export class AcExMarkupController {
             ) {
               const outline = shapeOutline()
               if (!outline || !g.callout) return
-              tip = acExComputeLeaderTipOnShape(outline, world)
+              tip = acexComputeLeaderTipOnShape(outline, world)
               g.callout.tip.x = tip.x
               g.callout.tip.y = tip.y
             } else if (g.type === 'callout') {
@@ -1838,7 +1838,7 @@ export class AcExMarkupController {
         })
       )
       cleanups.push(
-        acExBindMarkupPointerDrag({
+        acexBindMarkupPointerDrag({
           el: badge,
           clientToWorld,
           showSnapLoupe: false,
@@ -1879,7 +1879,7 @@ export class AcExMarkupController {
       (geometryType === 'arrow' || geometryType === 'line')
     ) {
       cleanups.push(
-        acExBindMarkupPointerDrag({
+        acexBindMarkupPointerDrag({
           el: startDot,
           clientToWorld: clientToWorldOsnap,
           isEnabled,
@@ -1898,7 +1898,7 @@ export class AcExMarkupController {
         })
       )
       cleanups.push(
-        acExBindMarkupPointerDrag({
+        acexBindMarkupPointerDrag({
           el: endDot,
           clientToWorld: clientToWorldOsnap,
           isEnabled,
@@ -1933,7 +1933,7 @@ export class AcExMarkupController {
       let originGeom: AcExMarkupGeometry | null = null
       let originCenter: AcExMarkupPoint2d | null = null
       cleanups.push(
-        acExBindMarkupPointerDrag({
+        acexBindMarkupPointerDrag({
           el: centerDot,
           clientToWorld: snapCenter ? clientToWorldOsnap : clientToWorld,
           showSnapLoupe: snapCenter,
@@ -1944,14 +1944,14 @@ export class AcExMarkupController {
             const record = this._findRecord(id)
             if (!record) return
             originGeom = structuredClone(record.geometry)
-            originCenter = acExMarkupCenter(record)
+            originCenter = acexMarkupCenter(record)
           },
           onMove: world => {
             const record = this._findRecord(id)
             if (!record || !originGeom || !originCenter) return
             const dx = world.x - originCenter.x
             const dy = world.y - originCenter.y
-            record.geometry = acExTranslateMarkupGeometry(originGeom, dx, dy)
+            record.geometry = acexTranslateMarkupGeometry(originGeom, dx, dy)
             syncAttachedDom(record.geometry)
             this._placeDomAt(centerDot, world)
             redraw()
@@ -1976,7 +1976,7 @@ export class AcExMarkupController {
     id: string
   ): HTMLElement {
     const dot = document.createElement('div')
-    dot.className = acExOverlayGripClassName('markup')
+    dot.className = acexOverlayGripClassName('markup')
     dot.dataset.markupId = id
     dot.dataset.wcsX = String(wcs.x)
     dot.dataset.wcsY = String(wcs.y)
@@ -2028,18 +2028,18 @@ export class AcExMarkupController {
         ctx.lineTo(b.x, b.y)
         ctx.stroke()
         if (g.type === 'arrow') {
-          acExDrawMarkupArrowHead(
+          acexDrawMarkupArrowHead(
             ctx,
             a,
             b,
             color,
             scaleArrowsWithView
-              ? acExScaledOverlayArrowSize(
+              ? acexScaledOverlayArrowSize(
                   ctx.canvas,
                   worldToScreen,
                   arrowSizeWcs
                 )
-              : acExOverlayArrowSize(strokeWidth, lineWidth)
+              : acexOverlayArrowSize(strokeWidth, lineWidth)
           )
         }
         break
@@ -2090,7 +2090,7 @@ export class AcExMarkupController {
         break
       }
       case 'cloud': {
-        acExStrokeMarkupCloud(
+        acexStrokeMarkupCloud(
           ctx,
           g.corner1,
           g.corner2,
@@ -2105,7 +2105,7 @@ export class AcExMarkupController {
       case 'callout': {
         const tip = worldToScreen(g.tip)
         const anchor = worldToScreen(g.anchor)
-        acExDrawMarkupLeader(
+        acexDrawMarkupLeader(
           ctx,
           tip,
           anchor,
@@ -2113,12 +2113,12 @@ export class AcExMarkupController {
           true,
           strokeWidth,
           scaleArrowsWithView
-            ? acExScaledOverlayArrowSize(
+            ? acexScaledOverlayArrowSize(
                 ctx.canvas,
                 worldToScreen,
                 arrowSizeWcs
               )
-            : acExOverlayArrowSize(strokeWidth, lineWidth)
+            : acexOverlayArrowSize(strokeWidth, lineWidth)
         )
         break
       }
@@ -2137,7 +2137,7 @@ export class AcExMarkupController {
     const tip = this._worldToOverlay(callout.tip)
     const anchor = this._worldToOverlay(callout.anchor)
     // Shape-attached leaders have no arrowhead (Design Review).
-    acExDrawMarkupLeader(ctx, tip, anchor, color, false, lineWidth)
+    acexDrawMarkupLeader(ctx, tip, anchor, color, false, lineWidth)
   }
 
   private _editText(id: string, badge: HTMLElement): void {
@@ -2277,7 +2277,7 @@ export class AcExMarkupController {
         }
       }
       if (
-        acExHitTestMarkup(
+        acexHitTestMarkup(
           item.record,
           clientX,
           clientY,
@@ -2359,7 +2359,7 @@ export class AcExMarkupController {
         const y = Number(el.dataset.wcsY)
         if (!Number.isFinite(x) || !Number.isFinite(y)) continue
         const screen = this._view.wcsToScreen(new THREE.Vector2(x, y))
-        acExPositionWcsOverlay(el, screen, rootRect, zoom)
+        acexPositionWcsOverlay(el, screen, rootRect, zoom)
       }
     }
     const placing = this._placingShapeCallout
@@ -2455,7 +2455,7 @@ export class AcExMarkupController {
         this._lastPointer.y
       )
       const anchor = point2(cursor)
-      const tip = acExComputeLeaderTipOnShape(placing.outline, anchor)
+      const tip = acexComputeLeaderTipOnShape(placing.outline, anchor)
       placing.tip = tip
       placing.anchor = anchor
       placing.badge.dataset.wcsX = String(anchor.x)
@@ -2482,10 +2482,10 @@ export class AcExMarkupController {
       this._lastPointer.x,
       this._lastPointer.y
     )
-    const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
+    const ctx = acexFitMarkupCanvas(this._previewCanvas, this._root)
     if (!ctx) return
     const color = this._drawColor
-    const lineWidth = acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
+    const lineWidth = acexMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
 
     if (this._points.length === 0) return
     const a = this._points[0]!
@@ -2506,7 +2506,7 @@ export class AcExMarkupController {
         lineWidth
       )
     } else if (this._mode === 'cloud') {
-      acExStrokeMarkupCloud(
+      acexStrokeMarkupCloud(
         ctx,
         point2(a),
         point2(b),
@@ -2527,14 +2527,14 @@ export class AcExMarkupController {
       const tip = this._worldToOverlay(point2(a))
       const anchor = this._worldToOverlay(point2(b))
       const scaled = this._scaledCanvasLineWidth(lineWidth, ctx.canvas)
-      acExDrawMarkupLeader(
+      acexDrawMarkupLeader(
         ctx,
         tip,
         anchor,
         color,
         true,
         scaled,
-        acExOverlayArrowSize(scaled, lineWidth)
+        acexOverlayArrowSize(scaled, lineWidth)
       )
     }
   }
@@ -2543,10 +2543,10 @@ export class AcExMarkupController {
     placing: AcExPlacingShapeCallout,
     withLeader: boolean
   ): void {
-    const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
+    const ctx = acexFitMarkupCanvas(this._previewCanvas, this._root)
     if (!ctx) return
     const color = this._drawColor
-    const lineWidth = acExMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
+    const lineWidth = acexMarkupCanvasLineWidth(ACEX_MARKUP_LINE_WEIGHT)
     const outline = placing.outline
     // Existing shape is already committed; only preview the new leader.
     if (!placing.existingId) {
@@ -2562,7 +2562,7 @@ export class AcExMarkupController {
           lineWidth
         )
       } else if (outline.kind === 'cloud') {
-        acExStrokeMarkupCloud(
+        acexStrokeMarkupCloud(
           ctx,
           outline.corner1,
           outline.corner2,
@@ -2587,7 +2587,7 @@ export class AcExMarkupController {
     if (!withLeader) return
     const tip = this._worldToOverlay(placing.tip)
     const anchor = this._worldToOverlay(placing.anchor)
-    acExDrawMarkupLeader(
+    acexDrawMarkupLeader(
       ctx,
       tip,
       anchor,
@@ -2607,7 +2607,7 @@ export class AcExMarkupController {
   }
 
   private _clearPreview(): void {
-    const ctx = acExFitMarkupCanvas(this._previewCanvas, this._root)
+    const ctx = acexFitMarkupCanvas(this._previewCanvas, this._root)
     if (ctx) {
       // already cleared by fit
     }
@@ -2668,8 +2668,8 @@ export class AcExMarkupController {
     // Tooltip stays action-oriented (click to hide / show).
     const titleKey = this._visible ? 'toolbar.markupHide' : 'toolbar.markupShow'
     const icon = this._visible
-      ? acExHtmlIcons.markupShow
-      : acExHtmlIcons.markupHide
+      ? AcExHtmlIcons.markupShow
+      : AcExHtmlIcons.markupHide
     const label = this._i18n.t(titleKey)
     buttons.forEach(btn => {
       btn.classList.toggle('active', this._visible)

--- a/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupGeometry.ts
@@ -42,7 +42,7 @@ export type AcExMarkupShapeOutline =
  * center toward the cursor with the shape outer frame (AABB for rect/cloud,
  * circle perimeter for circle).
  */
-export function acExComputeLeaderTipOnShape(
+export function acexComputeLeaderTipOnShape(
   outline: AcExMarkupShapeOutline,
   toward: AcExMarkupPoint2d
 ): AcExMarkupPoint2d {
@@ -88,9 +88,9 @@ const CLOUD_HIT_EXTRA_PX = 8
  * Hairline overlays (`baseLineWidth <= 0`) keep a constant
  * {@link ACEX_OVERLAY_ARROW_SIZE_PX}. Use this during jig / live preview so
  * the head stays a fixed screen size while the user zooms. After commit,
- * freeze that size in world units with `acExScaledOverlayArrowSize`.
+ * freeze that size in world units with `acexScaledOverlayArrowSize`.
  */
-export function acExOverlayArrowSize(
+export function acexOverlayArrowSize(
   scaledLineWidth: number,
   baseLineWidth = 2
 ): number {
@@ -102,7 +102,7 @@ export function acExOverlayArrowSize(
 /**
  * Whether geometry is a cloud / rect / circle with no attached callout.
  */
-export function acExIsAttachableShapeMarkup(
+export function acexIsAttachableShapeMarkup(
   geometry: AcExMarkupGeometry
 ): boolean {
   return (
@@ -116,7 +116,7 @@ export function acExIsAttachableShapeMarkup(
 /**
  * Shape outline used to constrain an attached-callout leader tip.
  */
-export function acExMarkupShapeOutlineFromGeometry(
+export function acexMarkupShapeOutlineFromGeometry(
   geometry: AcExMarkupGeometry
 ): AcExMarkupShapeOutline | undefined {
   if (geometry.type === 'circle') {
@@ -141,7 +141,7 @@ export function acExMarkupShapeOutlineFromGeometry(
  * (AABB for cloud/rect, circumference for circle). Does not hit interiors
  * or an already-attached callout leader.
  */
-export function acExHitTestMarkupShapeOutline(
+export function acexHitTestMarkupShapeOutline(
   geometry: AcExMarkupGeometry,
   clientX: number,
   clientY: number,
@@ -159,7 +159,7 @@ export function acExHitTestMarkupShapeOutline(
       const inside =
         clientX >= minX && clientX <= maxX && clientY >= minY && clientY <= maxY
       if (!inside) {
-        return acExDistToRectOutlinePx(clientX, clientY, a, b) <= thresholdPx
+        return acexDistToRectOutlinePx(clientX, clientY, a, b) <= thresholdPx
       }
       const distEdge = Math.min(
         Math.abs(clientX - minX),
@@ -180,7 +180,7 @@ export function acExHitTestMarkupShapeOutline(
       const inside =
         clientX >= minX && clientX <= maxX && clientY >= minY && clientY <= maxY
       if (!inside) {
-        return acExDistToRectOutlinePx(clientX, clientY, a, b) <= tol
+        return acexDistToRectOutlinePx(clientX, clientY, a, b) <= tol
       }
       const distEdge = Math.min(
         Math.abs(clientX - minX),
@@ -215,7 +215,7 @@ interface AcExMarkupCloudVertex {
 /**
  * Fit a canvas to its container and return a 2D context cleared for this frame.
  */
-export function acExFitMarkupCanvas(
+export function acexFitMarkupCanvas(
   canvas: HTMLCanvasElement,
   container: HTMLElement
 ): CanvasRenderingContext2D | null {
@@ -239,7 +239,7 @@ export function acExFitMarkupCanvas(
 }
 
 /** Draw a filled arrow head at `to`, pointing along `from` → `to`. */
-export function acExDrawMarkupArrowHead(
+export function acexDrawMarkupArrowHead(
   ctx: CanvasRenderingContext2D,
   from: { x: number; y: number },
   to: { x: number; y: number },
@@ -270,7 +270,7 @@ export function acExDrawMarkupArrowHead(
 }
 
 /** Draw a leader segment, optionally with an arrow head at the tip. */
-export function acExDrawMarkupLeader(
+export function acexDrawMarkupLeader(
   ctx: CanvasRenderingContext2D,
   tip: { x: number; y: number },
   anchor: { x: number; y: number },
@@ -286,18 +286,18 @@ export function acExDrawMarkupLeader(
   ctx.lineTo(anchor.x, anchor.y)
   ctx.stroke()
   if (withArrow) {
-    acExDrawMarkupArrowHead(
+    acexDrawMarkupArrowHead(
       ctx,
       anchor,
       tip,
       color,
-      arrowSizePx ?? acExOverlayArrowSize(lineWidth)
+      arrowSizePx ?? acexOverlayArrowSize(lineWidth)
     )
   }
 }
 
 /** Map CAD line weight to canvas stroke width in CSS pixels. */
-export function acExMarkupCanvasLineWidth(weight?: number): number {
+export function acexMarkupCanvasLineWidth(weight?: number): number {
   if (weight == null || !Number.isFinite(weight) || weight <= 0) return 0
   return Math.max(1, weight / 28)
 }
@@ -435,7 +435,7 @@ function tessellateMarkupCloud(
 }
 
 /** Stroke a revision cloud on a canvas context (screen projection). */
-export function acExStrokeMarkupCloud(
+export function acexStrokeMarkupCloud(
   ctx: CanvasRenderingContext2D,
   first: AcExMarkupPoint2d,
   second: AcExMarkupPoint2d,
@@ -482,7 +482,7 @@ export function acExStrokeMarkupCloud(
 }
 
 /** Shortest distance from a screen point to a line segment (pixels). */
-export function acExDistToSegmentPx(
+export function acexDistToSegmentPx(
   px: number,
   py: number,
   ax: number,
@@ -500,7 +500,7 @@ export function acExDistToSegmentPx(
 }
 
 /** Distance from a screen point to a rectangle outline (not the interior). */
-export function acExDistToRectOutlinePx(
+export function acexDistToRectOutlinePx(
   px: number,
   py: number,
   a: { x: number; y: number },
@@ -511,15 +511,15 @@ export function acExDistToRectOutlinePx(
   const minY = Math.min(a.y, b.y)
   const maxY = Math.max(a.y, b.y)
   return Math.min(
-    acExDistToSegmentPx(px, py, minX, minY, maxX, minY),
-    acExDistToSegmentPx(px, py, maxX, minY, maxX, maxY),
-    acExDistToSegmentPx(px, py, maxX, maxY, minX, maxY),
-    acExDistToSegmentPx(px, py, minX, maxY, minX, minY)
+    acexDistToSegmentPx(px, py, minX, minY, maxX, minY),
+    acexDistToSegmentPx(px, py, maxX, minY, maxX, maxY),
+    acexDistToSegmentPx(px, py, maxX, maxY, minX, maxY),
+    acexDistToSegmentPx(px, py, minX, maxY, minX, minY)
   )
 }
 
 /** Approximate center of a markup for badge placement / focus. */
-export function acExMarkupCenter(
+export function acexMarkupCenter(
   record: AcExMarkupRecord
 ): AcExMarkupPoint2d | null {
   const g = record.geometry
@@ -582,7 +582,7 @@ function expandExtentsByCallout(
  * Shapes include an attached callout tip and text-box anchor so zoom-to
  * frames the leader together with the shape.
  */
-export function acExMarkupBounds(
+export function acexMarkupBounds(
   geometry: AcExMarkupGeometry
 ): AcExExtents | null {
   switch (geometry.type) {
@@ -630,7 +630,7 @@ export function acExMarkupBounds(
  *
  * Used so zoom-to includes HTML text boxes / badges / stamps.
  */
-export function acExExpandExtentsByClientRects(
+export function acexExpandExtentsByClientRects(
   extents: AcExExtents | null,
   rects: ReadonlyArray<{
     left: number
@@ -652,7 +652,7 @@ export function acExExpandExtentsByClientRects(
 /**
  * Combined zoom-to extents: control geometry plus overlay rectangles.
  */
-export function acExMarkupFocusExtents(
+export function acexMarkupFocusExtents(
   geometry: AcExMarkupGeometry,
   overlayRects: ReadonlyArray<{
     left: number
@@ -662,14 +662,14 @@ export function acExMarkupFocusExtents(
   }>,
   clientToWorld: (clientX: number, clientY: number) => AcExMarkupPoint2d
 ): AcExExtents | null {
-  return acExExpandExtentsByClientRects(
-    acExMarkupBounds(geometry),
+  return acexExpandExtentsByClientRects(
+    acexMarkupBounds(geometry),
     overlayRects,
     clientToWorld
   )
 }
 
-function acExTranslatePoint(
+function acexTranslatePoint(
   p: AcExMarkupPoint2d,
   dx: number,
   dy: number
@@ -677,22 +677,22 @@ function acExTranslatePoint(
   return { x: p.x + dx, y: p.y + dy }
 }
 
-function acExTranslateAttachedCallout(
+function acexTranslateAttachedCallout(
   callout: AcExMarkupAttachedCallout,
   dx: number,
   dy: number
 ): AcExMarkupAttachedCallout {
   return {
     ...callout,
-    tip: acExTranslatePoint(callout.tip, dx, dy),
-    anchor: acExTranslatePoint(callout.anchor, dx, dy)
+    tip: acexTranslatePoint(callout.tip, dx, dy),
+    anchor: acexTranslatePoint(callout.anchor, dx, dy)
   }
 }
 
 /**
  * Translate markup geometry by a world-space offset (including attached callout).
  */
-export function acExTranslateMarkupGeometry(
+export function acexTranslateMarkupGeometry(
   geometry: AcExMarkupGeometry,
   dx: number,
   dy: number
@@ -701,54 +701,54 @@ export function acExTranslateMarkupGeometry(
     case 'cloud':
       return {
         ...geometry,
-        corner1: acExTranslatePoint(geometry.corner1, dx, dy),
-        corner2: acExTranslatePoint(geometry.corner2, dx, dy),
+        corner1: acexTranslatePoint(geometry.corner1, dx, dy),
+        corner2: acexTranslatePoint(geometry.corner2, dx, dy),
         callout: geometry.callout
-          ? acExTranslateAttachedCallout(geometry.callout, dx, dy)
+          ? acexTranslateAttachedCallout(geometry.callout, dx, dy)
           : undefined
       }
     case 'rect':
       return {
         ...geometry,
-        corner1: acExTranslatePoint(geometry.corner1, dx, dy),
-        corner2: acExTranslatePoint(geometry.corner2, dx, dy),
+        corner1: acexTranslatePoint(geometry.corner1, dx, dy),
+        corner2: acexTranslatePoint(geometry.corner2, dx, dy),
         callout: geometry.callout
-          ? acExTranslateAttachedCallout(geometry.callout, dx, dy)
+          ? acexTranslateAttachedCallout(geometry.callout, dx, dy)
           : undefined
       }
     case 'highlight':
       return {
         ...geometry,
-        corner1: acExTranslatePoint(geometry.corner1, dx, dy),
-        corner2: acExTranslatePoint(geometry.corner2, dx, dy)
+        corner1: acexTranslatePoint(geometry.corner1, dx, dy),
+        corner2: acexTranslatePoint(geometry.corner2, dx, dy)
       }
     case 'circle':
       return {
         ...geometry,
-        center: acExTranslatePoint(geometry.center, dx, dy),
+        center: acexTranslatePoint(geometry.center, dx, dy),
         callout: geometry.callout
-          ? acExTranslateAttachedCallout(geometry.callout, dx, dy)
+          ? acexTranslateAttachedCallout(geometry.callout, dx, dy)
           : undefined
       }
     case 'callout':
       return {
         ...geometry,
-        tip: acExTranslatePoint(geometry.tip, dx, dy),
-        anchor: acExTranslatePoint(geometry.anchor, dx, dy)
+        tip: acexTranslatePoint(geometry.tip, dx, dy),
+        anchor: acexTranslatePoint(geometry.anchor, dx, dy)
       }
     case 'arrow':
     case 'line':
       return {
         ...geometry,
-        start: acExTranslatePoint(geometry.start, dx, dy),
-        end: acExTranslatePoint(geometry.end, dx, dy)
+        start: acexTranslatePoint(geometry.start, dx, dy),
+        end: acexTranslatePoint(geometry.end, dx, dy)
       }
     case 'text':
     case 'stamp':
     case 'symbol':
       return {
         ...geometry,
-        position: acExTranslatePoint(geometry.position, dx, dy)
+        position: acexTranslatePoint(geometry.position, dx, dy)
       }
   }
 }
@@ -757,7 +757,7 @@ export function acExTranslateMarkupGeometry(
  * Hit-test markup geometry in screen space.
  * @returns true when the pointer is within `thresholdPx` of the stroke / shape.
  */
-export function acExHitTestMarkup(
+export function acexHitTestMarkup(
   record: AcExMarkupRecord,
   clientX: number,
   clientY: number,
@@ -777,14 +777,14 @@ export function acExHitTestMarkup(
       const a = worldToScreen(g.start)
       const b = worldToScreen(g.end)
       return (
-        acExDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <= thresholdPx
+        acexDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <= thresholdPx
       )
     }
     case 'callout': {
       const a = worldToScreen(g.tip)
       const b = worldToScreen(g.anchor)
       return (
-        acExDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <= thresholdPx
+        acexDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <= thresholdPx
       )
     }
     case 'rect':
@@ -871,6 +871,6 @@ function hitAttachedCallout(
   const a = worldToScreen(callout.tip)
   const b = worldToScreen(callout.anchor)
   return (
-    acExDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <= thresholdPx
+    acexDistToSegmentPx(clientX, clientY, a.x, a.y, b.x, b.y) <= thresholdPx
   )
 }

--- a/packages/cad-html-plugin/src/AcExMarkupGripDrag.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupGripDrag.ts
@@ -10,13 +10,13 @@
 
 import type { AcExMarkupPoint2d } from './AcExMarkupTypes'
 import {
-  acExHideMobileSnapLoupe,
-  acExRefreshMobileSnapLoupe
+  acexHideMobileSnapLoupe,
+  acexRefreshMobileSnapLoupe
 } from './AcExMobileSnapLoupe'
 import {
-  acExIsOverlayGrip,
-  acExIsOverlayGripSelected,
-  acExSetOverlayGripsDragging
+  acexIsOverlayGrip,
+  acexIsOverlayGripSelected,
+  acexSetOverlayGripsDragging
 } from './AcExOverlayGrip'
 
 /** Pointer movement (CSS px, squared) before a drag starts. */
@@ -27,7 +27,7 @@ const windowListenerOptions: AddEventListenerOptions = {
   passive: false
 }
 
-/** Options for {@link acExBindMarkupPointerDrag}. */
+/** Options for {@link acexBindMarkupPointerDrag}. */
 export interface AcExMarkupPointerDragOptions {
   /** DOM handle that receives pointerdown. */
   el: HTMLElement
@@ -61,11 +61,11 @@ export interface AcExMarkupPointerDragOptions {
  *
  * @returns Cleanup that removes listeners and cancels an in-progress drag.
  */
-export function acExBindMarkupPointerDrag(
+export function acexBindMarkupPointerDrag(
   options: AcExMarkupPointerDragOptions
 ): () => void {
   const { el, clientToWorld, onDragStart, onMove, onCommit } = options
-  const isGrip = acExIsOverlayGrip(el)
+  const isGrip = acexIsOverlayGrip(el)
   const idleCursor = options.cursor ?? 'grab'
   const showSnapLoupeOpt = options.showSnapLoupe !== false
 
@@ -81,14 +81,14 @@ export function acExBindMarkupPointerDrag(
 
   const dragAllowed = (): boolean => {
     if (options.isEnabled && !options.isEnabled()) return false
-    if (isGrip && !acExIsOverlayGripSelected(el)) return false
+    if (isGrip && !acexIsOverlayGripSelected(el)) return false
     return true
   }
 
   const restoreGrips = () => {
     if (!hidGrips) return
     hidGrips = false
-    acExSetOverlayGripsDragging(false)
+    acexSetOverlayGripsDragging(false)
   }
 
   const onPointerDown = (e: PointerEvent) => {
@@ -120,7 +120,7 @@ export function acExBindMarkupPointerDrag(
     const showSnapLoupe = showSnapLoupeOpt && e.pointerType === 'touch'
 
     const hideSnapLoupe = () => {
-      if (showSnapLoupe) acExHideMobileSnapLoupe()
+      if (showSnapLoupe) acexHideMobileSnapLoupe()
     }
 
     const detach = () => {
@@ -155,13 +155,13 @@ export function acExBindMarkupPointerDrag(
         el.style.cursor = 'grabbing'
         if (isGrip) {
           hidGrips = true
-          acExSetOverlayGripsDragging(true)
+          acexSetOverlayGripsDragging(true)
         }
         onDragStart?.()
       }
       const world = clientToWorld(ev.clientX, ev.clientY)
       if (showSnapLoupe) {
-        acExRefreshMobileSnapLoupe(ev.clientX, ev.clientY)
+        acexRefreshMobileSnapLoupe(ev.clientX, ev.clientY)
       }
       onMove(world, ev)
     }

--- a/packages/cad-html-plugin/src/AcExMarkupSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMarkupSidecar.ts
@@ -236,9 +236,9 @@ export function stringifyAcExMarkupSidecar(
 
 /**
  * Suggested sidecar file name for a drawing.
- * @example acExMarkupSidecarFileName('plan.dwg') → 'plan.markup.json'
+ * @example acexMarkupSidecarFileName('plan.dwg') → 'plan.markup.json'
  */
-export function acExMarkupSidecarFileName(drawingName?: string): string {
+export function acexMarkupSidecarFileName(drawingName?: string): string {
   if (!drawingName) return 'drawing.markup.json'
   const base = drawingName.replace(/\.(dwg|dxf|html)$/i, '')
   return `${base}.markup.json`

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -1,7 +1,7 @@
 /**
  * Measurement tools for the offline HTML viewer (distance, continuous, angle, arc, area, coordinate).
  *
- * @module AcExMeasurement
+ * @module acexMeasurement
  * @packageDocumentation
  */
 
@@ -11,28 +11,28 @@ import * as THREE from 'three'
 import type { AcExCommandSessionUiState } from './AcExCommandSessionPanel'
 import { AcExConfirmedPointMarks } from './AcExConfirmedPointMarks'
 import type { AcExHtmlI18n } from './AcExHtmlI18n'
-import { acExHtmlIcons } from './AcExHtmlIcons'
+import { AcExHtmlIcons } from './AcExHtmlIcons'
 import {
   ACEX_OVERLAY_ARROW_SIZE_PX,
-  acExPixelsPerWorldUnit,
-  acExPositionWcsOverlay,
-  acExResetOverlayViewScale,
-  acExScaledCanvasLineWidth,
-  acExScaledOverlayArrowSize,
-  acExScreenPxToWcs,
-  acExSeedOverlaySizesFromWcs
+  acexPixelsPerWorldUnit,
+  acexPositionWcsOverlay,
+  acexResetOverlayViewScale,
+  acexScaledCanvasLineWidth,
+  acexScaledOverlayArrowSize,
+  acexScreenPxToWcs,
+  acexSeedOverlaySizesFromWcs
 } from './AcExHtmlOverlayDom'
 import {
-  acExDrawMarkupArrowHead,
-  acExExpandExtentsByClientRects,
-  acExOverlayArrowSize
+  acexDrawMarkupArrowHead,
+  acexExpandExtentsByClientRects,
+  acexOverlayArrowSize
 } from './AcExMarkupGeometry'
-import { acExBindMarkupPointerDrag } from './AcExMarkupGripDrag'
+import { acexBindMarkupPointerDrag } from './AcExMarkupGripDrag'
 import {
   ACEX_MEASUREMENT_FONT_SIZE,
   ACEX_MEASUREMENT_LINE_WEIGHT,
-  acExMeasureCanvasLineWidth,
-  acExMeasurementSidecarFileName,
+  acexMeasureCanvasLineWidth,
+  acexMeasurementSidecarFileName,
   parseAcExMeasurementSidecar,
   stringifyAcExMeasurementSidecar
 } from './AcExMeasurementSidecar'
@@ -53,8 +53,8 @@ import {
   constrainToAcExTracking
 } from './AcExMeasureTracking'
 import type { AcExOsnapPoint } from './AcExOsnap'
-import { acExIsOverlayGrip, acExOverlayGripClassName } from './AcExOverlayGrip'
-import { acExExtentsMatchBox, type AcExSelectionMode } from './AcExSelectionBox'
+import { acexIsOverlayGrip, acexOverlayGripClassName } from './AcExOverlayGrip'
+import { acexExtentsMatchBox, type AcExSelectionMode } from './AcExSelectionBox'
 import type { AcExExtents } from './AcExSnapshotTypes'
 
 /**
@@ -125,7 +125,7 @@ interface AcExResolvedPoint {
 }
 
 /**
- * View/camera callbacks supplied by {@link AcExHtmlViewerRuntime} so measurement
+ * View/camera callbacks supplied by {@link acexHtmlViewerRuntime} so measurement
  * logic stays decoupled from orthographic pan/zoom implementation details.
  */
 export interface AcExMeasureViewApi {
@@ -339,7 +339,7 @@ function measurementFocusExtents(
   }>,
   clientToWorld: (clientX: number, clientY: number) => { x: number; y: number }
 ): AcExExtents | null {
-  const extents = acExExpandExtentsByClientRects(
+  const extents = acexExpandExtentsByClientRects(
     measurementGeometryExtents(geometry),
     overlayRects,
     clientToWorld
@@ -499,7 +499,7 @@ function interiorAngleArcScreenMetrics(
   const cx = sv.x
   const cy = sv.y
   const rWcs = angleArcRadiusWcs(vertex, arm1, arm2)
-  const r = rWcs * acExPixelsPerWorldUnit(wcsToScreen)
+  const r = rWcs * acexPixelsPerWorldUnit(wcsToScreen)
   const startAngle = Math.atan2(sa1.y - cy, sa1.x - cx)
   const endAngle = Math.atan2(sa2.y - cy, sa2.x - cx)
   const antiClockwise = normaliseAngle(endAngle - startAngle) > Math.PI
@@ -934,7 +934,7 @@ function segmentsIntersect(
  */
 function makeDotEl(): HTMLDivElement {
   const dot = document.createElement('div')
-  dot.className = acExOverlayGripClassName('measure')
+  dot.className = acexOverlayGripClassName('measure')
   return dot
 }
 
@@ -1475,7 +1475,7 @@ export class AcExMeasureController {
     const measure = this._committed.find(item => item.id === id)
     if (!measure) return false
     const rects = measure.parts.dom
-      .filter(el => !acExIsOverlayGrip(el) && !el.hidden)
+      .filter(el => !acexIsOverlayGrip(el) && !el.hidden)
       .map(el => el.getBoundingClientRect())
       .filter(rect => rect.width > 0 || rect.height > 0)
     const extents = measurementFocusExtents(
@@ -1588,7 +1588,7 @@ export class AcExMeasureController {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = acExMeasurementSidecarFileName(this._drawingName)
+    a.download = acexMeasurementSidecarFileName(this._drawingName)
     a.click()
     URL.revokeObjectURL(url)
     this._statusEl.textContent = this._i18n.t('status.measureExported', {
@@ -1783,7 +1783,7 @@ export class AcExMeasureController {
       }
       const bounds = measurementGeometryExtents(measure.record.geometry)
       if (!bounds) continue
-      if (acExExtentsMatchBox(bounds, box, mode)) {
+      if (acexExtentsMatchBox(bounds, box, mode)) {
         next.add(measure.id)
       }
     }
@@ -1907,8 +1907,8 @@ export class AcExMeasureController {
       ? 'toolbar.measureHide'
       : 'toolbar.measureShow'
     const icon = this._visible
-      ? acExHtmlIcons.markupShow
-      : acExHtmlIcons.markupHide
+      ? AcExHtmlIcons.markupShow
+      : AcExHtmlIcons.markupHide
     const label = this._i18n.t(titleKey)
     buttons.forEach(btn => {
       btn.classList.toggle('active', this._visible)
@@ -2142,7 +2142,7 @@ export class AcExMeasureController {
       canvas,
       points,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT),
+      acexMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT),
       undefined,
       options?.bothArrows,
       false,
@@ -2242,7 +2242,7 @@ export class AcExMeasureController {
     }
 
     parts.cleanups.push(
-      acExBindMarkupPointerDrag({
+      acexBindMarkupPointerDrag({
         el: dot,
         clientToWorld: (x, y) => this._clientToWorld(x, y),
         isEnabled: () => this._gripsEnabled(),
@@ -2396,7 +2396,7 @@ export class AcExMeasureController {
       this._touchMeasureGeometry(id, 'length', dist)
     }
     parts.cleanups.push(
-      acExBindMarkupPointerDrag({
+      acexBindMarkupPointerDrag({
         el: startDot,
         clientToWorld: (x, y) => this._clientToWorld(x, y),
         isEnabled,
@@ -2408,7 +2408,7 @@ export class AcExMeasureController {
         },
         onCommit
       }),
-      acExBindMarkupPointerDrag({
+      acexBindMarkupPointerDrag({
         el: endDot,
         clientToWorld: (x, y) => this._clientToWorld(x, y),
         isEnabled,
@@ -2591,7 +2591,7 @@ export class AcExMeasureController {
         arm1,
         arm2,
         style.color,
-        acExMeasureCanvasLineWidth(style.lineWeight),
+        acexMeasureCanvasLineWidth(style.lineWeight),
         style.strokeWidthWcs
       )
     }
@@ -2691,7 +2691,7 @@ export class AcExMeasureController {
       this._touchMeasureGeometry(id, null, 0)
     }
     const bind = (el: HTMLElement, target: THREE.Vector2) =>
-      acExBindMarkupPointerDrag({
+      acexBindMarkupPointerDrag({
         el,
         clientToWorld: (x, y) => this._clientToWorld(x, y),
         isEnabled,
@@ -2969,7 +2969,7 @@ export class AcExMeasureController {
         through,
         end,
         style.color,
-        acExMeasureCanvasLineWidth(style.lineWeight),
+        acexMeasureCanvasLineWidth(style.lineWeight),
         style.strokeWidthWcs
       )
     }
@@ -3135,7 +3135,7 @@ export class AcExMeasureController {
       this._touchMeasureGeometry(id, 'length', len)
     }
     const bind = (el: HTMLElement, target: THREE.Vector2) =>
-      acExBindMarkupPointerDrag({
+      acexBindMarkupPointerDrag({
         el,
         clientToWorld: (x, y) => this._clientToWorld(x, y),
         isEnabled,
@@ -3192,7 +3192,7 @@ export class AcExMeasureController {
         start,
         end,
         style.color,
-        acExMeasureCanvasLineWidth(style.lineWeight),
+        acexMeasureCanvasLineWidth(style.lineWeight),
         style.strokeWidthWcs
       )
     }
@@ -3283,7 +3283,7 @@ export class AcExMeasureController {
       this._touchMeasureGeometry(id, 'length', len)
     }
     const bind = (el: HTMLElement, target: THREE.Vector2) =>
-      acExBindMarkupPointerDrag({
+      acexBindMarkupPointerDrag({
         el,
         clientToWorld: (x, y) => this._clientToWorld(x, y),
         isEnabled,
@@ -3414,7 +3414,7 @@ export class AcExMeasureController {
         canvas,
         points,
         style.color,
-        acExMeasureCanvasLineWidth(style.lineWeight),
+        acexMeasureCanvasLineWidth(style.lineWeight),
         style.strokeWidthWcs
       )
     }
@@ -3491,7 +3491,7 @@ export class AcExMeasureController {
       const dot = dots[index]!
       const target = points[index]!
       parts.cleanups.push(
-        acExBindMarkupPointerDrag({
+        acexBindMarkupPointerDrag({
           el: dot,
           clientToWorld: (x, y) => this._clientToWorld(x, y),
           isEnabled,
@@ -3531,7 +3531,7 @@ export class AcExMeasureController {
         canvas,
         pts,
         style.color || this._measureCss(),
-        acExMeasureCanvasLineWidth(style.lineWeight),
+        acexMeasureCanvasLineWidth(style.lineWeight),
         style.strokeWidthWcs,
         bothArrows,
         bothArrows,
@@ -3546,10 +3546,10 @@ export class AcExMeasureController {
   private _placeDomAt(el: HTMLElement, wcs: { x: number; y: number }): void {
     el.dataset.wcsX = String(wcs.x)
     el.dataset.wcsY = String(wcs.y)
-    if (!acExIsOverlayGrip(el)) acExResetOverlayViewScale(el)
+    if (!acexIsOverlayGrip(el)) acexResetOverlayViewScale(el)
     const screen = this._view.wcsToScreen(new THREE.Vector2(wcs.x, wcs.y))
     const rootRect = this._overlayRootRect ?? this._root.getBoundingClientRect()
-    acExPositionWcsOverlay(el, screen, rootRect, this._view.getCameraZoom())
+    acexPositionWcsOverlay(el, screen, rootRect, this._view.getCameraZoom())
   }
 
   /** Replace selection with a single measurement (grip edit). @internal */
@@ -3663,19 +3663,19 @@ export class AcExMeasureController {
       : bothArrows && screen.length === 2
     if (drawArrows) {
       const arrowSize = scaleArrowsWithView
-        ? acExScaledOverlayArrowSize(
+        ? acexScaledOverlayArrowSize(
             canvas,
             p => this._wcsToScreenPoint(p),
             arrowSizeWcs
           )
-        : acExOverlayArrowSize(scaled, lineWidth)
+        : acexOverlayArrowSize(scaled, lineWidth)
       const last = segmentArrows ? screen.length - 1 : 1
       for (let i = 0; i < last; i++) {
         const a = screen[i]!
         const b = screen[i + 1]!
         if (Math.hypot(b.x - a.x, b.y - a.y) >= arrowSize) {
-          acExDrawMarkupArrowHead(ctx, b, a, strokeCss, arrowSize)
-          acExDrawMarkupArrowHead(ctx, a, b, strokeCss, arrowSize)
+          acexDrawMarkupArrowHead(ctx, b, a, strokeCss, arrowSize)
+          acexDrawMarkupArrowHead(ctx, a, b, strokeCss, arrowSize)
         }
       }
     }
@@ -3766,14 +3766,14 @@ export class AcExMeasureController {
       quantity,
       value
     })
-    acExSeedOverlaySizesFromWcs(
+    acexSeedOverlaySizesFromWcs(
       this._view.getCameraZoom(),
       p => this._wcsToScreenPoint(p),
       {
         textHeightWcs: style.textHeightWcs,
         arrowSizeWcs: style.arrowSizeWcs,
         fontSizePx: style.fontSize,
-        strokeScreenPx: acExMeasureCanvasLineWidth(
+        strokeScreenPx: acexMeasureCanvasLineWidth(
           ACEX_MEASUREMENT_LINE_WEIGHT
         ),
         elements: parts.dom,
@@ -3812,7 +3812,7 @@ export class AcExMeasureController {
       style.arrowSizeWcs != null && style.arrowSizeWcs > 0
         ? style.arrowSizeWcs
         : includeArrow
-          ? acExScreenPxToWcs(ACEX_OVERLAY_ARROW_SIZE_PX, wcsToScreen)
+          ? acexScreenPxToWcs(ACEX_OVERLAY_ARROW_SIZE_PX, wcsToScreen)
           : undefined
     return {
       ...rest,
@@ -3820,7 +3820,7 @@ export class AcExMeasureController {
       textHeightWcs:
         style.textHeightWcs != null && style.textHeightWcs > 0
           ? style.textHeightWcs
-          : acExScreenPxToWcs(style.fontSize, wcsToScreen),
+          : acexScreenPxToWcs(style.fontSize, wcsToScreen),
       ...(arrowSizeWcs != null && arrowSizeWcs > 0 ? { arrowSizeWcs } : {})
     }
   }
@@ -3835,7 +3835,7 @@ export class AcExMeasureController {
     return {
       ...rest,
       lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
-      textHeightWcs: acExScreenPxToWcs(style.fontSize, wcsToScreen)
+      textHeightWcs: acexScreenPxToWcs(style.fontSize, wcsToScreen)
     }
   }
 
@@ -3879,7 +3879,7 @@ export class AcExMeasureController {
     canvas: HTMLCanvasElement,
     strokeWidthWcs?: number
   ): number {
-    return acExScaledCanvasLineWidth(
+    return acexScaledCanvasLineWidth(
       baseLineWidth,
       canvas,
       this._view.getCameraZoom(),
@@ -4157,15 +4157,15 @@ export class AcExMeasureController {
           style.textHeightWcs =
             style.textHeightWcs * (patch.fontSize / prevFont)
         } else {
-          style.textHeightWcs = acExScreenPxToWcs(patch.fontSize, wcsToScreen)
+          style.textHeightWcs = acexScreenPxToWcs(patch.fontSize, wcsToScreen)
         }
         style.fontSize = patch.fontSize
       }
       if (patch.fontSize != null) {
-        acExSeedOverlaySizesFromWcs(this._view.getCameraZoom(), wcsToScreen, {
+        acexSeedOverlaySizesFromWcs(this._view.getCameraZoom(), wcsToScreen, {
           textHeightWcs: style.textHeightWcs,
           fontSizePx: style.fontSize,
-          strokeScreenPx: acExMeasureCanvasLineWidth(
+          strokeScreenPx: acexMeasureCanvasLineWidth(
             ACEX_MEASUREMENT_LINE_WEIGHT
           ),
           elements: measure.parts.dom,
@@ -4208,7 +4208,7 @@ export class AcExMeasureController {
         const y = Number(el.dataset.wcsY)
         if (!Number.isFinite(x) || !Number.isFinite(y)) return
         const screen = this._view.wcsToScreen(new THREE.Vector2(x, y))
-        acExPositionWcsOverlay(el, screen, rootRect, zoom)
+        acexPositionWcsOverlay(el, screen, rootRect, zoom)
       })
   }
 
@@ -4303,7 +4303,7 @@ export class AcExMeasureController {
       arm1,
       arm2,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
+      acexMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
     )
   }
 
@@ -4424,7 +4424,7 @@ export class AcExMeasureController {
       through,
       end,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
+      acexMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
     )
   }
 
@@ -4487,7 +4487,7 @@ export class AcExMeasureController {
       canvas,
       points,
       this._measureCss(),
-      acExMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
+      acexMeasureCanvasLineWidth(ACEX_MEASUREMENT_LINE_WEIGHT)
     )
   }
 }

--- a/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurementSidecar.ts
@@ -22,7 +22,7 @@ export const ACEX_MEASUREMENT_LINE_WEIGHT = 0
 export const ACEX_MEASUREMENT_FONT_SIZE = 13
 
 /** Map CAD line weight to canvas stroke width in CSS pixels. */
-export function acExMeasureCanvasLineWidth(weight?: number): number {
+export function acexMeasureCanvasLineWidth(weight?: number): number {
   if (weight == null || !Number.isFinite(weight) || weight <= 0) return 0
   return Math.max(1, weight / 28)
 }
@@ -195,9 +195,9 @@ export function stringifyAcExMeasurementSidecar(
 
 /**
  * Suggested sidecar file name for a drawing.
- * @example acExMeasurementSidecarFileName('plan.dwg') → 'plan.measurement.json'
+ * @example acexMeasurementSidecarFileName('plan.dwg') → 'plan.measurement.json'
  */
-export function acExMeasurementSidecarFileName(drawingName?: string): string {
+export function acexMeasurementSidecarFileName(drawingName?: string): string {
   if (!drawingName) return 'drawing.measurement.json'
   const base = drawingName.replace(/\.(dwg|dxf|html)$/i, '')
   return `${base}.measurement.json`

--- a/packages/cad-html-plugin/src/AcExMobileSnapLoupe.ts
+++ b/packages/cad-html-plugin/src/AcExMobileSnapLoupe.ts
@@ -25,7 +25,7 @@ let bridge: AcExMobileSnapLoupeBridge | null = null
  *
  * @param next - Loupe hooks from {@link createAcExHtmlViewerRuntime}, or null.
  */
-export function acExBindMobileSnapLoupe(
+export function acexBindMobileSnapLoupe(
   next: AcExMobileSnapLoupeBridge | null
 ): void {
   bridge = next
@@ -37,7 +37,7 @@ export function acExBindMobileSnapLoupe(
  * @param clientX - Sample X in client CSS pixels.
  * @param clientY - Sample Y in client CSS pixels.
  */
-export function acExRefreshMobileSnapLoupe(
+export function acexRefreshMobileSnapLoupe(
   clientX: number,
   clientY: number
 ): void {
@@ -47,7 +47,7 @@ export function acExRefreshMobileSnapLoupe(
 /**
  * Hides the shared snap loupe if visible.
  */
-export function acExHideMobileSnapLoupe(): void {
+export function acexHideMobileSnapLoupe(): void {
   bridge?.hide()
 }
 
@@ -56,6 +56,6 @@ export function acExHideMobileSnapLoupe(): void {
  *
  * @param active - True while the loupe should block one-finger pan.
  */
-export function acExSetMobileSnapLoupePreciseCapture(active: boolean): void {
+export function acexSetMobileSnapLoupePreciseCapture(active: boolean): void {
   bridge?.setPreciseCaptureActive?.(active)
 }

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -1077,7 +1077,7 @@ function segmentBounds(seg: AcExOsnapSegment): {
  * @param mode - Active snap mode from {@link findSnap} or measurement UI.
  * @returns CSS shape key used by {@link AcExOsnapMarker}.
  */
-export function acExOsnapModeToMarkerType(
+export function acexOsnapModeToMarkerType(
   mode: AcExOsnapMode
 ): 'rect' | 'triangle' | 'x' | 'circle' | 'diamond' | 'intersection' {
   switch (mode) {

--- a/packages/cad-html-plugin/src/AcExOsnapMarker.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapMarker.ts
@@ -1,10 +1,10 @@
 import type { AcExOsnapMode } from './AcExOsnap'
-import { acExOsnapModeToMarkerType } from './AcExOsnap'
+import { acexOsnapModeToMarkerType } from './AcExOsnap'
 
 /**
  * Visual shape of an object-snap marker in the offline HTML viewer.
  *
- * Selected by {@link acExOsnapModeToMarkerType} from {@link AcExOsnapMode}:
+ * Selected by {@link acexOsnapModeToMarkerType} from {@link AcExOsnapMode}:
  * - `rect` — endpoint, node
  * - `triangle` — midpoint
  * - `circle` — center
@@ -24,7 +24,7 @@ export type AcExOsnapMarkerShape =
  * Screen-space object snap marker for the offline HTML viewer.
  *
  * Renders a small glyph at the snapped screen position during measurement.
- * Shape follows {@link acExOsnapModeToMarkerType} so behavior matches the
+ * Shape follows {@link acexOsnapModeToMarkerType} so behavior matches the
  * main CAD viewer (square, triangle, circle, diamond, X).
  */
 export class AcExOsnapMarker {
@@ -59,7 +59,7 @@ export class AcExOsnapMarker {
    */
   show(clientX: number, clientY: number, mode: AcExOsnapMode): void {
     const rect = this.host.getBoundingClientRect()
-    const shape = acExOsnapModeToMarkerType(mode)
+    const shape = acexOsnapModeToMarkerType(mode)
     if (shape !== this.shape) {
       this.applyShape(shape)
     }

--- a/packages/cad-html-plugin/src/AcExOverlayGrip.ts
+++ b/packages/cad-html-plugin/src/AcExOverlayGrip.ts
@@ -15,7 +15,7 @@ const MARKUP_DOT = 'mlcad-markup-dot'
 const MEASURE_DOT = 'mlcad-measure-dot'
 
 /** True when `el` is a committed markup / measure endpoint grip. */
-export function acExIsOverlayGrip(el: Element | null | undefined): boolean {
+export function acexIsOverlayGrip(el: Element | null | undefined): boolean {
   if (!el) return false
   return (
     el.classList.contains(MARKUP_DOT) ||
@@ -25,7 +25,7 @@ export function acExIsOverlayGrip(el: Element | null | undefined): boolean {
 }
 
 /** True when the grip belongs to a currently selected overlay. */
-export function acExIsOverlayGripSelected(el: HTMLElement): boolean {
+export function acexIsOverlayGripSelected(el: HTMLElement): boolean {
   return (
     el.classList.contains('mlcad-markup-selected') ||
     el.classList.contains('mlcad-measure-selected')
@@ -35,7 +35,7 @@ export function acExIsOverlayGripSelected(el: HTMLElement): boolean {
 /**
  * Hide or restore every overlay endpoint grip (entity-grip drag behavior).
  */
-export function acExSetOverlayGripsDragging(dragging: boolean): void {
+export function acexSetOverlayGripsDragging(dragging: boolean): void {
   document
     .getElementById('mlcad-markup-overlays')
     ?.classList.toggle(ACEX_OVERLAY_GRIP_DRAGGING_CLASS, dragging)
@@ -45,7 +45,7 @@ export function acExSetOverlayGripsDragging(dragging: boolean): void {
 }
 
 /** CSS class list for a committed overlay endpoint circle. */
-export function acExOverlayGripClassName(kind: 'markup' | 'measure'): string {
+export function acexOverlayGripClassName(kind: 'markup' | 'measure'): string {
   const kindClass = kind === 'markup' ? MARKUP_DOT : MEASURE_DOT
   return `${kindClass} ${ACEX_OVERLAY_GRIP_CLASS}`
 }

--- a/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
+++ b/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
@@ -18,7 +18,7 @@ import type {
 } from './AcExSnapshotTypes'
 
 /** Shared camera zoom uniform updated by the offline HTML viewer. */
-export const acexCameraZoomUniform = { value: 1.0 }
+export const AcExCameraZoomUniform = { value: 1.0 }
 
 function asShaderMaterial(
   material: THREE.Material
@@ -278,7 +278,7 @@ export function createViewerLineMaterial(
       batch.linePattern.patternLength,
       batch.color,
       batch.linePattern.viewportScale,
-      acexCameraZoomUniform
+      AcExCameraZoomUniform
     )
   }
   return new THREE.LineBasicMaterial({ color: batch.color })
@@ -339,7 +339,7 @@ export function createViewerMeshMaterial(batch: AcExMeshBatch): THREE.Material {
       return createHatchPatternShaderMaterial(
         patternLines,
         batch.hatchPattern.patternAngle,
-        acexCameraZoomUniform,
+        AcExCameraZoomUniform,
         new THREE.Color(batch.color),
         0,
         (batch.side ?? THREE.FrontSide) as THREE.Side

--- a/packages/cad-html-plugin/src/AcExSelectionBox.ts
+++ b/packages/cad-html-plugin/src/AcExSelectionBox.ts
@@ -8,7 +8,7 @@ export type AcExSelectionMode = 'window' | 'crossing'
  *
  * Window requires full containment; crossing requires intersection.
  */
-export function acExExtentsMatchBox(
+export function acexExtentsMatchBox(
   item: AcExExtents,
   box: AcExExtents,
   mode: AcExSelectionMode
@@ -33,7 +33,7 @@ export function acExExtentsMatchBox(
  * Window vs crossing from drag direction in client (or canvas) space.
  * Left-to-right = window; right-to-left = crossing.
  */
-export function acExSelectionModeFromDrag(
+export function acexSelectionModeFromDrag(
   startX: number,
   endX: number
 ): AcExSelectionMode {

--- a/packages/cad-html-plugin/src/AcExSimulatedMouseCursor.ts
+++ b/packages/cad-html-plugin/src/AcExSimulatedMouseCursor.ts
@@ -70,7 +70,7 @@ function ensureCursor(host: HTMLElement): HTMLDivElement {
  * @param clientX - Sample X in viewport/client CSS pixels.
  * @param clientY - Sample Y in viewport/client CSS pixels.
  */
-export function acExRefreshSimulatedMouseCursor(
+export function acexRefreshSimulatedMouseCursor(
   host: HTMLElement,
   clientX: number,
   clientY: number
@@ -85,7 +85,7 @@ export function acExRefreshSimulatedMouseCursor(
 /**
  * Hides the simulated-mouse crosshair if visible.
  */
-export function acExHideSimulatedMouseCursor(): void {
+export function acexHideSimulatedMouseCursor(): void {
   if (!cursorRoot) return
   cursorRoot.style.display = 'none'
 }
@@ -93,7 +93,7 @@ export function acExHideSimulatedMouseCursor(): void {
 /**
  * Disposes the simulated-mouse cursor HUD (tests / teardown).
  */
-export function acExDisposeSimulatedMouseCursor(): void {
+export function acexDisposeSimulatedMouseCursor(): void {
   cursorRoot?.remove()
   cursorRoot = null
 }

--- a/packages/cad-html-plugin/src/AcExSnapLoupe.ts
+++ b/packages/cad-html-plugin/src/AcExSnapLoupe.ts
@@ -1,5 +1,5 @@
 import type { AcExOsnapMode } from './AcExOsnap'
-import { acExOsnapModeToMarkerType } from './AcExOsnap'
+import { acexOsnapModeToMarkerType } from './AcExOsnap'
 import type { AcExOsnapMarkerShape } from './AcExOsnapMarker'
 
 /** Square loupe size in CSS pixels. */
@@ -78,14 +78,14 @@ export class AcExSnapLoupe {
     this.root.style.display = 'block'
     this.visible = true
     if (snapCanvas && mode) {
-      const shape = acExOsnapModeToMarkerType(mode)
+      const shape = acexOsnapModeToMarkerType(mode)
       if (shape !== this.markerShape) {
         this.markerShape = shape
         this.marker.className = `mlcad-osnap-marker mlcad-osnap-marker--${shape}`
       } else {
         this.marker.classList.remove('mlcad-osnap-marker--hidden')
       }
-      const local = acExLoupeLocalFromCanvasDelta(
+      const local = acexLoupeLocalFromCanvasDelta(
         snapCanvas.x - canvasX,
         snapCanvas.y - canvasY
       )
@@ -129,7 +129,7 @@ export class AcExSnapLoupe {
  *   {@link ACEX_SNAP_LOUPE_ZOOM}.
  * @returns Loupe-local coordinates with origin at the loupe top-left.
  */
-export function acExLoupeLocalFromCanvasDelta(
+export function acexLoupeLocalFromCanvasDelta(
   dx: number,
   dy: number,
   size: number = ACEX_SNAP_LOUPE_SIZE_PX,

--- a/packages/cad-html-plugin/src/AcExTouchPickStrategy.ts
+++ b/packages/cad-html-plugin/src/AcExTouchPickStrategy.ts
@@ -19,7 +19,7 @@ export const ACEX_SIMULATED_MOUSE_OFFSET_Y_PX = 52
  *
  * Defaults to `true` when unset so offline HTML matches the live viewer.
  */
-export function acExIsSimulatedMouseEnabled(): boolean {
+export function acexIsSimulatedMouseEnabled(): boolean {
   if (typeof localStorage === 'undefined') return true
   try {
     const raw = localStorage.getItem(ACEX_SIMULATED_MOUSE_STORAGE_KEY)
@@ -35,7 +35,7 @@ export function acExIsSimulatedMouseEnabled(): boolean {
  *
  * @param enabled - True to use the crosshair-above-finger strategy.
  */
-export function acExSetSimulatedMouseEnabled(enabled: boolean): void {
+export function acexSetSimulatedMouseEnabled(enabled: boolean): void {
   if (typeof localStorage === 'undefined') return
   try {
     localStorage.setItem(
@@ -52,9 +52,9 @@ export function acExSetSimulatedMouseEnabled(enabled: boolean): void {
  *
  * @returns The new enabled state.
  */
-export function acExToggleSimulatedMouse(): boolean {
-  const next = !acExIsSimulatedMouseEnabled()
-  acExSetSimulatedMouseEnabled(next)
+export function acexToggleSimulatedMouse(): boolean {
+  const next = !acexIsSimulatedMouseEnabled()
+  acexSetSimulatedMouseEnabled(next)
   return next
 }
 
@@ -144,8 +144,8 @@ const simulatedMouseStrategy = new AcExSimulatedMouseTouchPickStrategy()
  *
  * Re-evaluated each call so toggling mid-command applies on the next sample.
  */
-export function acExTouchPickStrategy(): AcExTouchPickStrategy {
-  return acExIsSimulatedMouseEnabled()
+export function acexTouchPickStrategy(): AcExTouchPickStrategy {
+  return acexIsSimulatedMouseEnabled()
     ? simulatedMouseStrategy
     : loupeStrategy
 }

--- a/packages/cad-html-plugin/src/AcExTouchPointSession.ts
+++ b/packages/cad-html-plugin/src/AcExTouchPointSession.ts
@@ -47,25 +47,25 @@ let ignoreCompatMouseUntil = 0
  * mouse `pointerdown` + `click` near the finger. A drawing tool would
  * treat that as a real mouse pick unless this guard stays armed.
  */
-export function acExSinkFollowingClick() {
-  acExArmTouchMouseGuard()
+export function acexSinkFollowingClick() {
+  acexArmTouchMouseGuard()
   if (followingClickSink) return
   const sink = (event: Event) => {
     event.preventDefault()
     event.stopImmediatePropagation()
-    acExClearFollowingClickSink()
+    acexClearFollowingClickSink()
   }
   followingClickSink = sink
   window.addEventListener('click', sink, true)
   followingClickSinkTimer = setTimeout(() => {
-    acExClearFollowingClickSink()
+    acexClearFollowingClickSink()
   }, ACEX_TOUCH_MOUSE_GUARD_MS)
 }
 
 /**
- * Removes {@link acExSinkFollowingClick} if it is armed.
+ * Removes {@link acexSinkFollowingClick} if it is armed.
  */
-export function acExClearFollowingClickSink() {
+export function acexClearFollowingClickSink() {
   if (followingClickSinkTimer != null) {
     clearTimeout(followingClickSinkTimer)
     followingClickSinkTimer = null
@@ -80,7 +80,7 @@ export function acExClearFollowingClickSink() {
  *
  * @param now - Current time in milliseconds; defaults to `performance.now()`.
  */
-export function acExArmTouchMouseGuard(now: number = performance.now()) {
+export function acexArmTouchMouseGuard(now: number = performance.now()) {
   ignoreCompatMouseUntil = Math.max(
     ignoreCompatMouseUntil,
     now + ACEX_TOUCH_MOUSE_GUARD_MS
@@ -93,7 +93,7 @@ export function acExArmTouchMouseGuard(now: number = performance.now()) {
  *
  * @param now - Current time in milliseconds; defaults to `performance.now()`.
  */
-export function acExShouldIgnoreCompatMouse(
+export function acexShouldIgnoreCompatMouse(
   now: number = performance.now()
 ): boolean {
   return followingClickSink != null || now < ignoreCompatMouseUntil
@@ -102,8 +102,8 @@ export function acExShouldIgnoreCompatMouse(
 /**
  * Clears the click sink and mouse guard. Used by tests.
  */
-export function acExResetTouchMouseGuard() {
-  acExClearFollowingClickSink()
+export function acexResetTouchMouseGuard() {
+  acexClearFollowingClickSink()
   ignoreCompatMouseUntil = 0
 }
 

--- a/packages/cad-html-plugin/src/AcExTouchPointTutorial.ts
+++ b/packages/cad-html-plugin/src/AcExTouchPointTutorial.ts
@@ -44,7 +44,7 @@ function writePrefs(prefs: AcUiTouchPointTutorialPrefs): void {
  * Uses the same phone/pad gate as the live viewer ({@link acedIsMobileOrPadUi})
  * so wide tablets and touch devices are included, not only `max-width: 960px`.
  */
-export function acExShouldShowTouchPointTutorial(): boolean {
+export function acexShouldShowTouchPointTutorial(): boolean {
   return acuiShouldShowTouchPointTutorialFromPrefs(
     acedIsMobileOrPadUi,
     readPrefs()
@@ -55,7 +55,7 @@ export function acExShouldShowTouchPointTutorial(): boolean {
  * Shows the shared touch-point tutorial when the session panel opens on
  * phone/pad layouts in exported HTML.
  */
-export function acExMaybeShowTouchPointTutorial(
+export function acexMaybeShowTouchPointTutorial(
   i18n: AcExHtmlI18n,
   host: HTMLElement = document.getElementById('mlcad-canvas-host') ??
     document.body
@@ -75,7 +75,7 @@ export function acExMaybeShowTouchPointTutorial(
       hideForever: i18n.t('touchPointTutorial.hideForever'),
       ok: i18n.t('touchPointTutorial.ok')
     },
-    shouldShow: acExShouldShowTouchPointTutorial,
+    shouldShow: acexShouldShowTouchPointTutorial,
     readPrefs,
     writePrefs
   })


### PR DESCRIPTION
## Summary

Standardize the global identifier prefixes in the `cad-html-plugin` module so they match the conventions used by sibling modules (`aced`, `acap`, `acui`):

- Global functions: `acEx*` → `acex*` (all-lowercase `acex` prefix with camelCase), e.g. `acExHtmlIcons` → `acexHtmlIcons`, `acExIdlePointerStrategy` → `acexIdlePointerStrategy`.
- Classes / interfaces / types: keep the `AcEx*` PascalCase prefix (e.g. `AcExIdlePointerStrategy`, `AcExMarkupShapeOutline`).
- Constants / storage keys: `ACEX_*` uppercase snake_case (already in place, untouched).
- Filenames keep the `AcEx*` PascalCase prefix (unchanged).

All imports, call sites, JSDoc `@module` tags and unit tests in `packages/cad-html-plugin` are updated accordingly. No behavioral changes — pure mechanical rename (42 files, 590/590 symmetric insertions/deletions).

## Verification

- No remaining `acEx*`-style identifiers anywhere under `packages/` (classes `AcEx*` intentionally kept).
- IDE type diagnostics report zero errors after the rename.
- Existing unit tests updated to the new names.