### PR TITLE
feat: add multi-file ACEX HTML export package format

### DIFF
--- a/packages/cad-html-plugin/README.md
+++ b/packages/cad-html-plugin/README.md
@@ -16,10 +16,11 @@ The plugin path is designed for **lazy loading** so the export bundle is only do
 
 - **Display-only snapshot** — layers, layouts, line/mesh batches, extents, and drawing units (no editable DXF/DWG payload)
 - **Self-contained HTML** — gzip/base64 snapshot + inline viewer runtime; opens offline in any modern browser
+- **Multi-file ACEX package** — shell HTML + versioned `*.acex.json` + per-chunk `*.acex.gz`; export downloads a zip (unzip before hosting for progressive load)
 - **Offline viewer** — select / pan / zoom (extents, window, original view), layer panel, layout switching, measurement, Design Review markup annotations, object snap (OSNAP). Select, pan, and zoom tools exit any active measurement or review drawing tool.
 - **i18n** — embedded English / Chinese / Czech / Turkish UI; initial language follows the browser (`zh*` → Chinese, `cs*` → Czech, `tr*` → Turkish, otherwise English); the toolbar language button opens a strip to pick a locale, and the choice persists in `localStorage`
 - **Plugin API** — implements `AcApPlugin`; register once with `registerLazyHtmlPlugin`
-- **Composable API** — build snapshots from your own pipeline or call `packHtml` with a pre-built snapshot
+- **Composable API** — build snapshots from your own pipeline or call `packHtml` / `buildAcExPackage` with a pre-built snapshot
 
 ## Installation
 
@@ -93,7 +94,34 @@ In [`cad-viewer`](../cad-viewer), use `chtml` to open the export options dialog;
 ```typescript
 import { AcApHtmlConvertor } from '@mlightcad/cad-html-plugin'
 
+// Self-contained .html (default)
 await new AcApHtmlConvertor().convert('my-drawing.dwg')
+
+// Multi-file package as one .zip download (unzip before hosting)
+await new AcApHtmlConvertor().convert('my-drawing.dwg', {
+  exportFormat: 'multi'
+})
+```
+
+`-chtml` prompts for export format (Single / Multi). In `cad-viewer`, the `chtml` dialog offers the same choice.
+
+### Multi-file package (low-level)
+
+See **[docs/acex-package-format.md](./docs/acex-package-format.md)** for the on-disk format.
+
+```typescript
+import {
+  buildAcExPackage,
+  zipAcExPackageFiles,
+  packHtmlPackage
+} from '@mlightcad/cad-html-plugin'
+
+const pkg = buildAcExPackage(snapshot, {
+  viewerRuntime: runtime,
+  baseName: 'my-drawing'
+})
+const zipBytes = zipAcExPackageFiles(pkg)
+// Or serve pkg.files as a static directory after unzip
 ```
 
 ### Low-level snapshot assembly
@@ -161,9 +189,11 @@ import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.j
 | `@mlightcad/cad-html-plugin/register` | `registerLazyHtmlPlugin` and registration constants |
 | `AcApExportHtmlCmd`, `AcApHtmlConvertor` | `-chtml` command and full export workflow |
 | `AcApHtmlSnapshotBuilder` | Live Three.js scene → `AcExSnapshotV1` |
-| `packHtml`, `AcExPackHtmlOptions` | Assemble HTML from snapshot + runtime source |
+| `packHtml`, `AcExPackHtmlOptions` | Assemble self-contained HTML from snapshot + runtime |
+| `packHtmlPackage`, `buildAcExPackage`, `zipAcExPackageFiles` | Multi-file package shell, builder, and export zip |
 | `HTML_VIEWER_RUNTIME_FILE` | Default runtime filename (`viewer-runtime.iife.js`) |
-| `AcExSnapshotV1`, `ACEX_SNAPSHOT_VERSION`, batch/layer types | Snapshot schema |
+| `AcExSnapshot`, `ACEX_SNAPSHOT_VERSION`, batch/layer types | Snapshot schema |
+| Package format doc | [`docs/acex-package-format.md`](./docs/acex-package-format.md) |
 | `encodeSnapshot`, `decodeSnapshot` | Gzip/base64 codec for embedded payloads |
 | `collectBatchesFromObject3D` | THREE.js scene → line/mesh batches |
 | `buildViewerMetadata` | Database → viewer meta (units, extents, background, …) |

