### PR TITLE
docs: point API links to Read the Docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: '指南', link: '/zh/guide/ui/read-only' },
-          { text: 'API', link: '/api/' },
+          { text: 'API', link: 'https://cad-viewer.readthedocs.io/en/latest/' },
           { text: 'GitHub', link: 'https://github.com/mlightcad/cad-viewer' },
         ],
         sidebar: guideSidebar('/zh', {
@@ -107,7 +107,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'Guide', link: '/guide/ui/read-only' },
-          { text: 'API', link: '/api/' },
+          { text: 'API', link: 'https://cad-viewer.readthedocs.io/en/latest/' },
           { text: 'GitHub', link: 'https://github.com/mlightcad/cad-viewer' },
         ],
         sidebar: guideSidebar('', {
@@ -147,7 +147,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'ガイド', link: '/ja/guide/ui/read-only' },
-          { text: 'API', link: '/api/' },
+          { text: 'API', link: 'https://cad-viewer.readthedocs.io/en/latest/' },
           { text: 'GitHub', link: 'https://github.com/mlightcad/cad-viewer' },
         ],
         sidebar: guideSidebar('/ja', {
@@ -187,7 +187,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: '가이드', link: '/ko/guide/ui/read-only' },
-          { text: 'API', link: '/api/' },
+          { text: 'API', link: 'https://cad-viewer.readthedocs.io/en/latest/' },
           { text: 'GitHub', link: 'https://github.com/mlightcad/cad-viewer' },
         ],
         sidebar: guideSidebar('/ko', {
@@ -228,7 +228,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'الدليل', link: '/ar/guide/ui/read-only' },
-          { text: 'API', link: '/api/' },
+          { text: 'API', link: 'https://cad-viewer.readthedocs.io/en/latest/' },
           { text: 'GitHub', link: 'https://github.com/mlightcad/cad-viewer' },
         ],
         sidebar: guideSidebar('/ar', {
@@ -268,7 +268,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'Průvodce', link: '/cs/guide/ui/read-only' },
-          { text: 'API', link: '/api/' },
+          { text: 'API', link: 'https://cad-viewer.readthedocs.io/en/latest/' },
           { text: 'GitHub', link: 'https://github.com/mlightcad/cad-viewer' },
         ],
         sidebar: guideSidebar('/cs', {
@@ -308,7 +308,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'Rehber', link: '/tr/guide/ui/read-only' },
-          { text: 'API', link: '/api/' },
+          { text: 'API', link: 'https://cad-viewer.readthedocs.io/en/latest/' },
           { text: 'GitHub', link: 'https://github.com/mlightcad/cad-viewer' },
         ],
         sidebar: guideSidebar('/tr', {

--- a/docs/ar/index.md
+++ b/docs/ar/index.md
@@ -14,7 +14,7 @@ hero:
       link: /ar/guide/ui/read-only
     - theme: alt
       text: مرجع API
-      link: /api/
+      link: https://cad-viewer.readthedocs.io/en/latest/
 
 features:
   - icon: ⚡

--- a/docs/cs/index.md
+++ b/docs/cs/index.md
@@ -14,7 +14,7 @@ hero:
       link: /cs/guide/ui/read-only
     - theme: alt
       text: API dokumentace
-      link: /api/
+      link: https://cad-viewer.readthedocs.io/en/latest/
 
 features:
   - icon: ⚡

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hero:
       link: /guide/ui/read-only
     - theme: alt
       text: API Reference
-      link: /api/
+      link: https://cad-viewer.readthedocs.io/en/latest/
 
 features:
   - icon: ⚡

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -14,7 +14,7 @@ hero:
       link: /ja/guide/ui/read-only
     - theme: alt
       text: API リファレンス
-      link: /api/
+      link: https://cad-viewer.readthedocs.io/en/latest/
 
 features:
   - icon: ⚡

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -14,7 +14,7 @@ hero:
       link: /ko/guide/ui/read-only
     - theme: alt
       text: API 참조
-      link: /api/
+      link: https://cad-viewer.readthedocs.io/en/latest/
 
 features:
   - icon: ⚡

--- a/docs/tr/index.md
+++ b/docs/tr/index.md
@@ -14,7 +14,7 @@ hero:
       link: /tr/guide/ui/read-only
     - theme: alt
       text: API Belgeleri
-      link: /api/
+      link: https://cad-viewer.readthedocs.io/en/latest/
 
 features:
   - icon: ⚡

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -14,7 +14,7 @@ hero:
       link: /zh/guide/ui/read-only
     - theme: alt
       text: API 文档
-      link: /api/
+      link: https://cad-viewer.readthedocs.io/en/latest/
 
 features:
   - icon: ⚡


### PR DESCRIPTION
## Summary

Replace all `/api/` references in the VitePress documentation site with the Read the Docs URL `https://cad-viewer.readthedocs.io/en/latest/`.

This covers:
- 7 nav "API" menu entries in `docs/.vitepress/config.ts` (zh / en / ja / ko / ar / cs / tr)
- 7 "API Reference" / "API 文档" / ... hero action buttons on the home page (all 7 locale `index.md` files)

## Files changed

| File | Change |
|---|---|
| docs/.vitepress/config.ts | Replace `link: '/api/'` with the Read the Docs URL in 7 locale nav blocks |
| docs/index.md | Update hero action button link |
| docs/zh/index.md | Update hero action button link |
| docs/ja/index.md | Update hero action button link |
| docs/ko/index.md | Update hero action button link |
| docs/ar/index.md | Update hero action button link |
| docs/cs/index.md | Update hero action button link |
| docs/tr/index.md | Update hero action button link |

## Test plan

- [ ] Open each locale (zh / en / ja / ko / ar / cs / tr) home page and click "API Reference / API 文档 / ..." — opens Read the Docs in a new tab
- [ ] Click top-nav "API" link in each locale — opens Read the Docs
- [ ] Global grep for `/api/` under `docs/` returns no results
