### PR TITLE
fix: keep INT osnap responsive on dense blocks and touch

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts
@@ -57,7 +57,20 @@ function withWorkingDatabase(run: (db: AcDbDatabase) => void) {
 }
 
 function createMockView(
-  pickResults: Array<{ id: string; children?: Array<{ id: string }> }>
+  pickResults: Array<{
+    id: string
+    minX?: number
+    minY?: number
+    maxX?: number
+    maxY?: number
+    children?: Array<{
+      id: string
+      minX?: number
+      minY?: number
+      maxX?: number
+      maxY?: number
+    }>
+  }>
 ): AcEdBaseView {
   return {
     pick: jest.fn().mockReturnValue(pickResults),
@@ -138,6 +151,200 @@ describe('AcEdOsnapResolver', () => {
 
       expect(snap?.type).not.toBe(AcDbOsnapMode.Intersection)
       expect(snap?.type).toBe(AcDbOsnapMode.Nearest)
+    })
+  })
+
+  it('skips intersectWith for entity pairs whose extents do not overlap', () => {
+    withWorkingDatabase(db => {
+      const left = new AcDbLine(
+        new AcGePoint3d(0, 0, 0),
+        new AcGePoint3d(10, 0, 0)
+      )
+      const right = new AcDbLine(
+        new AcGePoint3d(100, 0, 0),
+        new AcGePoint3d(110, 0, 0)
+      )
+      db.tables.blockTable.modelSpace.appendEntity(left)
+      db.tables.blockTable.modelSpace.appendEntity(right)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Intersection,
+        AcDbOsnapMode.EndPoint
+      ])
+
+      const intersectSpy = jest.spyOn(left, 'intersectWith')
+      const view = createMockView([
+        { id: left.objectId },
+        { id: right.objectId }
+      ])
+      const resolver = new AcEdOsnapResolver(view)
+      resolver.resolve({
+        cursorWcs: { x: 5, y: 0 },
+        hitRadiusPx: 20
+      })
+
+      expect(intersectSpy).not.toHaveBeenCalled()
+      intersectSpy.mockRestore()
+    })
+  })
+
+  it('snaps to intersection using only hit INSERT children, not the whole block', () => {
+    withWorkingDatabase(db => {
+      const block = new AcDbBlockTableRecord()
+      block.name = 'INT_BLK'
+      db.tables.blockTable.add(block)
+
+      // Dense block contents that must not all participate in INT.
+      for (let i = 0; i < 40; i++) {
+        block.appendEntity(
+          new AcDbLine(new AcGePoint3d(i, -50, 0), new AcGePoint3d(i, 50, 0))
+        )
+      }
+      const diagonal = new AcDbLine(
+        new AcGePoint3d(0, 0, 0),
+        new AcGePoint3d(10, 10, 0)
+      )
+      block.appendEntity(diagonal)
+
+      const insert = new AcDbBlockReference('INT_BLK')
+      insert.position = new AcGePoint3d(0, 0, 0)
+      db.tables.blockTable.modelSpace.appendEntity(insert)
+
+      const crossing = new AcDbLine(
+        new AcGePoint3d(0, 10, 0),
+        new AcGePoint3d(10, 0, 0)
+      )
+      db.tables.blockTable.modelSpace.appendEntity(crossing)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Intersection
+      ])
+
+      const blockCurvesSpy = jest.spyOn(insert, 'subGetIntersectCurves')
+      const view = createMockView([
+        {
+          id: insert.objectId,
+          minX: 0,
+          minY: 0,
+          maxX: 10,
+          maxY: 10,
+          children: [
+            {
+              id: diagonal.objectId,
+              minX: 0,
+              minY: 0,
+              maxX: 10,
+              maxY: 10
+            }
+          ]
+        },
+        {
+          id: crossing.objectId,
+          minX: 0,
+          minY: 0,
+          maxX: 10,
+          maxY: 10
+        }
+      ])
+      const resolver = new AcEdOsnapResolver(view)
+      const snap = resolver.resolve({
+        cursorWcs: { x: 5.1, y: 4.9 },
+        hitRadiusPx: 20
+      })
+
+      expect(blockCurvesSpy).not.toHaveBeenCalled()
+      expect(snap).toEqual({
+        x: 5,
+        y: 5,
+        z: 0,
+        type: AcDbOsnapMode.Intersection
+      })
+      blockCurvesSpy.mockRestore()
+    })
+  })
+
+  it('snaps block-line × model polyline INT regardless of pick order', () => {
+    withWorkingDatabase(db => {
+      const block = new AcDbBlockTableRecord()
+      block.name = 'XFRAME_BLK'
+      db.tables.blockTable.add(block)
+
+      const diagonal = new AcDbLine(
+        new AcGePoint3d(0, 0, 0),
+        new AcGePoint3d(10, 10, 0)
+      )
+      block.appendEntity(diagonal)
+
+      const insert = new AcDbBlockReference('XFRAME_BLK')
+      insert.position = new AcGePoint3d(0, 0, 0)
+      db.tables.blockTable.modelSpace.appendEntity(insert)
+
+      const crossing = new AcDbPolyline()
+      crossing.addVertexAt(0, new AcGePoint2d(0, 10))
+      crossing.addVertexAt(1, new AcGePoint2d(10, 0))
+      db.tables.blockTable.modelSpace.appendEntity(crossing)
+
+      AcApSettingManager.instance.osnapModes = acdbOsnapModesToMask([
+        AcDbOsnapMode.Intersection
+      ])
+
+      const expectInt = (
+        pickResults: Array<{
+          id: string
+          minX?: number
+          minY?: number
+          maxX?: number
+          maxY?: number
+          children?: Array<{
+            id: string
+            minX?: number
+            minY?: number
+            maxX?: number
+            maxY?: number
+          }>
+        }>
+      ) => {
+        const resolver = new AcEdOsnapResolver(createMockView(pickResults))
+        expect(
+          resolver.resolve({
+            cursorWcs: { x: 5.1, y: 4.9 },
+            hitRadiusPx: 20
+          })
+        ).toEqual({
+          x: 5,
+          y: 5,
+          z: 0,
+          type: AcDbOsnapMode.Intersection
+        })
+      }
+
+      const insertHit = {
+        id: insert.objectId,
+        minX: 0,
+        minY: 0,
+        maxX: 10,
+        maxY: 10,
+        children: [
+          {
+            id: diagonal.objectId,
+            minX: 0,
+            minY: 0,
+            maxX: 10,
+            maxY: 10
+          }
+        ]
+      }
+      const polyHit = {
+        id: crossing.objectId,
+        minX: 0,
+        minY: 0,
+        maxX: 10,
+        maxY: 10
+      }
+
+      // Polyline listed first forces A=polyline, B=block-line (needs A→B fallback).
+      expectInt([polyHit, insertHit])
+      expectInt([insertHit, polyHit])
     })
   })
 