--- a/packages/cad-html-plugin/__tests__/AcApExportHtmlCmd.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcApExportHtmlCmd.spec.ts
@@ -31,6 +31,8 @@ jest.mock('@mlightcad/cad-simple-viewer', () => {
     AcApI18n: {
       t: (key: string) => {
         const globals: Record<string, string> = {
+          'jig.chtml.keywords.single.global': 'Single',
+          'jig.chtml.keywords.multi.global': 'Multi',
           'jig.chtml.keywords.yes.global': 'Yes',
           'jig.chtml.keywords.no.global': 'No',
           'jig.chtml.keywords.extents.global': 'Extents',
@@ -79,6 +81,7 @@ function none() {
 }
 
 const defaultExportOptions = {
+  exportFormat: 'single',
   exportInvisibleLayers: true,
   exportLayouts: true,
   initialView: 'fit',
@@ -106,14 +109,16 @@ describe('AcApExportHtmlCmd prompt defaults', () => {
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
+      .mockResolvedValueOnce(none())
 
     await cmd.execute(context)
 
-    expect(getKeywords).toHaveBeenCalledTimes(4)
+    expect(getKeywords).toHaveBeenCalledTimes(5)
     expect(getKeywords.mock.calls[0][0].allowNone).toBe(true)
     expect(getKeywords.mock.calls[1][0].allowNone).toBe(true)
     expect(getKeywords.mock.calls[2][0].allowNone).toBe(true)
     expect(getKeywords.mock.calls[3][0].allowNone).toBe(true)
+    expect(getKeywords.mock.calls[4][0].allowNone).toBe(true)
 
     expect(convert()).toHaveBeenCalledWith(
       'drawing.dwg',
@@ -124,6 +129,10 @@ describe('AcApExportHtmlCmd prompt defaults', () => {
 
   test('accepts default keyword (OK) for all prompts and exports', async () => {
     getKeywords
+      .mockResolvedValueOnce({
+        status: AcEdPromptStatus.OK,
+        stringResult: 'Single'
+      })
       .mockResolvedValueOnce({
         status: AcEdPromptStatus.OK,
         stringResult: 'Yes'
@@ -150,8 +159,29 @@ describe('AcApExportHtmlCmd prompt defaults', () => {
     )
   })
 
+  test('exports multi-file package when Multi keyword is selected', async () => {
+    getKeywords
+      .mockResolvedValueOnce({
+        status: AcEdPromptStatus.OK,
+        stringResult: 'Multi'
+      })
+      .mockResolvedValueOnce(none())
+      .mockResolvedValueOnce(none())
+      .mockResolvedValueOnce(none())
+      .mockResolvedValueOnce(none())
+
+    await cmd.execute(context)
+
+    expect(convert()).toHaveBeenCalledWith(
+      'drawing.dwg',
+      { ...defaultExportOptions, exportFormat: 'multi' },
+      context.view
+    )
+  })
+
   test('exports with view-only viewer mode when View keyword is selected', async () => {
     getKeywords
+      .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
@@ -171,6 +201,7 @@ describe('AcApExportHtmlCmd prompt defaults', () => {
 
   test('exports without layouts when No is selected for the layouts prompt', async () => {
     getKeywords
+      .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce({
         status: AcEdPromptStatus.OK,
@@ -200,11 +231,12 @@ describe('AcApExportHtmlCmd prompt defaults', () => {
   test('cancels export when the layouts prompt is cancelled', async () => {
     getKeywords
       .mockResolvedValueOnce(none())
+      .mockResolvedValueOnce(none())
       .mockResolvedValueOnce({ status: AcEdPromptStatus.Cancel })
 
     await cmd.execute(context)
 
-    expect(getKeywords).toHaveBeenCalledTimes(2)
+    expect(getKeywords).toHaveBeenCalledTimes(3)
     expect(AcApHtmlConvertor).not.toHaveBeenCalled()
   })
 
@@ -213,11 +245,12 @@ describe('AcApExportHtmlCmd prompt defaults', () => {
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
+      .mockResolvedValueOnce(none())
       .mockResolvedValueOnce({ status: AcEdPromptStatus.Cancel })
 
     await cmd.execute(context)
 
-    expect(getKeywords).toHaveBeenCalledTimes(4)
+    expect(getKeywords).toHaveBeenCalledTimes(5)
     expect(AcApHtmlConvertor).not.toHaveBeenCalled()
   })
 
@@ -227,14 +260,19 @@ describe('AcApExportHtmlCmd prompt defaults', () => {
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
       .mockResolvedValueOnce(none())
+      .mockResolvedValueOnce(none())
 
     await cmd.execute(context)
 
-    const invisibleLayersPrompt = getKeywords.mock.calls[0][0]
-    const layoutsPrompt = getKeywords.mock.calls[1][0]
-    const initialViewPrompt = getKeywords.mock.calls[2][0]
-    const viewerModePrompt = getKeywords.mock.calls[3][0]
+    const exportFormatPrompt = getKeywords.mock.calls[0][0]
+    const invisibleLayersPrompt = getKeywords.mock.calls[1][0]
+    const layoutsPrompt = getKeywords.mock.calls[2][0]
+    const initialViewPrompt = getKeywords.mock.calls[3][0]
+    const viewerModePrompt = getKeywords.mock.calls[4][0]
 
+    expect(exportFormatPrompt.keywords.default).toEqual(
+      expect.objectContaining({ global: 'Single' })
+    )
     expect(invisibleLayersPrompt.keywords.default).toEqual(
       expect.objectContaining({ global: 'Yes' })
     )

--- a/packages/cad-html-plugin/__tests__/AcExMeshTextureExport.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExMeshTextureExport.spec.ts
@@ -1,0 +1,123 @@
+/** @jest-environment jsdom */
+
+// Value import after the polyfill: `@mlightcad/data-model` needs TextDecoder in jsdom.
+import { TextDecoder, TextEncoder } from 'util'
+Object.assign(globalThis, { TextDecoder, TextEncoder })
+
+import * as THREE from 'three'
+
+import { readMeshBatch, writeMeshBatch } from '../src/AcExBatchBinaryCodec'
+import { AcExBinaryReader, AcExBinaryWriter } from '../src/AcExBinaryIO'
+import {
+  exportUvsForPositionSlice,
+  isTransparentImagePlaceholder
+} from '../src/AcExMeshTextureExport'
+import { decodeSnapshot, encodeSnapshot } from '../src/AcExSnapshotCodec'
+import { ACEX_SNAPSHOT_VERSION } from '../src/AcExSnapshotTypes'
+
+describe('AcEx mesh texture export', () => {
+  it('round-trips uvs + png texture through the binary mesh codec', () => {
+    const png = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10, 0, 1, 2, 3])
+    const writer = new AcExBinaryWriter()
+    writeMeshBatch(writer, {
+      layer: '0',
+      color: 0xffffff,
+      offset: [1, 2, 0],
+      positions: Float32Array.from([0, 0, 0, 10, 0, 0, 10, 5, 0, 0, 5, 0]),
+      indices: Uint32Array.from([0, 1, 2, 0, 2, 3]),
+      uvs: Float32Array.from([0, 0, 1, 0, 1, 1, 0, 1]),
+      texture: { mimeType: 'image/png', bytes: png },
+      side: THREE.DoubleSide
+    })
+
+    const decoded = readMeshBatch(new AcExBinaryReader(writer.toUint8Array()))
+    expect(decoded.uvs).toEqual(Float32Array.from([0, 0, 1, 0, 1, 1, 0, 1]))
+    expect(decoded.texture?.mimeType).toBe('image/png')
+    expect(Array.from(decoded.texture?.bytes ?? [])).toEqual(Array.from(png))
+  })
+
+  it('round-trips a textured mesh through encodeSnapshot', () => {
+    const snapshot = {
+      version: ACEX_SNAPSHOT_VERSION,
+      meta: {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        extents: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        units: {
+          insunits: 4,
+          lunits: 2,
+          luprec: 4,
+          aunits: 0,
+          auprec: 0,
+          measurement: 1,
+          ltscale: 1,
+          angbase: 0,
+          angdir: 0
+        },
+        background: 0
+      },
+      layers: [{ name: '0', color: 0xffffff, visible: true }],
+      layouts: [
+        {
+          btrId: 'ms',
+          name: '*Model_Space',
+          isModelSpace: true,
+          lineBatches: [],
+          meshBatches: [
+            {
+              layer: '0',
+              color: 0xffffff,
+              offset: [0, 0, 0] as [number, number, number],
+              positions: Float32Array.from([0, 0, 0, 1, 0, 0, 1, 1, 0]),
+              indices: Uint32Array.from([0, 1, 2]),
+              uvs: Float32Array.from([0, 0, 1, 0, 1, 1]),
+              texture: {
+                mimeType: 'image/png',
+                bytes: Uint8Array.from([1, 2, 3, 4])
+              }
+            }
+          ]
+        }
+      ],
+      activeLayoutBtrId: 'ms'
+    }
+
+    const decoded = decodeSnapshot(encodeSnapshot(snapshot).payload)
+    const mesh = decoded.layouts[0]!.meshBatches[0]!
+    expect(mesh.uvs?.length).toBe(6)
+    expect(Array.from(mesh.texture!.bytes)).toEqual([1, 2, 3, 4])
+  })
+
+  it('exports uvs trimmed to the position vertex count', () => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(new Float32Array(12), 3)
+    )
+    geometry.setAttribute(
+      'uv',
+      new THREE.BufferAttribute(new Float32Array([0, 0, 1, 0, 1, 1, 0, 1, 9, 9]), 2)
+    )
+    const uvs = exportUvsForPositionSlice(
+      geometry,
+      new Float32Array(12) // 4 vertices
+    )
+    expect(uvs).toEqual(Float32Array.from([0, 0, 1, 0, 1, 1, 0, 1]))
+  })
+
+  it('detects transparent IMAGE/OLE placeholders without a map', () => {
+    expect(
+      isTransparentImagePlaceholder(
+        new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
+      )
+    ).toBe(true)
+    expect(
+      isTransparentImagePlaceholder(
+        new THREE.MeshBasicMaterial({
+          map: new THREE.Texture(),
+          transparent: true,
+          opacity: 1
+        })
+      )
+    ).toBe(false)
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExOsnapCatalogCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapCatalogCodec.spec.ts
@@ -1,0 +1,131 @@
+import {
+  decodeOsnapCatalogGzip,
+  encodeOsnapCatalogBinary,
+  encodeOsnapCatalogGzip,
+  splitOsnapPrimitives
+} from '../src/AcExOsnapCatalogCodec'
+import type { AcExOsnapCatalog } from '../src/AcExOsnapPrimitiveTypes'
+
+describe('AcExOsnapCatalogCodec', () => {
+  it('round-trips mixed primitive kinds through ACEO gzip', () => {
+    const catalog: AcExOsnapCatalog = {
+      primitives: [
+        { kind: 'line', layer: '0', x0: 1, y0: 2, x1: 3, y1: 4 },
+        { kind: 'circle', layer: 'L1', cx: 0, cy: 0, r: 5, normalSign: -1 },
+        {
+          kind: 'arc',
+          layer: 'L1',
+          cx: 1,
+          cy: 1,
+          r: 2,
+          startAngle: 0,
+          endAngle: Math.PI,
+          normalSign: 1
+        },
+        {
+          kind: 'ellipse',
+          layer: '0',
+          cx: 0,
+          cy: 0,
+          majorX: 1,
+          majorY: 0,
+          majorR: 4,
+          minorR: 2,
+          startAngle: 0,
+          endAngle: Math.PI * 2,
+          closed: true,
+          normalSign: 1
+        },
+        {
+          kind: 'spline',
+          layer: 'S',
+          controlPoints: [0, 0, 1, 1, 2, 0],
+          degree: 2,
+          knots: [0, 0, 0, 1, 1, 1],
+          weights: [1, 1, 1],
+          closed: false,
+          fitPoints: [0, 0, 2, 0]
+        },
+        { kind: 'point', layer: '0', x: 9, y: 8 }
+      ]
+    }
+
+    const { compressed } = encodeOsnapCatalogGzip(catalog)
+    expect(compressed[0]).toBe(0x1f)
+    expect(compressed[1]).toBe(0x8b)
+
+    const decoded = decodeOsnapCatalogGzip(compressed)
+    expect(decoded).toEqual(catalog)
+  })
+
+  it('is much smaller than JSON for dense line catalogs', () => {
+    const primitives = Array.from({ length: 2000 }, (_, i) => ({
+      kind: 'line' as const,
+      layer: i % 2 === 0 ? 'A' : 'B',
+      x0: i,
+      y0: i + 0.5,
+      x1: i + 1,
+      y1: i + 1.5
+    }))
+    const catalog: AcExOsnapCatalog = { primitives }
+    const jsonBytes = Buffer.byteLength(JSON.stringify(catalog))
+    const binaryBytes = encodeOsnapCatalogBinary(catalog).byteLength
+    expect(binaryBytes).toBeLessThan(jsonBytes * 0.6)
+  })
+
+  it('splits dense catalogs into multiple slices', () => {
+    const primitives = Array.from({ length: 100 }, (_, i) => ({
+      kind: 'line' as const,
+      layer: '0',
+      x0: i,
+      y0: 0,
+      x1: i + 1,
+      y1: 1
+    }))
+    const slices = splitOsnapPrimitives(primitives, 200)
+    expect(slices.length).toBeGreaterThan(1)
+    expect(slices.reduce((n, s) => n + s.length, 0)).toBe(100)
+  })
+})
+
+describe('AcExOsnapIndex.rebuildAsync', () => {
+  it('bulk-loads RBush after building entries in yieldable batches', async () => {
+    const { AcExOsnapIndex } = await import('../src/AcExOsnap')
+    const primitives = Array.from({ length: 6000 }, (_, i) => ({
+      kind: 'line' as const,
+      layer: '0',
+      x0: i,
+      y0: 0,
+      x1: i + 1,
+      y1: 1
+    }))
+    let yields = 0
+    const index = new AcExOsnapIndex()
+    const loadSpy = jest.spyOn(
+      (index as unknown as { primitiveTree: { load: (e: unknown) => void } })
+        .primitiveTree,
+      'load'
+    )
+    await index.rebuildAsync(
+      {
+        btrId: 'ms',
+        name: 'Model',
+        isModelSpace: true,
+        lineBatches: [],
+        meshBatches: [],
+        osnap: { primitives }
+      },
+      async () => {
+        yields += 1
+      }
+    )
+    expect(yields).toBeGreaterThan(0)
+    expect(loadSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (loadSpy.mock.calls[0]![0] as unknown[]).length
+    ).toBe(6000)
+    const snap = index.findSnap(10.1, 0.1, 2)
+    expect(snap).toBeTruthy()
+    loadSpy.mockRestore()
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExPackage.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPackage.spec.ts
@@ -1,0 +1,343 @@
+import { strFromU8, zipSync } from 'fflate'
+
+import { buildAcExPackage, splitLayoutIntoSlices } from '../src/AcExPackageBuilder'
+import {
+  decodeChunkGzip,
+  encodeChunkGzip
+} from '../src/AcExChunkBinaryCodec'
+import {
+  isSafePackageHref,
+  loadAcExPackage,
+  parseAcExPackageManifest,
+  resolveChunkUrl,
+  resolvePackageManifestUrl,
+  snapshotSkeletonFromManifest
+} from '../src/AcExPackageLoader'
+import {
+  unzipAcExPackageFiles,
+  zipAcExPackageFiles
+} from '../src/AcExPackageZip'
+import { ACEX_SNAPSHOT_VERSION } from '../src/AcExSnapshotTypes'
+import type { AcExSnapshot } from '../src/AcExSnapshotTypes'
+
+function f32(values: number[]): Float32Array {
+  return Float32Array.from(values)
+}
+
+function makeSnapshot(): AcExSnapshot {
+  return {
+    version: ACEX_SNAPSHOT_VERSION,
+    meta: {
+      title: 'demo',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      extents: { minX: 0, minY: 0, maxX: 100, maxY: 50 },
+      viewExtents: { minX: 0, minY: 0, maxX: 100, maxY: 50 },
+      units: {
+        insunits: 4,
+        lunits: 2,
+        luprec: 4,
+        aunits: 0,
+        auprec: 0,
+        measurement: 1,
+        ltscale: 1,
+        angbase: 0,
+        angdir: 0
+      },
+      background: 0,
+      viewerMode: 'view',
+      exportLayouts: true
+    },
+    layers: [{ name: '0', color: 0xffffff, visible: true }],
+    layouts: [
+      {
+        btrId: 'ms',
+        name: '*Model_Space',
+        isModelSpace: true,
+        lineBatches: [
+          {
+            layer: '0',
+            color: 0xff0000,
+            offset: [0, 0, 0],
+            positions: f32([0, 0, 0, 10, 0, 0])
+          },
+          {
+            layer: '0',
+            color: 0x00ff00,
+            offset: [0, 0, 0],
+            positions: f32([0, 0, 0, 0, 10, 0])
+          }
+        ],
+        meshBatches: [
+          {
+            layer: '0',
+            color: 0x0000ff,
+            offset: [0, 0, 0],
+            positions: f32([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+            indices: Uint32Array.from([0, 1, 2])
+          }
+        ]
+      },
+      {
+        btrId: 'ps',
+        name: 'Layout1',
+        isModelSpace: false,
+        lineBatches: [
+          {
+            layer: '0',
+            color: 0xffffff,
+            offset: [0, 0, 0],
+            positions: f32([0, 0, 0, 5, 5, 0])
+          }
+        ],
+        meshBatches: []
+      }
+    ],
+    activeLayoutBtrId: 'ms'
+  }
+}
+
+describe('AcEx package format', () => {
+  it('round-trips a geometry chunk through gzip', () => {
+    const chunk = {
+      version: ACEX_SNAPSHOT_VERSION,
+      layoutBtrId: 'ms',
+      lineBatches: [
+        {
+          layer: '0',
+          color: 1,
+          offset: [1, 2, 3] as [number, number, number],
+          positions: f32([0, 0, 0, 1, 1, 0])
+        }
+      ],
+      meshBatches: []
+    }
+    const { compressed } = encodeChunkGzip(chunk)
+    const decoded = decodeChunkGzip(compressed)
+    expect(decoded.layoutBtrId).toBe('ms')
+    expect(decoded.lineBatches[0]?.positions).toEqual(chunk.lineBatches[0]!.positions)
+  })
+
+  it('splits oversized layouts into multiple slices', () => {
+    const layout = makeSnapshot().layouts[0]!
+    const slices = splitLayoutIntoSlices(layout, 400)
+    expect(slices.length).toBeGreaterThan(1)
+    const lineCount = slices.reduce((n, s) => n + s.lineBatches.length, 0)
+    const meshCount = slices.reduce((n, s) => n + s.meshBatches.length, 0)
+    expect(lineCount).toBe(layout.lineBatches.length)
+    expect(meshCount).toBe(layout.meshBatches.length)
+  })
+
+  it('builds a package and restores geometry via progressive fetch', async () => {
+    const snapshot = makeSnapshot()
+    const pkg = buildAcExPackage(snapshot, {
+      viewerRuntime: '/* runtime */',
+      baseName: 'demo',
+      maxChunkBytes: 400
+    })
+
+    expect(pkg.manifest.format).toBe('acex-package')
+    expect(pkg.manifest.packageVersion).toBe(1)
+    expect(pkg.html).toContain('id="mlcad-package"')
+    expect(pkg.html).toContain('demo.acex.json')
+    expect(pkg.files.some(f => f.path === 'viewer.html')).toBe(true)
+    expect(pkg.files.some(f => f.path === 'demo.acex.json')).toBe(true)
+    expect(pkg.manifest.chunks.length).toBeGreaterThan(1)
+
+    const fileMap = new Map(pkg.files.map(f => [f.path, f.bytes]))
+    const fetchImpl: typeof fetch = async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const path =
+        [...fileMap.keys()].find(
+          key => url === key || url.endsWith(`/${key}`) || url.endsWith(key)
+        ) ?? null
+      const bytes = path ? fileMap.get(path) : undefined
+      if (!bytes || !path) {
+        return new Response(null, { status: 404 })
+      }
+      if (path.endsWith('.json')) {
+        return new Response(strFromU8(bytes), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      // Copy into a fresh ArrayBuffer so Response accepts the body type.
+      const copy = new Uint8Array(bytes.byteLength)
+      copy.set(bytes)
+      return new Response(copy, { status: 200 })
+    }
+
+    const progresses: number[] = []
+    const loaded = await loadAcExPackage({
+      manifestUrl: 'https://cdn.example/demo.acex.json',
+      fetchImpl,
+      onChunk: (_layout, _chunk, progress) => {
+        progresses.push(progress.loadedChunks)
+      }
+    })
+
+    expect(progresses.length).toBe(pkg.manifest.chunks.length)
+    expect(loaded.layouts[0]?.lineBatches.length).toBe(
+      snapshot.layouts[0]!.lineBatches.length
+    )
+    expect(loaded.layouts[0]?.meshBatches.length).toBe(
+      snapshot.layouts[0]!.meshBatches.length
+    )
+    expect(loaded.layouts[1]?.lineBatches.length).toBe(1)
+  })
+
+  it('zips and unzips package files without loss', () => {
+    const pkg = buildAcExPackage(makeSnapshot(), {
+      viewerRuntime: '/* runtime */',
+      baseName: 'demo'
+    })
+    const zipped = zipAcExPackageFiles(pkg)
+    const unzipped = unzipAcExPackageFiles(zipped)
+    expect(unzipped.map(f => f.path).sort()).toEqual(
+      pkg.files.map(f => f.path).sort()
+    )
+    for (const file of unzipped) {
+      const original = pkg.files.find(f => f.path === file.path)!
+      expect(Array.from(file.bytes)).toEqual(Array.from(original.bytes))
+    }
+  })
+
+  it('parses manifest and builds an empty skeleton', () => {
+    const pkg = buildAcExPackage(makeSnapshot(), {
+      viewerRuntime: '/* runtime */',
+      baseName: 'demo'
+    })
+    const manifest = parseAcExPackageManifest(pkg.manifest)
+    const skeleton = snapshotSkeletonFromManifest(manifest)
+    expect(skeleton.layouts[0]?.lineBatches).toEqual([])
+    expect(skeleton.layouts[0]?.osnap).toBeUndefined()
+    expect(skeleton.activeLayoutBtrId).toBe('ms')
+  })
+
+  it('rejects unsafe package hrefs and absolute chunk URLs', () => {
+    expect(isSafePackageHref('./demo.acex.json')).toBe(true)
+    expect(isSafePackageHref('chunks/L0-000.acex.gz')).toBe(true)
+    expect(isSafePackageHref('https://evil.example/x')).toBe(false)
+    expect(isSafePackageHref('../escape.acex.gz')).toBe(false)
+    expect(isSafePackageHref('/abs.acex.gz')).toBe(false)
+
+    expect(() =>
+      resolveChunkUrl('https://cdn.example/pkg/demo.acex.json', 'chunks/a.acex.gz')
+    ).not.toThrow()
+    expect(() =>
+      resolveChunkUrl(
+        'https://cdn.example/pkg/demo.acex.json',
+        'https://evil.example/x'
+      )
+    ).toThrow(/relative package path/)
+    expect(() =>
+      resolveChunkUrl('https://cdn.example/pkg/demo.acex.json', '../x.acex.gz')
+    ).toThrow(/relative package path/)
+
+    expect(
+      resolvePackageManifestUrl('./demo.acex.json', 'https://cdn.example/pkg/viewer.html')
+    ).toBe('https://cdn.example/pkg/demo.acex.json')
+    expect(() =>
+      resolvePackageManifestUrl(
+        'https://evil.example/demo.acex.json',
+        'https://cdn.example/pkg/viewer.html'
+      )
+    ).toThrow(/relative package path/)
+
+    const pkg = buildAcExPackage(makeSnapshot(), {
+      viewerRuntime: '/* runtime */',
+      baseName: 'demo'
+    })
+    const evil = {
+      ...pkg.manifest,
+      chunks: [
+        {
+          ...pkg.manifest.chunks[0]!,
+          href: 'https://evil.example/chunk.acex.gz'
+        }
+      ]
+    }
+    expect(() => parseAcExPackageManifest(evil)).toThrow(/chunk href/)
+  })
+
+  it('rejects zip-slip paths when unzipping', () => {
+    const evil = zipSync({
+      'chunks/ok.acex.gz': new Uint8Array([1, 2, 3]),
+      '../escape.txt': new Uint8Array([4, 5, 6])
+    })
+    expect(() => unzipAcExPackageFiles(evil)).toThrow(/Unsafe path/)
+  })
+
+  it('stores OSNAP as multiple gzip ACEO chunks loaded after geometry', async () => {
+    const snapshot = makeSnapshot()
+    snapshot.meta.viewerMode = 'measure'
+    snapshot.layouts[0]!.osnap = {
+      primitives: Array.from({ length: 40 }, (_, i) => ({
+        kind: 'line' as const,
+        layer: i % 2 === 0 ? '0' : 'A',
+        x0: i,
+        y0: 0,
+        x1: i + 1,
+        y1: 1
+      }))
+    }
+
+    const pkg = buildAcExPackage(snapshot, {
+      viewerRuntime: '/* runtime */',
+      baseName: 'demo',
+      // Force multiple OSNAP chunks (~37 bytes/line → 200 bytes ≈ several slices).
+      maxOsnapChunkBytes: 200
+    })
+
+    const layoutRef = pkg.manifest.layouts[0]!
+    expect(layoutRef.osnapChunkIds!.length).toBeGreaterThan(1)
+    expect(pkg.manifest.osnapChunks!.length).toBe(
+      layoutRef.osnapChunkIds!.length
+    )
+    expect(JSON.stringify(pkg.manifest)).not.toContain('"primitives"')
+
+    for (const id of layoutRef.osnapChunkIds!) {
+      const ref = pkg.manifest.osnapChunks!.find(c => c.id === id)!
+      const file = pkg.files.find(f => f.path === ref.href)!
+      expect(file.bytes[0]).toBe(0x1f)
+      expect(file.bytes[1]).toBe(0x8b)
+    }
+
+    const fileMap = new Map(pkg.files.map(f => [f.path, f.bytes]))
+    const fetchImpl: typeof fetch = async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const path =
+        [...fileMap.keys()].find(
+          key => url === key || url.endsWith(`/${key}`) || url.endsWith(key)
+        ) ?? null
+      const bytes = path ? fileMap.get(path) : undefined
+      if (!bytes || !path) {
+        return new Response(null, { status: 404 })
+      }
+      if (path.endsWith('.json')) {
+        return new Response(strFromU8(bytes), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      const copy = new Uint8Array(bytes.byteLength)
+      copy.set(bytes)
+      return new Response(copy, { status: 200 })
+    }
+
+    const geometryOnly = await loadAcExPackage({
+      manifestUrl: 'https://cdn.example/demo.acex.json',
+      fetchImpl,
+      loadOsnap: false
+    })
+    expect(geometryOnly.layouts[0]?.osnap).toBeUndefined()
+    expect(geometryOnly.layouts[0]?.lineBatches.length).toBeGreaterThan(0)
+
+    const loaded = await loadAcExPackage({
+      manifestUrl: 'https://cdn.example/demo.acex.json',
+      fetchImpl
+    })
+    expect(loaded.layouts[0]?.osnap?.primitives).toEqual(
+      snapshot.layouts[0]!.osnap!.primitives
+    )
+  })
+})

--- a/packages/cad-html-plugin/docs/acex-package-format.md
+++ b/packages/cad-html-plugin/docs/acex-package-format.md
@@ -1,0 +1,188 @@
+# ACEX multi-file package format
+
+Display-only render data for the offline HTML viewer, split so a shell page can
+download geometry **progressively** (fetch one compressed chunk, decompress,
+paint, repeat).
+
+> **Export zip vs hosted files**  
+> CAD export may download a single `.zip` that contains the package directory.
+> That zip is for **distribution only**. Unzip before hosting. The offline
+> viewer does **not** open a zip in place; it fetches `viewer.html`, then
+> `*.acex.json`, then individual `chunks/*.acex.gz` files.
+
+## Directory layout
+
+```text
+drawing/
+  viewer.html                 # HTML/CSS/JS shell only
+  drawing.acex.json           # package manifest (small metadata + indexes)
+  chunks/
+    L0-000.acex.gz            # gzip ACEC geometry (binary, not base64)
+    L0-001.acex.gz
+    L0-osnap-000.osnap.gz     # gzip ACEO OSNAP slice (measure mode)
+    L0-osnap-001.osnap.gz
+    L1-000.acex.gz
+```
+
+### Shell HTML
+
+Contains `#mlcad-package` (JSON) instead of an embedded snapshot:
+
+```html
+<script id="mlcad-package" type="application/json">
+{"manifestUrl":"./drawing.acex.json"}
+</script>
+```
+
+`manifestUrl` may be relative to the HTML file or an absolute CDN URL.
+
+## Versioning
+
+| Field | Where | Meaning |
+|-------|--------|---------|
+| `packageVersion` | manifest | Package / protocol version. Current: **1**. |
+| `snapshotVersion` | manifest + ACEC header | Batch schema version. Matches `ACEX_SNAPSHOT_VERSION` (currently **4**). |
+
+Bump `packageVersion` for breaking manifest changes. Bump `snapshotVersion` for
+breaking batch / ACEC changes. Decoders must reject unsupported versions.
+
+OSNAP catalogs are **not** inlined in the JSON manifest. They ship as optional
+`chunks/L{n}-osnap-{slice}.osnap.gz` binary sidecars so the manifest stays small
+and first paint never waits on snap data.
+
+## Manifest (`*.acex.json`)
+
+MIME: `application/json`
+
+```json
+{
+  "format": "acex-package",
+  "packageVersion": 1,
+  "snapshotVersion": 4,
+  "meta": { "...": "same shape as AcExSnapshot.meta" },
+  "layers": [{ "name": "0", "color": 16777215, "visible": true }],
+  "activeLayoutBtrId": "...",
+  "layouts": [
+    {
+      "btrId": "...",
+      "name": "*Model_Space",
+      "isModelSpace": true,
+      "viewports": null,
+      "chunkIds": ["L0-000", "L0-001"],
+      "osnapChunkIds": ["L0-osnap-000", "L0-osnap-001"]
+    }
+  ],
+  "chunks": [
+    {
+      "id": "L0-000",
+      "href": "chunks/L0-000.acex.gz",
+      "layoutBtrId": "...",
+      "byteLength": 12345,
+      "compressedByteLength": 4000,
+      "lineBatchCount": 12,
+      "meshBatchCount": 3
+    }
+  ],
+  "osnapChunks": [
+    {
+      "id": "L0-osnap-000",
+      "href": "chunks/L0-osnap-000.osnap.gz",
+      "layoutBtrId": "...",
+      "byteLength": 500000,
+      "compressedByteLength": 120000,
+      "primitiveCount": 12000
+    }
+  ]
+}
+```
+
+Notes:
+
+- Geometry and OSNAP catalogs are **not** inlined in the manifest.
+- `chunks` is ordered with the active layout’s geometry first (first-paint hint).
+- `osnapChunks` / `osnapChunkIds` are omitted for view-only exports.
+- Optional `sha256` on chunk refs is reserved; loaders may ignore it.
+- Unknown JSON fields must be ignored by readers (forward compatible).
+
+## Geometry chunk (`*.acex.gz`)
+
+Each file is **raw gzip** of one **ACEC** binary payload (not base64, not a
+multi-entry zip archive). File magic after gunzip is `ACEC` (`0x43454341`).
+
+### ACEC binary (little-endian)
+
+| Offset / field | Type | Description |
+|----------------|------|-------------|
+| magic | `u32` | `0x43454341` (`ACEC`) |
+| version | `u8` | `snapshotVersion` |
+| reserved | `u8` × 3 | Must be `0`; ignore on read |
+| layoutBtrId | length-prefixed UTF-8 | Owning layout |
+| lineBatchCount | `u32` | |
+| line batches | … | Same encoding as ACEX snapshot batches |
+| meshBatchCount | `u32` | |
+| mesh batches | … | Same encoding as ACEX snapshot batches |
+
+Batch records reuse the ACEX feature-flag scheme (`F_LINE_*`, `F_MESH_*`):
+
+- **Append-only flags** — never renumber existing bits.
+- Readers **ignore unknown flag bits** only when those bits carry no payload; new payload-bearing flags require a `snapshotVersion` bump.
+- Geometry buffers are length-prefixed `Float32` / `Uint32` arrays, 4-byte aligned.
+- **v4** `F_MESH_TEXTURE` (128): after other mesh flag payloads, writes `uvs` (`Float32Array`), MIME string, then raw image bytes (length-prefixed). Used for raster IMAGE and OLE frames.
+
+### Geometry chunking rules
+
+1. Split primarily **by layout**.
+2. If a layout’s estimated uncompressed size exceeds ~512 KiB, split further by
+   batch groups into `L{layoutIndex}-{slice:000}`.
+3. Empty layouts still emit one empty chunk so the layout remains addressable.
+
+## OSNAP chunk (`*-osnap-*.osnap.gz`)
+
+Each file is **raw gzip** of one **ACEO** binary payload (measure-mode exports).
+Coordinates are IEEE-754 **float64**; layer names are dictionary-compressed.
+Large catalogs are split (~512 KiB estimated uncompressed per file) so hosts can
+fetch snap slices in **parallel** after the drawing is already visible.
+
+### ACEO binary (little-endian)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| magic | `u32` | `0x4F454341` (`ACEO`) |
+| version | `u8` | Currently **1** |
+| reserved | `u8` × 3 | Must be `0` |
+| layerCount | `u32` | |
+| layers | strings | Length-prefixed UTF-8 dictionary |
+| primitiveCount | `u32` | |
+| primitives | … | kind `u8` + layer index `u32` + kind-specific f64 fields |
+
+Kind codes: `1` line, `2` circle, `3` arc, `4` ellipse, `5` spline, `6` point.
+
+### OSNAP chunking rules
+
+1. Split by layout, then by estimated ACEO size into `L{layoutIndex}-osnap-{slice:000}`.
+2. Each slice is a self-contained ACEO catalog (own layer dictionary).
+3. Loaders concatenate primitives in `osnapChunkIds` order.
+
+## Loading sequence
+
+1. Open `viewer.html`.
+2. Read `#mlcad-package` → `GET` manifest (small JSON).
+3. Initialize viewer chrome from `meta` / `layers` (extents, layer panel).
+4. For the active layout (and model space when paper viewports need it):
+   `GET` each geometry `href` → gunzip → decode ACEC → append batches → paint → yield.
+5. Drawing is usable for pan/zoom. **Then** (measure mode only): fetch all
+   `osnapChunks` for that layout **in parallel** → gunzip → decode ACEO →
+   concatenate → rebuild snap index.
+6. Load remaining layouts lazily when the user switches layout (geometry first,
+   OSNAP last).
+
+## Relationship to single-file HTML
+
+Self-contained HTML still embeds one gzip+base64 **ACEX** snapshot
+(`magic 0x58454341`). Multi-file packages share the same batch schema
+(`snapshotVersion`) but ship geometry as ACEC chunks plus a JSON manifest.
+OSNAP in single-file HTML remains inside the ACEX snapshot; only the multi-file
+package splits it into ACEO sidecars.
+
+Password / expiry protection applies to **single-file** export only in the
+current product UI.

--- a/packages/cad-html-plugin/package.json
+++ b/packages/cad-html-plugin/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist",
     "lib",
+    "docs",
     "README.md",
     "package.json"
   ],

--- a/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
+++ b/packages/cad-html-plugin/src/AcApExportHtmlCmd.ts
@@ -54,6 +54,11 @@ export class AcApExportHtmlCmd extends AcEdCommand {
   private async promptOptions(): Promise<AcApHtmlExportOptions | undefined> {
     const defaults = resolveAcApHtmlExportOptions()
 
+    const exportFormat = await this.promptExportFormat()
+    if (exportFormat === undefined) {
+      return undefined
+    }
+
     const exportInvisibleLayers = await this.promptYesNo(
       'jig.chtml.exportInvisibleLayers',
       defaults.exportInvisibleLayers
@@ -81,11 +86,52 @@ export class AcApExportHtmlCmd extends AcEdCommand {
     }
 
     return resolveAcApHtmlExportOptions({
+      exportFormat,
       exportInvisibleLayers,
       exportLayouts,
       initialView,
       viewerMode
     })
+  }
+
+  private async promptExportFormat(): Promise<
+    AcApHtmlExportOptions['exportFormat'] | undefined
+  > {
+    const defaults = resolveAcApHtmlExportOptions()
+    const prompt = new AcEdPromptKeywordOptions(
+      AcApI18n.t('jig.chtml.exportFormat')
+    )
+    prompt.allowNone = true
+    const single = prompt.keywords.add(
+      AcApI18n.t('jig.chtml.keywords.single.display'),
+      AcApI18n.t('jig.chtml.keywords.single.global'),
+      AcApI18n.t('jig.chtml.keywords.single.local')
+    )
+    const multi = prompt.keywords.add(
+      AcApI18n.t('jig.chtml.keywords.multi.display'),
+      AcApI18n.t('jig.chtml.keywords.multi.global'),
+      AcApI18n.t('jig.chtml.keywords.multi.local')
+    )
+    prompt.keywords.default =
+      defaults.exportFormat === 'multi' ? multi : single
+
+    const result = await AcApDocManager.instance.editor.getKeywords(prompt)
+    if (result.status === AcEdPromptStatus.Cancel) {
+      return undefined
+    }
+    if (result.status === AcEdPromptStatus.None) {
+      return defaults.exportFormat
+    }
+    if (
+      result.status === AcEdPromptStatus.OK ||
+      result.status === AcEdPromptStatus.Keyword
+    ) {
+      if (!result.stringResult) {
+        return defaults.exportFormat
+      }
+      return result.stringResult === 'Multi' ? 'multi' : 'single'
+    }
+    return undefined
   }
 
   private async promptYesNo(

--- a/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlConvertor.ts
@@ -22,16 +22,19 @@ import {
   resolveAcApHtmlExpiresAt
 } from './AcExHtmlAccess'
 import { packHtml } from './AcExHtmlPackager'
+import { buildAcExPackage } from './AcExPackageBuilder'
+import { zipAcExPackageFiles } from './AcExPackageZip'
 import { encodeSnapshot } from './AcExSnapshotCodec'
 import type { AcExSnapshot } from './AcExSnapshotTypes'
 
 /**
- * Orchestrates export of the active drawing to a downloadable HTML file.
+ * Orchestrates export of the active drawing to a downloadable HTML file
+ * or multi-file ACEX package zip.
  *
  * Workflow:
  * 1. Build a display-only {@link AcExSnapshot} from the current scene and database.
  * 2. Fetch the IIFE viewer runtime (inlined into the HTML).
- * 3. Package snapshot + runtime via `packHtml` and trigger a browser download.
+ * 3. Package as self-contained HTML (`single`) or zip of package files (`multi`).
  *
  * A busy indicator is shown for the duration of the operation. The UI thread
  * is yielded between heavy steps so the browser can repaint.
@@ -86,10 +89,8 @@ export class AcApHtmlConvertor {
    * Exports the document currently open in {@link AcApDocManager}.
    *
    * @param fileName - Optional base name for the download (without extension).
-   *   When omitted, the active document's `fileName` is used. A `.html` suffix
-   *   is always applied; `.dwg` / `.dxf` suffixes on the input are stripped.
-   * @param options - Export options such as invisible-layer inclusion, layout
-   *   inclusion, and initial view.
+   *   When omitted, the active document's `fileName` is used.
+   * @param options - Export options including {@link AcApHtmlExportOptions.exportFormat}.
    * @param view - Optional view to export from. Defaults to the active view.
    * @returns Resolves when packaging and download complete.
    */
@@ -111,11 +112,12 @@ export class AcApHtmlConvertor {
       )
 
       const sourceName = fileName || document.fileName || document.docTitle
+      const baseName = getDrawingExportBaseName(sourceName)
       const snapshot = await this._snapshotBuilder.buildAsync(
         exportView.cadScene,
         document.database,
         {
-          title: getDrawingExportBaseName(sourceName),
+          title: baseName,
           background: exportView.backgroundColor,
           exportInvisibleLayers: resolved.exportInvisibleLayers,
           exportLayouts: resolved.exportLayouts,
@@ -135,6 +137,21 @@ export class AcApHtmlConvertor {
       const viewerRuntime = await this.loadViewerRuntime()
 
       await accmYieldForPaint()
+
+      if (resolved.exportFormat === 'multi') {
+        const pkg = buildAcExPackage(snapshot, {
+          viewerRuntime,
+          baseName
+        })
+        const zipBytes = zipAcExPackageFiles(pkg)
+        await accmYieldForPaint()
+        this.downloadBytes(
+          zipBytes,
+          resolveExportDownloadName(sourceName, 'zip'),
+          'application/zip'
+        )
+        return
+      }
 
       const expiresAt = resolveAcApHtmlExpiresAt(
         resolved.expiryDays,
@@ -168,7 +185,7 @@ export class AcApHtmlConvertor {
    * Skips scene collection; useful for tests, CLI tooling, or re-exporting a
    * snapshot produced elsewhere.
    *
-   * @param snapshot - Complete v1 snapshot to embed in the HTML.
+   * @param snapshot - Complete snapshot to embed in the HTML.
    * @param downloadName - File name passed to the browser download API (should
    *   include the `.html` extension).
    * @returns Resolves when packaging and download complete.
@@ -221,7 +238,24 @@ export class AcApHtmlConvertor {
    * @param downloadName - Value for the anchor `download` attribute.
    */
   private downloadHtml(content: string, downloadName: string) {
-    const blob = new Blob([content], { type: 'text/html;charset=utf-8' })
+    this.downloadBytes(
+      new TextEncoder().encode(content),
+      downloadName,
+      'text/html;charset=utf-8'
+    )
+  }
+
+  /**
+   * Triggers a client-side download of raw bytes.
+   */
+  private downloadBytes(
+    bytes: Uint8Array,
+    downloadName: string,
+    mimeType: string
+  ) {
+    const copy = new Uint8Array(bytes.byteLength)
+    copy.set(bytes)
+    const blob = new Blob([copy], { type: mimeType })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url

--- a/packages/cad-html-plugin/src/AcApHtmlExportOptions.ts
+++ b/packages/cad-html-plugin/src/AcApHtmlExportOptions.ts
@@ -13,9 +13,22 @@ export type { AcApHtmlExpiryDays } from './AcExHtmlAccess'
 const HTML_VIEWER_CAMERA_FRUSTUM = 400
 
 /**
+ * HTML export packaging mode.
+ *
+ * - `single` — one self-contained `.html` with embedded snapshot (default).
+ * - `multi` — multi-file ACEX package zipped as one `.zip` download; unzip before hosting.
+ */
+export type AcApHtmlExportFormat = 'single' | 'multi'
+
+/**
  * User-configurable options for HTML export (`-chtml`, dialog, and CLI).
  */
 export interface AcApHtmlExportOptions {
+  /**
+   * Packaging mode. Defaults to `'single'`.
+   * Password and expiry apply only to `'single'`.
+   */
+  exportFormat?: AcApHtmlExportFormat
   /**
    * When `true`, off/frozen layers are converted and written into the snapshot.
    * Defaults to `true` for backward compatibility with pre-option HTML export.
@@ -40,16 +53,19 @@ export interface AcApHtmlExportOptions {
   /**
    * How long the exported HTML remains valid. Defaults to `'never'`.
    * Use `'custom'` with {@link AcApHtmlExportOptions.expiresAt} for an absolute time.
+   * Ignored when {@link AcApHtmlExportOptions.exportFormat} is `'multi'`.
    */
   expiryDays?: AcApHtmlExpiryDays
   /**
    * Absolute expiry timestamp (Unix ms). Used when {@link AcApHtmlExportOptions.expiryDays}
    * is `'custom'`. Ignored for relative periods and `'never'`.
+   * Ignored when {@link AcApHtmlExportOptions.exportFormat} is `'multi'`.
    */
   expiresAt?: number | null
   /**
    * Optional password required to open the exported HTML. When set, the snapshot
    * payload is encrypted in the file.
+   * Ignored when {@link AcApHtmlExportOptions.exportFormat} is `'multi'`.
    */
   password?: string
 }
@@ -66,14 +82,17 @@ export function resolveAcApHtmlExportOptions(
   expiresAt: number | null
   password: string
 } {
+  const exportFormat: AcApHtmlExportFormat =
+    options.exportFormat === 'multi' ? 'multi' : 'single'
   return {
+    exportFormat,
     exportInvisibleLayers: options.exportInvisibleLayers !== false,
     exportLayouts: options.exportLayouts !== false,
     initialView: options.initialView ?? 'fit',
     viewerMode: options.viewerMode ?? 'measure',
-    expiryDays: options.expiryDays ?? 'never',
-    expiresAt: options.expiresAt ?? null,
-    password: options.password?.trim() ?? ''
+    expiryDays: exportFormat === 'multi' ? 'never' : (options.expiryDays ?? 'never'),
+    expiresAt: exportFormat === 'multi' ? null : (options.expiresAt ?? null),
+    password: exportFormat === 'multi' ? '' : (options.password?.trim() ?? '')
   }
 }
 /**

--- a/packages/cad-html-plugin/src/AcExBatchBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExBatchBinaryCodec.ts
@@ -1,0 +1,229 @@
+import type { AcExBinaryReader, AcExBinaryWriter } from './AcExBinaryIO'
+import type { AcExLineBatch, AcExMeshBatch } from './AcExSnapshotTypes'
+
+/** Optional line-batch feature flags (append-only; never renumber). */
+export const F_LINE_INDICES = 1
+export const F_LINE_PATTERN = 2
+export const F_LINE_DISTANCES = 4
+export const F_LINE_WIDTH = 8
+export const F_LINE_RENDER_ORDER = 16
+
+/** Optional mesh-batch feature flags (append-only; never renumber). */
+export const F_MESH_INDICES = 1
+export const F_MESH_HATCH = 2
+export const F_MESH_GRADIENT_FILL = 4
+export const F_MESH_GRADIENT_POS = 8
+export const F_MESH_SIDE = 16
+export const F_MESH_POINTS = 32
+export const F_MESH_RENDER_ORDER = 64
+/** v4: uvs + embedded raster texture (IMAGE / OLE). */
+export const F_MESH_TEXTURE = 128
+
+/**
+ * Rough uncompressed payload size for chunk-size budgeting.
+ * Includes geometry buffers plus a small fixed overhead for headers/strings.
+ */
+export function estimateLineBatchBytes(batch: AcExLineBatch): number {
+  let size = 256 + batch.positions.byteLength
+  if (batch.indices) size += batch.indices.byteLength
+  if (batch.lineDistances) size += batch.lineDistances.byteLength
+  if (batch.linePattern) size += 64 + batch.linePattern.pattern.length * 8
+  return size
+}
+
+/**
+ * Rough uncompressed payload size for chunk-size budgeting.
+ */
+export function estimateMeshBatchBytes(batch: AcExMeshBatch): number {
+  let size = 256 + batch.positions.byteLength
+  if (batch.indices) size += batch.indices.byteLength
+  if (batch.gradientPositions) size += batch.gradientPositions.byteLength
+  if (batch.uvs) size += batch.uvs.byteLength
+  if (batch.texture) size += batch.texture.bytes.byteLength + 64
+  if (batch.hatchPattern) size += 128
+  if (batch.gradientFill) size += 64
+  return size
+}
+
+/** Writes one {@link AcExLineBatch} with length-prefixed buffers and feature flags. */
+export function writeLineBatch(
+  writer: AcExBinaryWriter,
+  batch: AcExLineBatch
+): void {
+  writer.writeString(batch.layer)
+  writer.writeU32(batch.color >>> 0)
+  writer.writeF64(batch.offset[0]!)
+  writer.writeF64(batch.offset[1]!)
+  writer.writeF64(batch.offset[2]!)
+  writer.writeFloat32Array(batch.positions)
+
+  let flags = 0
+  if (batch.indices && batch.indices.length > 0) flags |= F_LINE_INDICES
+  if (batch.linePattern) flags |= F_LINE_PATTERN
+  if (batch.lineDistances && batch.lineDistances.length > 0) {
+    flags |= F_LINE_DISTANCES
+  }
+  if (batch.lineWidth != null && batch.lineWidth > 0) {
+    flags |= F_LINE_WIDTH
+  }
+  if (batch.renderOrder != null && batch.renderOrder !== 0) {
+    flags |= F_LINE_RENDER_ORDER
+  }
+  writer.writeU8(flags)
+
+  if (flags & F_LINE_INDICES) {
+    writer.writeUint32Array(batch.indices!)
+  }
+  if (flags & F_LINE_PATTERN) {
+    writer.writeJson(batch.linePattern!)
+  }
+  if (flags & F_LINE_DISTANCES) {
+    writer.writeFloat32Array(batch.lineDistances!)
+  }
+  if (flags & F_LINE_WIDTH) {
+    writer.writeF32(batch.lineWidth!)
+  }
+  if (flags & F_LINE_RENDER_ORDER) {
+    writer.writeI32(batch.renderOrder!)
+  }
+}
+
+/** Reads one {@link AcExLineBatch}; unknown flag bits are ignored (reserved). */
+export function readLineBatch(reader: AcExBinaryReader): AcExLineBatch {
+  const layer = reader.readString()
+  const color = reader.readU32()
+  const offset: [number, number, number] = [
+    reader.readF64(),
+    reader.readF64(),
+    reader.readF64()
+  ]
+  const positions = reader.readFloat32Array()
+  const flags = reader.readU8()
+
+  const batch: AcExLineBatch = { layer, color, offset, positions }
+  if (flags & F_LINE_INDICES) {
+    batch.indices = reader.readUint32Array()
+  }
+  if (flags & F_LINE_PATTERN) {
+    batch.linePattern =
+      reader.readJson<NonNullable<AcExLineBatch['linePattern']>>()
+  }
+  if (flags & F_LINE_DISTANCES) {
+    batch.lineDistances = reader.readFloat32Array()
+  }
+  if (flags & F_LINE_WIDTH) {
+    batch.lineWidth = reader.readF32()
+  }
+  if (flags & F_LINE_RENDER_ORDER) {
+    batch.renderOrder = reader.readI32()
+  }
+  return batch
+}
+
+/** Writes one {@link AcExMeshBatch} with length-prefixed buffers and feature flags. */
+export function writeMeshBatch(
+  writer: AcExBinaryWriter,
+  batch: AcExMeshBatch
+): void {
+  writer.writeString(batch.layer)
+  writer.writeU32(batch.color >>> 0)
+  writer.writeF64(batch.offset[0]!)
+  writer.writeF64(batch.offset[1]!)
+  writer.writeF64(batch.offset[2]!)
+  writer.writeFloat32Array(batch.positions)
+
+  let flags = 0
+  if (batch.indices && batch.indices.length > 0) flags |= F_MESH_INDICES
+  if (batch.hatchPattern) flags |= F_MESH_HATCH
+  if (batch.gradientFill) flags |= F_MESH_GRADIENT_FILL
+  if (batch.gradientPositions && batch.gradientPositions.length > 0) {
+    flags |= F_MESH_GRADIENT_POS
+  }
+  if (batch.side != null) flags |= F_MESH_SIDE
+  if (batch.points) flags |= F_MESH_POINTS
+  if (batch.renderOrder != null && batch.renderOrder !== 0) {
+    flags |= F_MESH_RENDER_ORDER
+  }
+  if (
+    batch.texture &&
+    batch.texture.bytes.length > 0 &&
+    batch.uvs &&
+    batch.uvs.length >= 2
+  ) {
+    flags |= F_MESH_TEXTURE
+  }
+  writer.writeU8(flags)
+
+  if (flags & F_MESH_INDICES) {
+    writer.writeUint32Array(batch.indices!)
+  }
+  if (flags & F_MESH_HATCH) {
+    writer.writeJson(batch.hatchPattern!)
+  }
+  if (flags & F_MESH_GRADIENT_FILL) {
+    writer.writeJson(batch.gradientFill!)
+  }
+  if (flags & F_MESH_GRADIENT_POS) {
+    writer.writeFloat32Array(batch.gradientPositions!)
+  }
+  if (flags & F_MESH_SIDE) {
+    writer.writeU8(batch.side!)
+  }
+  if (flags & F_MESH_RENDER_ORDER) {
+    writer.writeI32(batch.renderOrder!)
+  }
+  if (flags & F_MESH_TEXTURE) {
+    writer.writeFloat32Array(batch.uvs!)
+    writer.writeString(batch.texture!.mimeType || 'image/png')
+    writer.writeU32(batch.texture!.bytes.byteLength)
+    writer.writeBytes(batch.texture!.bytes)
+  }
+}
+
+/** Reads one {@link AcExMeshBatch}; unknown flag bits are ignored (reserved). */
+export function readMeshBatch(reader: AcExBinaryReader): AcExMeshBatch {
+  const layer = reader.readString()
+  const color = reader.readU32()
+  const offset: [number, number, number] = [
+    reader.readF64(),
+    reader.readF64(),
+    reader.readF64()
+  ]
+  const positions = reader.readFloat32Array()
+  const flags = reader.readU8()
+
+  const batch: AcExMeshBatch = { layer, color, offset, positions }
+  if (flags & F_MESH_INDICES) {
+    batch.indices = reader.readUint32Array()
+  }
+  if (flags & F_MESH_HATCH) {
+    batch.hatchPattern =
+      reader.readJson<NonNullable<AcExMeshBatch['hatchPattern']>>()
+  }
+  if (flags & F_MESH_GRADIENT_FILL) {
+    batch.gradientFill =
+      reader.readJson<NonNullable<AcExMeshBatch['gradientFill']>>()
+  }
+  if (flags & F_MESH_GRADIENT_POS) {
+    batch.gradientPositions = reader.readFloat32Array()
+  }
+  if (flags & F_MESH_SIDE) {
+    batch.side = reader.readU8()
+  }
+  if (flags & F_MESH_POINTS) {
+    batch.points = true
+  }
+  if (flags & F_MESH_RENDER_ORDER) {
+    batch.renderOrder = reader.readI32()
+  }
+  if (flags & F_MESH_TEXTURE) {
+    batch.uvs = reader.readFloat32Array()
+    const mimeType = reader.readString() || 'image/png'
+    const byteLength = reader.readU32()
+    batch.texture = {
+      mimeType,
+      bytes: reader.readBytes(byteLength)
+    }
+  }
+  return batch
+}

--- a/packages/cad-html-plugin/src/AcExBinaryIO.ts
+++ b/packages/cad-html-plugin/src/AcExBinaryIO.ts
@@ -1,0 +1,258 @@
+import { strFromU8, strToU8 } from 'fflate'
+
+/** Hard cap for length-prefixed strings inside ACEX binary payloads. */
+export const ACEX_MAX_BINARY_STRING_BYTES = 1 * 1024 * 1024
+
+/** Hard cap for a single length-prefixed typed-array payload. */
+export const ACEX_MAX_BINARY_ARRAY_BYTES = 64 * 1024 * 1024
+
+/**
+ * Little-endian binary writer used by ACEX snapshot and ACEC chunk codecs.
+ * Geometry buffers are length-prefixed and 4-byte aligned.
+ */
+export class AcExBinaryWriter {
+  private readonly chunks: Uint8Array[] = []
+  private length = 0
+
+  writeU8(value: number): void {
+    const chunk = new Uint8Array(1)
+    chunk[0] = value & 0xff
+    this.chunks.push(chunk)
+    this.length += 1
+  }
+
+  writeU32(value: number): void {
+    const chunk = new Uint8Array(4)
+    new DataView(chunk.buffer).setUint32(0, value >>> 0, true)
+    this.chunks.push(chunk)
+    this.length += 4
+  }
+
+  writeI32(value: number): void {
+    const chunk = new Uint8Array(4)
+    new DataView(chunk.buffer).setInt32(0, value | 0, true)
+    this.chunks.push(chunk)
+    this.length += 4
+  }
+
+  writeF32(value: number): void {
+    const chunk = new Uint8Array(4)
+    new DataView(chunk.buffer).setFloat32(0, value, true)
+    this.chunks.push(chunk)
+    this.length += 4
+  }
+
+  writeF64(value: number): void {
+    const chunk = new Uint8Array(8)
+    new DataView(chunk.buffer).setFloat64(0, value, true)
+    this.chunks.push(chunk)
+    this.length += 8
+  }
+
+  writeBytes(bytes: Uint8Array): void {
+    this.chunks.push(bytes)
+    this.length += bytes.length
+  }
+
+  writeString(value: string): void {
+    const bytes = strToU8(value)
+    this.writeU32(bytes.length)
+    this.writeBytes(bytes)
+  }
+
+  writeJson(value: unknown): void {
+    this.writeString(JSON.stringify(value))
+  }
+
+  writeFloat32Array(array: Float32Array): void {
+    this.alignTo(4)
+    const bytes = new Uint8Array(
+      array.buffer,
+      array.byteOffset,
+      array.byteLength
+    )
+    this.writeU32(bytes.length)
+    this.writeBytes(bytes)
+  }
+
+  writeUint32Array(array: Uint32Array): void {
+    this.alignTo(4)
+    const bytes = new Uint8Array(
+      array.buffer,
+      array.byteOffset,
+      array.byteLength
+    )
+    this.writeU32(bytes.length)
+    this.writeBytes(bytes)
+  }
+
+  private alignTo(alignment: number): void {
+    const remainder = this.length % alignment
+    if (remainder === 0) {
+      return
+    }
+    const pad = alignment - remainder
+    for (let i = 0; i < pad; i++) {
+      this.writeU8(0)
+    }
+  }
+
+  toUint8Array(): Uint8Array {
+    const result = new Uint8Array(this.length)
+    let offset = 0
+    for (const chunk of this.chunks) {
+      result.set(chunk, offset)
+      offset += chunk.length
+    }
+    return result
+  }
+}
+
+/**
+ * Little-endian binary reader paired with {@link AcExBinaryWriter}.
+ */
+export class AcExBinaryReader {
+  private offset = 0
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  private ensureAvailable(byteCount: number): void {
+    if (byteCount < 0 || !Number.isFinite(byteCount)) {
+      throw new Error('Invalid binary length')
+    }
+    if (this.offset + byteCount > this.bytes.length) {
+      throw new Error('Unexpected end of binary buffer')
+    }
+  }
+
+  readU8(): number {
+    this.ensureAvailable(1)
+    return this.bytes[this.offset++]!
+  }
+
+  readU32(): number {
+    this.ensureAvailable(4)
+    const view = new DataView(
+      this.bytes.buffer,
+      this.bytes.byteOffset + this.offset,
+      4
+    )
+    const value = view.getUint32(0, true)
+    this.offset += 4
+    return value
+  }
+
+  readI32(): number {
+    this.ensureAvailable(4)
+    const view = new DataView(
+      this.bytes.buffer,
+      this.bytes.byteOffset + this.offset,
+      4
+    )
+    const value = view.getInt32(0, true)
+    this.offset += 4
+    return value
+  }
+
+  readF32(): number {
+    this.ensureAvailable(4)
+    const view = new DataView(
+      this.bytes.buffer,
+      this.bytes.byteOffset + this.offset,
+      4
+    )
+    const value = view.getFloat32(0, true)
+    this.offset += 4
+    return value
+  }
+
+  readF64(): number {
+    this.ensureAvailable(8)
+    const view = new DataView(
+      this.bytes.buffer,
+      this.bytes.byteOffset + this.offset,
+      8
+    )
+    const value = view.getFloat64(0, true)
+    this.offset += 8
+    return value
+  }
+
+  readBytes(length: number): Uint8Array {
+    this.ensureAvailable(length)
+    const slice = this.bytes.subarray(this.offset, this.offset + length)
+    this.offset += length
+    return slice
+  }
+
+  readString(): string {
+    const length = this.readU32()
+    if (length === 0) {
+      return ''
+    }
+    if (length > ACEX_MAX_BINARY_STRING_BYTES) {
+      throw new Error('Binary string exceeds size limit')
+    }
+    return strFromU8(this.readBytes(length))
+  }
+
+  readJson<T>(): T {
+    const text = this.readString()
+    if (text.length === 0) {
+      throw new Error('Expected JSON payload')
+    }
+    return JSON.parse(text) as T
+  }
+
+  private alignTo(alignment: number): void {
+    const remainder = this.offset % alignment
+    if (remainder === 0) {
+      return
+    }
+    const pad = alignment - remainder
+    this.ensureAvailable(pad)
+    this.offset += pad
+  }
+
+  readFloat32Array(): Float32Array {
+    this.alignTo(4)
+    const byteLength = this.readU32()
+    if (byteLength === 0) {
+      return new Float32Array(0)
+    }
+    if (byteLength % 4 !== 0) {
+      throw new Error('Invalid float32 buffer length')
+    }
+    if (byteLength > ACEX_MAX_BINARY_ARRAY_BYTES) {
+      throw new Error('Float32 buffer exceeds size limit')
+    }
+    const bytes = this.readBytes(byteLength)
+    if (bytes.byteOffset % 4 === 0) {
+      return new Float32Array(bytes.buffer, bytes.byteOffset, byteLength / 4)
+    }
+    const copy = new ArrayBuffer(byteLength)
+    new Uint8Array(copy).set(bytes)
+    return new Float32Array(copy)
+  }
+
+  readUint32Array(): Uint32Array {
+    this.alignTo(4)
+    const byteLength = this.readU32()
+    if (byteLength === 0) {
+      return new Uint32Array(0)
+    }
+    if (byteLength % 4 !== 0) {
+      throw new Error('Invalid uint32 buffer length')
+    }
+    if (byteLength > ACEX_MAX_BINARY_ARRAY_BYTES) {
+      throw new Error('Uint32 buffer exceeds size limit')
+    }
+    const bytes = this.readBytes(byteLength)
+    if (bytes.byteOffset % 4 === 0) {
+      return new Uint32Array(bytes.buffer, bytes.byteOffset, byteLength / 4)
+    }
+    const copy = new ArrayBuffer(byteLength)
+    new Uint8Array(copy).set(bytes)
+    return new Uint32Array(copy)
+  }
+}

--- a/packages/cad-html-plugin/src/AcExChunkBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExChunkBinaryCodec.ts
@@ -1,0 +1,121 @@
+import {
+  readLineBatch,
+  readMeshBatch,
+  writeLineBatch,
+  writeMeshBatch
+} from './AcExBatchBinaryCodec'
+import { AcExBinaryReader, AcExBinaryWriter } from './AcExBinaryIO'
+import { compressSnapshotBinary, decompressSnapshotBinary } from './AcExSnapshotCompression'
+import {
+  ACEX_SNAPSHOT_VERSION,
+  type AcExLineBatch,
+  type AcExMeshBatch
+} from './AcExSnapshotTypes'
+
+/** Magic for ACEC geometry chunks (`ACEC` little-endian). */
+export const ACEC_CHUNK_MAGIC = 0x43454341
+
+/** Hard cap on line/mesh batch count inside one ACEC chunk. */
+export const ACEX_MAX_BATCHES_PER_CHUNK = 100_000
+
+/**
+ * Uncompressed geometry chunk: batches for one layout slice.
+ * Schema version matches {@link ACEX_SNAPSHOT_VERSION}.
+ */
+export interface AcExGeometryChunk {
+  /** Snapshot / batch schema version. */
+  version: typeof ACEX_SNAPSHOT_VERSION
+  /** Layout BTR id these batches belong to. */
+  layoutBtrId: string
+  lineBatches: AcExLineBatch[]
+  meshBatches: AcExMeshBatch[]
+}
+
+/**
+ * Encodes an uncompressed ACEC geometry chunk.
+ */
+export function encodeChunkBinary(chunk: AcExGeometryChunk): Uint8Array {
+  if (chunk.version !== ACEX_SNAPSHOT_VERSION) {
+    throw new Error(`Unsupported chunk version: ${chunk.version}`)
+  }
+
+  const writer = new AcExBinaryWriter()
+  writer.writeU32(ACEC_CHUNK_MAGIC)
+  writer.writeU8(ACEX_SNAPSHOT_VERSION)
+  writer.writeU8(0)
+  writer.writeU8(0)
+  writer.writeU8(0)
+  writer.writeString(chunk.layoutBtrId)
+
+  writer.writeU32(chunk.lineBatches.length)
+  for (const batch of chunk.lineBatches) {
+    writeLineBatch(writer, batch)
+  }
+
+  writer.writeU32(chunk.meshBatches.length)
+  for (const batch of chunk.meshBatches) {
+    writeMeshBatch(writer, batch)
+  }
+
+  return writer.toUint8Array()
+}
+
+/**
+ * Decodes an uncompressed ACEC geometry chunk.
+ */
+export function decodeChunkBinary(bytes: Uint8Array): AcExGeometryChunk {
+  const reader = new AcExBinaryReader(bytes)
+  const magic = reader.readU32()
+  if (magic !== ACEC_CHUNK_MAGIC) {
+    throw new Error('Invalid chunk magic')
+  }
+
+  const version = reader.readU8()
+  reader.readU8()
+  reader.readU8()
+  reader.readU8()
+  if (version !== ACEX_SNAPSHOT_VERSION) {
+    throw new Error(`Unsupported chunk version: ${version}`)
+  }
+
+  const layoutBtrId = reader.readString()
+  const lineBatchCount = reader.readU32()
+  if (lineBatchCount > ACEX_MAX_BATCHES_PER_CHUNK) {
+    throw new Error('Chunk line batch count exceeds limit')
+  }
+  const lineBatches: AcExLineBatch[] = []
+  for (let i = 0; i < lineBatchCount; i++) {
+    lineBatches.push(readLineBatch(reader))
+  }
+
+  const meshBatchCount = reader.readU32()
+  if (meshBatchCount > ACEX_MAX_BATCHES_PER_CHUNK) {
+    throw new Error('Chunk mesh batch count exceeds limit')
+  }
+  const meshBatches: AcExMeshBatch[] = []
+  for (let i = 0; i < meshBatchCount; i++) {
+    meshBatches.push(readMeshBatch(reader))
+  }
+
+  return {
+    version: ACEX_SNAPSHOT_VERSION,
+    layoutBtrId,
+    lineBatches,
+    meshBatches
+  }
+}
+
+/** Encodes and gzip-compresses a geometry chunk (`.acex.gz` payload). */
+export function encodeChunkGzip(chunk: AcExGeometryChunk): {
+  uncompressed: Uint8Array
+  compressed: Uint8Array
+} {
+  const uncompressed = encodeChunkBinary(chunk)
+  const compressed = compressSnapshotBinary(uncompressed).bytes
+  return { uncompressed, compressed }
+}
+
+/** Gunzips and decodes a `.acex.gz` geometry chunk payload. */
+export function decodeChunkGzip(compressed: Uint8Array): AcExGeometryChunk {
+  return decodeChunkBinary(decompressSnapshotBinary(compressed))
+}

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -188,6 +188,9 @@ export type AcExHtmlMessageKey =
   | 'status.zoomLayer'
   | 'status.loadFailed'
   | 'status.noLayout'
+  | 'status.loadingChunks'
+  | 'status.loadingOsnap'
+  | 'status.buildingOsnap'
   | 'access.title'
   | 'access.passwordPrompt'
   | 'access.passwordPlaceholder'
@@ -402,7 +405,10 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       areaTotal: 'Area total: {value}',
       zoomLayer: 'Zoom: {name}',
       loadFailed: 'Failed to load drawing: {error}',
-      noLayout: 'No layout data in snapshot.'
+      noLayout: 'No layout data in snapshot.',
+      loadingChunks: 'Loading geometry… {loaded}/{total}',
+      loadingOsnap: 'Loading object snap… {loaded}/{total}',
+      buildingOsnap: 'Building object snap index…'
     },
     access: {
       title: 'Protected drawing',
@@ -606,7 +612,10 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       areaTotal: '面积合计：{value}',
       zoomLayer: '缩放：{name}',
       loadFailed: '无法加载图纸：{error}',
-      noLayout: '快照中没有布局数据。'
+      noLayout: '快照中没有布局数据。',
+      loadingChunks: '正在加载几何… {loaded}/{total}',
+      loadingOsnap: '正在加载对象捕捉… {loaded}/{total}',
+      buildingOsnap: '正在构建对象捕捉索引…'
     },
     access: {
       title: '受保护的图纸',
@@ -814,7 +823,10 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       areaTotal: 'Celková plocha: {value}',
       zoomLayer: 'Zoom: {name}',
       loadFailed: 'Nepodařilo se načíst výkres: {error}',
-      noLayout: 'Snímek neobsahuje data rozvržení.'
+      noLayout: 'Snímek neobsahuje data rozvržení.',
+      loadingChunks: 'Načítání geometrie… {loaded}/{total}',
+      loadingOsnap: 'Načítání uchopování… {loaded}/{total}',
+      buildingOsnap: 'Sestavování indexu uchopování…'
     },
     access: {
       title: 'Chráněný výkres',
@@ -1025,7 +1037,10 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       areaTotal: 'Toplam alan: {value}',
       zoomLayer: 'Yakınlaştır: {name}',
       loadFailed: 'Çizim yüklenemedi: {error}',
-      noLayout: 'Anlık görüntüde yerleşim verisi yok.'
+      noLayout: 'Anlık görüntüde yerleşim verisi yok.',
+      loadingChunks: 'Geometri yükleniyor… {loaded}/{total}',
+      loadingOsnap: 'Nesne yakalama yükleniyor… {loaded}/{total}',
+      buildingOsnap: 'Nesne yakalama dizini oluşturuluyor…'
     },
     access: {
       title: 'Korumalı çizim',
@@ -1229,7 +1244,10 @@ const AR_MESSAGES: AcExMessageTree = {
     'areaTotal': 'إجمالي المساحة: {value}',
     'zoomLayer': 'تكبير: {name}',
     'loadFailed': 'فشل تحميل الرسم: {error}',
-    'noLayout': 'لا توجد بيانات تخطيط في اللقطة.'
+    'noLayout': 'لا توجد بيانات تخطيط في اللقطة.',
+    'loadingChunks': 'جاري تحميل الهندسة… {loaded}/{total}',
+    'loadingOsnap': 'جاري تحميل الالتقاط… {loaded}/{total}',
+    'buildingOsnap': 'جاري بناء فهرس الالتقاط…'
   },
   access: {
     title: 'رسم محمي',

--- a/packages/cad-html-plugin/src/AcExHtmlPackager.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlPackager.ts
@@ -28,6 +28,24 @@ export interface AcExPackHtmlOptions {
 }
 
 /**
+ * Options for {@link packHtmlPackage}: shell HTML that loads a remote package.
+ */
+export interface AcExPackHtmlPackageOptions {
+  /**
+   * Page `<title>`.
+   * Falls back to {@link AcExSnapshot.meta.title} or `"CAD Drawing"`.
+   */
+  title?: string
+  /** Inline viewer bootstrap script (IIFE). */
+  viewerRuntime: string
+  /**
+   * URL of the `*.acex.json` manifest relative to the HTML file
+   * (or an absolute CDN URL).
+   */
+  manifestUrl: string
+}
+
+/**
  * Builds a self-contained HTML document with an embedded compressed snapshot
  * and inline viewer runtime.
  *
@@ -70,6 +88,46 @@ export function packHtml(
 <body>
 ${buildAcExHtmlShellBody(loadingBg, viewerMode, exportLayouts)}
 ${accessScript}  <script id="mlcad-snapshot" type="${snapshotType}">${encoded.payload}</script>
+  <script>${escapeInlineScript(runtime)}</script>
+</body>
+</html>`
+}
+
+/**
+ * Builds a shell HTML document that loads render data from a package manifest URL.
+ * Contains only HTML/CSS/JS — no embedded geometry.
+ *
+ * @param snapshot - Used for title, locale, background, and viewer mode chrome.
+ * @param options - Runtime source and manifest URL.
+ */
+export function packHtmlPackage(
+  snapshot: AcExSnapshot,
+  options: AcExPackHtmlPackageOptions
+): string {
+  const title = options.title ?? snapshot.meta.title ?? 'CAD Drawing'
+  const runtime = options.viewerRuntime
+  const loadingBg = `#${snapshot.meta.background.toString(16).padStart(6, '0')}`
+  const htmlLang = resolveAcExHtmlLocale(snapshot.meta.locale) ?? 'en'
+  const viewerMode = snapshot.meta.viewerMode ?? 'measure'
+  const exportLayouts = snapshot.meta.exportLayouts !== false
+  const packageConfig = JSON.stringify({
+    manifestUrl: options.manifestUrl
+  })
+
+  return `<!DOCTYPE html>
+<html lang="${htmlLang}">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="generator" content="mlightcad-cad-html-plugin" />
+  <title>${escapeHtml(title)}</title>
+  <style>${ACEX_HTML_SHELL_CSS}</style>
+</head>
+<body>
+${buildAcExHtmlShellBody(loadingBg, viewerMode, exportLayouts)}
+  <script id="mlcad-package" type="application/json">${escapeInlineJson(
+    packageConfig
+  )}</script>
   <script>${escapeInlineScript(runtime)}</script>
 </body>
 </html>`

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -5,6 +5,7 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
+import { decodeChunkGzip } from './AcExChunkBinaryCodec'
 import {
   AcExCommandSessionPanel,
   type AcExCommandSessionUiState
@@ -62,6 +63,14 @@ import {
 import { AcExOsnapIndex } from './AcExOsnap'
 import { AcExOsnapMarker } from './AcExOsnapMarker'
 import {
+  loadAcExPackageLayoutOsnap,
+  parseAcExPackageManifest,
+  resolveChunkUrl,
+  resolvePackageManifestUrl,
+  snapshotSkeletonFromManifest
+} from './AcExPackageLoader'
+import type { AcExPackageManifest } from './AcExPackageTypes'
+import {
   computeViewportCamera,
   findDrillThroughViewport,
   modelPointToPaper,
@@ -88,6 +97,7 @@ import {
   AcExSnapLoupe
 } from './AcExSnapLoupe'
 import { decodeSnapshot } from './AcExSnapshotCodec'
+import { ACEX_MAX_COMPRESSED_BYTES } from './AcExSnapshotCompression'
 import type {
   AcExExtents,
   AcExLayoutSnapshot,
@@ -129,8 +139,20 @@ function hideLoading(): void {
 function showViewerError(message: string): void {
   const loading = document.getElementById('mlcad-loading')
   if (!loading) return
-  loading.innerHTML = `<div style="padding:24px;color:#e8eaed;text-align:center;max-width:480px;line-height:1.5">${message}</div>`
+  loading.replaceChildren()
+  const box = document.createElement('div')
+  box.style.cssText =
+    'padding:24px;color:#e8eaed;text-align:center;max-width:480px;line-height:1.5'
+  box.textContent = message
+  loading.appendChild(box)
+  loading.classList.remove('mlcad-loading--done')
 }
+
+/**
+ * Set by {@link bootstrap} once `render` exists so async IMAGE/OLE textures can
+ * force a frame after decode (mesh materials start at opacity 0).
+ */
+let requestViewerTextureRepaint: (() => void) | null = null
 
 /** Fallback when view mode omits the footer status bar. */
 function createHiddenStatusSink(): HTMLElement {
@@ -343,7 +365,8 @@ async function resolveSnapshotPayload(
 async function startViewer(): Promise<void> {
   const root = document.getElementById('mlcad-root')
   const snapshotEl = document.getElementById('mlcad-snapshot')
-  if (!root || !snapshotEl) {
+  const packageEl = document.getElementById('mlcad-package')
+  if (!root || (!snapshotEl && !packageEl)) {
     hideLoading()
     return
   }
@@ -351,19 +374,59 @@ async function startViewer(): Promise<void> {
   const i18n = new AcExHtmlI18n(detectAcExHtmlLocale())
   i18n.applyToDocument()
 
-  const resolved = await resolveSnapshotPayload(snapshotEl, i18n)
-  if (!resolved) {
-    return
-  }
-  const { payload, expiresAt } = resolved
-
   const statusEl =
     document.getElementById('mlcad-status-bar') ?? createHiddenStatusSink()
   wireStatusBarVisibility(statusEl)
 
   let snapshot: AcExSnapshot
+  let expiresAt: number | null = null
+  let packageSession: {
+    manifest: AcExPackageManifest
+    manifestUrl: string
+    loadedLayouts: Set<string>
+    loadedOsnapLayouts: Set<string>
+  } | null = null
+
   try {
-    snapshot = decodeSnapshot(payload)
+    if (packageEl) {
+      const config = JSON.parse(packageEl.textContent?.trim() || '{}') as {
+        manifestUrl?: string
+      }
+      const manifestUrl = config.manifestUrl?.trim()
+      if (!manifestUrl) {
+        throw new Error('Missing manifestUrl in package config')
+      }
+      const absoluteManifestUrl = resolvePackageManifestUrl(
+        manifestUrl,
+        window.location.href
+      )
+      const manifestResponse = await fetch(absoluteManifestUrl)
+      if (!manifestResponse.ok) {
+        throw new Error(
+          `Failed to load package manifest (${manifestResponse.status})`
+        )
+      }
+      const manifest = parseAcExPackageManifest(await manifestResponse.json())
+      snapshot = snapshotSkeletonFromManifest(manifest)
+      packageSession = {
+        manifest,
+        manifestUrl: absoluteManifestUrl,
+        loadedLayouts: new Set(),
+        loadedOsnapLayouts: new Set()
+      }
+      removeSnapshotElement(packageEl)
+    } else if (snapshotEl) {
+      const resolved = await resolveSnapshotPayload(snapshotEl, i18n)
+      if (!resolved) {
+        return
+      }
+      expiresAt = resolved.expiresAt
+      snapshot = decodeSnapshot(resolved.payload)
+      removeSnapshotElement(snapshotEl)
+    } else {
+      hideLoading()
+      return
+    }
   } catch (error) {
     showViewerError(i18n.t('status.loadFailed', { error: String(error) }))
     return
@@ -472,17 +535,18 @@ async function startViewer(): Promise<void> {
     return group
   }
 
-  const populateLayoutGeometry = (
-    next: AcExLayoutSnapshot,
+  const appendBatchesToScene = (
+    lineBatches: AcExLineBatch[],
+    meshBatches: AcExMeshBatch[],
     groups: Map<string, THREE.Group>,
     parent: THREE.Object3D,
     materials: LineMaterial[]
   ) => {
-    for (const batch of next.lineBatches) {
+    for (const batch of lineBatches) {
       const object = createLineObject(batch, materials, wideLineResolution)
       if (object) getOrCreateLayerGroup(groups, parent, batch.layer).add(object)
     }
-    for (const batch of next.meshBatches) {
+    for (const batch of meshBatches) {
       const object = batch.points
         ? createPointObject(batch)
         : createMeshObject(batch)
@@ -490,26 +554,203 @@ async function startViewer(): Promise<void> {
     }
   }
 
-  if (modelLayout) {
-    populateLayoutGeometry(
-      modelLayout,
-      modelLayerGroups,
-      modelRoot,
-      modelWideLineMaterials
+  const populateLayoutGeometry = (
+    next: AcExLayoutSnapshot,
+    groups: Map<string, THREE.Group>,
+    parent: THREE.Object3D,
+    materials: LineMaterial[]
+  ) => {
+    appendBatchesToScene(
+      next.lineBatches,
+      next.meshBatches,
+      groups,
+      parent,
+      materials
     )
   }
+
+  /** Set after {@link render} exists; paints each package chunk as it arrives. */
+  let paintPackageChunk: (() => void) | null = null
+
+  const disposeObject3D = (object: THREE.Object3D) => {
+    object.traverse(child => {
+      const mesh = child as THREE.Mesh
+      if (mesh.geometry) mesh.geometry.dispose()
+      const material = mesh.material
+      if (Array.isArray(material)) {
+        material.forEach(item => item.dispose())
+      } else if (material) {
+        material.dispose()
+      }
+    })
+  }
+
+  const disposePaperGeometry = () => {
+    for (const group of paperLayerGroups.values()) {
+      paperRoot.remove(group)
+      disposeObject3D(group)
+    }
+    paperLayerGroups.clear()
+    paperWideLineMaterials.length = 0
+  }
+
+  const clearLayoutSceneGeometry = (target: AcExLayoutSnapshot) => {
+    if (target.isModelSpace) {
+      for (const group of modelLayerGroups.values()) {
+        modelRoot.remove(group)
+        disposeObject3D(group)
+      }
+      modelLayerGroups.clear()
+      modelWideLineMaterials.length = 0
+    } else {
+      disposePaperGeometry()
+    }
+  }
+
+  const loadPackageLayoutGeometry = async (
+    target: AcExLayoutSnapshot
+  ): Promise<void> => {
+    if (!packageSession || packageSession.loadedLayouts.has(target.btrId)) {
+      return
+    }
+    const layoutRef = packageSession.manifest.layouts.find(
+      item => item.btrId === target.btrId
+    )
+    if (!layoutRef) {
+      packageSession.loadedLayouts.add(target.btrId)
+      return
+    }
+    const chunkById = new Map(
+      packageSession.manifest.chunks.map(chunk => [chunk.id, chunk])
+    )
+    const chunks = layoutRef.chunkIds
+      .map(id => chunkById.get(id))
+      .filter((chunk): chunk is NonNullable<typeof chunk> => chunk != null)
+
+    let loadedChunks = 0
+    try {
+      for (const chunkRef of chunks) {
+        statusEl.textContent = i18n.t('status.loadingChunks', {
+          loaded: String(loadedChunks),
+          total: String(chunks.length)
+        })
+        const url = resolveChunkUrl(packageSession.manifestUrl, chunkRef.href)
+        const response = await fetch(url)
+        if (!response.ok) {
+          throw new Error(
+            `Failed to load geometry chunk (${response.status})`
+          )
+        }
+        const contentLength = response.headers.get('content-length')
+        if (contentLength != null) {
+          const declared = Number(contentLength)
+          if (
+            Number.isFinite(declared) &&
+            declared > ACEX_MAX_COMPRESSED_BYTES
+          ) {
+            throw new Error('Geometry chunk exceeds size limit')
+          }
+        }
+        const buffer = await response.arrayBuffer()
+        if (buffer.byteLength > ACEX_MAX_COMPRESSED_BYTES) {
+          throw new Error('Geometry chunk exceeds size limit')
+        }
+        const compressed = new Uint8Array(buffer)
+        const decoded = decodeChunkGzip(compressed)
+        const lineStart = target.lineBatches.length
+        const meshStart = target.meshBatches.length
+        target.lineBatches.push(...decoded.lineBatches)
+        target.meshBatches.push(...decoded.meshBatches)
+
+        const isModel = target.isModelSpace
+        appendBatchesToScene(
+          target.lineBatches.slice(lineStart),
+          target.meshBatches.slice(meshStart),
+          isModel ? modelLayerGroups : paperLayerGroups,
+          isModel ? modelRoot : paperRoot,
+          isModel ? modelWideLineMaterials : paperWideLineMaterials
+        )
+        loadedChunks += 1
+        statusEl.textContent = i18n.t('status.loadingChunks', {
+          loaded: String(loadedChunks),
+          total: String(chunks.length)
+        })
+        // Show this chunk immediately — do not wait for remaining downloads.
+        paintPackageChunk?.()
+        await accmYieldForPaint()
+      }
+
+      packageSession.loadedLayouts.add(target.btrId)
+    } catch (error) {
+      // Drop partial batches and scene objects so a retry cannot duplicate geometry.
+      target.lineBatches.length = 0
+      target.meshBatches.length = 0
+      clearLayoutSceneGeometry(target)
+      throw error
+    }
+  }
+
+  /**
+   * Downloads OSNAP after geometry is already visible. Multiple ACEO chunks are
+   * fetched in parallel; viewing does not depend on this data.
+   */
+  const loadPackageLayoutOsnap = async (
+    target: AcExLayoutSnapshot
+  ): Promise<void> => {
+    if (
+      !packageSession ||
+      !measureEnabled ||
+      packageSession.loadedOsnapLayouts.has(target.btrId)
+    ) {
+      return
+    }
+    await loadAcExPackageLayoutOsnap(
+      packageSession.manifest,
+      packageSession.manifestUrl,
+      target.btrId,
+      target,
+      {
+        yieldFn: async () => {
+          paintPackageChunk?.()
+          await accmYieldForPaint()
+        },
+        onChunk: progress => {
+          statusEl.textContent = i18n.t('status.loadingOsnap', {
+            loaded: String(progress.loadedChunks),
+            total: String(progress.totalChunks)
+          })
+        }
+      }
+    )
+    packageSession.loadedOsnapLayouts.add(target.btrId)
+  }
+
+  // Attach roots before any progressive fetch so appended batches are visible.
   if (layout.isModelSpace) {
     scene.add(modelRoot)
   } else {
     scene.add(paperRoot)
-    populateLayoutGeometry(
-      layout,
-      paperLayerGroups,
-      paperRoot,
-      paperWideLineMaterials
-    )
     if (hasPaperViewports) {
       modelScene.add(modelRoot)
+    }
+  }
+
+  if (!packageSession) {
+    if (modelLayout) {
+      populateLayoutGeometry(
+        modelLayout,
+        modelLayerGroups,
+        modelRoot,
+        modelWideLineMaterials
+      )
+    }
+    if (!layout.isModelSpace) {
+      populateLayoutGeometry(
+        layout,
+        paperLayerGroups,
+        paperRoot,
+        paperWideLineMaterials
+      )
     }
   }
 
@@ -546,23 +787,44 @@ async function startViewer(): Promise<void> {
     }
   }
 
-  if (measureEnabled) {
-    osnapIndex = new AcExOsnapIndex()
-    osnapMarker = new AcExOsnapMarker(root)
-    osnapIndex.rebuild(layout)
+  const rebuildOsnapForLoadedGeometry = async () => {
+    if (!measureEnabled) return
+    if (!osnapIndex) {
+      osnapIndex = new AcExOsnapIndex()
+      osnapMarker = new AcExOsnapMarker(root)
+    }
+    const primitiveCount = layout.osnap?.primitives.length ?? 0
+    if (primitiveCount > 8000) {
+      statusEl.textContent = i18n.t('status.buildingOsnap')
+      await accmYieldForPaint()
+    }
+    await osnapIndex.rebuildAsync(layout, async () => {
+      render()
+      await accmYieldForPaint()
+    })
     applyOsnapLayerVisibility(osnapIndex)
     if (hasPaperViewports && modelLayout) {
-      modelOsnapIndex = new AcExOsnapIndex()
-      modelOsnapIndex.rebuild(modelLayout)
+      if (!modelOsnapIndex) {
+        modelOsnapIndex = new AcExOsnapIndex()
+      }
+      await modelOsnapIndex.rebuildAsync(modelLayout, async () => {
+        render()
+        await accmYieldForPaint()
+      })
       applyOsnapLayerVisibility(modelOsnapIndex)
     }
-    // Keep inactive-layout catalogs so the user can switch back.
     if (!canSwitchLayouts) {
       releaseSnapshotOsnapCatalogs(snapshot)
     }
   }
 
-  removeSnapshotElement(snapshotEl)
+  // Embedded path has full geometry now; package path rebuilds after progressive load.
+  if (measureEnabled && !packageSession) {
+    await rebuildOsnapForLoadedGeometry()
+  } else if (measureEnabled) {
+    osnapIndex = new AcExOsnapIndex()
+    osnapMarker = new AcExOsnapMarker(root)
+  }
 
   const updateCameraFrustum = (width?: number, height?: number) => {
     const size = getCanvasSize()
@@ -1120,6 +1382,21 @@ async function startViewer(): Promise<void> {
     renderSnapLoupe()
   }
 
+  paintPackageChunk = () => {
+    const next = computeLayerExtentsMap(
+      layout.lineBatches,
+      layout.meshBatches
+    )
+    layerExtents.clear()
+    for (const [name, extents] of next) {
+      layerExtents.set(name, extents)
+    }
+    render()
+  }
+  requestViewerTextureRepaint = () => {
+    render()
+  }
+
   if (measureEnabled) {
     measure = new AcExMeasureController({
       root,
@@ -1367,32 +1644,43 @@ async function startViewer(): Promise<void> {
     }
   }
 
-  const disposeObject3D = (object: THREE.Object3D) => {
-    object.traverse(child => {
-      const mesh = child as THREE.Mesh
-      if (mesh.geometry) mesh.geometry.dispose()
-      const material = mesh.material
-      if (Array.isArray(material)) {
-        material.forEach(item => item.dispose())
-      } else if (material) {
-        material.dispose()
-      }
-    })
-  }
-
-  const disposePaperGeometry = () => {
-    for (const group of paperLayerGroups.values()) {
-      paperRoot.remove(group)
-      disposeObject3D(group)
-    }
-    paperLayerGroups.clear()
-    paperWideLineMaterials.length = 0
-  }
-
   const switchLayout = (btrId: string) => {
+    void switchLayoutAsync(btrId)
+  }
+
+  const remountLayoutRoots = (
+    target: AcExLayoutSnapshot,
+    rebuildPaper: boolean
+  ) => {
+    layout = target
+    if (target.isModelSpace) {
+      scene.add(modelRoot)
+    } else {
+      scene.add(paperRoot)
+      if (rebuildPaper) {
+        populateLayoutGeometry(
+          target,
+          paperLayerGroups,
+          paperRoot,
+          paperWideLineMaterials
+        )
+        if (backgroundSwapped) {
+          flipNearBlackWhiteMaterials(paperRoot)
+        }
+      }
+      if (hasPaperViewports) {
+        modelScene.add(modelRoot)
+      }
+    }
+  }
+
+  const switchLayoutAsync = async (btrId: string) => {
     if (btrId === layout.btrId) return
     const next = snapshot.layouts.find(item => item.btrId === btrId)
     if (!next) return
+
+    const previousLayout = layout
+    const previousWasPaper = !previousLayout.isModelSpace
 
     lastViewByLayout.set(layout.btrId, captureViewState())
     navToolsRef.current?.cancelZoomWindow()
@@ -1407,16 +1695,70 @@ async function startViewer(): Promise<void> {
     modelRoot.removeFromParent()
 
     layout = next
+
+    const needsPackageLoad =
+      packageSession != null &&
+      !packageSession.loadedLayouts.has(layout.btrId)
+
+    if (needsPackageLoad && packageSession) {
+      try {
+        await loadPackageLayoutGeometry(layout)
+        if (
+          !layout.isModelSpace &&
+          hasPaperViewports &&
+          modelLayout &&
+          !packageSession.loadedLayouts.has(modelLayout.btrId)
+        ) {
+          await loadPackageLayoutGeometry(modelLayout)
+        }
+      } catch (error) {
+        statusEl.textContent = i18n.t('status.loadFailed', {
+          error: String(error)
+        })
+        // Partial next geometry was cleared by loadPackageLayoutGeometry; restore prior layout.
+        if (!next.isModelSpace) {
+          disposePaperGeometry()
+        }
+        remountLayoutRoots(previousLayout, previousWasPaper)
+        const restored = lastViewByLayout.get(previousLayout.btrId)
+        if (restored) {
+          flyTo(restored.centerX, restored.centerY, restored.zoom)
+        } else {
+          fit()
+        }
+        const restoredExtents = computeLayerExtentsMap(
+          previousLayout.lineBatches,
+          previousLayout.meshBatches
+        )
+        layerExtents.clear()
+        for (const [name, extents] of restoredExtents) {
+          layerExtents.set(name, extents)
+        }
+        layoutExtents = resolveLayoutViewExtents(previousLayout)
+        layerPanel?.syncLayerZoomButtons()
+        measure?.syncLayoutVisibility()
+        markup?.syncLayoutVisibility()
+        layoutMenuRef.current?.refresh()
+        recomputeOsnapThresholdWcs()
+        bumpSnapCacheKey()
+        render()
+        return
+      }
+    }
+
     if (layout.isModelSpace) {
       scene.add(modelRoot)
     } else {
       scene.add(paperRoot)
-      populateLayoutGeometry(
-        layout,
-        paperLayerGroups,
-        paperRoot,
-        paperWideLineMaterials
-      )
+      // Fresh package load already uploaded batches; otherwise rebuild after dispose.
+      if (!needsPackageLoad) {
+        populateLayoutGeometry(
+          layout,
+          paperLayerGroups,
+          paperRoot,
+          paperWideLineMaterials
+        )
+      }
       if (backgroundSwapped) {
         flipNearBlackWhiteMaterials(paperRoot)
       }
@@ -1437,9 +1779,24 @@ async function startViewer(): Promise<void> {
     layerPanel?.syncLayerZoomButtons()
 
     if (osnapIndex) {
-      osnapIndex.rebuild(layout)
-      for (const [name, visible] of layerVisible) {
-        osnapIndex.setLayerHidden(name, visible === false)
+      // Defer rebuild when ACEO sidecars are still pending — tessellating all
+      // line/mesh batches first would freeze the UI and delay Network fetches.
+      const layoutRef = packageSession?.manifest.layouts.find(
+        item => item.btrId === layout.btrId
+      )
+      const pendingOsnap =
+        packageSession != null &&
+        measureEnabled &&
+        !packageSession.loadedOsnapLayouts.has(layout.btrId) &&
+        (layoutRef?.osnapChunkIds?.length ?? 0) > 0
+      if (!pendingOsnap) {
+        await osnapIndex.rebuildAsync(layout, async () => {
+          render()
+          await accmYieldForPaint()
+        })
+        for (const [name, visible] of layerVisible) {
+          osnapIndex.setLayerHidden(name, visible === false)
+        }
       }
     }
 
@@ -1458,6 +1815,27 @@ async function startViewer(): Promise<void> {
     recomputeOsnapThresholdWcs()
     bumpSnapCacheKey()
     render()
+
+    // OSNAP last: geometry is already on screen.
+    if (packageSession && measureEnabled) {
+      try {
+        await loadPackageLayoutOsnap(layout)
+        if (
+          !layout.isModelSpace &&
+          hasPaperViewports &&
+          modelLayout
+        ) {
+          await loadPackageLayoutOsnap(modelLayout)
+        }
+        await rebuildOsnapForLoadedGeometry()
+        bumpSnapCacheKey()
+        render()
+      } catch (error) {
+        statusEl.textContent = i18n.t('status.loadFailed', {
+          error: String(error)
+        })
+      }
+    }
   }
 
   controls.addEventListener('change', () => {
@@ -1759,7 +2137,8 @@ async function startViewer(): Promise<void> {
   lastViewByLayout.set(layout.btrId, initialView)
   // Shared typed arrays back the snapshot and THREE attributes. Releasing
   // them would prevent switching to other layouts later in this session.
-  if (!canSwitchLayouts) {
+  // Package mode releases after progressive geometry has finished loading.
+  if (!canSwitchLayouts && !packageSession) {
     releaseLayerGroupsGeometryCpuArrays(paperLayerGroups)
     releaseLayerGroupsGeometryCpuArrays(modelLayerGroups)
     releaseSnapshotBatchBuffers(snapshot)
@@ -1775,7 +2154,52 @@ async function startViewer(): Promise<void> {
       }
     })
   }
+  // Reveal the canvas before package chunks finish so each chunk can paint
+  // as soon as it arrives (progressive loading).
   hideLoading()
+
+  if (packageSession) {
+    try {
+      const firstPaintLayouts: AcExLayoutSnapshot[] = [layout]
+      if (!layout.isModelSpace && hasPaperViewports && modelLayout) {
+        firstPaintLayouts.push(modelLayout)
+      }
+      for (const target of firstPaintLayouts) {
+        await loadPackageLayoutGeometry(target)
+      }
+      layoutExtents = resolveLayoutViewExtents(
+        layout,
+        snapshot.meta.viewExtents ?? snapshot.meta.extents
+      )
+      layerPanel?.syncLayerZoomButtons()
+      recomputeOsnapThresholdWcs()
+      bumpSnapCacheKey()
+      measure?.refreshIdleStatus()
+      render()
+
+      // Do NOT rebuild OSNAP from tessellated batches here. On large drawings
+      // collectBatchSegments freezes the main thread for seconds and prevents
+      // ACEO fetches from even starting (nothing appears in Network).
+      if (measureEnabled) {
+        for (const target of firstPaintLayouts) {
+          await loadPackageLayoutOsnap(target)
+        }
+        await rebuildOsnapForLoadedGeometry()
+        recomputeOsnapThresholdWcs()
+        bumpSnapCacheKey()
+        measure?.refreshIdleStatus()
+        render()
+      }
+
+      if (!canSwitchLayouts) {
+        releaseLayerGroupsGeometryCpuArrays(paperLayerGroups)
+        releaseLayerGroupsGeometryCpuArrays(modelLayerGroups)
+        releaseSnapshotBatchBuffers(snapshot)
+      }
+    } catch (error) {
+      showViewerError(i18n.t('status.loadFailed', { error: String(error) }))
+    }
+  }
 }
 
 interface AcExLayerRowRefs {
@@ -2808,7 +3232,14 @@ function createMeshObject(batch: AcExMeshBatch): THREE.Mesh | null {
       new THREE.BufferAttribute(batch.gradientPositions, 2)
     )
   }
-  const material = createViewerMeshMaterial(batch)
+  if (batch.uvs && batch.uvs.length >= 2) {
+    geometry.setAttribute('uv', new THREE.BufferAttribute(batch.uvs, 2))
+  }
+  const material = createViewerMeshMaterial(batch, {
+    onTextureLoad: () => {
+      requestViewerTextureRepaint?.()
+    }
+  })
   const object = new THREE.Mesh(geometry, material)
   applyBatchPose(object, {
     offset: batch.offset,

--- a/packages/cad-html-plugin/src/AcExMeshTextureExport.ts
+++ b/packages/cad-html-plugin/src/AcExMeshTextureExport.ts
@@ -1,0 +1,235 @@
+import * as THREE from 'three'
+
+import { copyFloat32Range } from './AcExBatchBuffers'
+import type { AcExMeshTexture } from './AcExSnapshotTypes'
+
+/**
+ * Encodes a THREE texture image to PNG bytes for HTML snapshot embedding.
+ * Returns `undefined` when the texture has no drawable image payload.
+ */
+export function encodeTextureForExport(
+  texture: THREE.Texture
+): AcExMeshTexture | undefined {
+  const image = texture.image as unknown
+  if (!image || typeof document === 'undefined') {
+    return undefined
+  }
+
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return undefined
+  }
+
+  try {
+    if (image instanceof ImageData) {
+      canvas.width = image.width
+      canvas.height = image.height
+      ctx.putImageData(image, 0, 0)
+    } else if (isDataTextureImage(image)) {
+      canvas.width = image.width
+      canvas.height = image.height
+      const rgba = toUint8ClampedRgba(image.data, image.width * image.height)
+      const imageData = new ImageData(
+        new Uint8ClampedArray(rgba),
+        image.width,
+        image.height
+      )
+      ctx.putImageData(imageData, 0, 0)
+    } else if (isCanvasImageSource(image)) {
+      const size = readImageSourceSize(image)
+      if (!size) {
+        return undefined
+      }
+      canvas.width = size.width
+      canvas.height = size.height
+      // Draw without compensating texture.flipY — TextureLoader on playback
+      // applies the same default flipY as the live viewer.
+      ctx.drawImage(image, 0, 0)
+    } else {
+      return undefined
+    }
+  } catch {
+    return undefined
+  }
+
+  const dataUrl = canvas.toDataURL('image/png')
+  const comma = dataUrl.indexOf(',')
+  if (comma < 0) {
+    return undefined
+  }
+  const binary = atob(dataUrl.slice(comma + 1))
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return { mimeType: 'image/png', bytes }
+}
+
+function isCanvasImageSource(image: unknown): image is CanvasImageSource & {
+  width: number
+  height: number
+} {
+  return (
+    image instanceof HTMLImageElement ||
+    image instanceof HTMLCanvasElement ||
+    (typeof OffscreenCanvas !== 'undefined' &&
+      image instanceof OffscreenCanvas) ||
+    (typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap) ||
+    (typeof HTMLVideoElement !== 'undefined' &&
+      image instanceof HTMLVideoElement)
+  )
+}
+
+function isDataTextureImage(
+  image: unknown
+): image is { data: ArrayLike<number>; width: number; height: number } {
+  if (!image || typeof image !== 'object') {
+    return false
+  }
+  const record = image as {
+    data?: unknown
+    width?: unknown
+    height?: unknown
+  }
+  return (
+    record.data != null &&
+    typeof record.width === 'number' &&
+    typeof record.height === 'number' &&
+    record.width >= 1 &&
+    record.height >= 1
+  )
+}
+
+function readImageSourceSize(
+  image: CanvasImageSource & { width: number; height: number }
+): { width: number; height: number } | undefined {
+  let width = Number(image.width)
+  let height = Number(image.height)
+  if (image instanceof HTMLImageElement) {
+    width = image.naturalWidth || image.width
+    height = image.naturalHeight || image.height
+  } else if (typeof HTMLVideoElement !== 'undefined' && image instanceof HTMLVideoElement) {
+    width = image.videoWidth || image.width
+    height = image.videoHeight || image.height
+  }
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width < 1 ||
+    height < 1
+  ) {
+    return undefined
+  }
+  return { width, height }
+}
+
+function toUint8ClampedRgba(
+  data: ArrayLike<number>,
+  pixelCount: number
+): Uint8ClampedArray {
+  const expected = pixelCount * 4
+  if (data instanceof Uint8ClampedArray && data.length >= expected) {
+    return data.length === expected ? data : data.subarray(0, expected)
+  }
+  const out = new Uint8ClampedArray(expected)
+  const sourceLength = Math.min(expected, data.length)
+  for (let i = 0; i < sourceLength; i++) {
+    out[i] = data[i]!
+  }
+  // Expand RGB → RGBA when the source only stores 3 channels.
+  if (data.length >= pixelCount * 3 && data.length < expected) {
+    for (let p = pixelCount - 1; p >= 0; p--) {
+      const src = p * 3
+      const dst = p * 4
+      out[dst] = data[src]!
+      out[dst + 1] = data[src + 1]!
+      out[dst + 2] = data[src + 2]!
+      out[dst + 3] = 255
+    }
+  }
+  return out
+}
+
+/**
+ * Reads UV coordinates from a geometry so they stay aligned with an exported
+ * position slice (same vertex count after compact/trim).
+ */
+export function exportUvsForPositionSlice(
+  geometry: THREE.BufferGeometry,
+  positions: Float32Array
+): Float32Array | undefined {
+  const attribute = geometry.getAttribute('uv') as
+    | THREE.BufferAttribute
+    | undefined
+  if (!attribute || attribute.count === 0 || attribute.itemSize < 2) {
+    return undefined
+  }
+  const vertexCount = Math.floor(positions.length / 3)
+  const expected = vertexCount * 2
+  if (expected <= 0) {
+    return undefined
+  }
+  const array = attribute.array as ArrayLike<number>
+  const available = attribute.count * attribute.itemSize
+  if (available < expected) {
+    return undefined
+  }
+  return copyFloat32Range(array, 0, expected)
+}
+
+/**
+ * True when a mesh material is an unloaded IMAGE/OLE placeholder (transparent,
+ * no map) that would otherwise export as a solid white fill.
+ */
+export function isTransparentImagePlaceholder(
+  material: THREE.Material
+): boolean {
+  const meshMaterial = material as THREE.MeshBasicMaterial
+  if (meshMaterial.map) {
+    return false
+  }
+  return (
+    meshMaterial.transparent === true &&
+    typeof meshMaterial.opacity === 'number' &&
+    meshMaterial.opacity < 0.01
+  )
+}
+
+/**
+ * Builds a THREE texture from exported PNG (or other) bytes.
+ */
+export function createTextureFromExportedBytes(
+  texture: AcExMeshTexture,
+  options: {
+    onLoad?: (loaded: THREE.Texture) => void
+    onError?: () => void
+  } = {}
+): THREE.Texture {
+  const bytes = copyBytes(texture.bytes)
+  const blob = new Blob([bytes as BlobPart], {
+    type: texture.mimeType || 'image/png'
+  })
+  const url = URL.createObjectURL(blob)
+  const result = new THREE.TextureLoader().load(
+    url,
+    loaded => {
+      URL.revokeObjectURL(url)
+      options.onLoad?.(loaded)
+    },
+    undefined,
+    () => {
+      URL.revokeObjectURL(url)
+      options.onError?.()
+    }
+  )
+  result.colorSpace = THREE.SRGBColorSpace
+  result.needsUpdate = true
+  return result
+}
+
+function copyBytes(bytes: Uint8Array): Uint8Array {
+  const copy = new Uint8Array(bytes.byteLength)
+  copy.set(bytes)
+  return copy
+}

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -33,6 +33,15 @@ import type {
 export type { AcExOsnapMode, AcExOsnapPoint } from './AcExOsnapPrimitiveTypes'
 export { ACEX_DEFAULT_OSNAP_MODES } from './AcExOsnapPrimitiveTypes'
 
+/** Primitives / segments processed between yields in {@link AcExOsnapIndex.rebuildAsync}. */
+const OSNAP_INDEX_YIELD_BATCH = 2500
+
+function yieldToBrowser(): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, 0)
+  })
+}
+
 /**
  * One line segment in WCS (XY) indexed for legacy tessellated object snap.
  * @internal
@@ -608,9 +617,36 @@ export class AcExOsnapIndex {
    * Loads analytic primitives and tessellated segments into RBush trees.
    * Snap candidates are computed lazily during {@link findSnap}.
    *
+   * Prefer {@link rebuildAsync} for large analytic catalogs (~10⁵+ primitives)
+   * so the UI thread can paint between batches.
+   *
    * @param layout - Active layout snapshot (batches + optional {@link AcExLayoutSnapshot.osnap}).
    */
   rebuild(layout: AcExLayoutSnapshot): void {
+    this.resetFromLayout(layout)
+    this.loadPrimitiveTreeSync()
+    this.loadSegmentTreeSync()
+  }
+
+  /**
+   * Like {@link rebuild}, but yields while preparing RBush entries so large
+   * OSNAP catalogs do not freeze the canvas during bounds computation.
+   * Entries are still passed to RBush via a single bulk {@link RBush.load}
+   * (not per-item `insert`).
+   *
+   * @param layout - Active layout snapshot.
+   * @param yieldFn - Called between entry-building batches (defaults to a macrotask yield).
+   */
+  async rebuildAsync(
+    layout: AcExLayoutSnapshot,
+    yieldFn: () => Promise<void> = yieldToBrowser
+  ): Promise<void> {
+    this.resetFromLayout(layout)
+    await this.loadPrimitiveTreeAsync(yieldFn)
+    await this.loadSegmentTreeAsync(yieldFn)
+  }
+
+  private resetFromLayout(layout: AcExLayoutSnapshot): void {
     this.primitiveTree.clear()
     this.segmentTree.clear()
     this.hiddenLayers.clear()
@@ -623,34 +659,82 @@ export class AcExOsnapIndex {
       this.segments = collected.segments
       this.segmentLayers = collected.segmentLayers
     }
+  }
 
-    if (this.primitives.length === 0 && this.segments.length === 0) {
+  private loadPrimitiveTreeSync(): void {
+    if (this.primitives.length === 0) {
       return
     }
+    const primitiveEntries: AcExRbushEntry[] = new Array(this.primitives.length)
+    for (let i = 0; i < this.primitives.length; i++) {
+      primitiveEntries[i] = {
+        ...primitiveBounds(this.primitives[i]!),
+        index: i
+      }
+    }
+    this.primitiveTree.load(primitiveEntries)
+  }
 
-    if (this.primitives.length > 0) {
-      const primitiveEntries: AcExRbushEntry[] = new Array(
-        this.primitives.length
-      )
-      for (let i = 0; i < this.primitives.length; i++) {
+  private loadSegmentTreeSync(): void {
+    if (this.segments.length === 0) {
+      return
+    }
+    const segmentEntries: AcExRbushEntry[] = new Array(this.segments.length)
+    for (let i = 0; i < this.segments.length; i++) {
+      segmentEntries[i] = {
+        ...segmentBounds(this.segments[i]!),
+        index: i
+      }
+    }
+    this.segmentTree.load(segmentEntries)
+  }
+
+  private async loadPrimitiveTreeAsync(
+    yieldFn: () => Promise<void>
+  ): Promise<void> {
+    const count = this.primitives.length
+    if (count === 0) {
+      return
+    }
+    // Build the entry array in yieldable batches, then bulk-load once.
+    // Per-item `insert` is far slower than RBush's packed `load`.
+    const primitiveEntries: AcExRbushEntry[] = new Array(count)
+    for (let start = 0; start < count; start += OSNAP_INDEX_YIELD_BATCH) {
+      const end = Math.min(start + OSNAP_INDEX_YIELD_BATCH, count)
+      for (let i = start; i < end; i++) {
         primitiveEntries[i] = {
           ...primitiveBounds(this.primitives[i]!),
           index: i
         }
       }
-      this.primitiveTree.load(primitiveEntries)
+      if (end < count) {
+        await yieldFn()
+      }
     }
+    this.primitiveTree.load(primitiveEntries)
+  }
 
-    if (this.segments.length > 0) {
-      const segmentEntries: AcExRbushEntry[] = new Array(this.segments.length)
-      for (let i = 0; i < this.segments.length; i++) {
+  private async loadSegmentTreeAsync(
+    yieldFn: () => Promise<void>
+  ): Promise<void> {
+    const count = this.segments.length
+    if (count === 0) {
+      return
+    }
+    const segmentEntries: AcExRbushEntry[] = new Array(count)
+    for (let start = 0; start < count; start += OSNAP_INDEX_YIELD_BATCH) {
+      const end = Math.min(start + OSNAP_INDEX_YIELD_BATCH, count)
+      for (let i = start; i < end; i++) {
         segmentEntries[i] = {
           ...segmentBounds(this.segments[i]!),
           index: i
         }
       }
-      this.segmentTree.load(segmentEntries)
+      if (end < count) {
+        await yieldFn()
+      }
     }
+    this.segmentTree.load(segmentEntries)
   }
 
   /**

--- a/packages/cad-html-plugin/src/AcExOsnapCatalogCodec.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapCatalogCodec.ts
@@ -1,0 +1,378 @@
+import { AcExBinaryReader, AcExBinaryWriter } from './AcExBinaryIO'
+import type {
+  AcExOsnapCatalog,
+  AcExOsnapPrimitive
+} from './AcExOsnapPrimitiveTypes'
+import {
+  compressSnapshotBinary,
+  decompressSnapshotBinary
+} from './AcExSnapshotCompression'
+
+/** Magic for ACEO osnap catalog payloads (`ACEO` little-endian). */
+export const ACEO_OSNAP_MAGIC = 0x4f454341
+
+/** Current ACEO payload schema version. */
+export const ACEO_OSNAP_VERSION = 1 as const
+
+/** Hard cap on primitives inside one ACEO chunk. */
+export const ACEX_MAX_OSNAP_PRIMITIVES_PER_CHUNK = 500_000
+
+/** Hard cap on layer dictionary entries inside one ACEO chunk. */
+export const ACEX_MAX_OSNAP_LAYERS_PER_CHUNK = 100_000
+
+const KIND_LINE = 1
+const KIND_CIRCLE = 2
+const KIND_ARC = 3
+const KIND_ELLIPSE = 4
+const KIND_SPLINE = 5
+const KIND_POINT = 6
+
+/**
+ * Rough uncompressed ACEO size estimate for one primitive (used when splitting
+ * catalogs into downloadable chunks). Prefer slightly overestimating.
+ */
+export function estimateOsnapPrimitiveBytes(
+  primitive: AcExOsnapPrimitive
+): number {
+  // kind(1) + layerIndex(4) + payload; ignore shared layer-dictionary overhead.
+  switch (primitive.kind) {
+    case 'line':
+      return 1 + 4 + 32
+    case 'circle':
+      return 1 + 4 + 24 + 1
+    case 'arc':
+      return 1 + 4 + 40 + 1
+    case 'ellipse':
+      return 1 + 4 + 64 + 1 + 1
+    case 'point':
+      return 1 + 4 + 16
+    case 'spline': {
+      const floats =
+        primitive.controlPoints.length +
+        primitive.knots.length +
+        primitive.weights.length +
+        (primitive.fitPoints?.length ?? 0)
+      return 1 + 4 + 4 + 1 + floats * 8 + 16
+    }
+    default: {
+      const _exhaustive: never = primitive
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Splits OSNAP primitives into slices that stay under `maxChunkBytes` (estimate).
+ */
+export function splitOsnapPrimitives(
+  primitives: AcExOsnapPrimitive[],
+  maxChunkBytes: number
+): AcExOsnapPrimitive[][] {
+  if (primitives.length === 0) {
+    return []
+  }
+  const slices: AcExOsnapPrimitive[][] = []
+  let current: AcExOsnapPrimitive[] = []
+  let estimated = 64
+
+  const flush = () => {
+    if (current.length === 0) return
+    slices.push(current)
+    current = []
+    estimated = 64
+  }
+
+  for (const primitive of primitives) {
+    const size = estimateOsnapPrimitiveBytes(primitive)
+    if (
+      current.length > 0 &&
+      estimated + size > maxChunkBytes
+    ) {
+      flush()
+    }
+    current.push(primitive)
+    estimated += size
+  }
+  flush()
+  return slices
+}
+
+/**
+ * Encodes an analytic OSNAP catalog to uncompressed ACEO bytes.
+ * Coordinates stay float64; layer names are dictionary-compressed.
+ */
+export function encodeOsnapCatalogBinary(
+  catalog: AcExOsnapCatalog
+): Uint8Array {
+  const writer = new AcExBinaryWriter()
+  writer.writeU32(ACEO_OSNAP_MAGIC)
+  writer.writeU8(ACEO_OSNAP_VERSION)
+  writer.writeU8(0)
+  writer.writeU8(0)
+  writer.writeU8(0)
+
+  const layers: string[] = []
+  const layerIndex = new Map<string, number>()
+  const layerId = (name: string): number => {
+    const existing = layerIndex.get(name)
+    if (existing != null) return existing
+    const id = layers.length
+    layers.push(name)
+    layerIndex.set(name, id)
+    return id
+  }
+
+  // First pass collects layers in encounter order so encode is deterministic.
+  for (const primitive of catalog.primitives) {
+    layerId(primitive.layer)
+  }
+
+  writer.writeU32(layers.length)
+  for (const layer of layers) {
+    writer.writeString(layer)
+  }
+
+  writer.writeU32(catalog.primitives.length)
+  for (const primitive of catalog.primitives) {
+    writePrimitive(writer, primitive, layerId(primitive.layer))
+  }
+
+  return writer.toUint8Array()
+}
+
+/**
+ * Decodes an uncompressed ACEO osnap catalog.
+ */
+export function decodeOsnapCatalogBinary(bytes: Uint8Array): AcExOsnapCatalog {
+  const reader = new AcExBinaryReader(bytes)
+  const magic = reader.readU32()
+  if (magic !== ACEO_OSNAP_MAGIC) {
+    throw new Error('Invalid osnap catalog magic')
+  }
+  const version = reader.readU8()
+  reader.readU8()
+  reader.readU8()
+  reader.readU8()
+  if (version !== ACEO_OSNAP_VERSION) {
+    throw new Error(`Unsupported osnap catalog version: ${version}`)
+  }
+
+  const layerCount = reader.readU32()
+  if (layerCount > ACEX_MAX_OSNAP_LAYERS_PER_CHUNK) {
+    throw new Error('Osnap layer count exceeds limit')
+  }
+  const layers: string[] = []
+  for (let i = 0; i < layerCount; i++) {
+    layers.push(reader.readString())
+  }
+
+  const primitiveCount = reader.readU32()
+  if (primitiveCount > ACEX_MAX_OSNAP_PRIMITIVES_PER_CHUNK) {
+    throw new Error('Osnap primitive count exceeds limit')
+  }
+  const primitives: AcExOsnapPrimitive[] = []
+  for (let i = 0; i < primitiveCount; i++) {
+    primitives.push(readPrimitive(reader, layers))
+  }
+
+  return { primitives }
+}
+
+/** Encodes and gzip-compresses an OSNAP catalog (`.osnap.gz` payload). */
+export function encodeOsnapCatalogGzip(catalog: AcExOsnapCatalog): {
+  uncompressed: Uint8Array
+  compressed: Uint8Array
+} {
+  const uncompressed = encodeOsnapCatalogBinary(catalog)
+  const compressed = compressSnapshotBinary(uncompressed).bytes
+  return { uncompressed, compressed }
+}
+
+/** Gunzips and decodes a `.osnap.gz` catalog payload. */
+export function decodeOsnapCatalogGzip(
+  compressed: Uint8Array
+): AcExOsnapCatalog {
+  return decodeOsnapCatalogBinary(decompressSnapshotBinary(compressed))
+}
+
+function writeNormalSign(writer: AcExBinaryWriter, sign: 1 | -1): void {
+  writer.writeU8(sign < 0 ? 0 : 1)
+}
+
+function readNormalSign(reader: AcExBinaryReader): 1 | -1 {
+  return reader.readU8() === 0 ? -1 : 1
+}
+
+function writeF64Array(writer: AcExBinaryWriter, values: number[]): void {
+  writer.writeU32(values.length)
+  for (const value of values) {
+    writer.writeF64(value)
+  }
+}
+
+function readF64Array(reader: AcExBinaryReader): number[] {
+  const count = reader.readU32()
+  if (count > ACEX_MAX_OSNAP_PRIMITIVES_PER_CHUNK) {
+    throw new Error('Float64 array count exceeds limit')
+  }
+  const values: number[] = []
+  for (let i = 0; i < count; i++) {
+    values.push(reader.readF64())
+  }
+  return values
+}
+
+function writePrimitive(
+  writer: AcExBinaryWriter,
+  primitive: AcExOsnapPrimitive,
+  layer: number
+): void {
+  switch (primitive.kind) {
+    case 'line':
+      writer.writeU8(KIND_LINE)
+      writer.writeU32(layer)
+      writer.writeF64(primitive.x0)
+      writer.writeF64(primitive.y0)
+      writer.writeF64(primitive.x1)
+      writer.writeF64(primitive.y1)
+      return
+    case 'circle':
+      writer.writeU8(KIND_CIRCLE)
+      writer.writeU32(layer)
+      writer.writeF64(primitive.cx)
+      writer.writeF64(primitive.cy)
+      writer.writeF64(primitive.r)
+      writeNormalSign(writer, primitive.normalSign)
+      return
+    case 'arc':
+      writer.writeU8(KIND_ARC)
+      writer.writeU32(layer)
+      writer.writeF64(primitive.cx)
+      writer.writeF64(primitive.cy)
+      writer.writeF64(primitive.r)
+      writer.writeF64(primitive.startAngle)
+      writer.writeF64(primitive.endAngle)
+      writeNormalSign(writer, primitive.normalSign)
+      return
+    case 'ellipse':
+      writer.writeU8(KIND_ELLIPSE)
+      writer.writeU32(layer)
+      writer.writeF64(primitive.cx)
+      writer.writeF64(primitive.cy)
+      writer.writeF64(primitive.majorX)
+      writer.writeF64(primitive.majorY)
+      writer.writeF64(primitive.majorR)
+      writer.writeF64(primitive.minorR)
+      writer.writeF64(primitive.startAngle)
+      writer.writeF64(primitive.endAngle)
+      writer.writeU8(primitive.closed ? 1 : 0)
+      writeNormalSign(writer, primitive.normalSign ?? 1)
+      return
+    case 'spline':
+      writer.writeU8(KIND_SPLINE)
+      writer.writeU32(layer)
+      writeF64Array(writer, primitive.controlPoints)
+      writer.writeU32(primitive.degree)
+      writeF64Array(writer, primitive.knots)
+      writeF64Array(writer, primitive.weights)
+      writer.writeU8(primitive.closed ? 1 : 0)
+      writeF64Array(writer, primitive.fitPoints ?? [])
+      return
+    case 'point':
+      writer.writeU8(KIND_POINT)
+      writer.writeU32(layer)
+      writer.writeF64(primitive.x)
+      writer.writeF64(primitive.y)
+      return
+    default: {
+      const _exhaustive: never = primitive
+      throw new Error(`Unsupported osnap primitive: ${String(_exhaustive)}`)
+    }
+  }
+}
+
+function readPrimitive(
+  reader: AcExBinaryReader,
+  layers: string[]
+): AcExOsnapPrimitive {
+  const kind = reader.readU8()
+  const layerIdx = reader.readU32()
+  const layer = layers[layerIdx]
+  if (layer == null) {
+    throw new Error(`Invalid osnap layer index: ${layerIdx}`)
+  }
+
+  switch (kind) {
+    case KIND_LINE:
+      return {
+        kind: 'line',
+        layer,
+        x0: reader.readF64(),
+        y0: reader.readF64(),
+        x1: reader.readF64(),
+        y1: reader.readF64()
+      }
+    case KIND_CIRCLE:
+      return {
+        kind: 'circle',
+        layer,
+        cx: reader.readF64(),
+        cy: reader.readF64(),
+        r: reader.readF64(),
+        normalSign: readNormalSign(reader)
+      }
+    case KIND_ARC:
+      return {
+        kind: 'arc',
+        layer,
+        cx: reader.readF64(),
+        cy: reader.readF64(),
+        r: reader.readF64(),
+        startAngle: reader.readF64(),
+        endAngle: reader.readF64(),
+        normalSign: readNormalSign(reader)
+      }
+    case KIND_ELLIPSE:
+      return {
+        kind: 'ellipse',
+        layer,
+        cx: reader.readF64(),
+        cy: reader.readF64(),
+        majorX: reader.readF64(),
+        majorY: reader.readF64(),
+        majorR: reader.readF64(),
+        minorR: reader.readF64(),
+        startAngle: reader.readF64(),
+        endAngle: reader.readF64(),
+        closed: reader.readU8() !== 0,
+        normalSign: readNormalSign(reader)
+      }
+    case KIND_SPLINE: {
+      const controlPoints = readF64Array(reader)
+      const degree = reader.readU32()
+      const knots = readF64Array(reader)
+      const weights = readF64Array(reader)
+      const closed = reader.readU8() !== 0
+      const fitPoints = readF64Array(reader)
+      return {
+        kind: 'spline',
+        layer,
+        controlPoints,
+        degree,
+        knots,
+        weights,
+        closed,
+        ...(fitPoints.length > 0 ? { fitPoints } : {})
+      }
+    }
+    case KIND_POINT:
+      return {
+        kind: 'point',
+        layer,
+        x: reader.readF64(),
+        y: reader.readF64()
+      }
+    default:
+      throw new Error(`Unsupported osnap primitive kind: ${kind}`)
+  }
+}

--- a/packages/cad-html-plugin/src/AcExPackageBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExPackageBuilder.ts
@@ -1,0 +1,304 @@
+import { strToU8 } from 'fflate'
+
+import {
+  estimateLineBatchBytes,
+  estimateMeshBatchBytes
+} from './AcExBatchBinaryCodec'
+import {
+  type AcExGeometryChunk,
+  encodeChunkGzip} from './AcExChunkBinaryCodec'
+import { packHtmlPackage } from './AcExHtmlPackager'
+import {
+  encodeOsnapCatalogGzip,
+  splitOsnapPrimitives
+} from './AcExOsnapCatalogCodec'
+import {
+  ACEX_DEFAULT_CHUNK_MAX_BYTES,
+  ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES,
+  ACEX_PACKAGE_VERSION,
+  ACEX_SNAPSHOT_VERSION,
+  type AcExPackageChunkRef,
+  type AcExPackageFiles,
+  type AcExPackageLayoutRef,
+  type AcExPackageManifest,
+  type AcExPackageOsnapChunkRef
+} from './AcExPackageTypes'
+import type {
+  AcExLayoutSnapshot,
+  AcExLineBatch,
+  AcExMeshBatch,
+  AcExSnapshot
+} from './AcExSnapshotTypes'
+
+export interface AcExBuildPackageOptions {
+  /** Inline viewer runtime IIFE source. */
+  viewerRuntime: string
+  /** Base name for files (no extension), e.g. `drawing`. */
+  baseName?: string
+  /** Max uncompressed ACEC bytes per geometry chunk. */
+  maxChunkBytes?: number
+  /** Max estimated uncompressed ACEO bytes per OSNAP chunk. */
+  maxOsnapChunkBytes?: number
+  /**
+   * Relative or absolute manifest URL embedded in the shell HTML.
+   * Defaults to `./{baseName}.acex.json`.
+   */
+  manifestUrl?: string
+}
+
+interface GeometrySlice {
+  lineBatches: AcExLineBatch[]
+  meshBatches: AcExMeshBatch[]
+  estimatedBytes: number
+}
+
+/**
+ * Splits a layout's batches into slices that stay under `maxChunkBytes`.
+ * Empty layouts still produce one empty slice so the layout remains addressable.
+ */
+export function splitLayoutIntoSlices(
+  layout: AcExLayoutSnapshot,
+  maxChunkBytes: number
+): GeometrySlice[] {
+  const slices: GeometrySlice[] = []
+  let current: GeometrySlice = {
+    lineBatches: [],
+    meshBatches: [],
+    estimatedBytes: 64
+  }
+
+  const flush = () => {
+    if (
+      current.lineBatches.length === 0 &&
+      current.meshBatches.length === 0 &&
+      slices.length > 0
+    ) {
+      return
+    }
+    slices.push(current)
+    current = { lineBatches: [], meshBatches: [], estimatedBytes: 64 }
+  }
+
+  const pushLine = (batch: AcExLineBatch) => {
+    const size = estimateLineBatchBytes(batch)
+    if (
+      current.estimatedBytes + size > maxChunkBytes &&
+      (current.lineBatches.length > 0 || current.meshBatches.length > 0)
+    ) {
+      flush()
+    }
+    current.lineBatches.push(batch)
+    current.estimatedBytes += size
+  }
+
+  const pushMesh = (batch: AcExMeshBatch) => {
+    const size = estimateMeshBatchBytes(batch)
+    if (
+      current.estimatedBytes + size > maxChunkBytes &&
+      (current.lineBatches.length > 0 || current.meshBatches.length > 0)
+    ) {
+      flush()
+    }
+    current.meshBatches.push(batch)
+    current.estimatedBytes += size
+  }
+
+  for (const batch of layout.lineBatches) {
+    pushLine(batch)
+  }
+  for (const batch of layout.meshBatches) {
+    pushMesh(batch)
+  }
+
+  if (
+    slices.length === 0 ||
+    current.lineBatches.length > 0 ||
+    current.meshBatches.length > 0
+  ) {
+    flush()
+  }
+
+  if (slices.length === 0) {
+    slices.push({ lineBatches: [], meshBatches: [], estimatedBytes: 64 })
+  }
+
+  return slices
+}
+
+/**
+ * Builds a multi-file ACEX package from an in-memory {@link AcExSnapshot}.
+ * Active layout chunks are listed first so hosts can prioritize first paint.
+ */
+export function buildAcExPackage(
+  snapshot: AcExSnapshot,
+  options: AcExBuildPackageOptions
+): AcExPackageFiles {
+  if (snapshot.version !== ACEX_SNAPSHOT_VERSION) {
+    throw new Error(`Unsupported snapshot version: ${snapshot.version}`)
+  }
+
+  const baseName = sanitizeBaseName(
+    options.baseName ?? snapshot.meta.title ?? 'drawing'
+  )
+  const maxChunkBytes = options.maxChunkBytes ?? ACEX_DEFAULT_CHUNK_MAX_BYTES
+  const maxOsnapChunkBytes =
+    options.maxOsnapChunkBytes ?? ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES
+  const manifestFileName = `${baseName}.acex.json`
+  const manifestUrl = options.manifestUrl ?? `./${manifestFileName}`
+
+  const orderedLayouts = orderLayoutsForExport(
+    snapshot.layouts,
+    snapshot.activeLayoutBtrId
+  )
+
+  const chunkRefs: AcExPackageChunkRef[] = []
+  const osnapChunkRefs: AcExPackageOsnapChunkRef[] = []
+  const layoutRefs: AcExPackageLayoutRef[] = []
+  const files: AcExPackageFiles['files'] = []
+  const layoutIndexByBtrId = new Map<string, number>()
+
+  orderedLayouts.forEach((layout, layoutIndex) => {
+    layoutIndexByBtrId.set(layout.btrId, layoutIndex)
+    const slices = splitLayoutIntoSlices(layout, maxChunkBytes)
+    const chunkIds: string[] = []
+
+    slices.forEach((slice, sliceIndex) => {
+      const id = `L${layoutIndex}-${String(sliceIndex).padStart(3, '0')}`
+      const href = `chunks/${id}.acex.gz`
+      const geometry: AcExGeometryChunk = {
+        version: ACEX_SNAPSHOT_VERSION,
+        layoutBtrId: layout.btrId,
+        lineBatches: slice.lineBatches,
+        meshBatches: slice.meshBatches
+      }
+      const { uncompressed, compressed } = encodeChunkGzip(geometry)
+
+      chunkIds.push(id)
+      chunkRefs.push({
+        id,
+        href,
+        layoutBtrId: layout.btrId,
+        byteLength: uncompressed.byteLength,
+        compressedByteLength: compressed.byteLength,
+        lineBatchCount: slice.lineBatches.length,
+        meshBatchCount: slice.meshBatches.length
+      })
+      files.push({ path: href, bytes: compressed })
+    })
+
+    const layoutRef: AcExPackageLayoutRef = {
+      btrId: layout.btrId,
+      name: layout.name,
+      isModelSpace: layout.isModelSpace,
+      viewports: layout.viewports,
+      chunkIds
+    }
+
+    const osnapPrimitives = layout.osnap?.primitives
+    if (osnapPrimitives && osnapPrimitives.length > 0) {
+      const osnapSlices = splitOsnapPrimitives(
+        osnapPrimitives,
+        maxOsnapChunkBytes
+      )
+      const osnapChunkIds: string[] = []
+      osnapSlices.forEach((primitives, sliceIndex) => {
+        const id = `L${layoutIndex}-osnap-${String(sliceIndex).padStart(3, '0')}`
+        const href = `chunks/${id}.osnap.gz`
+        const { uncompressed, compressed } = encodeOsnapCatalogGzip({
+          primitives
+        })
+        osnapChunkIds.push(id)
+        osnapChunkRefs.push({
+          id,
+          href,
+          layoutBtrId: layout.btrId,
+          byteLength: uncompressed.byteLength,
+          compressedByteLength: compressed.byteLength,
+          primitiveCount: primitives.length
+        })
+        files.push({ path: href, bytes: compressed })
+      })
+      layoutRef.osnapChunkIds = osnapChunkIds
+    }
+
+    layoutRefs.push(layoutRef)
+  })
+
+  // Restore original layout order in the manifest (UI order), but chunk list
+  // already prefers active layout because we encoded active first.
+  const layoutsInOriginalOrder = snapshot.layouts.map(layout => {
+    const index = layoutIndexByBtrId.get(layout.btrId)!
+    return layoutRefs[index]!
+  })
+
+  // Reorder chunkRefs: active layout chunks first, then remaining in layout order.
+  const activeChunkIds = new Set(
+    layoutsInOriginalOrder.find(l => l.btrId === snapshot.activeLayoutBtrId)
+      ?.chunkIds ?? []
+  )
+  const orderedChunks = [
+    ...chunkRefs.filter(c => activeChunkIds.has(c.id)),
+    ...chunkRefs.filter(c => !activeChunkIds.has(c.id))
+  ]
+
+  const activeOsnapIds = new Set(
+    layoutsInOriginalOrder.find(l => l.btrId === snapshot.activeLayoutBtrId)
+      ?.osnapChunkIds ?? []
+  )
+  const orderedOsnapChunks = [
+    ...osnapChunkRefs.filter(c => activeOsnapIds.has(c.id)),
+    ...osnapChunkRefs.filter(c => !activeOsnapIds.has(c.id))
+  ]
+
+  const manifest: AcExPackageManifest = {
+    format: 'acex-package',
+    packageVersion: ACEX_PACKAGE_VERSION,
+    snapshotVersion: ACEX_SNAPSHOT_VERSION,
+    meta: snapshot.meta,
+    layers: snapshot.layers,
+    activeLayoutBtrId: snapshot.activeLayoutBtrId,
+    layouts: layoutsInOriginalOrder,
+    chunks: orderedChunks,
+    ...(orderedOsnapChunks.length > 0
+      ? { osnapChunks: orderedOsnapChunks }
+      : {})
+  }
+
+  const manifestJson = `${JSON.stringify(manifest)}\n`
+  files.unshift({
+    path: manifestFileName,
+    bytes: strToU8(manifestJson)
+  })
+
+  const html = packHtmlPackage(snapshot, {
+    title: snapshot.meta.title,
+    viewerRuntime: options.viewerRuntime,
+    manifestUrl
+  })
+  files.unshift({
+    path: 'viewer.html',
+    bytes: strToU8(html)
+  })
+
+  return {
+    html,
+    manifest,
+    manifestFileName,
+    files
+  }
+}
+
+function orderLayoutsForExport(
+  layouts: AcExLayoutSnapshot[],
+  activeLayoutBtrId: string
+): AcExLayoutSnapshot[] {
+  const active = layouts.find(l => l.btrId === activeLayoutBtrId)
+  const rest = layouts.filter(l => l.btrId !== activeLayoutBtrId)
+  return active ? [active, ...rest] : [...layouts]
+}
+
+function sanitizeBaseName(name: string): string {
+  const trimmed = name.trim().replace(/\.(dwg|dxf|html|zip)$/i, '')
+  const safe = trimmed.replace(/[^\w.\-()+ ]+/g, '_').replace(/\s+/g, '_')
+  return safe.length > 0 ? safe : 'drawing'
+}

--- a/packages/cad-html-plugin/src/AcExPackageLoader.ts
+++ b/packages/cad-html-plugin/src/AcExPackageLoader.ts
@@ -1,0 +1,459 @@
+import { decodeChunkGzip } from './AcExChunkBinaryCodec'
+import { decodeOsnapCatalogGzip } from './AcExOsnapCatalogCodec'
+import type { AcExOsnapPrimitive } from './AcExOsnapPrimitiveTypes'
+import {
+  ACEX_PACKAGE_VERSION,
+  ACEX_SNAPSHOT_VERSION,
+  type AcExPackageChunkRef,
+  type AcExPackageManifest,
+  type AcExPackageOsnapChunkRef
+} from './AcExPackageTypes'
+import { ACEX_MAX_COMPRESSED_BYTES } from './AcExSnapshotCompression'
+import type {
+  AcExLayoutSnapshot,
+  AcExLineBatch,
+  AcExMeshBatch,
+  AcExSnapshot
+} from './AcExSnapshotTypes'
+
+export interface AcExPackageLoadProgress {
+  loadedChunks: number
+  totalChunks: number
+  layoutBtrId: string
+  chunkId: string
+}
+
+export interface AcExPackageLoaderOptions {
+  /** Absolute or relative URL of the `*.acex.json` manifest. */
+  manifestUrl: string
+  /** Optional fetch implementation (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch
+  /** Called after each geometry chunk is decoded. */
+  onChunk?: (
+    layout: AcExLayoutSnapshot,
+    chunk: AcExPackageChunkRef,
+    progress: AcExPackageLoadProgress
+  ) => void | Promise<void>
+  /**
+   * When `false`, skip OSNAP sidecars (geometry only). Defaults to `true`.
+   * Viewers that paint first should load geometry with this `false`, then call
+   * {@link loadAcExPackageLayoutOsnap} after first paint.
+   */
+  loadOsnap?: boolean
+  /** When set, only these layout BTR ids are fetched (others stay empty). */
+  layoutFilter?: ReadonlySet<string> | string[]
+}
+
+export interface AcExPackageOsnapLoadOptions {
+  fetchImpl?: typeof fetch
+  /**
+   * Called after each OSNAP chunk is decoded (before the next decode).
+   * Use to update status UI and yield for paint.
+   */
+  onChunk?: (
+    progress: AcExPackageLoadProgress
+  ) => void | Promise<void>
+  /** Yield between decode steps so the canvas stays responsive. */
+  yieldFn?: () => Promise<void>
+}
+
+const SAFE_PACKAGE_HREF =
+  /^(?:\.[/\\])?[A-Za-z0-9._-]+(?:[/\\][A-Za-z0-9._-]+)*$/
+
+/**
+ * Returns true when `href` is a relative package path (no scheme, `..`, or
+ * absolute URL). Used for manifest chunk refs and package `manifestUrl`.
+ */
+export function isSafePackageHref(href: string): boolean {
+  const trimmed = href.trim()
+  if (!trimmed || trimmed !== href) {
+    return false
+  }
+  if (
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('\\') ||
+    trimmed.startsWith('//') ||
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)
+  ) {
+    return false
+  }
+  if (trimmed.includes('..') || trimmed.includes('\\')) {
+    return false
+  }
+  return SAFE_PACKAGE_HREF.test(trimmed)
+}
+
+function assertSafePackageHref(href: string, label: string): void {
+  if (!isSafePackageHref(href)) {
+    throw new Error(`Invalid ${label}: must be a relative package path`)
+  }
+}
+
+/**
+ * Parses and validates a package manifest JSON value.
+ */
+export function parseAcExPackageManifest(data: unknown): AcExPackageManifest {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Invalid package manifest')
+  }
+  const manifest = data as AcExPackageManifest
+  if (manifest.format !== 'acex-package') {
+    throw new Error('Unsupported package format')
+  }
+  if (manifest.packageVersion !== ACEX_PACKAGE_VERSION) {
+    throw new Error(
+      `Unsupported package version: ${String(manifest.packageVersion)}`
+    )
+  }
+  if (manifest.snapshotVersion !== ACEX_SNAPSHOT_VERSION) {
+    throw new Error(
+      `Unsupported snapshot version: ${String(manifest.snapshotVersion)}`
+    )
+  }
+  if (!Array.isArray(manifest.layouts) || !Array.isArray(manifest.chunks)) {
+    throw new Error('Invalid package manifest structure')
+  }
+  for (const chunk of manifest.chunks) {
+    if (!chunk || typeof chunk !== 'object') {
+      throw new Error('Invalid package chunk entry')
+    }
+    assertSafePackageHref(chunk.href, 'chunk href')
+  }
+  for (const chunk of manifest.osnapChunks ?? []) {
+    if (!chunk || typeof chunk !== 'object') {
+      throw new Error('Invalid package osnap chunk entry')
+    }
+    assertSafePackageHref(chunk.href, 'osnap chunk href')
+  }
+  return manifest
+}
+
+/**
+ * Builds an empty {@link AcExSnapshot} skeleton from a manifest (no geometry yet).
+ * OSNAP catalogs are loaded later via {@link loadAcExPackageLayoutOsnap}.
+ */
+export function snapshotSkeletonFromManifest(
+  manifest: AcExPackageManifest
+): AcExSnapshot {
+  return {
+    version: ACEX_SNAPSHOT_VERSION,
+    meta: manifest.meta,
+    layers: manifest.layers,
+    activeLayoutBtrId: manifest.activeLayoutBtrId,
+    layouts: manifest.layouts.map(layout => ({
+      btrId: layout.btrId,
+      name: layout.name,
+      isModelSpace: layout.isModelSpace,
+      lineBatches: [],
+      meshBatches: [],
+      viewports: layout.viewports
+    }))
+  }
+}
+
+/**
+ * Resolves a chunk href against the manifest URL.
+ * Only relative package paths under the manifest directory are allowed.
+ */
+export function resolveChunkUrl(manifestUrl: string, href: string): string {
+  assertSafePackageHref(href, 'chunk href')
+  let resolved: URL
+  let manifest: URL
+  try {
+    resolved = new URL(href, manifestUrl)
+    manifest = new URL(manifestUrl)
+  } catch {
+    throw new Error('Invalid chunk or manifest URL')
+  }
+  if (resolved.protocol !== manifest.protocol || resolved.host !== manifest.host) {
+    throw new Error('Chunk URL must share the manifest origin')
+  }
+  const basePath = manifest.pathname.replace(/[^/]*$/, '')
+  const resolvedPath = resolved.pathname
+  if (!resolvedPath.startsWith(basePath)) {
+    throw new Error('Chunk URL escapes package directory')
+  }
+  // Reject encoded `..` segments after URL normalization.
+  if (resolvedPath.split('/').includes('..')) {
+    throw new Error('Chunk URL escapes package directory')
+  }
+  return resolved.toString()
+}
+
+/**
+ * Resolves a package `manifestUrl` from viewer.html config against the page URL.
+ * Absolute and cross-origin URLs are rejected.
+ */
+export function resolvePackageManifestUrl(
+  manifestUrl: string,
+  pageUrl: string
+): string {
+  assertSafePackageHref(manifestUrl, 'manifestUrl')
+  let resolved: URL
+  let page: URL
+  try {
+    resolved = new URL(manifestUrl, pageUrl)
+    page = new URL(pageUrl)
+  } catch {
+    throw new Error('Invalid manifestUrl')
+  }
+  if (resolved.protocol !== page.protocol || resolved.host !== page.host) {
+    throw new Error('manifestUrl must be same-origin')
+  }
+  return resolved.toString()
+}
+
+async function fetchCompressedBytes(
+  fetchImpl: typeof fetch,
+  url: string,
+  label: string
+): Promise<Uint8Array> {
+  const response = await fetchImpl(url)
+  if (!response.ok) {
+    throw new Error(`Failed to load ${label} (${response.status})`)
+  }
+  const contentLength = response.headers.get('content-length')
+  if (contentLength != null) {
+    const declared = Number(contentLength)
+    if (Number.isFinite(declared) && declared > ACEX_MAX_COMPRESSED_BYTES) {
+      throw new Error(`${label} exceeds size limit`)
+    }
+  }
+  const buffer = await response.arrayBuffer()
+  if (buffer.byteLength > ACEX_MAX_COMPRESSED_BYTES) {
+    throw new Error(`${label} exceeds size limit`)
+  }
+  return new Uint8Array(buffer)
+}
+
+/**
+ * Fetches the package manifest, then progressively downloads geometry chunks.
+ * OSNAP sidecars load afterward (unless {@link AcExPackageLoaderOptions.loadOsnap}
+ * is `false`) so display data is not blocked by snap catalogs.
+ */
+export async function loadAcExPackage(
+  options: AcExPackageLoaderOptions
+): Promise<AcExSnapshot> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const loadOsnap = options.loadOsnap !== false
+  const manifestResponse = await fetchImpl(options.manifestUrl)
+  if (!manifestResponse.ok) {
+    throw new Error(
+      `Failed to load package manifest (${manifestResponse.status})`
+    )
+  }
+  const manifest = parseAcExPackageManifest(await manifestResponse.json())
+  const snapshot = snapshotSkeletonFromManifest(manifest)
+
+  const layoutById = new Map(
+    snapshot.layouts.map(layout => [layout.btrId, layout])
+  )
+
+  const filter =
+    options.layoutFilter == null
+      ? null
+      : options.layoutFilter instanceof Set
+        ? options.layoutFilter
+        : new Set(options.layoutFilter)
+
+  const chunksToLoad = manifest.chunks.filter(
+    chunk => filter == null || filter.has(chunk.layoutBtrId)
+  )
+
+  let loadedChunks = 0
+  for (const chunkRef of chunksToLoad) {
+    const layout = layoutById.get(chunkRef.layoutBtrId)
+    if (!layout) {
+      throw new Error('Unknown layout for package chunk')
+    }
+
+    const url = resolveChunkUrl(options.manifestUrl, chunkRef.href)
+    const compressed = await fetchCompressedBytes(
+      fetchImpl,
+      url,
+      'geometry chunk'
+    )
+    const decoded = decodeChunkGzip(compressed)
+    if (decoded.layoutBtrId !== chunkRef.layoutBtrId) {
+      throw new Error('Chunk layout mismatch')
+    }
+
+    appendBatches(layout, decoded.lineBatches, decoded.meshBatches)
+    loadedChunks += 1
+
+    await options.onChunk?.(layout, chunkRef, {
+      loadedChunks,
+      totalChunks: chunksToLoad.length,
+      layoutBtrId: chunkRef.layoutBtrId,
+      chunkId: chunkRef.id
+    })
+  }
+
+  if (loadOsnap) {
+    for (const layoutRef of manifest.layouts) {
+      if (filter != null && !filter.has(layoutRef.btrId)) {
+        continue
+      }
+      const layout = layoutById.get(layoutRef.btrId)
+      if (!layout) {
+        continue
+      }
+      await loadAcExPackageLayoutOsnap(
+        manifest,
+        options.manifestUrl,
+        layoutRef.btrId,
+        layout,
+        { fetchImpl }
+      )
+    }
+  }
+
+  return snapshot
+}
+
+/**
+ * Loads geometry chunks for a single layout into an existing snapshot skeleton.
+ * Does not load OSNAP — call {@link loadAcExPackageLayoutOsnap} after paint.
+ */
+export async function loadAcExPackageLayout(
+  manifest: AcExPackageManifest,
+  manifestUrl: string,
+  layoutBtrId: string,
+  layout: AcExLayoutSnapshot,
+  options: Pick<AcExPackageLoaderOptions, 'fetchImpl' | 'onChunk'> = {}
+): Promise<void> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const layoutRef = manifest.layouts.find(l => l.btrId === layoutBtrId)
+  if (!layoutRef) {
+    throw new Error(`Layout not found: ${layoutBtrId}`)
+  }
+  const chunkById = new Map(manifest.chunks.map(c => [c.id, c]))
+  const chunks = layoutRef.chunkIds
+    .map(id => chunkById.get(id))
+    .filter((c): c is AcExPackageChunkRef => c != null)
+
+  let loadedChunks = 0
+  for (const chunkRef of chunks) {
+    const url = resolveChunkUrl(manifestUrl, chunkRef.href)
+    const compressed = await fetchCompressedBytes(
+      fetchImpl,
+      url,
+      'geometry chunk'
+    )
+    const decoded = decodeChunkGzip(compressed)
+    appendBatches(layout, decoded.lineBatches, decoded.meshBatches)
+    loadedChunks += 1
+    await options.onChunk?.(layout, chunkRef, {
+      loadedChunks,
+      totalChunks: chunks.length,
+      layoutBtrId,
+      chunkId: chunkRef.id
+    })
+  }
+}
+
+/**
+ * Loads OSNAP ACEO chunks for one layout (no-op when absent).
+ *
+ * Prefetches the next compressed chunk while decoding the current one, but
+ * never gunzips/decodes more than one chunk at a time — parallel decode of
+ * dozens of ~500 KiB ACEO payloads freezes the main thread on large drawings.
+ */
+export async function loadAcExPackageLayoutOsnap(
+  manifest: AcExPackageManifest,
+  manifestUrl: string,
+  layoutBtrId: string,
+  layout: AcExLayoutSnapshot,
+  options: AcExPackageOsnapLoadOptions = {}
+): Promise<void> {
+  if (layout.osnap) {
+    return
+  }
+  const layoutRef = manifest.layouts.find(l => l.btrId === layoutBtrId)
+  if (!layoutRef) {
+    return
+  }
+  const ids = layoutRef.osnapChunkIds
+  if (!ids || ids.length === 0) {
+    return
+  }
+  const osnapById = new Map(
+    (manifest.osnapChunks ?? []).map(chunk => [chunk.id, chunk])
+  )
+  const refs = ids
+    .map(id => osnapById.get(id))
+    .filter((c): c is AcExPackageOsnapChunkRef => c != null)
+  if (refs.length === 0) {
+    return
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch
+  const yieldFn =
+    options.yieldFn ??
+    (() =>
+      new Promise<void>(resolve => {
+        setTimeout(resolve, 0)
+      }))
+
+  const totalPrimitives = refs.reduce((sum, ref) => sum + ref.primitiveCount, 0)
+  const primitives: AcExOsnapPrimitive[] =
+    totalPrimitives > 0 ? new Array(totalPrimitives) : []
+  let writeOffset = 0
+
+  const fetchCompressed = async (
+    chunkRef: AcExPackageOsnapChunkRef
+  ): Promise<Uint8Array> => {
+    const url = resolveChunkUrl(manifestUrl, chunkRef.href)
+    return fetchCompressedBytes(fetchImpl, url, 'osnap chunk')
+  }
+
+  let nextFetch =
+    refs.length > 0 ? fetchCompressed(refs[0]!) : Promise.resolve(null)
+
+  for (let i = 0; i < refs.length; i++) {
+    const chunkRef = refs[i]!
+    const compressed = await nextFetch
+    nextFetch =
+      i + 1 < refs.length
+        ? fetchCompressed(refs[i + 1]!)
+        : Promise.resolve(null)
+
+    if (!compressed) {
+      throw new Error('Missing osnap chunk bytes')
+    }
+
+    const decoded = decodeOsnapCatalogGzip(compressed)
+    const slice = decoded.primitives
+    if (totalPrimitives > 0) {
+      for (let p = 0; p < slice.length; p++) {
+        primitives[writeOffset++] = slice[p]!
+      }
+    } else {
+      for (const primitive of slice) {
+        primitives.push(primitive)
+      }
+    }
+
+    await options.onChunk?.({
+      loadedChunks: i + 1,
+      totalChunks: refs.length,
+      layoutBtrId,
+      chunkId: chunkRef.id
+    })
+    await yieldFn()
+  }
+
+  if (totalPrimitives > 0 && writeOffset !== totalPrimitives) {
+    primitives.length = writeOffset
+  }
+  layout.osnap = { primitives }
+}
+
+function appendBatches(
+  layout: AcExLayoutSnapshot,
+  lineBatches: AcExLineBatch[],
+  meshBatches: AcExMeshBatch[]
+): void {
+  layout.lineBatches.push(...lineBatches)
+  layout.meshBatches.push(...meshBatches)
+}

--- a/packages/cad-html-plugin/src/AcExPackageTypes.ts
+++ b/packages/cad-html-plugin/src/AcExPackageTypes.ts
@@ -1,0 +1,134 @@
+import {
+  ACEX_SNAPSHOT_VERSION,
+  type AcExLayerSnapshot,
+  type AcExSnapshot,
+  type AcExSnapshotVersion,
+  type AcExViewportSnapshot
+} from './AcExSnapshotTypes'
+
+/** Current multi-file package / manifest protocol version. */
+export const ACEX_PACKAGE_VERSION = 1 as const
+
+export type AcExPackageVersion = typeof ACEX_PACKAGE_VERSION
+
+/** Snapshot schema version embedded in package manifests (matches ACEX batches). */
+export type AcExPackageSnapshotVersion = AcExSnapshotVersion
+
+/** One gzip-compressed geometry chunk listed in the package manifest. */
+export interface AcExPackageChunkRef {
+  /** Stable chunk id (also used in the default file name). */
+  id: string
+  /** Relative URL from the manifest file (e.g. `chunks/L0-000.acex.gz`). */
+  href: string
+  /** Layout BTR id this chunk belongs to. */
+  layoutBtrId: string
+  /** Uncompressed ACEC byte length. */
+  byteLength: number
+  /** Gzip-compressed byte length. */
+  compressedByteLength: number
+  /** Number of line batches in this chunk. */
+  lineBatchCount: number
+  /** Number of mesh batches in this chunk. */
+  meshBatchCount: number
+  /** Optional content hash (hex SHA-256). Not required by the loader. */
+  sha256?: string
+}
+
+/**
+ * One gzip-compressed ACEO OSNAP chunk (measure mode).
+ * Loaded after geometry so viewing does not wait on snap catalogs.
+ */
+export interface AcExPackageOsnapChunkRef {
+  /** Stable chunk id (also used in the default file name). */
+  id: string
+  /** Relative URL from the manifest (e.g. `chunks/L0-osnap-000.osnap.gz`). */
+  href: string
+  /** Layout BTR id this chunk belongs to. */
+  layoutBtrId: string
+  /** Uncompressed ACEO byte length. */
+  byteLength: number
+  /** Gzip-compressed byte length. */
+  compressedByteLength: number
+  /** Number of analytic primitives in this chunk. */
+  primitiveCount: number
+  /** Optional content hash (hex SHA-256). Not required by the loader. */
+  sha256?: string
+}
+
+/**
+ * Layout directory entry in the package manifest.
+ * Geometry and OSNAP catalogs live in referenced files, not inline.
+ */
+export interface AcExPackageLayoutRef {
+  btrId: string
+  name: string
+  isModelSpace: boolean
+  /** Paper-space viewports (model space omits this). */
+  viewports?: AcExViewportSnapshot[]
+  /** Geometry chunks for this layout, in paint order. */
+  chunkIds: string[]
+  /**
+   * OSNAP chunk ids for this layout (measure mode).
+   * Omitted when the layout has no analytic snap data.
+   */
+  osnapChunkIds?: string[]
+}
+
+/**
+ * Versioned package manifest (`*.acex.json`).
+ * Small JSON fetched first; geometry is loaded progressively from chunks.
+ */
+export interface AcExPackageManifest {
+  /** Discriminator for package manifests. */
+  format: 'acex-package'
+  /** Package protocol version ({@link ACEX_PACKAGE_VERSION}). */
+  packageVersion: AcExPackageVersion
+  /** Batch / snapshot schema version ({@link ACEX_SNAPSHOT_VERSION}). */
+  snapshotVersion: AcExPackageSnapshotVersion
+  /** Document-level metadata (same shape as {@link AcExSnapshot.meta}). */
+  meta: AcExSnapshot['meta']
+  layers: AcExLayerSnapshot[]
+  activeLayoutBtrId: string
+  layouts: AcExPackageLayoutRef[]
+  /** Flat geometry chunk list; layouts reference ids via {@link AcExPackageLayoutRef.chunkIds}. */
+  chunks: AcExPackageChunkRef[]
+  /**
+   * Flat OSNAP chunk list (measure mode). Layouts reference ids via
+   * {@link AcExPackageLayoutRef.osnapChunkIds}. Omitted or empty for view-only.
+   */
+  osnapChunks?: AcExPackageOsnapChunkRef[]
+}
+
+/** One file in a multi-file package before zipping for download. */
+export interface AcExPackageFile {
+  /** Path relative to the package root (forward slashes). */
+  path: string
+  /** File bytes (UTF-8 for text, raw for binary). */
+  bytes: Uint8Array
+}
+
+/**
+ * Complete multi-file package ready to zip or write to disk.
+ */
+export interface AcExPackageFiles {
+  /** Shell HTML (`viewer.html`) with `#mlcad-package` config. */
+  html: string
+  /** Manifest object (also serialized as `*.acex.json`). */
+  manifest: AcExPackageManifest
+  /** Manifest file name at package root (e.g. `drawing.acex.json`). */
+  manifestFileName: string
+  /** All package files including HTML, manifest, and chunk `.acex.gz` files. */
+  files: AcExPackageFile[]
+}
+
+/** Default max uncompressed ACEC size per geometry chunk (~512 KiB). */
+export const ACEX_DEFAULT_CHUNK_MAX_BYTES = 512 * 1024
+
+/**
+ * Default max estimated uncompressed ACEO size per OSNAP chunk (~512 KiB).
+ * Large measure catalogs are split so hosts can fetch snap data in parallel.
+ */
+export const ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES = 512 * 1024
+
+export { ACEX_SNAPSHOT_VERSION }
+

--- a/packages/cad-html-plugin/src/AcExPackageZip.ts
+++ b/packages/cad-html-plugin/src/AcExPackageZip.ts
@@ -1,0 +1,48 @@
+import { unzipSync, zipSync } from 'fflate'
+
+import type { AcExPackageFile, AcExPackageFiles } from './AcExPackageTypes'
+
+function isSafeZipPath(path: string): boolean {
+  if (!path || path.startsWith('/') || path.includes('\\') || path.includes('\0')) {
+    return false
+  }
+  const parts = path.split('/')
+  return parts.every(
+    part =>
+      part.length > 0 &&
+      part !== '.' &&
+      part !== '..' &&
+      /^[A-Za-z0-9._-]+$/.test(part)
+  )
+}
+
+/**
+ * Zips multi-file package contents for a single browser download.
+ * Paths inside the archive match the hosted directory layout.
+ */
+export function zipAcExPackageFiles(pkg: AcExPackageFiles): Uint8Array {
+  const entries: Record<string, Uint8Array> = {}
+  for (const file of pkg.files) {
+    if (!isSafeZipPath(file.path)) {
+      throw new Error(`Unsafe package path: ${file.path}`)
+    }
+    entries[file.path] = file.bytes
+  }
+  return zipSync(entries, { level: 6 })
+}
+
+/**
+ * Unzips a package archive produced by {@link zipAcExPackageFiles}.
+ * Entries with path traversal or absolute paths are rejected.
+ */
+export function unzipAcExPackageFiles(bytes: Uint8Array): AcExPackageFile[] {
+  const entries = unzipSync(bytes)
+  const files: AcExPackageFile[] = []
+  for (const [path, data] of Object.entries(entries)) {
+    if (!isSafeZipPath(path)) {
+      throw new Error('Unsafe path in package archive')
+    }
+    files.push({ path, bytes: data })
+  }
+  return files
+}

--- a/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
+++ b/packages/cad-html-plugin/src/AcExPatternSnapshot.ts
@@ -8,6 +8,7 @@ import * as THREE from 'three'
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 
 import { copyFloat32Range } from './AcExBatchBuffers'
+import { createTextureFromExportedBytes } from './AcExMeshTextureExport'
 import type {
   AcExGradientFill,
   AcExHatchPattern,
@@ -327,10 +328,23 @@ export function transformHatchPatternToWorldSpace(
   }
 }
 
+/** Optional hooks when building viewer materials from exported mesh batches. */
+export interface AcExViewerMeshMaterialOptions {
+  /**
+   * Called after an async IMAGE/OLE texture becomes ready. Offline viewers should
+   * pass their `render()` so the mesh is not stuck at opacity 0 until the next
+   * pan/zoom.
+   */
+  onTextureLoad?: () => void
+}
+
 /**
  * Creates a viewer material for one exported mesh batch.
  */
-export function createViewerMeshMaterial(batch: AcExMeshBatch): THREE.Material {
+export function createViewerMeshMaterial(
+  batch: AcExMeshBatch,
+  options: AcExViewerMeshMaterialOptions = {}
+): THREE.Material {
   if (batch.hatchPattern && batch.hatchPattern.patternLines.length > 0) {
     try {
       const patternLines = batch.hatchPattern.patternLines.map(
@@ -361,6 +375,26 @@ export function createViewerMeshMaterial(batch: AcExMeshBatch): THREE.Material {
     } catch {
       // Fall back to a solid fill if gradient shader creation fails.
     }
+  }
+  if (batch.texture && batch.uvs && batch.uvs.length >= 2) {
+    // Stay invisible until the blob texture decodes — otherwise MeshBasicMaterial
+    // shows a solid white fill (same class of bug as live AcTrImage placeholders).
+    const material = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      side: THREE.DoubleSide,
+      transparent: true,
+      opacity: 0,
+      depthWrite: false
+    })
+    material.map = createTextureFromExportedBytes(batch.texture, {
+      onLoad: () => {
+        material.opacity = 1
+        material.depthWrite = true
+        material.needsUpdate = true
+        options.onTextureLoad?.()
+      }
+    })
+    return material
   }
   return new THREE.MeshBasicMaterial({
     color: batch.color,

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -22,6 +22,11 @@ import {
   readBatchWorldOffset
 } from './AcExBatchBuffers'
 import {
+  encodeTextureForExport,
+  exportUvsForPositionSlice,
+  isTransparentImagePlaceholder
+} from './AcExMeshTextureExport'
+import {
   computeLineDistancesForSegments,
   exportVertexAttributeSlice,
   extractGradientFill,
@@ -464,7 +469,7 @@ function buildMeshBatch(
   object: THREE.Object3D,
   slice: AcExBufferGeometrySlice,
   offset: [number, number, number]
-): AcExMeshBatch {
+): AcExMeshBatch | undefined {
   const style = readMaterialStyle(material)
   const hatchPattern = resolveExportedHatchPattern(object, style.hatchPattern)
   const gradientPositions = style.gradientFill
@@ -480,6 +485,23 @@ function buildMeshBatch(
     side: style.side,
     ...slice
   }
+
+  const meshMaterial = material as THREE.MeshBasicMaterial
+  if (meshMaterial.map) {
+    const texture = encodeTextureForExport(meshMaterial.map)
+    const uvs = exportUvsForPositionSlice(geometry, slice.positions)
+    if (!texture || !uvs) {
+      // Prefer omitting a broken IMAGE/OLE frame over a solid white fill.
+      return undefined
+    }
+    batch.texture = texture
+    batch.uvs = uvs
+    // Textured IMAGE/OLE meshes multiply by material color; keep white so the
+    // PNG is shown at full intensity (matches live AcTrImage).
+    batch.color = 0xffffff
+    batch.side = THREE.DoubleSide
+  }
+
   assignRenderOrder(batch, object, material)
   return batch
 }
@@ -548,15 +570,19 @@ function exportBatchedPoint(
   if (slice.positions.length === 0) {
     return undefined
   }
+  const mesh = buildMeshBatch(
+    batch.geometry,
+    batch.material as THREE.Material,
+    batch,
+    slice,
+    readWorldOffset(batch)
+  )
+  if (!mesh) {
+    return undefined
+  }
   return {
     points: true,
-    ...buildMeshBatch(
-      batch.geometry,
-      batch.material as THREE.Material,
-      batch,
-      slice,
-      readWorldOffset(batch)
-    )
+    ...mesh
   }
 }
 
@@ -646,16 +672,22 @@ export function collectBatchesFromObject3D(
       !(child instanceof AcTrBatchedMesh)
     ) {
       if (!shouldExportPlainDrawable(child)) return
+      const material = readExportMaterial(child)
+      if (isTransparentImagePlaceholder(material)) return
       const rawSlice = exportBufferGeometrySlice(child.geometry)
       if (rawSlice.positions.length === 0) return
-      const material = readExportMaterial(child)
       const style = readMaterialStyle(material)
       const { offset, ...slice } = exportSceneDrawableSlice(child, rawSlice, {
         preserveWorldSpaceForPatternFill: !!style.hatchPattern
       })
-      meshBatches.push(
-        buildMeshBatch(child.geometry, material, child, slice, offset)
+      const mesh = buildMeshBatch(
+        child.geometry,
+        material,
+        child,
+        slice,
+        offset
       )
+      if (mesh) meshBatches.push(mesh)
     }
   })
 

--- a/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotBinaryCodec.ts
@@ -1,5 +1,5 @@
-import { strFromU8, strToU8 } from 'fflate'
-
+import { readLineBatch, readMeshBatch, writeLineBatch, writeMeshBatch } from './AcExBatchBinaryCodec'
+import { AcExBinaryReader, AcExBinaryWriter } from './AcExBinaryIO'
 import {
   ACEX_SNAPSHOT_VERSION,
   type AcExLayoutSnapshot,
@@ -9,20 +9,6 @@ import {
 } from './AcExSnapshotTypes'
 
 const MAGIC = 0x58454341 // 'ACEX' little-endian
-
-const F_LINE_INDICES = 1
-const F_LINE_PATTERN = 2
-const F_LINE_DISTANCES = 4
-const F_LINE_WIDTH = 8
-const F_LINE_RENDER_ORDER = 16
-
-const F_MESH_INDICES = 1
-const F_MESH_HATCH = 2
-const F_MESH_GRADIENT_FILL = 4
-const F_MESH_GRADIENT_POS = 8
-const F_MESH_SIDE = 16
-const F_MESH_POINTS = 32
-const F_MESH_RENDER_ORDER = 64
 
 /**
  * Serializes a snapshot to a compact binary byte array.
@@ -38,7 +24,7 @@ export function encodeSnapshotBinary(snapshot: AcExSnapshot): Uint8Array {
     throw new Error(`Unsupported snapshot version: ${snapshot.version}`)
   }
 
-  const writer = new BinaryWriter()
+  const writer = new AcExBinaryWriter()
   writer.writeU32(MAGIC)
   writer.writeU8(ACEX_SNAPSHOT_VERSION)
   writer.writeU8(0)
@@ -61,7 +47,7 @@ export function encodeSnapshotBinary(snapshot: AcExSnapshot): Uint8Array {
  * Parses a binary snapshot byte array produced by {@link encodeSnapshotBinary}.
  */
 export function decodeSnapshotBinary(bytes: Uint8Array): AcExSnapshot {
-  const reader = new BinaryReader(bytes)
+  const reader = new AcExBinaryReader(bytes)
   const magic = reader.readU32()
   if (magic !== MAGIC) {
     throw new Error('Invalid snapshot magic')
@@ -93,7 +79,7 @@ export function decodeSnapshotBinary(bytes: Uint8Array): AcExSnapshot {
   }
 }
 
-function writeLayout(writer: BinaryWriter, layout: AcExLayoutSnapshot): void {
+function writeLayout(writer: AcExBinaryWriter, layout: AcExLayoutSnapshot): void {
   writer.writeString(layout.btrId)
   writer.writeString(layout.name)
   writer.writeU8(layout.isModelSpace ? 1 : 0)
@@ -111,7 +97,7 @@ function writeLayout(writer: BinaryWriter, layout: AcExLayoutSnapshot): void {
   }
 }
 
-function readLayout(reader: BinaryReader): AcExLayoutSnapshot {
+function readLayout(reader: AcExBinaryReader): AcExLayoutSnapshot {
   const btrId = reader.readString()
   const name = reader.readString()
   const isModelSpace = reader.readU8() !== 0
@@ -142,373 +128,5 @@ function readLayout(reader: BinaryReader): AcExLayoutSnapshot {
     meshBatches,
     osnap,
     viewports
-  }
-}
-
-function writeLineBatch(writer: BinaryWriter, batch: AcExLineBatch): void {
-  writer.writeString(batch.layer)
-  writer.writeU32(batch.color >>> 0)
-  writer.writeF64(batch.offset[0]!)
-  writer.writeF64(batch.offset[1]!)
-  writer.writeF64(batch.offset[2]!)
-  writer.writeFloat32Array(batch.positions)
-
-  let flags = 0
-  if (batch.indices && batch.indices.length > 0) flags |= F_LINE_INDICES
-  if (batch.linePattern) flags |= F_LINE_PATTERN
-  if (batch.lineDistances && batch.lineDistances.length > 0) {
-    flags |= F_LINE_DISTANCES
-  }
-  if (batch.lineWidth != null && batch.lineWidth > 0) {
-    flags |= F_LINE_WIDTH
-  }
-  if (batch.renderOrder != null && batch.renderOrder !== 0) {
-    flags |= F_LINE_RENDER_ORDER
-  }
-  writer.writeU8(flags)
-
-  if (flags & F_LINE_INDICES) {
-    writer.writeUint32Array(batch.indices!)
-  }
-  if (flags & F_LINE_PATTERN) {
-    writer.writeJson(batch.linePattern!)
-  }
-  if (flags & F_LINE_DISTANCES) {
-    writer.writeFloat32Array(batch.lineDistances!)
-  }
-  if (flags & F_LINE_WIDTH) {
-    writer.writeF32(batch.lineWidth!)
-  }
-  if (flags & F_LINE_RENDER_ORDER) {
-    writer.writeI32(batch.renderOrder!)
-  }
-}
-
-function readLineBatch(reader: BinaryReader): AcExLineBatch {
-  const layer = reader.readString()
-  const color = reader.readU32()
-  const offset: [number, number, number] = [
-    reader.readF64(),
-    reader.readF64(),
-    reader.readF64()
-  ]
-  const positions = reader.readFloat32Array()
-  const flags = reader.readU8()
-
-  const batch: AcExLineBatch = { layer, color, offset, positions }
-  if (flags & F_LINE_INDICES) {
-    batch.indices = reader.readUint32Array()
-  }
-  if (flags & F_LINE_PATTERN) {
-    batch.linePattern =
-      reader.readJson<NonNullable<AcExLineBatch['linePattern']>>()
-  }
-  if (flags & F_LINE_DISTANCES) {
-    batch.lineDistances = reader.readFloat32Array()
-  }
-  if (flags & F_LINE_WIDTH) {
-    batch.lineWidth = reader.readF32()
-  }
-  if (flags & F_LINE_RENDER_ORDER) {
-    batch.renderOrder = reader.readI32()
-  }
-  return batch
-}
-
-function writeMeshBatch(writer: BinaryWriter, batch: AcExMeshBatch): void {
-  writer.writeString(batch.layer)
-  writer.writeU32(batch.color >>> 0)
-  writer.writeF64(batch.offset[0]!)
-  writer.writeF64(batch.offset[1]!)
-  writer.writeF64(batch.offset[2]!)
-  writer.writeFloat32Array(batch.positions)
-
-  let flags = 0
-  if (batch.indices && batch.indices.length > 0) flags |= F_MESH_INDICES
-  if (batch.hatchPattern) flags |= F_MESH_HATCH
-  if (batch.gradientFill) flags |= F_MESH_GRADIENT_FILL
-  if (batch.gradientPositions && batch.gradientPositions.length > 0) {
-    flags |= F_MESH_GRADIENT_POS
-  }
-  if (batch.side != null) flags |= F_MESH_SIDE
-  if (batch.points) flags |= F_MESH_POINTS
-  if (batch.renderOrder != null && batch.renderOrder !== 0) {
-    flags |= F_MESH_RENDER_ORDER
-  }
-  writer.writeU8(flags)
-
-  if (flags & F_MESH_INDICES) {
-    writer.writeUint32Array(batch.indices!)
-  }
-  if (flags & F_MESH_HATCH) {
-    writer.writeJson(batch.hatchPattern!)
-  }
-  if (flags & F_MESH_GRADIENT_FILL) {
-    writer.writeJson(batch.gradientFill!)
-  }
-  if (flags & F_MESH_GRADIENT_POS) {
-    writer.writeFloat32Array(batch.gradientPositions!)
-  }
-  if (flags & F_MESH_SIDE) {
-    writer.writeU8(batch.side!)
-  }
-  if (flags & F_MESH_RENDER_ORDER) {
-    writer.writeI32(batch.renderOrder!)
-  }
-}
-
-function readMeshBatch(reader: BinaryReader): AcExMeshBatch {
-  const layer = reader.readString()
-  const color = reader.readU32()
-  const offset: [number, number, number] = [
-    reader.readF64(),
-    reader.readF64(),
-    reader.readF64()
-  ]
-  const positions = reader.readFloat32Array()
-  const flags = reader.readU8()
-
-  const batch: AcExMeshBatch = { layer, color, offset, positions }
-  if (flags & F_MESH_INDICES) {
-    batch.indices = reader.readUint32Array()
-  }
-  if (flags & F_MESH_HATCH) {
-    batch.hatchPattern =
-      reader.readJson<NonNullable<AcExMeshBatch['hatchPattern']>>()
-  }
-  if (flags & F_MESH_GRADIENT_FILL) {
-    batch.gradientFill =
-      reader.readJson<NonNullable<AcExMeshBatch['gradientFill']>>()
-  }
-  if (flags & F_MESH_GRADIENT_POS) {
-    batch.gradientPositions = reader.readFloat32Array()
-  }
-  if (flags & F_MESH_SIDE) {
-    batch.side = reader.readU8()
-  }
-  if (flags & F_MESH_POINTS) {
-    batch.points = true
-  }
-  if (flags & F_MESH_RENDER_ORDER) {
-    batch.renderOrder = reader.readI32()
-  }
-  return batch
-}
-
-class BinaryWriter {
-  private readonly chunks: Uint8Array[] = []
-  private length = 0
-
-  writeU8(value: number): void {
-    const chunk = new Uint8Array(1)
-    chunk[0] = value & 0xff
-    this.chunks.push(chunk)
-    this.length += 1
-  }
-
-  writeU32(value: number): void {
-    const chunk = new Uint8Array(4)
-    new DataView(chunk.buffer).setUint32(0, value >>> 0, true)
-    this.chunks.push(chunk)
-    this.length += 4
-  }
-
-  writeI32(value: number): void {
-    const chunk = new Uint8Array(4)
-    new DataView(chunk.buffer).setInt32(0, value | 0, true)
-    this.chunks.push(chunk)
-    this.length += 4
-  }
-
-  writeF32(value: number): void {
-    const chunk = new Uint8Array(4)
-    new DataView(chunk.buffer).setFloat32(0, value, true)
-    this.chunks.push(chunk)
-    this.length += 4
-  }
-
-  writeF64(value: number): void {
-    const chunk = new Uint8Array(8)
-    new DataView(chunk.buffer).setFloat64(0, value, true)
-    this.chunks.push(chunk)
-    this.length += 8
-  }
-
-  writeBytes(bytes: Uint8Array): void {
-    this.chunks.push(bytes)
-    this.length += bytes.length
-  }
-
-  writeString(value: string): void {
-    const bytes = strToU8(value)
-    this.writeU32(bytes.length)
-    this.writeBytes(bytes)
-  }
-
-  writeJson(value: unknown): void {
-    this.writeString(JSON.stringify(value))
-  }
-
-  writeFloat32Array(array: Float32Array): void {
-    this.alignTo(4)
-    const bytes = new Uint8Array(
-      array.buffer,
-      array.byteOffset,
-      array.byteLength
-    )
-    this.writeU32(bytes.length)
-    this.writeBytes(bytes)
-  }
-
-  writeUint32Array(array: Uint32Array): void {
-    this.alignTo(4)
-    const bytes = new Uint8Array(
-      array.buffer,
-      array.byteOffset,
-      array.byteLength
-    )
-    this.writeU32(bytes.length)
-    this.writeBytes(bytes)
-  }
-
-  private alignTo(alignment: number): void {
-    const remainder = this.length % alignment
-    if (remainder === 0) {
-      return
-    }
-    const pad = alignment - remainder
-    for (let i = 0; i < pad; i++) {
-      this.writeU8(0)
-    }
-  }
-
-  toUint8Array(): Uint8Array {
-    const result = new Uint8Array(this.length)
-    let offset = 0
-    for (const chunk of this.chunks) {
-      result.set(chunk, offset)
-      offset += chunk.length
-    }
-    return result
-  }
-}
-
-class BinaryReader {
-  private offset = 0
-
-  constructor(private readonly bytes: Uint8Array) {}
-
-  readU8(): number {
-    return this.bytes[this.offset++]!
-  }
-
-  readU32(): number {
-    const view = new DataView(
-      this.bytes.buffer,
-      this.bytes.byteOffset + this.offset,
-      4
-    )
-    const value = view.getUint32(0, true)
-    this.offset += 4
-    return value
-  }
-
-  readI32(): number {
-    const view = new DataView(
-      this.bytes.buffer,
-      this.bytes.byteOffset + this.offset,
-      4
-    )
-    const value = view.getInt32(0, true)
-    this.offset += 4
-    return value
-  }
-
-  readF32(): number {
-    const view = new DataView(
-      this.bytes.buffer,
-      this.bytes.byteOffset + this.offset,
-      4
-    )
-    const value = view.getFloat32(0, true)
-    this.offset += 4
-    return value
-  }
-
-  readF64(): number {
-    const view = new DataView(
-      this.bytes.buffer,
-      this.bytes.byteOffset + this.offset,
-      8
-    )
-    const value = view.getFloat64(0, true)
-    this.offset += 8
-    return value
-  }
-
-  readBytes(length: number): Uint8Array {
-    const slice = this.bytes.subarray(this.offset, this.offset + length)
-    this.offset += length
-    return slice
-  }
-
-  readString(): string {
-    const length = this.readU32()
-    if (length === 0) {
-      return ''
-    }
-    return strFromU8(this.readBytes(length))
-  }
-
-  readJson<T>(): T {
-    const text = this.readString()
-    if (text.length === 0) {
-      throw new Error('Expected JSON payload')
-    }
-    return JSON.parse(text) as T
-  }
-
-  private alignTo(alignment: number): void {
-    const remainder = this.offset % alignment
-    if (remainder === 0) {
-      return
-    }
-    this.offset += alignment - remainder
-  }
-
-  readFloat32Array(): Float32Array {
-    this.alignTo(4)
-    const byteLength = this.readU32()
-    if (byteLength === 0) {
-      return new Float32Array(0)
-    }
-    if (byteLength % 4 !== 0) {
-      throw new Error('Invalid float32 buffer length')
-    }
-    const bytes = this.readBytes(byteLength)
-    if (bytes.byteOffset % 4 === 0) {
-      return new Float32Array(bytes.buffer, bytes.byteOffset, byteLength / 4)
-    }
-    const copy = new ArrayBuffer(byteLength)
-    new Uint8Array(copy).set(bytes)
-    return new Float32Array(copy)
-  }
-
-  readUint32Array(): Uint32Array {
-    this.alignTo(4)
-    const byteLength = this.readU32()
-    if (byteLength === 0) {
-      return new Uint32Array(0)
-    }
-    if (byteLength % 4 !== 0) {
-      throw new Error('Invalid uint32 buffer length')
-    }
-    const bytes = this.readBytes(byteLength)
-    if (bytes.byteOffset % 4 === 0) {
-      return new Uint32Array(bytes.buffer, bytes.byteOffset, byteLength / 4)
-    }
-    const copy = new ArrayBuffer(byteLength)
-    new Uint8Array(copy).set(bytes)
-    return new Uint32Array(copy)
   }
 }

--- a/packages/cad-html-plugin/src/AcExSnapshotCompression.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotCompression.ts
@@ -3,6 +3,15 @@ import { gunzipSync, gzipSync } from 'fflate'
 /** Snapshot payload compression stored on the HTML script `type` attribute. */
 export const ACEX_SNAPSHOT_COMPRESSION = 'gzip' as const
 
+/**
+ * Hard cap on gunzip output for ACEX payloads (single-file snapshot or package
+ * chunk). Rejects zip bombs after inflate; compressed input is also capped.
+ */
+export const ACEX_MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024
+
+/** Hard cap on compressed gzip bytes accepted before inflate. */
+export const ACEX_MAX_COMPRESSED_BYTES = 32 * 1024 * 1024
+
 export type AcExSnapshotCompression = typeof ACEX_SNAPSHOT_COMPRESSION
 
 export interface AcExCompressedSnapshotBinary {
@@ -28,5 +37,12 @@ export function compressSnapshotBinary(
 
 /** Decompresses a gzip snapshot binary payload from an exported HTML file. */
 export function decompressSnapshotBinary(data: Uint8Array): Uint8Array {
-  return gunzipSync(data)
+  if (data.byteLength > ACEX_MAX_COMPRESSED_BYTES) {
+    throw new Error('Compressed payload exceeds size limit')
+  }
+  const result = gunzipSync(data)
+  if (result.byteLength > ACEX_MAX_DECOMPRESSED_BYTES) {
+    throw new Error('Decompressed payload exceeds size limit')
+  }
+  return result
 }

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -11,8 +11,11 @@ import type { AcExOsnapCatalog } from './AcExOsnapPrimitiveTypes'
  * is a backward-compatible flag on v3 batches: hatch fills use `-1` so they
  * sit below linework on the shared Z plane, matching the live viewer's
  * `AcGiSubEntityTraits.drawOrder` / `Object3D.renderOrder` tiers.
+ *
+ * v4 adds optional textured mesh payloads ({@link AcExMeshBatch.uvs} +
+ * {@link AcExMeshBatch.texture}) for raster images and OLE frames.
  */
-export const ACEX_SNAPSHOT_VERSION = 3 as const
+export const ACEX_SNAPSHOT_VERSION = 4 as const
 
 /**
  * Literal type of the supported snapshot schema version.
@@ -181,11 +184,21 @@ export interface AcExGradientFill {
 }
 
 /**
+ * Embedded raster texture for an image / OLE mesh batch (PNG bytes).
+ */
+export interface AcExMeshTexture {
+  /** MIME type, typically `image/png`. */
+  mimeType: string
+  /** Encoded image bytes. */
+  bytes: Uint8Array
+}
+
+/**
  * One packed mesh or point batch (filled regions, MText quads, point glyphs, etc.)
  * rendered in the offline viewer.
  */
 export interface AcExMeshBatch {
-  /** Layer name used for grouping and visibility in the viewer. */
+  /** Layer name used for grouping and visibility in the offline viewer. */
   layer: string
   /** Fill color as 24-bit RGB hex. */
   color: number
@@ -215,6 +228,15 @@ export interface AcExMeshBatch {
    * Required when {@link AcExMeshBatch.gradientFill} is set.
    */
   gradientPositions?: Float32Array
+  /**
+   * Per-vertex UVs `[u0, v0, u1, v1, …]` paired with {@link AcExMeshBatch.texture}.
+   * Vertex count must match {@link AcExMeshBatch.positions}.
+   */
+  uvs?: Float32Array
+  /**
+   * Raster texture for IMAGE / OLE frames. Requires {@link AcExMeshBatch.uvs}.
+   */
+  texture?: AcExMeshTexture
   /** Material side when a custom fill shader is used (`0` = front, `1` = back). */
   side?: number
   /**

--- a/packages/cad-html-plugin/src/AcExViewerMemory.ts
+++ b/packages/cad-html-plugin/src/AcExViewerMemory.ts
@@ -75,6 +75,8 @@ function clearLayoutBatchBuffers(layout: AcExLayoutSnapshot): void {
     batch.positions = new Float32Array(0)
     if (batch.indices) batch.indices = new Uint32Array(0)
     if (batch.gradientPositions) batch.gradientPositions = new Float32Array(0)
+    if (batch.uvs) batch.uvs = new Float32Array(0)
+    if (batch.texture) batch.texture = { mimeType: '', bytes: new Uint8Array(0) }
   }
   layout.meshBatches.length = 0
 }

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -37,7 +37,7 @@ export {
   splineToAcGe,
   type AcExOsnapAcGeCurve
 } from './AcExOsnapPrimitiveToAcGe'
-export { packHtml, type AcExPackHtmlOptions } from './AcExHtmlPackager'
+export { packHtml, packHtmlPackage, type AcExPackHtmlOptions, type AcExPackHtmlPackageOptions } from './AcExHtmlPackager'
 export {
   type AcApHtmlExpiryDays,
   type AcExHtmlAccessManifest,
@@ -63,6 +63,55 @@ export {
   resolveAcExHtmlLocale
 } from './AcExHtmlI18n'
 
+export {
+  ACEX_PACKAGE_VERSION,
+  ACEX_DEFAULT_CHUNK_MAX_BYTES,
+  ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES,
+  type AcExPackageVersion,
+  type AcExPackageChunkRef,
+  type AcExPackageOsnapChunkRef,
+  type AcExPackageLayoutRef,
+  type AcExPackageManifest,
+  type AcExPackageFile,
+  type AcExPackageFiles
+} from './AcExPackageTypes'
+export {
+  encodeChunkBinary,
+  decodeChunkBinary,
+  encodeChunkGzip,
+  decodeChunkGzip,
+  ACEC_CHUNK_MAGIC,
+  type AcExGeometryChunk
+} from './AcExChunkBinaryCodec'
+export {
+  buildAcExPackage,
+  splitLayoutIntoSlices,
+  type AcExBuildPackageOptions
+} from './AcExPackageBuilder'
+export {
+  parseAcExPackageManifest,
+  snapshotSkeletonFromManifest,
+  resolveChunkUrl,
+  resolvePackageManifestUrl,
+  isSafePackageHref,
+  loadAcExPackage,
+  loadAcExPackageLayout,
+  loadAcExPackageLayoutOsnap,
+  type AcExPackageLoadProgress,
+  type AcExPackageLoaderOptions
+} from './AcExPackageLoader'
+export {
+  encodeOsnapCatalogBinary,
+  decodeOsnapCatalogBinary,
+  encodeOsnapCatalogGzip,
+  decodeOsnapCatalogGzip,
+  splitOsnapPrimitives,
+  estimateOsnapPrimitiveBytes,
+  ACEO_OSNAP_MAGIC,
+  ACEO_OSNAP_VERSION
+} from './AcExOsnapCatalogCodec'
+export { zipAcExPackageFiles, unzipAcExPackageFiles } from './AcExPackageZip'
+
 /**
  * Default filename of the offline HTML viewer IIFE bundle
  * produced by the viewer build target.
@@ -72,6 +121,7 @@ export const HTML_VIEWER_RUNTIME_FILE = 'viewer-runtime.iife.js'
 export { AcApExportHtmlCmd } from './AcApExportHtmlCmd'
 export { AcApHtmlConvertor } from './AcApHtmlConvertor'
 export {
+  type AcApHtmlExportFormat,
   type AcApHtmlExportOptions,
   captureAcApHtmlViewState,
   resolveAcApHtmlExportOptions

--- a/packages/cad-simple-viewer/src/i18n/ar/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/ar/jig.ts
@@ -1971,6 +1971,9 @@ export default {
   chtml: {
     ...enJig.chtml,
 
+    exportFormat:
+      'تنسيق التصدير [ملف واحد(S)/حزمة متعددة الملفات(M)]',
+
     exportInvisibleLayers:
       'تصدير الطبقات غير المرئية',
 
@@ -1985,6 +1988,16 @@ export default {
   ,
     keywords: {
       ...enJig.chtml.keywords,
+      single: {
+        display: 'ملف واحد(S)',
+        local: 'ملف واحد',
+        global: 'Single'
+      },
+      multi: {
+        display: 'حزمة متعددة الملفات(M)',
+        local: 'حزمة متعددة الملفات',
+        global: 'Multi'
+      },
       yes: {
         display: 'نعم(Y)',
         local: 'نعم',

--- a/packages/cad-simple-viewer/src/i18n/cs/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/cs/jig.ts
@@ -1213,11 +1213,22 @@ export default {
     }
   },
   chtml: {
+    exportFormat: 'Formát exportu [Jeden soubor(S)/Vícesouborový balíček(M)]',
     exportInvisibleLayers: 'Exportovat neviditelné hladiny',
     exportLayouts: 'Exportovat rozvržení',
     initialView: 'Počáteční pohled při otevření HTML',
     viewerMode: 'Režim offline prohlížeče',
     keywords: {
+      single: {
+        display: 'Jeden soubor(S)',
+        local: 'Jeden soubor',
+        global: 'Single'
+      },
+      multi: {
+        display: 'Vícesouborový balíček(M)',
+        local: 'Vícesouborový balíček',
+        global: 'Multi'
+      },
       yes: {
         display: 'Ano(Y)',
         local: 'Ano',

--- a/packages/cad-simple-viewer/src/i18n/en/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/jig.ts
@@ -1216,11 +1216,22 @@ export default {
     }
   },
   chtml: {
+    exportFormat: 'Export format [Single(S)/Multi-file package(M)]',
     exportInvisibleLayers: 'Export invisible layers',
     exportLayouts: 'Export layouts',
     initialView: 'Initial view when opening HTML',
     viewerMode: 'Offline viewer mode',
     keywords: {
+      single: {
+        display: 'Single(S)',
+        local: 'Single',
+        global: 'Single'
+      },
+      multi: {
+        display: 'Multi-file package(M)',
+        local: 'Multi-file package',
+        global: 'Multi'
+      },
       yes: {
         display: 'Yes(Y)',
         local: 'Yes',

--- a/packages/cad-simple-viewer/src/i18n/tr/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/tr/jig.ts
@@ -1216,11 +1216,22 @@ export default {
     }
   },
   chtml: {
+    exportFormat: 'Dışa aktarma biçimi [Tek dosya(S)/Çok dosyalı paket(M)]',
     exportInvisibleLayers: 'Görünmez katmanları dışa aktar',
     exportLayouts: 'Yerleşimleri dışa aktar',
     initialView: 'HTML açılırken başlangıç görünümü',
     viewerMode: 'Çevrimdışı görüntüleyici modu',
     keywords: {
+      single: {
+        display: 'Tek dosya(S)',
+        local: 'Tek dosya',
+        global: 'Single'
+      },
+      multi: {
+        display: 'Çok dosyalı paket(M)',
+        local: 'Çok dosyalı paket',
+        global: 'Multi'
+      },
       yes: {
         display: 'Evet(E)',
         local: 'Evet',

--- a/packages/cad-simple-viewer/src/i18n/zh/jig.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/jig.ts
@@ -1204,11 +1204,22 @@ export default {
     }
   },
   chtml: {
+    exportFormat: '导出格式 [单文件(S)/多文件包(M)]',
     exportInvisibleLayers: '是否导出不可见图层',
     exportLayouts: '是否导出布局',
     initialView: '打开 HTML 时的初始视图',
     viewerMode: '离线查看器模式',
     keywords: {
+      single: {
+        display: '单文件(S)',
+        local: '单文件',
+        global: 'Single'
+      },
+      multi: {
+        display: '多文件包(M)',
+        local: '多文件包',
+        global: 'Multi'
+      },
       yes: {
         display: '是(Y)',
         local: '是',

--- a/packages/cad-viewer/src/component/dialog/MlExportHtmlDlg.vue
+++ b/packages/cad-viewer/src/component/dialog/MlExportHtmlDlg.vue
@@ -10,10 +10,56 @@
     <div class="ml-export-html-dlg">
       <el-tabs v-model="activeTab" class="ml-export-html-dlg__tabs">
         <el-tab-pane
-          :label="t('dialog.exportHtmlDlg.tabExport')"
-          name="export"
+          :label="t('dialog.exportHtmlDlg.tabData')"
+          name="data"
         >
           <div class="ml-export-html-dlg__tab-body">
+            <ml-fieldset-group
+              :title="t('dialog.exportHtmlDlg.exportFormat')"
+              class="ml-export-html-dlg__section"
+            >
+              <el-radio-group
+                v-model="form.exportFormat"
+                class="ml-export-html-dlg__card-group"
+                @change="handleExportFormatChange"
+              >
+                <label
+                  class="ml-export-html-dlg__card"
+                  :class="{ 'is-selected': form.exportFormat === 'single' }"
+                >
+                  <el-radio
+                    value="single"
+                    class="ml-export-html-dlg__card-radio"
+                  />
+                  <span class="ml-export-html-dlg__card-body">
+                    <span class="ml-export-html-dlg__card-title">{{
+                      t('dialog.exportHtmlDlg.exportFormatSingle')
+                    }}</span>
+                    <span class="ml-export-html-dlg__card-hint">{{
+                      t('dialog.exportHtmlDlg.exportFormatSingleHint')
+                    }}</span>
+                  </span>
+                </label>
+                <label
+                  class="ml-export-html-dlg__card"
+                  :class="{ 'is-selected': form.exportFormat === 'multi' }"
+                >
+                  <el-radio
+                    value="multi"
+                    class="ml-export-html-dlg__card-radio"
+                  />
+                  <span class="ml-export-html-dlg__card-body">
+                    <span class="ml-export-html-dlg__card-title">{{
+                      t('dialog.exportHtmlDlg.exportFormatMulti')
+                    }}</span>
+                    <span class="ml-export-html-dlg__card-hint">{{
+                      t('dialog.exportHtmlDlg.exportFormatMultiHint')
+                    }}</span>
+                  </span>
+                </label>
+              </el-radio-group>
+            </ml-fieldset-group>
+
             <div class="ml-export-html-dlg__settings-row">
               <ml-fieldset-group
                 :title="t('dialog.exportHtmlDlg.layersSection')"
@@ -59,7 +105,14 @@
                 </div>
               </ml-fieldset-group>
             </div>
+          </div>
+        </el-tab-pane>
 
+        <el-tab-pane
+          :label="t('dialog.exportHtmlDlg.tabDisplay')"
+          name="display"
+        >
+          <div class="ml-export-html-dlg__tab-body">
             <ml-fieldset-group
               :title="t('dialog.exportHtmlDlg.initialView')"
               class="ml-export-html-dlg__section"
@@ -149,8 +202,16 @@
         <el-tab-pane
           :label="t('dialog.exportHtmlDlg.tabSecurity')"
           name="security"
+          :disabled="form.exportFormat === 'multi'"
         >
           <div class="ml-export-html-dlg__tab-body">
+            <p
+              v-if="form.exportFormat === 'multi'"
+              class="ml-export-html-dlg__section-hint"
+            >
+              {{ t('dialog.exportHtmlDlg.securitySingleOnlyHint') }}
+            </p>
+            <template v-else>
             <ml-fieldset-group
               :title="t('dialog.exportHtmlDlg.expirySection')"
               class="ml-export-html-dlg__section"
@@ -222,6 +283,7 @@
                 {{ t('dialog.exportHtmlDlg.passwordHint') }}
               </p>
             </ml-fieldset-group>
+            </template>
           </div>
         </el-tab-pane>
       </el-tabs>
@@ -237,6 +299,7 @@
  */
 import type {
   AcApHtmlExpiryDays,
+  AcApHtmlExportFormat,
   AcApHtmlExportOptions,
   AcExInitialViewMode,
   AcExViewerMode
@@ -282,6 +345,10 @@ export interface MlExportHtmlDlgProps {
  */
 export interface MlExportHtmlDlgForm {
   /**
+   * Packaging mode: self-contained HTML or multi-file package zip.
+   */
+  exportFormat: AcApHtmlExportFormat
+  /**
    * When `true`, off/frozen layer geometry is included in the exported snapshot.
    */
   exportInvisibleLayers: boolean
@@ -321,7 +388,7 @@ const emit = defineEmits<MlExportHtmlDlgEmits>()
 
 const { t } = useI18n()
 
-const activeTab = ref<'export' | 'security'>('export')
+const activeTab = ref<'data' | 'display' | 'security'>('data')
 
 /** Bridges `v-model` on the base dialog to `modelValue` / `update:modelValue`. */
 const visible = computed({
@@ -334,6 +401,7 @@ const canCopyPassword = computed(() => form.password.trim().length > 0)
 
 /** Export options bound to the dialog form controls. */
 const form = reactive<MlExportHtmlDlgForm>({
+  exportFormat: 'single',
   exportInvisibleLayers: true,
   exportLayouts: true,
   initialView: 'fit',
@@ -347,6 +415,7 @@ const form = reactive<MlExportHtmlDlgForm>({
  * Restores {@link form} to HTML export package defaults.
  */
 function resetForm() {
+  form.exportFormat = 'single'
   form.exportInvisibleLayers = true
   form.exportLayouts = true
   form.initialView = 'fit'
@@ -354,7 +423,16 @@ function resetForm() {
   form.expiryDays = 'never'
   form.customExpiresAt = defaultCustomExpiresAt()
   form.password = ''
-  activeTab.value = 'export'
+  activeTab.value = 'data'
+}
+
+/**
+ * Leaves the security tab when switching to multi-file export.
+ */
+function handleExportFormatChange() {
+  if (form.exportFormat === 'multi' && activeTab.value === 'security') {
+    activeTab.value = 'data'
+  }
 }
 
 /**
@@ -432,7 +510,7 @@ async function handleOk() {
   const document = docManager.curDocument
   const view = docManager.curView
 
-  if (form.expiryDays === 'custom') {
+  if (form.exportFormat === 'single' && form.expiryDays === 'custom') {
     const customExpiresAt = form.customExpiresAt?.getTime()
     if (customExpiresAt == null || Number.isNaN(customExpiresAt)) {
       ElMessage({
@@ -453,16 +531,20 @@ async function handleOk() {
   }
 
   const options: AcApHtmlExportOptions = {
+    exportFormat: form.exportFormat,
     exportInvisibleLayers: form.exportInvisibleLayers,
     exportLayouts: form.exportLayouts,
     initialView: form.initialView,
     viewerMode: form.viewerMode,
-    expiryDays: form.expiryDays,
+    expiryDays: form.exportFormat === 'multi' ? 'never' : form.expiryDays,
     expiresAt:
-      form.expiryDays === 'custom'
+      form.exportFormat === 'single' && form.expiryDays === 'custom'
         ? (form.customExpiresAt?.getTime() ?? null)
         : null,
-    password: form.password.trim() || undefined
+    password:
+      form.exportFormat === 'single'
+        ? form.password.trim() || undefined
+        : undefined
   }
 
   try {
@@ -560,6 +642,9 @@ async function handleOk() {
   grid-template-columns: 1fr 1fr;
   gap: 8px;
   width: 100%;
+  /* Override Element Plus `.el-radio-group { align-items: center }` so the
+     shorter card (e.g. self-contained HTML) stays top-aligned. */
+  align-items: stretch;
 }
 
 .ml-export-html-dlg__card {

--- a/packages/cad-viewer/src/locale/ar/dialog.ts
+++ b/packages/cad-viewer/src/locale/ar/dialog.ts
@@ -95,8 +95,18 @@ export default {
   exportHtmlDlg: {
     ...enDialog.exportHtmlDlg,
     title: 'تصدير إلى HTML',
-    tabExport: 'تصدير',
+    tabData: 'البيانات',
+    tabDisplay: 'العرض',
     tabSecurity: 'الأمان',
+
+    exportFormat: 'تنسيق التصدير',
+    exportFormatSingle: 'HTML مستقل',
+    exportFormatSingleHint: 'ملف .html واحد يمكن فتحه دون اتصال',
+    exportFormatMulti: 'حزمة متعددة الملفات (ZIP)',
+    exportFormatMultiHint:
+      'يُنزّل zip؛ بعد فك الضغط والاستضافة يمكن التحميل التدريجي. كلمة المرور والصلاحية لـ HTML المستقل فقط',
+    securitySingleOnlyHint:
+      'كلمة المرور والصلاحية متاحتان فقط لتصدير HTML المستقل.',
 
     layersSection: 'الطبقات',
     exportInvisibleLayers: 'تصدير الطبقات غير المرئية',

--- a/packages/cad-viewer/src/locale/cs/dialog.ts
+++ b/packages/cad-viewer/src/locale/cs/dialog.ts
@@ -71,8 +71,17 @@ export default {
   },
   exportHtmlDlg: {
     title: 'Exportovat do HTML',
-    tabExport: 'Export',
+    tabData: 'Data',
+    tabDisplay: 'Zobrazení',
     tabSecurity: 'Zabezpečení',
+    exportFormat: 'Formát exportu',
+    exportFormatSingle: 'Samostatné HTML',
+    exportFormatSingleHint: 'Jeden soubor .html, který se otevře offline',
+    exportFormatMulti: 'Vícesouborový balíček (ZIP)',
+    exportFormatMultiHint:
+      'Stáhne zip; po rozbalení a nasazení lze načítat postupně. Heslo a platnost platí jen pro samostatné HTML',
+    securitySingleOnlyHint:
+      'Heslo a platnost jsou dostupné pouze pro export samostatného HTML.',
     layersSection: 'Hladiny',
     exportInvisibleLayers: 'Exportovat neviditelné hladiny',
     exportInvisibleLayersHint:

--- a/packages/cad-viewer/src/locale/en/dialog.ts
+++ b/packages/cad-viewer/src/locale/en/dialog.ts
@@ -71,8 +71,17 @@ export default {
   },
   exportHtmlDlg: {
     title: 'Export to HTML',
-    tabExport: 'Export',
+    tabData: 'Data',
+    tabDisplay: 'Display',
     tabSecurity: 'Security',
+    exportFormat: 'Export format',
+    exportFormatSingle: 'Self-contained HTML',
+    exportFormatSingleHint: 'Single .html file that opens offline',
+    exportFormatMulti: 'Multi-file package (ZIP)',
+    exportFormatMultiHint:
+      'Download a zip; unzip and host for progressive loading. Password and expiry apply only to self-contained HTML',
+    securitySingleOnlyHint:
+      'Password and expiry are available only for self-contained HTML export.',
     layersSection: 'Layers',
     exportInvisibleLayers: 'Export invisible layers',
     exportInvisibleLayersHint:

--- a/packages/cad-viewer/src/locale/tr/dialog.ts
+++ b/packages/cad-viewer/src/locale/tr/dialog.ts
@@ -71,8 +71,17 @@ export default {
   },
   exportHtmlDlg: {
     title: 'HTML Olarak Dışa Aktar',
-    tabExport: 'Dışa Aktar',
+    tabData: 'Veri',
+    tabDisplay: 'Görünüm',
     tabSecurity: 'Güvenlik',
+    exportFormat: 'Dışa aktarma biçimi',
+    exportFormatSingle: 'Tek dosyalı HTML',
+    exportFormatSingleHint: 'Çevrimdışı açılabilen tek .html dosyası',
+    exportFormatMulti: 'Çok dosyalı paket (ZIP)',
+    exportFormatMultiHint:
+      'Bir zip indirir; açıp barındırınca aşamalı yükleme yapılır. Parola ve süre yalnızca tek dosyalı HTML için geçerlidir',
+    securitySingleOnlyHint:
+      'Parola ve geçerlilik yalnızca tek dosyalı HTML dışa aktarımında kullanılabilir.',
     layersSection: 'Katmanlar',
     exportInvisibleLayers: 'Görünmez katmanları dışa aktar',
     exportInvisibleLayersHint:

--- a/packages/cad-viewer/src/locale/zh/dialog.ts
+++ b/packages/cad-viewer/src/locale/zh/dialog.ts
@@ -71,8 +71,16 @@ export default {
   },
   exportHtmlDlg: {
     title: '导出为 HTML',
-    tabExport: '导出',
+    tabData: '数据',
+    tabDisplay: '显示',
     tabSecurity: '安全',
+    exportFormat: '导出格式',
+    exportFormatSingle: '自包含 HTML',
+    exportFormatSingleHint: '单个 .html 文件，可离线直接打开',
+    exportFormatMulti: '多文件包 (ZIP)',
+    exportFormatMultiHint:
+      '下载 zip；解压后托管可边下载边渲染。密码与有效期仅支持自包含 HTML',
+    securitySingleOnlyHint: '密码与有效期仅适用于自包含 HTML 导出。',
     layersSection: '图层',
     exportInvisibleLayers: '导出不可见图层',
     exportInvisibleLayersHint: '将关闭或冻结图层上的几何图形包含在导出文件中',


### PR DESCRIPTION
## Summary
- Add multi-file ACEX package export (`exportFormat: multi`) with chunked geometry/OSNAP sidecars, progressive package viewer loading, and export dialog packaging options.
- Harden package loading: same-origin relative URL allowlist, binary/gzip size limits, safe zip paths, and `textContent` error UI to avoid DOM XSS.
- Fix layout-switch blank canvas / duplicate geometry on failed chunk loads, and repaint after async IMAGE/OLE texture decode.

## Test plan
- [ ] Export HTML as self-contained (`single`) — existing password/expiry still work
- [ ] Export as multi-file package zip, unzip, host locally, open `viewer.html`
- [ ] Switch layouts in multi-file viewer; interrupt network mid-chunk and confirm no blank canvas / no duplicate geometry on retry
- [ ] Confirm IMAGE/OLE textures appear without needing pan/zoom
- [ ] `pnpm test -- packages/cad-html-plugin/__tests__/AcExPackage.spec.ts`