--- a/packages/cad-simple-viewer/src/editor/input/AcEdOsnapCenterMarks.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdOsnapCenterMarks.ts
@@ -186,17 +186,30 @@ function collectFromOsnapCenter(
   return points.map(point => markFromPoint(point))
 }
 
-function findBlockSubEntity(
+/** Full INSERT transform (OCS blockTransform + extrusion), matching intersect curves. */
+function fullInsertionTransform(blockRef: AcDbBlockReference): AcGeMatrix3d {
+  return new AcGeMatrix3d()
+    .setFromExtrusionDirection(blockRef.normal)
+    .multiply(blockRef.blockTransform)
+}
+
+/**
+ * Resolves a block-reference sub-entity identified by a spatial-index gsMark.
+ *
+ * Returns the leaf entity and the cumulative transform that maps its local
+ * geometry into the caller space (typically WCS).
+ */
+export function resolveBlockSubEntity(
   blockRef: AcDbBlockReference,
   gsMark: AcDbObjectId,
-  parentMat: AcGeMatrix3d
+  parentMat: AcGeMatrix3d = new AcGeMatrix3d()
 ): { entity: AcDbEntity; transform: AcGeMatrix3d } | undefined {
   const blockTableRecord = blockRef.blockTableRecord
   if (!blockTableRecord) return undefined
 
   const thisMat = new AcGeMatrix3d().multiplyMatrices(
     parentMat,
-    blockRef.blockTransform
+    fullInsertionTransform(blockRef)
   )
   const targetId = canonicalGsMark(gsMark)
 
@@ -205,7 +218,7 @@ function findBlockSubEntity(
       return { entity, transform: thisMat }
     }
     if (entity instanceof AcDbBlockReference) {
-      const nested = findBlockSubEntity(entity, gsMark, thisMat)
+      const nested = resolveBlockSubEntity(entity, gsMark, thisMat)
       if (nested) return nested
     }
   }
@@ -221,7 +234,7 @@ function collectBlockCenterMarks(
     return collectFromOsnapCenter(blockRef, pickPoint)
   }
 
-  const found = findBlockSubEntity(blockRef, gsMark, new AcGeMatrix3d())
+  const found = resolveBlockSubEntity(blockRef, gsMark)
   if (!found) {
     return collectFromOsnapCenter(blockRef, pickPoint, canonicalGsMark(gsMark))
   }

--- a/packages/cad-simple-viewer/src/editor/input/AcEdOsnapResolver.ts
+++ b/packages/cad-simple-viewer/src/editor/input/AcEdOsnapResolver.ts
@@ -1,23 +1,35 @@
 import {
+  AcDbArc,
+  AcDbBlockReference,
+  AcDbCircle,
   AcDbEntity,
   acdbHasOsnapMode,
   acdbHostApplicationServices,
+  AcDbLine,
   acdbMaskToOsnapModes,
   AcDbObjectId,
   AcDbOsnapMode,
+  AcGeBox3d,
   AcGeGeometryUtil,
+  AcGeMatrix3d,
   AcGePoint2dLike,
+  AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/data-model'
 
 import { AcApSettingManager } from '../../app/AcApSettingManager'
 import { AcEdBaseView } from '../view/AcEdBaseView'
 import {
+  AcEdSpatialQueryResultItemEx,
+  isEffectiveSpatialQueryHit
+} from '../view/AcEdSpatialQueryResult'
+import {
   type AcEdOsnapCenterMark,
   canonicalGsMark,
   centerMarksCoincide,
   collectCenterMarksFromEntity,
-  mergeAcquiredCenterMarks
+  mergeAcquiredCenterMarks,
+  resolveBlockSubEntity
 } from './AcEdOsnapCenterMarks'
 import { AcEdMarkerType } from './marker/AcEdMarker'
 
@@ -38,8 +50,153 @@ export interface AcEdOsnapResolveOptions {
 
 const DEFAULT_HIT_RADIUS_PX = 20
 
-/** Max nearby entities considered per intersection query (matches HTML viewer). */
-const MAX_INTERSECTION_SOURCES = 48
+/**
+ * Max nearby geometry sources considered per intersection query.
+ * Prefer pick-hit subentities (INSERT children) over whole block refs.
+ */
+const MAX_INTERSECTION_SOURCES = 16
+
+/** Hard cap on pairwise `intersectWith` calls per resolve. */
+const MAX_INTERSECTION_PAIR_TESTS = 48
+
+/** Wall-clock budget for pairwise intersection math per resolve. */
+const INTERSECTION_TIME_BUDGET_MS = 8
+
+/**
+ * Skip leaf entities whose curve primitive count exceeds this. Fat polylines /
+ * splines must not expand into INT snap on every touch move.
+ */
+const MAX_PRIMITIVES_PER_SOURCE = 32
+
+type IntersectionSource = {
+  key: string
+  box: AcGeBox3d
+  entity: AcDbEntity
+  /** Maps entity-local geometry into WCS. Identity for model-space entities. */
+  transform: AcGeMatrix3d
+}
+
+function boxesOverlapXY(a: AcGeBox3d, b: AcGeBox3d): boolean {
+  return (
+    a.min.x <= b.max.x &&
+    a.max.x >= b.min.x &&
+    a.min.y <= b.max.y &&
+    a.max.y >= b.min.y
+  )
+}
+
+function boxFromSpatialItem(item: {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}): AcGeBox3d {
+  return new AcGeBox3d(
+    { x: item.minX, y: item.minY, z: -Infinity },
+    { x: item.maxX, y: item.maxY, z: Infinity }
+  )
+}
+
+function isIdentityTransform(matrix: AcGeMatrix3d): boolean {
+  return matrix.equals(AcGeMatrix3d.IDENTITY)
+}
+
+/**
+ * Builds a disposable entity whose geometry is `entity` transformed by
+ * `matrix`, without mutating database-resident entities.
+ *
+ * Returns the original entity when `matrix` is identity. Returns `undefined`
+ * when the entity type cannot be safely copied for cross-transform INT.
+ */
+function transformedEntityCopy(
+  entity: AcDbEntity,
+  matrix: AcGeMatrix3d
+): AcDbEntity | undefined {
+  if (isIdentityTransform(matrix)) return entity
+
+  if (entity instanceof AcDbLine) {
+    return new AcDbLine(
+      new AcGePoint3d(entity.startPoint).applyMatrix4(matrix),
+      new AcGePoint3d(entity.endPoint).applyMatrix4(matrix)
+    )
+  }
+
+  if (entity instanceof AcDbCircle) {
+    const scale = matrix.getMaxScaleOnAxis()
+    if (!(scale > 0) || !Number.isFinite(scale)) return undefined
+    return new AcDbCircle(
+      new AcGePoint3d(entity.center).applyMatrix4(matrix),
+      entity.radius * scale,
+      entity.normal
+    )
+  }
+
+  if (entity instanceof AcDbArc) {
+    const scale = matrix.getMaxScaleOnAxis()
+    if (!(scale > 0) || !Number.isFinite(scale)) return undefined
+    return new AcDbArc(
+      new AcGePoint3d(entity.center).applyMatrix4(matrix),
+      entity.radius * scale,
+      entity.startAngle,
+      entity.endAngle,
+      entity.normal
+    )
+  }
+
+  return undefined
+}
+
+function isLightIntersectionEntity(entity: AcDbEntity): boolean {
+  const count = entity.subGetIntersectCurves().length
+  return count > 0 && count <= MAX_PRIMITIVES_PER_SOURCE
+}
+
+/**
+ * Maps local intersect points through `frame` into WCS.
+ */
+function mapIntersectPointsToWcs(
+  local: AcGePoint3d[],
+  frame: AcGeMatrix3d
+): AcGePoint3d[] {
+  if (isIdentityTransform(frame)) return local
+  return local.map(point =>
+    new AcGePoint3d(point.x, point.y, point.z).applyMatrix4(frame)
+  )
+}
+
+/**
+ * Intersects two osnap sources without mutating database entities.
+ * Same-frame pairs use local `intersectWith` then map to WCS; cross-frame
+ * pairs express one entity in the other's local space via a disposable copy.
+ * Tries B→A first, then A→B, so order does not drop polyline/spline partners
+ * when the other side is a transformable Line/Circle/Arc.
+ */
+function intersectSources(
+  a: IntersectionSource,
+  b: IntersectionSource
+): AcGePoint3d[] {
+  if (a.transform.equals(b.transform)) {
+    return mapIntersectPointsToWcs(a.entity.intersectWith(b.entity), a.transform)
+  }
+
+  const bToA = new AcGeMatrix3d().multiplyMatrices(
+    a.transform.clone().invert(),
+    b.transform
+  )
+  const bInA = transformedEntityCopy(b.entity, bToA)
+  if (bInA) {
+    return mapIntersectPointsToWcs(a.entity.intersectWith(bInA), a.transform)
+  }
+
+  const aToB = new AcGeMatrix3d().multiplyMatrices(
+    b.transform.clone().invert(),
+    a.transform
+  )
+  const aInB = transformedEntityCopy(a.entity, aToB)
+  if (!aInB) return []
+
+  return mapIntersectPointsToWcs(b.entity.intersectWith(aInB), b.transform)
+}
 
 /**
  * Resolves object snap points for a view during interactive input.
@@ -88,11 +245,12 @@ export class AcEdOsnapResolver {
     const lastPoint = options.lastPoint ?? options.cursorWcs
     const p1 = this._view.screenToWorld({ x: 0, y: 0 })
     const p2 = this._view.screenToWorld({ x: hitRadiusPx, y: 0 })
-    const threshold = p2.x - p1.x
+    const threshold = Math.abs(p2.x - p1.x)
     const snapPoints = this.collectOsnapPoints(
       options.cursorWcs,
       lastPoint,
-      hitRadiusPx
+      hitRadiusPx,
+      threshold
     )
 
     for (const mark of this._acquiredCenters) {
@@ -214,14 +372,90 @@ export class AcEdOsnapResolver {
   }
 
   private collectIntersectionOsnapPoints(
-    entities: AcDbEntity[],
-    osnapPoints: AcEdOsnapPoint[]
+    pickResults: AcEdSpatialQueryResultItemEx[],
+    modelSpace: { getIdAt: (id: AcDbObjectId) => AcDbEntity | undefined },
+    osnapPoints: AcEdOsnapPoint[],
+    cursorWcs: AcGePoint2dLike,
+    threshold: number
   ) {
-    const sources = entities.slice(0, MAX_INTERSECTION_SOURCES)
+    const sources: IntersectionSource[] = []
+    const seenKeys = new Set<string>()
+
+    const tryAdd = (source: IntersectionSource) => {
+      if (sources.length >= MAX_INTERSECTION_SOURCES) return
+      if (seenKeys.has(source.key)) return
+      if (source.box.isEmpty()) return
+      if (!isLightIntersectionEntity(source.entity)) return
+      seenKeys.add(source.key)
+      sources.push(source)
+    }
+
+    for (const item of pickResults) {
+      if (sources.length >= MAX_INTERSECTION_SOURCES) break
+      if (!isEffectiveSpatialQueryHit(item)) continue
+      const entity = modelSpace.getIdAt(item.id)
+      if (!entity) continue
+
+      if (item.children && item.children.length > 0) {
+        // INSERT (and other hierarchical hits): only the aperture-hit children.
+        // Never expand the whole block definition into INT snap.
+        for (const child of item.children) {
+          if (sources.length >= MAX_INTERSECTION_SOURCES) break
+          const gsMark = canonicalGsMark(child.id)
+          const key = `${item.id}:${gsMark}`
+          if (entity instanceof AcDbBlockReference) {
+            const found = resolveBlockSubEntity(entity, gsMark)
+            if (!found) continue
+            tryAdd({
+              key,
+              box: boxFromSpatialItem(child),
+              entity: found.entity,
+              transform: found.transform
+            })
+          } else {
+            tryAdd({
+              key,
+              box: boxFromSpatialItem(child),
+              entity,
+              transform: new AcGeMatrix3d()
+            })
+          }
+        }
+        continue
+      }
+
+      if (entity instanceof AcDbBlockReference) {
+        // Coarse root hit without children — skip. Whole-block intersectWith
+        // would expand every nested curve and freeze dense blocks on mobile.
+        continue
+      }
+
+      tryAdd({
+        key: item.id,
+        box: entity.geometricExtents,
+        entity,
+        transform: new AcGeMatrix3d()
+      })
+    }
+
+    if (sources.length < 2) return
+
+    const threshSq = threshold * threshold
+    const started = performance.now()
+    let pairTests = 0
+
     for (let i = 0; i < sources.length; i++) {
-      for (let j = i; j < sources.length; j++) {
-        const points = sources[i].intersectWith(sources[j])
+      for (let j = i + 1; j < sources.length; j++) {
+        if (pairTests >= MAX_INTERSECTION_PAIR_TESTS) return
+        if (performance.now() - started > INTERSECTION_TIME_BUDGET_MS) return
+        if (!boxesOverlapXY(sources[i].box, sources[j].box)) continue
+
+        pairTests++
+        const points = intersectSources(sources[i], sources[j])
         for (const point of points) {
+          const dx = point.x - cursorWcs.x
+          const dy = point.y - cursorWcs.y
+          if (dx * dx + dy * dy > threshSq) continue
           osnapPoints.push({
             x: point.x,
             y: point.y,
@@ -236,7 +470,8 @@ export class AcEdOsnapResolver {
   private collectOsnapPoints(
     cursorWcs: AcGePoint2dLike,
     lastPoint: AcGePoint2dLike,
-    hitRadiusPx: number
+    hitRadiusPx: number,
+    threshold: number
   ): AcEdOsnapPoint[] {
     const results = this._view.pick(cursorWcs, hitRadiusPx)
     const db = acdbHostApplicationServices().workingDatabase
@@ -245,17 +480,9 @@ export class AcEdOsnapResolver {
     const pickPoint = AcGeGeometryUtil.point2dToPoint3d(cursorWcs)
     const last = AcGeGeometryUtil.point2dToPoint3d(lastPoint)
 
-    const uniqueEntities: AcDbEntity[] = []
-    const seenIds = new Set<AcDbObjectId>()
-
     results.forEach(item => {
       const entity = modelSpace.getIdAt(item.id)
       if (!entity) return
-
-      if (!seenIds.has(item.id)) {
-        seenIds.add(item.id)
-        uniqueEntities.push(entity)
-      }
 
       if (item.children && item.children.length > 0) {
         item.children.forEach(child =>
@@ -283,7 +510,13 @@ export class AcEdOsnapResolver {
         AcDbOsnapMode.Intersection
       )
     ) {
-      this.collectIntersectionOsnapPoints(uniqueEntities, osnapPoints)
+      this.collectIntersectionOsnapPoints(
+        results,
+        modelSpace,
+        osnapPoints,
+        cursorWcs,
+        threshold
+      )
     }
 
     this.updateAcquiredCenters(results, modelSpace, pickPoint)

--- a/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
+++ b/packages/cad-simple-viewer/src/editor/input/ui/AcEdFloatingInput.ts
@@ -113,6 +113,14 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   /** Long-press / short-tap state for one-finger point picking. */
   private readonly touchSession = new AcEdTouchPointSession()
   /**
+   * Latest finger sample waiting for the next animation frame during precise
+   * touch pick. Coalesces high-frequency touchmove into one osnap resolve per
+   * frame so expensive INT tests cannot pile up on the main thread.
+   */
+  private pendingTouchPreciseFinger: { x: number; y: number } | null = null
+  /** `requestAnimationFrame` id for {@link pendingTouchPreciseFinger}, or null. */
+  private touchPreciseRafId: number | null = null
+  /**
    * When true, a left-button mouse/pen `pointerdown` landed on this prompt's
    * canvas, so the following `click` may commit. Touch never sets this:
    * phone/pad hide dynamic input, so a leftover compatibility `click` would
@@ -311,6 +319,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
 
   override dispose() {
     if (this.disposed) return
+    this.cancelTouchPreciseSchedule()
     super.dispose()
 
     this.parent.removeEventListener('click', this.boundOnClick)
@@ -451,10 +460,12 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     if (e.pointerType !== 'touch') return
     if (e.pointerId !== this.touchSession.pointerId) return
     const moved = this.touchSession.move(e.clientX, e.clientY, true)
-    if (moved === 'panning') return
+    if (moved === 'panning') {
+      this.cancelTouchPreciseSchedule()
+      return
+    }
     if (!this.visible || !this.touchSession.isLoupe) return
-    this.applyTouchPreciseSample(e.clientX, e.clientY)
-    this.refreshTouchPreciseHud()
+    this.scheduleTouchPreciseSample(e.clientX, e.clientY)
   }
 
   /**
@@ -484,6 +495,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     acedSinkFollowingClick()
     this.releaseTouchCapture()
     if (this.touchSession.isPicking) return
+    this.cancelTouchPreciseSchedule()
     this.touchSession.cancel()
     this.view.setNavigationEnabled(true)
     this.hideTouchPreciseHud()
@@ -513,12 +525,14 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     const touch = e.touches[0] ?? e.changedTouches[0]
     if (!touch) return
     const moved = this.touchSession.move(touch.clientX, touch.clientY, true)
-    if (moved === 'panning') return
+    if (moved === 'panning') {
+      this.cancelTouchPreciseSchedule()
+      return
+    }
     if (!this.touchSession.isLoupe) return
     e.preventDefault()
     if (!this.visible) return
-    this.applyTouchPreciseSample(touch.clientX, touch.clientY)
-    this.refreshTouchPreciseHud()
+    this.scheduleTouchPreciseSample(touch.clientX, touch.clientY)
   }
 
   /**
@@ -566,6 +580,7 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
     const wasPrecise = this.touchSession.isLoupe
     const action = this.touchSession.end()
     this.view.setNavigationEnabled(true)
+    this.cancelTouchPreciseSchedule()
     this.hideTouchPreciseHud()
     // Finger-up coords must not seed the next prompt's jig preview.
     this.view.clearCursorPos()
@@ -618,6 +633,34 @@ export class AcEdFloatingInput<T> extends AcEdFloatingMessage {
   private applyTouchPreciseSample(fingerX: number, fingerY: number) {
     const sample = acedTouchPickStrategy().mapFingerToSample(fingerX, fingerY)
     this.applyClientSample(sample.x, sample.y)
+  }
+
+  /**
+   * Coalesces finger samples to one osnap / HUD update per animation frame.
+   * Touchmove can fire faster than a single INT resolve finishes; running every
+   * event synchronously freezes the UI on dense geometry.
+   */
+  private scheduleTouchPreciseSample(fingerX: number, fingerY: number) {
+    this.pendingTouchPreciseFinger = { x: fingerX, y: fingerY }
+    if (this.touchPreciseRafId != null) return
+    this.touchPreciseRafId = requestAnimationFrame(() => {
+      this.touchPreciseRafId = null
+      const finger = this.pendingTouchPreciseFinger
+      this.pendingTouchPreciseFinger = null
+      if (!finger || this.disposed || !this.visible) return
+      if (!this.touchSession.isLoupe) return
+      this.applyTouchPreciseSample(finger.x, finger.y)
+      this.refreshTouchPreciseHud()
+    })
+  }
+
+  /** Drops any pending coalesced touch sample without applying it. */
+  private cancelTouchPreciseSchedule() {
+    if (this.touchPreciseRafId != null) {
+      cancelAnimationFrame(this.touchPreciseRafId)
+      this.touchPreciseRafId = null
+    }
+    this.pendingTouchPreciseFinger = null
   }
 
   /** HUD host wiring loupe / simulated-mouse helpers to this view. */


### PR DESCRIPTION
## Summary
- Prefer aperture-hit INSERT children for intersection snap instead of expanding whole dense block definitions, and skip non-overlapping pairs with pair/time budgets.
- Fix full INSERT transform (extrusion × blockTransform) when resolving block sub-entities, and make cross-frame INT try both A↔B copies so polyline partners are not order-dependent.
- Coalesce precise touch-pick samples to one osnap/HUD update per animation frame to avoid main-thread INT pile-ups.

## Test plan
- [ ] Run `pnpm exec jest packages/cad-simple-viewer/__tests__/AcEdOsnapResolver.spec.ts`
- [ ] On a drawing with dense blocks, enable INT and move the cursor / touch loupe near crossings — UI stays responsive and INT still snaps on hit children
- [ ] Confirm block-line × model polyline INT works regardless of pick order
- [ ] Confirm precise touch pick cancels cleanly on pan / finger-up / dispose (no stale HUD)
