### PR TITLE
fix: harden hybrid OSNAP and reject non-finite spatial boxes

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
@@ -113,6 +113,117 @@ describe('AcExOsnapIndex', () => {
     expect(index.findSnap(5, 0.1, 1)?.mode).toBe('nearest')
   })
 
+  it('ignores NaN primitive bounds so one bad entry cannot poison snap search', () => {
+    const index = new AcExOsnapIndex(['endpoint'])
+    index.rebuild({
+      ...layout,
+      lineBatches: [],
+      osnap: {
+        primitives: [
+          {
+            kind: 'line',
+            layer: '0',
+            x0: NaN,
+            y0: NaN,
+            x1: NaN,
+            y1: NaN
+          },
+          {
+            kind: 'line',
+            layer: '0',
+            x0: 0,
+            y0: 0,
+            x1: 10,
+            y1: 0
+          }
+        ]
+      }
+    })
+    expect(index.findSnap(0.2, 0.1, 1)).toEqual({
+      x: 0,
+      y: 0,
+      mode: 'endpoint'
+    })
+  })
+
+  it('ignores NaN line-batch vertices so tessellated geometry cannot poison snap', () => {
+    const index = new AcExOsnapIndex(['endpoint', 'nearest'])
+    index.rebuild({
+      ...layout,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0],
+          positions: Float32Array.from([
+            NaN,
+            NaN,
+            0,
+            NaN,
+            NaN,
+            0,
+            0,
+            0,
+            0,
+            10,
+            0,
+            0
+          ]),
+          indices: Uint32Array.from([0, 1, 2, 3])
+        }
+      ],
+      meshBatches: [
+        {
+          layer: '0',
+          color: 0xff0000,
+          offset: [0, 0, 0],
+          // Huge hatch-like mesh must not be indexed for osnap.
+          positions: Float32Array.from([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          indices: Uint32Array.from([0, 1, 2])
+        }
+      ],
+      osnap: { primitives: [] }
+    })
+    expect(index.findSnap(0.2, 0.1, 1)).toEqual({
+      x: 0,
+      y: 0,
+      mode: 'endpoint'
+    })
+    // Mesh triangle edges are not indexed — a pick on the fill must miss.
+    expect(index.findSnap(0.2, 0.2, 0.05)).toBeUndefined()
+  })
+
+  it('skips text/point glyph line batches marked excludeFromOsnap', () => {
+    const index = new AcExOsnapIndex(['endpoint', 'nearest'])
+    index.rebuild({
+      ...layout,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0],
+          excludeFromOsnap: true,
+          positions: Float32Array.from([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]),
+          indices: Uint32Array.from([0, 1, 1, 2, 2, 3, 3, 0])
+        },
+        {
+          layer: '0',
+          color: 0xff0000,
+          offset: [0, 0, 0],
+          positions: Float32Array.from([10, 0, 0, 20, 0, 0]),
+          indices: Uint32Array.from([0, 1])
+        }
+      ],
+      osnap: { primitives: [] }
+    })
+    expect(index.findSnap(0.5, 0.5, 1)).toBeUndefined()
+    expect(index.findSnap(10.2, 0.1, 1)).toEqual({
+      x: 10,
+      y: 0,
+      mode: 'endpoint'
+    })
+  })
+
   it('snaps to intersection from catalog primitives', () => {
     const index = new AcExOsnapIndex(['intersection', 'endpoint'])
     index.rebuild({
@@ -595,6 +706,40 @@ describe('AcExOsnapIndex', () => {
     index.rebuild(crossLayout)
     const snap = index.findSnap(5.1, 4.9, 1)
     expect(snap).toEqual({ x: 5, y: 5, mode: 'intersection' })
+  })
+
+  it('snaps to circle×line intersection when lines come from batches', () => {
+    const hybridLayout = {
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0] as [number, number, number],
+          // Horizontal chord through circle center (radius 10 at origin).
+          positions: f32([-20, 0, 0, 20, 0, 0])
+        }
+      ],
+      meshBatches: [],
+      osnap: {
+        primitives: [
+          {
+            kind: 'circle' as const,
+            layer: '0',
+            cx: 0,
+            cy: 0,
+            r: 10,
+            normalSign: 1 as const
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(hybridLayout)
+    const snap = index.findSnap(10.1, 0.1, 1)
+    expect(snap).toEqual({ x: 10, y: 0, mode: 'intersection' })
   })
 
   it('rebuilds large tessellated layouts without blowing the call stack', () => {

--- a/packages/cad-html-plugin/__tests__/AcExOsnapCatalogCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapCatalogCodec.spec.ts
@@ -89,9 +89,12 @@ describe('AcExOsnapCatalogCodec', () => {
 })
 
 describe('AcExOsnapIndex.rebuildAsync', () => {
-  it('bulk-loads RBush after building entries in yieldable batches', async () => {
+  it('bulk-loads RBush after building entries and yields on wall-clock budget', async () => {
     const { AcExOsnapIndex } = await import('../src/AcExOsnap')
-    const primitives = Array.from({ length: 6000 }, (_, i) => ({
+    // Must exceed OSNAP_INDEX_YIELD_CHECK_EVERY (8192) so the scheduler samples
+    // the wall-clock budget at least once.
+    const primitiveCount = 9000
+    const primitives = Array.from({ length: primitiveCount }, (_, i) => ({
       kind: 'line' as const,
       layer: '0',
       x0: i,
@@ -100,6 +103,10 @@ describe('AcExOsnapIndex.rebuildAsync', () => {
       y1: 1
     }))
     let yields = 0
+    let nowCall = 0
+    const nowSpy = jest
+      .spyOn(performance, 'now')
+      .mockImplementation(() => (nowCall++) * 250)
     const index = new AcExOsnapIndex()
     const loadSpy = jest.spyOn(
       (index as unknown as { primitiveTree: { load: (e: unknown) => void } })
@@ -123,9 +130,10 @@ describe('AcExOsnapIndex.rebuildAsync', () => {
     expect(loadSpy).toHaveBeenCalledTimes(1)
     expect(
       (loadSpy.mock.calls[0]![0] as unknown[]).length
-    ).toBe(6000)
+    ).toBe(primitiveCount)
     const snap = index.findSnap(10.1, 0.1, 2)
     expect(snap).toBeTruthy()
     loadSpy.mockRestore()
+    nowSpy.mockRestore()
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
@@ -33,7 +33,7 @@ import { buildOsnapCatalog } from '../src/AcExOsnapPrimitiveBuilder'
 import { AcExOsnapIndex } from '../src/AcExOsnap'
 
 describe('buildOsnapCatalog', () => {
-  it('exports snap primitives for geometry inside block references', () => {
+  it('omits line primitives from block references (lines come from geometry batches)', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -49,18 +49,10 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(insert)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    const line = catalog.primitives.find(p => p.kind === 'line')
-    expect(line).toEqual({
-      kind: 'line',
-      layer: '0',
-      x0: 100,
-      y0: 50,
-      x1: 110,
-      y1: 50
-    })
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
   })
 
-  it('exports snap primitives for rotated block references', () => {
+  it('omits line primitives from rotated block references', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -77,14 +69,10 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(insert)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    const line = catalog.primitives.find(p => p.kind === 'line')
-    expect(line?.x0).toBeCloseTo(0, 5)
-    expect(line?.y0).toBeCloseTo(0, 5)
-    expect(line?.x1).toBeCloseTo(0, 5)
-    expect(line?.y1).toBeCloseTo(10, 5)
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
   })
 
-  it('exports all snap-capable primitives', () => {
+  it('exports analytic curves but omits straight lines', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
     modelSpace.appendEntity(
@@ -104,11 +92,11 @@ describe('buildOsnapCatalog', () => {
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
 
-    expect(catalog.primitives.some(prim => prim.kind === 'line')).toBe(true)
+    expect(catalog.primitives.some(prim => prim.kind === 'line')).toBe(false)
     expect(catalog.primitives.some(prim => prim.kind === 'ellipse')).toBe(true)
   })
 
-  it('exports polyline segments as line primitives', () => {
+  it('omits straight polyline segments from the catalog', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
     const polyline = new AcDbPolyline()
@@ -118,7 +106,7 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(polyline)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    expect(catalog.primitives.filter(p => p.kind === 'line').length).toBe(2)
+    expect(catalog.primitives.filter(p => p.kind === 'line').length).toBe(0)
   })
 
   it('snaps nearest on both CCW and CW polyline bulge segments', () => {
@@ -226,7 +214,7 @@ describe('buildOsnapCatalog', () => {
     ).toBeCloseTo(second.radius, 5)
   })
 
-  it('exports snap primitives for dimension anonymous blocks', () => {
+  it('omits dimension extension lines from the catalog (derived from batches at runtime)', () => {
     const db = new AcDbDatabase()
     acdbHostApplicationServices().workingDatabase = db
     const modelSpace = db.tables.blockTable.modelSpace
@@ -244,34 +232,10 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(dimension)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    expect(catalog.primitives.length).toBeGreaterThan(0)
-
-    const extensionLine = catalog.primitives.find(
-      (p): p is Extract<typeof p, { kind: 'line' }> =>
-        p.kind === 'line' &&
-        Math.abs(p.x0) < 1e-10 &&
-        Math.abs(p.x1) < 1e-10 &&
-        p.y0 < p.y1
-    )
-    expect(extensionLine).toBeDefined()
-
-    const index = new AcExOsnapIndex(['endpoint'])
-    index.rebuild({
-      btrId: modelSpace.objectId,
-      name: 'Model',
-      isModelSpace: true,
-      lineBatches: [],
-      meshBatches: [],
-      osnap: catalog
-    })
-
-    const endpointSnap = index.findSnap(0.1, extensionLine!.y0 + 0.05, 1)
-    expect(endpointSnap?.mode).toBe('endpoint')
-    expect(endpointSnap?.x).toBeCloseTo(0, 5)
-    expect(endpointSnap?.y).toBeCloseTo(extensionLine!.y0, 5)
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
   })
 
-  it('exports snap primitives for ray, xline, trace, leader, text, and point', () => {
+  it('exports points for text/point and omits ray/xline/trace/leader lines', () => {
     const db = new AcDbDatabase()
     acdbHostApplicationServices().workingDatabase = db
     const modelSpace = db.tables.blockTable.modelSpace
@@ -307,7 +271,7 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(point)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    expect(catalog.primitives.some(p => p.kind === 'line')).toBe(true)
+    expect(catalog.primitives.some(p => p.kind === 'line')).toBe(false)
     expect(catalog.primitives.some(p => p.kind === 'point' && p.x === 60)).toBe(
       true
     )
@@ -316,7 +280,7 @@ describe('buildOsnapCatalog', () => {
     )
   })
 
-  it('exports snap primitives for MLINE reference path', () => {
+  it('omits MLINE path lines from the catalog', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -353,26 +317,10 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(mline)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    const lines = catalog.primitives.filter(p => p.kind === 'line')
-    expect(lines).toHaveLength(2)
-    expect(lines[0]).toMatchObject({
-      kind: 'line',
-      layer: '0',
-      x0: 0,
-      y0: 0,
-      x1: 10,
-      y1: 0
-    })
-    expect(lines[1]).toMatchObject({
-      kind: 'line',
-      x0: 10,
-      y0: 0,
-      x1: 10,
-      y1: 10
-    })
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
   })
 
-  it('exports snap primitives for MLEADER leader lines and text anchor', () => {
+  it('exports MLEADER text anchors and omits leader lines from the catalog', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -390,7 +338,7 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(mleader)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    expect(catalog.primitives.some(p => p.kind === 'line')).toBe(true)
+    expect(catalog.primitives.some(p => p.kind === 'line')).toBe(false)
     expect(
       catalog.primitives.some(
         p => p.kind === 'point' && p.x === 20 && p.y === 20
@@ -402,7 +350,14 @@ describe('buildOsnapCatalog', () => {
       btrId: modelSpace.objectId,
       name: 'Model',
       isModelSpace: true,
-      lineBatches: [],
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0],
+          positions: Float32Array.from([0, 0, 0, 10, 10, 0])
+        }
+      ],
       meshBatches: [],
       osnap: catalog
     })
@@ -412,7 +367,7 @@ describe('buildOsnapCatalog', () => {
     expect(snap?.y).toBeCloseTo(0, 5)
   })
 
-  it('exports snap primitives for hatch boundary loops', () => {
+  it('omits hatch polyline boundary lines from the catalog', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -431,14 +386,10 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(hatch)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    const lines = catalog.primitives.filter(p => p.kind === 'line')
-    expect(lines.length).toBeGreaterThanOrEqual(4)
-    expect(
-      lines.some(p => p.x0 === 0 && p.y0 === 0 && p.x1 === 20 && p.y1 === 0)
-    ).toBe(true)
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
   })
 
-  it('exports snap primitives for hatch edge loops with arcs', () => {
+  it('omits hatch edge-loop lines from the catalog', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -452,10 +403,10 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(hatch)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(4)
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
   })
 
-  it('exports snap primitives for raster image frame boundary', () => {
+  it('exports raster image insertion points and omits frame lines', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -466,14 +417,13 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(image)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    const lines = catalog.primitives.filter(p => p.kind === 'line')
-    expect(lines.length).toBeGreaterThanOrEqual(4)
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
     expect(
       catalog.primitives.some(p => p.kind === 'point' && p.x === 5 && p.y === 5)
     ).toBe(true)
   })
 
-  it('exports snap primitives for procedural table grid lines', () => {
+  it('exports table insertion points and omits grid lines', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -484,8 +434,7 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(table)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    const lines = catalog.primitives.filter(p => p.kind === 'line')
-    expect(lines.length).toBeGreaterThanOrEqual(6)
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
     expect(
       catalog.primitives.some(
         p => p.kind === 'point' && p.x === 10 && p.y === 20
@@ -493,7 +442,7 @@ describe('buildOsnapCatalog', () => {
     ).toBe(true)
   })
 
-  it('exports snap primitives for table anonymous blocks', () => {
+  it('omits table anonymous-block lines from the catalog', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -509,13 +458,44 @@ describe('buildOsnapCatalog', () => {
     modelSpace.appendEntity(table)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    const line = catalog.primitives.find(p => p.kind === 'line')
-    expect(line).toMatchObject({
-      kind: 'line',
-      x0: 0,
-      y0: 0,
-      x1: 12,
-      y1: 0
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
+  })
+
+  it('indexes curve ACEO with lineBatches for hybrid snap', () => {
+    const index = new AcExOsnapIndex()
+    index.rebuild({
+      btrId: 'ms',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0],
+          positions: Float32Array.from([0, 0, 0, 10, 0, 0])
+        }
+      ],
+      meshBatches: [],
+      osnap: {
+        primitives: [
+          {
+            kind: 'circle',
+            layer: '0',
+            cx: 5,
+            cy: 5,
+            r: 2,
+            normalSign: 1
+          }
+        ]
+      }
     })
+
+    const end = index.findSnap(0.1, 0.1, 2)
+    expect(end?.mode).toBe('endpoint')
+    expect(end?.x).toBeCloseTo(0, 5)
+
+    const center = index.findSnap(5.1, 5.1, 2)
+    expect(center?.mode).toBe('center')
+    expect(center?.x).toBeCloseTo(5, 5)
   })
 })

--- a/packages/cad-html-plugin/__tests__/AcExPackage.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPackage.spec.ts
@@ -213,6 +213,16 @@ describe('AcEx package format', () => {
     expect(skeleton.activeLayoutBtrId).toBe('ms')
   })
 
+  it('sanitizes drawing titles with spaces and plus signs for zip-safe paths', () => {
+    const pkg = buildAcExPackage(makeSnapshot(), {
+      viewerRuntime: '/* runtime */',
+      baseName: 'FJP-898E-G-_-V01 + 1'
+    })
+    expect(pkg.manifestFileName).toBe('FJP-898E-G-_-V01_1.acex.json')
+    expect(isSafePackageHref(`./${pkg.manifestFileName}`)).toBe(true)
+    expect(() => zipAcExPackageFiles(pkg)).not.toThrow()
+  })
+
   it('rejects unsafe package hrefs and absolute chunk URLs', () => {
     expect(isSafePackageHref('./demo.acex.json')).toBe(true)
     expect(isSafePackageHref('chunks/L0-000.acex.gz')).toBe(true)
@@ -272,19 +282,19 @@ describe('AcEx package format', () => {
     snapshot.meta.viewerMode = 'measure'
     snapshot.layouts[0]!.osnap = {
       primitives: Array.from({ length: 40 }, (_, i) => ({
-        kind: 'line' as const,
+        kind: 'circle' as const,
         layer: i % 2 === 0 ? '0' : 'A',
-        x0: i,
-        y0: 0,
-        x1: i + 1,
-        y1: 1
+        cx: i,
+        cy: 0,
+        r: 1,
+        normalSign: 1 as const
       }))
     }
 
     const pkg = buildAcExPackage(snapshot, {
       viewerRuntime: '/* runtime */',
       baseName: 'demo',
-      // Force multiple OSNAP chunks (~37 bytes/line → 200 bytes ≈ several slices).
+      // Force multiple OSNAP chunks.
       maxOsnapChunkBytes: 200
     })
 

--- a/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSceneBatchCollector.spec.ts
@@ -13,6 +13,7 @@ jest.mock('@mlightcad/three-renderer', () => {
   )
   const {
     getMaterialMetadata,
+    getSceneDrawableUserData,
     isBatchGeometryActive,
     isBatchGeometryVisible,
     isHighlightCloneDrawable,
@@ -26,6 +27,7 @@ jest.mock('@mlightcad/three-renderer', () => {
     AcTrBatchedMesh,
     AcTrBatchedPoint,
     getMaterialMetadata,
+    getSceneDrawableUserData,
     isBatchGeometryActive,
     isBatchGeometryVisible,
     isHighlightCloneDrawable,

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCodec.spec.ts
@@ -266,6 +266,93 @@ describe('AcExSnapshotCodec', () => {
     expect(decoded.layouts[0]!.viewports?.[0]?.twist).toBeCloseTo(Math.PI / 4)
   })
 
+  it('self-contained HTML payloads shrink when osnap omits duplicated line primitives', () => {
+    const meta = {
+      createdAt: '2026-01-01T00:00:00.000Z',
+      extents: { minX: 0, minY: 0, maxX: 100, maxY: 100 },
+      units: {
+        insunits: 4,
+        lunits: 2,
+        luprec: 4,
+        aunits: 0,
+        auprec: 0,
+        measurement: 1,
+        ltscale: 1,
+        angbase: 0,
+        angdir: 0
+      },
+      background: 0
+    }
+    const lineBatch = {
+      layer: '0',
+      color: 0xff0000,
+      offset: [0, 0, 0] as [number, number, number],
+      positions: f32([0, 0, 0, 10, 0, 0, 10, 10, 0, 0, 10, 0]),
+      indices: Uint32Array.from([0, 1, 1, 2, 2, 3, 3, 0])
+    }
+    const linePrimitives = Array.from({ length: 2000 }, (_, i) => ({
+      kind: 'line' as const,
+      layer: '0',
+      x0: i,
+      y0: 0,
+      x1: i + 1,
+      y1: 1
+    }))
+    const withDuplicatedLines = {
+      version: ACEX_SNAPSHOT_VERSION,
+      meta,
+      layers: [{ name: '0', color: 0xffffff, visible: true }],
+      layouts: [
+        {
+          btrId: 'ms',
+          name: '*Model_Space',
+          isModelSpace: true,
+          lineBatches: [lineBatch],
+          meshBatches: [],
+          osnap: { primitives: linePrimitives }
+        }
+      ],
+      activeLayoutBtrId: 'ms'
+    }
+    const curvesOnly = {
+      version: ACEX_SNAPSHOT_VERSION,
+      meta,
+      layers: [{ name: '0', color: 0xffffff, visible: true }],
+      layouts: [
+        {
+          btrId: 'ms',
+          name: '*Model_Space',
+          isModelSpace: true,
+          lineBatches: [lineBatch],
+          meshBatches: [],
+          osnap: {
+            primitives: [
+              {
+                kind: 'circle' as const,
+                layer: '0',
+                cx: 5,
+                cy: 5,
+                r: 2,
+                normalSign: 1 as const
+              }
+            ]
+          }
+        }
+      ],
+      activeLayoutBtrId: 'ms'
+    }
+
+    const legacyPayload = encodeSnapshot(withDuplicatedLines).payload
+    const compactPayload = encodeSnapshot(curvesOnly).payload
+    expect(compactPayload.length).toBeLessThan(legacyPayload.length * 0.25)
+
+    const decoded = decodeSnapshot(compactPayload)
+    expect(decoded.layouts[0]!.osnap?.primitives.every(p => p.kind !== 'line')).toBe(
+      true
+    )
+    expect(decoded.layouts[0]!.lineBatches[0]!.positions.length).toBeGreaterThan(0)
+  })
+
   it('round-trips signed renderOrder so hatch fills stay below linework', () => {
     const snapshot = {
       version: ACEX_SNAPSHOT_VERSION,

--- a/packages/cad-html-plugin/__tests__/AcExSnapshotCompression.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExSnapshotCompression.spec.ts
@@ -1,4 +1,6 @@
 import {
+  ACEX_MAX_COMPRESSED_BYTES,
+  ACEX_MAX_DECOMPRESSED_BYTES,
   ACEX_SNAPSHOT_COMPRESSION,
   compressSnapshotBinary,
   decompressSnapshotBinary
@@ -12,5 +14,18 @@ describe('AcExSnapshotCompression', () => {
     expect(Array.from(decompressSnapshotBinary(compressed.bytes))).toEqual(
       Array.from(input)
     )
+  })
+
+  it('rejects compressed input above the hard cap without inflating', () => {
+    const oversized = new Uint8Array(ACEX_MAX_COMPRESSED_BYTES + 1)
+    expect(() => decompressSnapshotBinary(oversized)).toThrow(
+      'Compressed payload exceeds size limit'
+    )
+  })
+
+  it('allows CAD-scale decompressed snapshots below the hard cap', () => {
+    // ~80 MiB was a common failure mode under the former 64 MiB ceiling.
+    expect(ACEX_MAX_DECOMPRESSED_BYTES).toBeGreaterThan(80 * 1024 * 1024)
+    expect(ACEX_MAX_COMPRESSED_BYTES).toBeGreaterThan(40 * 1024 * 1024)
   })
 })

--- a/packages/cad-html-plugin/docs/acex-package-format.md
+++ b/packages/cad-html-plugin/docs/acex-package-format.md
@@ -140,8 +140,15 @@ Batch records reuse the ACEX feature-flag scheme (`F_LINE_*`, `F_MESH_*`):
 
 Each file is **raw gzip** of one **ACEO** binary payload (measure-mode exports).
 Coordinates are IEEE-754 **float64**; layer names are dictionary-compressed.
-Large catalogs are split (~512 KiB estimated uncompressed per file) so hosts can
-fetch snap slices in **parallel** after the drawing is already visible.
+
+**Straight `line` primitives are not stored in ACEO.** They duplicate display
+`lineBatches` already downloaded for rendering. After geometry loads (and before
+CPU batch buffers are released), the viewer extracts snap segments from those
+batches and indexes them together with analytic ACEO curves (circle / arc /
+ellipse / spline / point, including polyline bulge arcs and hatch curve edges).
+
+Large curve catalogs are still split (~512 KiB estimated uncompressed per file)
+so hosts can fetch snap slices after the drawing is already visible.
 
 ### ACEO binary (little-endian)
 
@@ -155,13 +162,14 @@ fetch snap slices in **parallel** after the drawing is already visible.
 | primitiveCount | `u32` | |
 | primitives | … | kind `u8` + layer index `u32` + kind-specific f64 fields |
 
-Kind codes: `1` line, `2` circle, `3` arc, `4` ellipse, `5` spline, `6` point.
+Kind codes: `1` line (legacy / unused on export), `2` circle, `3` arc, `4` ellipse, `5` spline, `6` point.
 
 ### OSNAP chunking rules
 
 1. Split by layout, then by estimated ACEO size into `L{layoutIndex}-osnap-{slice:000}`.
 2. Each slice is a self-contained ACEO catalog (own layer dictionary).
 3. Loaders concatenate primitives in `osnapChunkIds` order.
+4. Empty curve catalogs omit `osnapChunks` / `osnapChunkIds`; line snap still works from geometry.
 
 ## Loading sequence
 
@@ -170,19 +178,23 @@ Kind codes: `1` line, `2` circle, `3` arc, `4` ellipse, `5` spline, `6` point.
 3. Initialize viewer chrome from `meta` / `layers` (extents, layer panel).
 4. For the active layout (and model space when paper viewports need it):
    `GET` each geometry `href` → gunzip → decode ACEC → append batches → paint → yield.
-5. Drawing is usable for pan/zoom. **Then** (measure mode only): fetch all
-   `osnapChunks` for that layout **in parallel** → gunzip → decode ACEO →
-   concatenate → rebuild snap index.
-6. Load remaining layouts lazily when the user switches layout (geometry first,
-   OSNAP last).
+5. Drawing is usable for pan/zoom. **Then** (measure mode):
+   - `GET` ACEO curve chunks (small when lines are omitted) → decode → concatenate.
+   - Build hybrid snap index: **line segments from resident `lineBatches`** + analytic ACEO primitives (yielded / bulk `RBush.load`).
+6. Release CPU geometry buffers after the hybrid index is ready.
+7. Load remaining layouts lazily when the user switches layout (geometry first, OSNAP last).
 
 ## Relationship to single-file HTML
 
-Self-contained HTML still embeds one gzip+base64 **ACEX** snapshot
-(`magic 0x58454341`). Multi-file packages share the same batch schema
-(`snapshotVersion`) but ship geometry as ACEC chunks plus a JSON manifest.
-OSNAP in single-file HTML remains inside the ACEX snapshot; only the multi-file
-package splits it into ACEO sidecars.
+Self-contained HTML embeds one gzip+base64 **ACEX** snapshot
+(`magic 0x58454341`). The **same** snapshot builder is used as for multi-file
+packages: measure-mode OSNAP catalogs omit straight `line` primitives and keep
+only analytic curves/points. The offline runtime rebuilds line snap from the
+embedded `lineBatches` before releasing CPU buffers, so single-file HTML is
+smaller for line-heavy drawings without losing endpoint/midpoint snap.
+
+Multi-file packages additionally split geometry into ACEC chunks and OSNAP into
+ACEO sidecars; the catalog content rules are identical.
 
 Password / expiry protection applies to **single-file** export only in the
 current product UI.

--- a/packages/cad-html-plugin/src/AcExBatchBinaryCodec.ts
+++ b/packages/cad-html-plugin/src/AcExBatchBinaryCodec.ts
@@ -7,6 +7,8 @@ export const F_LINE_PATTERN = 2
 export const F_LINE_DISTANCES = 4
 export const F_LINE_WIDTH = 8
 export const F_LINE_RENDER_ORDER = 16
+/** Text/point glyph strokes — display only; skip hybrid OSNAP. */
+export const F_LINE_EXCLUDE_OSNAP = 32
 
 /** Optional mesh-batch feature flags (append-only; never renumber). */
 export const F_MESH_INDICES = 1
@@ -69,6 +71,9 @@ export function writeLineBatch(
   if (batch.renderOrder != null && batch.renderOrder !== 0) {
     flags |= F_LINE_RENDER_ORDER
   }
+  if (batch.excludeFromOsnap) {
+    flags |= F_LINE_EXCLUDE_OSNAP
+  }
   writer.writeU8(flags)
 
   if (flags & F_LINE_INDICES) {
@@ -116,6 +121,9 @@ export function readLineBatch(reader: AcExBinaryReader): AcExLineBatch {
   }
   if (flags & F_LINE_RENDER_ORDER) {
     batch.renderOrder = reader.readI32()
+  }
+  if (flags & F_LINE_EXCLUDE_OSNAP) {
+    batch.excludeFromOsnap = true
   }
   return batch
 }

--- a/packages/cad-html-plugin/src/AcExBinaryIO.ts
+++ b/packages/cad-html-plugin/src/AcExBinaryIO.ts
@@ -3,8 +3,13 @@ import { strFromU8, strToU8 } from 'fflate'
 /** Hard cap for length-prefixed strings inside ACEX binary payloads. */
 export const ACEX_MAX_BINARY_STRING_BYTES = 1 * 1024 * 1024
 
-/** Hard cap for a single length-prefixed typed-array payload. */
-export const ACEX_MAX_BINARY_ARRAY_BYTES = 64 * 1024 * 1024
+/**
+ * Hard cap for a single length-prefixed typed-array payload (`Float32Array` /
+ * `Uint32Array`). Large site plans can put tens of millions of vertices in one
+ * line/mesh batch; keep this aligned with the ACEX decompressed payload ceiling
+ * (`512 MiB`).
+ */
+export const ACEX_MAX_BINARY_ARRAY_BYTES = 512 * 1024 * 1024
 
 /**
  * Little-endian binary writer used by ACEX snapshot and ACEC chunk codecs.

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -60,7 +60,7 @@ import {
   acexRefreshMobileSnapLoupe,
   acexSetMobileSnapLoupePreciseCapture
 } from './AcExMobileSnapLoupe'
-import { AcExOsnapIndex } from './AcExOsnap'
+import { AcExOsnapIndex, estimateOsnapRebuildWork } from './AcExOsnap'
 import { AcExOsnapMarker } from './AcExOsnapMarker'
 import {
   loadAcExPackageLayoutOsnap,
@@ -787,41 +787,55 @@ async function startViewer(): Promise<void> {
     }
   }
 
+  const clearStatusBar = () => {
+    statusEl.textContent = ''
+    statusEl.hidden = true
+  }
+
+  const osnapIndexYield = (): Promise<void> =>
+    // Prefer a macrotask over `accmYieldForPaint` / rAF: waiting a full frame
+    // per slice turned million-edge hybrid indexes into multi-minute jobs.
+    new Promise(resolve => {
+      setTimeout(resolve, 0)
+    })
+
   const rebuildOsnapForLoadedGeometry = async () => {
     if (!measureEnabled) return
     if (!osnapIndex) {
       osnapIndex = new AcExOsnapIndex()
       osnapMarker = new AcExOsnapMarker(root)
     }
-    const primitiveCount = layout.osnap?.primitives.length ?? 0
-    if (primitiveCount > 8000) {
+    const workEstimate =
+      estimateOsnapRebuildWork(layout) +
+      (hasPaperViewports && modelLayout
+        ? estimateOsnapRebuildWork(modelLayout)
+        : 0)
+    if (workEstimate > 8000) {
+      statusEl.hidden = false
       statusEl.textContent = i18n.t('status.buildingOsnap')
       await accmYieldForPaint()
     }
-    await osnapIndex.rebuildAsync(layout, async () => {
-      render()
-      await accmYieldForPaint()
-    })
-    applyOsnapLayerVisibility(osnapIndex)
-    if (hasPaperViewports && modelLayout) {
-      if (!modelOsnapIndex) {
-        modelOsnapIndex = new AcExOsnapIndex()
+    try {
+      await osnapIndex.rebuildAsync(layout, osnapIndexYield)
+      applyOsnapLayerVisibility(osnapIndex)
+      if (hasPaperViewports && modelLayout) {
+        if (!modelOsnapIndex) {
+          modelOsnapIndex = new AcExOsnapIndex()
+        }
+        await modelOsnapIndex.rebuildAsync(modelLayout, osnapIndexYield)
+        applyOsnapLayerVisibility(modelOsnapIndex)
       }
-      await modelOsnapIndex.rebuildAsync(modelLayout, async () => {
-        render()
-        await accmYieldForPaint()
-      })
-      applyOsnapLayerVisibility(modelOsnapIndex)
-    }
-    if (!canSwitchLayouts) {
-      releaseSnapshotOsnapCatalogs(snapshot)
+      if (!canSwitchLayouts) {
+        releaseSnapshotOsnapCatalogs(snapshot)
+      }
+    } finally {
+      clearStatusBar()
     }
   }
 
-  // Embedded path has full geometry now; package path rebuilds after progressive load.
-  if (measureEnabled && !packageSession) {
-    await rebuildOsnapForLoadedGeometry()
-  } else if (measureEnabled) {
+  // Create empty indexes now; hybrid rebuild runs after first paint so the
+  // canvas is interactive while tessellated line snap is prepared.
+  if (measureEnabled) {
     osnapIndex = new AcExOsnapIndex()
     osnapMarker = new AcExOsnapMarker(root)
   }
@@ -1790,12 +1804,19 @@ async function startViewer(): Promise<void> {
         !packageSession.loadedOsnapLayouts.has(layout.btrId) &&
         (layoutRef?.osnapChunkIds?.length ?? 0) > 0
       if (!pendingOsnap) {
-        await osnapIndex.rebuildAsync(layout, async () => {
-          render()
+        // Hybrid rebuild needs resident lineBatches when ACEO has no lines.
+        const workEstimate = estimateOsnapRebuildWork(layout)
+        if (workEstimate > 8000) {
+          statusEl.textContent = i18n.t('status.buildingOsnap')
           await accmYieldForPaint()
-        })
-        for (const [name, visible] of layerVisible) {
-          osnapIndex.setLayerHidden(name, visible === false)
+        }
+        try {
+          await osnapIndex.rebuildAsync(layout, osnapIndexYield)
+          for (const [name, visible] of layerVisible) {
+            osnapIndex.setLayerHidden(name, visible === false)
+          }
+        } finally {
+          clearStatusBar()
         }
       }
     }
@@ -1830,6 +1851,7 @@ async function startViewer(): Promise<void> {
         await rebuildOsnapForLoadedGeometry()
         bumpSnapCacheKey()
         render()
+        measure?.refreshIdleStatus()
       } catch (error) {
         statusEl.textContent = i18n.t('status.loadFailed', {
           error: String(error)
@@ -2137,8 +2159,9 @@ async function startViewer(): Promise<void> {
   lastViewByLayout.set(layout.btrId, initialView)
   // Shared typed arrays back the snapshot and THREE attributes. Releasing
   // them would prevent switching to other layouts later in this session.
-  // Package mode releases after progressive geometry has finished loading.
-  if (!canSwitchLayouts && !packageSession) {
+  // Defer CPU buffer release until after hybrid OSNAP when measure is on —
+  // line snap is rebuilt from resident lineBatches.
+  if (!canSwitchLayouts && !packageSession && !measureEnabled) {
     releaseLayerGroupsGeometryCpuArrays(paperLayerGroups)
     releaseLayerGroupsGeometryCpuArrays(modelLayerGroups)
     releaseSnapshotBatchBuffers(snapshot)
@@ -2154,9 +2177,26 @@ async function startViewer(): Promise<void> {
       }
     })
   }
-  // Reveal the canvas before package chunks finish so each chunk can paint
-  // as soon as it arrives (progressive loading).
+  // Reveal the canvas before package chunks / OSNAP indexing finish so the
+  // drawing paints while background work continues.
   hideLoading()
+
+  if (!packageSession && measureEnabled) {
+    try {
+      await rebuildOsnapForLoadedGeometry()
+      recomputeOsnapThresholdWcs()
+      bumpSnapCacheKey()
+      measure?.refreshIdleStatus()
+      render()
+    } catch (error) {
+      showViewerError(i18n.t('status.loadFailed', { error: String(error) }))
+    }
+    if (!canSwitchLayouts) {
+      releaseLayerGroupsGeometryCpuArrays(paperLayerGroups)
+      releaseLayerGroupsGeometryCpuArrays(modelLayerGroups)
+      releaseSnapshotBatchBuffers(snapshot)
+    }
+  }
 
   if (packageSession) {
     try {
@@ -2177,9 +2217,9 @@ async function startViewer(): Promise<void> {
       measure?.refreshIdleStatus()
       render()
 
-      // Do NOT rebuild OSNAP from tessellated batches here. On large drawings
-      // collectBatchSegments freezes the main thread for seconds and prevents
-      // ACEO fetches from even starting (nothing appears in Network).
+      // ACEO now holds curves/points only (lines come from geometry batches).
+      // Load the small catalog first, then build a hybrid index while CPU
+      // lineBatches are still resident — before releaseSnapshotBatchBuffers.
       if (measureEnabled) {
         for (const target of firstPaintLayouts) {
           await loadPackageLayoutOsnap(target)

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -26,20 +26,57 @@ import type {
 import { ACEX_DEFAULT_OSNAP_MODES } from './AcExOsnapPrimitiveTypes'
 import type {
   AcExLayoutSnapshot,
-  AcExLineBatch,
-  AcExMeshBatch
+  AcExLineBatch
 } from './AcExSnapshotTypes'
 
 export type { AcExOsnapMode, AcExOsnapPoint } from './AcExOsnapPrimitiveTypes'
 export { ACEX_DEFAULT_OSNAP_MODES } from './AcExOsnapPrimitiveTypes'
 
-/** Primitives / segments processed between yields in {@link AcExOsnapIndex.rebuildAsync}. */
-const OSNAP_INDEX_YIELD_BATCH = 2500
+/**
+ * How often to check the wall-clock budget while walking segments / building
+ * RBush entries. Checking every item is wasteful; yielding every ~1000 items via
+ * `requestAnimationFrame` made million-edge indexes take minutes of idle waits.
+ */
+const OSNAP_INDEX_YIELD_CHECK_EVERY = 8192
+
+/** Target main-thread slice length before yielding to the event loop. */
+const OSNAP_INDEX_YIELD_BUDGET_MS = 200
 
 function yieldToBrowser(): Promise<void> {
   return new Promise(resolve => {
     setTimeout(resolve, 0)
   })
+}
+
+/**
+ * Yields only after {@link OSNAP_INDEX_YIELD_BUDGET_MS} of continuous work,
+ * sampled every {@link OSNAP_INDEX_YIELD_CHECK_EVERY} items.
+ * Returns a promise only when a yield is actually scheduled (callers should
+ * `await` only when non-null) so tight loops avoid millions of Promise allocs.
+ */
+function createOsnapYieldScheduler(
+  yieldFn: () => Promise<void>
+): {
+  /** @returns A promise to await when yielding; otherwise `undefined`. */
+  afterItem: () => Promise<void> | undefined
+} {
+  let itemsSinceCheck = 0
+  let sliceStart = performance.now()
+  return {
+    afterItem: () => {
+      itemsSinceCheck += 1
+      if (itemsSinceCheck < OSNAP_INDEX_YIELD_CHECK_EVERY) {
+        return undefined
+      }
+      itemsSinceCheck = 0
+      if (performance.now() - sliceStart < OSNAP_INDEX_YIELD_BUDGET_MS) {
+        return undefined
+      }
+      return yieldFn().then(() => {
+        sliceStart = performance.now()
+      })
+    }
+  }
 }
 
 /**
@@ -400,13 +437,14 @@ export function extractLineBatchSnapSegments(
 }
 
 /**
- * Collects all tessellated snap segments from a layout snapshot.
+ * Collects tessellated snap segments from drawable {@link AcExLineBatch}s.
  *
- * Iterates {@link AcExLayoutSnapshot.lineBatches} through
- * {@link extractLineBatchSnapSegments} and appends mesh outline edges from
- * {@link AcExLayoutSnapshot.meshBatches}. The result supplements (or replaces,
- * when no catalog is present) analytic {@link AcExLayoutSnapshot.osnap} primitives
- * inside {@link AcExOsnapIndex}.
+ * Mesh / hatch triangulation (`meshBatches`) is intentionally skipped: those
+ * edges are display fills, not CAD snap targets, and indexing every triangle
+ * edge on large drawings can take minutes and flood RBush.
+ *
+ * Segments with non-finite endpoints are dropped so one NaN polyline cannot
+ * poison RBush parent bounds (same failure mode as the main viewer spatial index).
  *
  * @param layout - Active layout snapshot.
  * @returns Flat list of WCS segments and parallel layer names for spatial indexing.
@@ -419,57 +457,88 @@ function collectBatchSegments(layout: AcExLayoutSnapshot): {
   const segments: AcExOsnapSegment[] = []
   const segmentLayers: string[] = []
   const pushSegment = (seg: AcExOsnapSegment, layer: string) => {
+    if (!isFiniteSegment(seg)) return
     segments.push(seg)
     segmentLayers.push(layer)
   }
 
   for (const batch of layout.lineBatches) {
+    if (batch.excludeFromOsnap) continue
     for (const seg of extractLineBatchSnapSegments(batch)) {
-      pushSegment(seg, batch.layer)
-    }
-  }
-  for (const batch of layout.meshBatches) {
-    for (const seg of iterMeshEdges(batch)) {
       pushSegment(seg, batch.layer)
     }
   }
   return { segments, segmentLayers }
 }
 
-function* iterMeshEdges(batch: AcExMeshBatch): Generator<AcExOsnapSegment> {
-  const [ox, oy] = batch.offset
-  const p = batch.positions
-  const read = (vi: number): { x: number; y: number } => ({
-    x: toWcsCoord(p[vi * 3]!, ox),
-    y: toWcsCoord(p[vi * 3 + 1]!, oy)
-  })
-
-  function* triangleEdges(
-    a: number,
-    b: number,
-    c: number
-  ): Generator<AcExOsnapSegment> {
-    const v0 = read(a)
-    const v1 = read(b)
-    const v2 = read(c)
-    yield { x0: v0.x, y0: v0.y, x1: v1.x, y1: v1.y }
-    yield { x0: v1.x, y0: v1.y, x1: v2.x, y1: v2.y }
-    yield { x0: v2.x, y0: v2.y, x1: v0.x, y1: v0.y }
-  }
-
-  if (batch.indices && batch.indices.length >= 3) {
-    for (let i = 0; i + 2 < batch.indices.length; i += 3) {
-      yield* triangleEdges(
-        batch.indices[i]!,
-        batch.indices[i + 1]!,
-        batch.indices[i + 2]!
-      )
+function layoutHasDrawableLineBatches(layout: AcExLayoutSnapshot): boolean {
+  for (const batch of layout.lineBatches) {
+    if (batch.excludeFromOsnap) continue
+    if (batch.positions.length >= 6) {
+      return true
     }
-    return
   }
-  if (p.length >= 9) {
-    yield* triangleEdges(0, 1, 2)
+  return false
+}
+
+/**
+ * Like {@link collectBatchSegments}, but time-slices the walk so the UI stays
+ * responsive without yielding on every few thousand edges (rAF-per-chunk made
+ * large drawings take minutes).
+ */
+async function collectBatchSegmentsAsync(
+  layout: AcExLayoutSnapshot,
+  yieldFn: () => Promise<void>
+): Promise<{
+  segments: AcExOsnapSegment[]
+  segmentLayers: string[]
+}> {
+  const segments: AcExOsnapSegment[] = []
+  const segmentLayers: string[] = []
+  const schedule = createOsnapYieldScheduler(yieldFn)
+
+  for (const batch of layout.lineBatches) {
+    if (batch.excludeFromOsnap) continue
+    // Stream solid batches via the generator; avoid materializing the whole
+    // batch into an intermediate array before the first yield can run.
+    const source = batch.linePattern
+      ? extractLineBatchSnapSegments(batch)
+      : iterLineSegments(batch)
+    for (const seg of source) {
+      if (!isFiniteSegment(seg)) continue
+      segments.push(seg)
+      segmentLayers.push(batch.layer)
+      const wait = schedule.afterItem()
+      if (wait) await wait
+    }
   }
+  return { segments, segmentLayers }
+}
+
+function isFiniteSegment(seg: AcExOsnapSegment): boolean {
+  return (
+    Number.isFinite(seg.x0) &&
+    Number.isFinite(seg.y0) &&
+    Number.isFinite(seg.x1) &&
+    Number.isFinite(seg.y1)
+  )
+}
+
+/**
+ * Rough item count for deciding whether to show a "building OSNAP" status.
+ * Counts analytic primitives + line-batch edges only (meshes are not indexed).
+ */
+export function estimateOsnapRebuildWork(layout: AcExLayoutSnapshot): number {
+  let n = layout.osnap?.primitives.length ?? 0
+  for (const batch of layout.lineBatches) {
+    if (batch.excludeFromOsnap) continue
+    if (batch.indices && batch.indices.length >= 2) {
+      n += (batch.indices.length / 2) | 0
+    } else {
+      n += (batch.positions.length / 6) | 0
+    }
+  }
+  return n
 }
 
 /** RBush entry referencing an index in {@link AcExOsnapIndex}'s arrays. @internal */
@@ -506,6 +575,20 @@ function searchBox(
     maxX: px + threshold,
     maxY: py + threshold
   }
+}
+
+function isFiniteBounds(box: {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}): boolean {
+  return (
+    Number.isFinite(box.minX) &&
+    Number.isFinite(box.minY) &&
+    Number.isFinite(box.maxX) &&
+    Number.isFinite(box.maxY)
+  )
 }
 
 function primitiveBounds(prim: AcExOsnapPrimitive): {
@@ -614,34 +697,36 @@ export class AcExOsnapIndex {
   /**
    * Builds spatial indexes from the active layout snapshot.
    *
-   * Loads analytic primitives and tessellated segments into RBush trees.
-   * Snap candidates are computed lazily during {@link findSnap}.
+   * Loads analytic curve/point primitives (when present) and tessellated line
+   * segments from {@link AcExLineBatch} into RBush trees. Straight edges are
+   * expected from batches; ACEO catalogs omit `line` kinds to avoid duplication.
    *
-   * Prefer {@link rebuildAsync} for large analytic catalogs (~10⁵+ primitives)
-   * so the UI thread can paint between batches.
+   * Prefer {@link rebuildAsync} for large layouts so the UI thread can paint
+   * between batches.
    *
    * @param layout - Active layout snapshot (batches + optional {@link AcExLayoutSnapshot.osnap}).
    */
   rebuild(layout: AcExLayoutSnapshot): void {
     this.resetFromLayout(layout)
+    this.collectSegmentsFromLayout(layout)
     this.loadPrimitiveTreeSync()
     this.loadSegmentTreeSync()
   }
 
   /**
-   * Like {@link rebuild}, but yields while preparing RBush entries so large
-   * OSNAP catalogs do not freeze the canvas during bounds computation.
-   * Entries are still passed to RBush via a single bulk {@link RBush.load}
-   * (not per-item `insert`).
+   * Like {@link rebuild}, but yields while collecting batch segments and while
+   * preparing RBush entries. Entries are still passed to RBush via a single bulk
+   * {@link RBush.load} (not per-item `insert`).
    *
    * @param layout - Active layout snapshot.
-   * @param yieldFn - Called between entry-building batches (defaults to a macrotask yield).
+   * @param yieldFn - Called between work batches (defaults to a macrotask yield).
    */
   async rebuildAsync(
     layout: AcExLayoutSnapshot,
     yieldFn: () => Promise<void> = yieldToBrowser
   ): Promise<void> {
     this.resetFromLayout(layout)
+    await this.collectSegmentsFromLayoutAsync(layout, yieldFn)
     await this.loadPrimitiveTreeAsync(yieldFn)
     await this.loadSegmentTreeAsync(yieldFn)
   }
@@ -652,41 +737,74 @@ export class AcExOsnapIndex {
     this.hiddenLayers.clear()
     this.segments = []
     this.segmentLayers = []
+    // Drop non-finite analytic primitives up front (NaN polyline / bad arcs).
+    // Leaving them out of `this.primitives` avoids any query path that walks
+    // the array without going through the RBush finite filter.
+    this.primitives = (layout.osnap?.primitives ?? []).filter(prim =>
+      isFiniteBounds(primitiveBounds(prim))
+    )
+  }
 
-    this.primitives = layout.osnap?.primitives ?? []
-    if (this.primitives.length === 0) {
-      const collected = collectBatchSegments(layout)
-      this.segments = collected.segments
-      this.segmentLayers = collected.segmentLayers
+  private collectSegmentsFromLayout(layout: AcExLayoutSnapshot): void {
+    if (!layoutHasDrawableLineBatches(layout)) {
+      return
     }
+    const collected = collectBatchSegments(layout)
+    this.segments = collected.segments
+    this.segmentLayers = collected.segmentLayers
+  }
+
+  private async collectSegmentsFromLayoutAsync(
+    layout: AcExLayoutSnapshot,
+    yieldFn: () => Promise<void>
+  ): Promise<void> {
+    if (!layoutHasDrawableLineBatches(layout)) {
+      return
+    }
+    const collected = await collectBatchSegmentsAsync(layout, yieldFn)
+    this.segments = collected.segments
+    this.segmentLayers = collected.segmentLayers
   }
 
   private loadPrimitiveTreeSync(): void {
     if (this.primitives.length === 0) {
       return
     }
-    const primitiveEntries: AcExRbushEntry[] = new Array(this.primitives.length)
+    const primitiveEntries: AcExRbushEntry[] = []
     for (let i = 0; i < this.primitives.length; i++) {
-      primitiveEntries[i] = {
-        ...primitiveBounds(this.primitives[i]!),
-        index: i
+      const bounds = primitiveBounds(this.primitives[i]!)
+      // One NaN bbox poisons RBush so every later findSnap returns empty.
+      if (!isFiniteBounds(bounds)) {
+        continue
       }
+      primitiveEntries.push({
+        ...bounds,
+        index: i
+      })
     }
-    this.primitiveTree.load(primitiveEntries)
+    if (primitiveEntries.length > 0) {
+      this.primitiveTree.load(primitiveEntries)
+    }
   }
 
   private loadSegmentTreeSync(): void {
     if (this.segments.length === 0) {
       return
     }
-    const segmentEntries: AcExRbushEntry[] = new Array(this.segments.length)
+    const segmentEntries: AcExRbushEntry[] = []
     for (let i = 0; i < this.segments.length; i++) {
-      segmentEntries[i] = {
-        ...segmentBounds(this.segments[i]!),
-        index: i
+      const bounds = segmentBounds(this.segments[i]!)
+      if (!isFiniteBounds(bounds)) {
+        continue
       }
+      segmentEntries.push({
+        ...bounds,
+        index: i
+      })
     }
-    this.segmentTree.load(segmentEntries)
+    if (segmentEntries.length > 0) {
+      this.segmentTree.load(segmentEntries)
+    }
   }
 
   private async loadPrimitiveTreeAsync(
@@ -696,22 +814,23 @@ export class AcExOsnapIndex {
     if (count === 0) {
       return
     }
-    // Build the entry array in yieldable batches, then bulk-load once.
-    // Per-item `insert` is far slower than RBush's packed `load`.
-    const primitiveEntries: AcExRbushEntry[] = new Array(count)
-    for (let start = 0; start < count; start += OSNAP_INDEX_YIELD_BATCH) {
-      const end = Math.min(start + OSNAP_INDEX_YIELD_BATCH, count)
-      for (let i = start; i < end; i++) {
-        primitiveEntries[i] = {
-          ...primitiveBounds(this.primitives[i]!),
-          index: i
-        }
+    const schedule = createOsnapYieldScheduler(yieldFn)
+    const primitiveEntries: AcExRbushEntry[] = []
+    for (let i = 0; i < count; i++) {
+      const bounds = primitiveBounds(this.primitives[i]!)
+      if (!isFiniteBounds(bounds)) {
+        continue
       }
-      if (end < count) {
-        await yieldFn()
-      }
+      primitiveEntries.push({
+        ...bounds,
+        index: i
+      })
+      const wait = schedule.afterItem()
+      if (wait) await wait
     }
-    this.primitiveTree.load(primitiveEntries)
+    if (primitiveEntries.length > 0) {
+      this.primitiveTree.load(primitiveEntries)
+    }
   }
 
   private async loadSegmentTreeAsync(
@@ -721,20 +840,23 @@ export class AcExOsnapIndex {
     if (count === 0) {
       return
     }
-    const segmentEntries: AcExRbushEntry[] = new Array(count)
-    for (let start = 0; start < count; start += OSNAP_INDEX_YIELD_BATCH) {
-      const end = Math.min(start + OSNAP_INDEX_YIELD_BATCH, count)
-      for (let i = start; i < end; i++) {
-        segmentEntries[i] = {
-          ...segmentBounds(this.segments[i]!),
-          index: i
-        }
+    const schedule = createOsnapYieldScheduler(yieldFn)
+    const segmentEntries: AcExRbushEntry[] = []
+    for (let i = 0; i < count; i++) {
+      const bounds = segmentBounds(this.segments[i]!)
+      if (!isFiniteBounds(bounds)) {
+        continue
       }
-      if (end < count) {
-        await yieldFn()
-      }
+      segmentEntries.push({
+        ...bounds,
+        index: i
+      })
+      const wait = schedule.afterItem()
+      if (wait) await wait
     }
-    this.segmentTree.load(segmentEntries)
+    if (segmentEntries.length > 0) {
+      this.segmentTree.load(segmentEntries)
+    }
   }
 
   /**
@@ -798,9 +920,9 @@ export class AcExOsnapIndex {
   /**
    * Finds the best snap point near the cursor in WCS.
    *
-   * Queries analytic {@link AcExLayoutSnapshot.osnap} primitives first; only when
-   * no primitive candidate lies within the aperture does the search fall back to
-   * tessellated {@link AcExLineBatch} / mesh segments.
+   * Queries analytic {@link AcExLayoutSnapshot.osnap} curve primitives together
+   * with tessellated {@link AcExLineBatch} segments (lines are derived from
+   * geometry, not duplicated in ACEO). Hatch/mesh triangulation is not indexed.
    *
    * Uses AutoCAD-style mode priority: endpoint / midpoint / center beat
    * quadrant / node, which beat nearest. Within the same
@@ -956,6 +1078,39 @@ export class AcExOsnapIndex {
         for (const point of intersectLineSegmentPoints(
           segA,
           segB,
+          paramTol,
+          geomTol
+        )) {
+          const d2 = distSq(px, py, point.x, point.y)
+          if (d2 <= bestDistSq) {
+            bestDistSq = d2
+            best = { x: point.x, y: point.y, mode: 'intersection' }
+          }
+        }
+      }
+    }
+
+    // Hybrid exports keep curves in ACEO and straight edges in line batches.
+    // Without prim×seg pairs, circle/arc ∩ line intersections would disappear.
+    for (const primIndex of primIndices) {
+      const prim = this.primitives[primIndex]!
+      if (this.hiddenLayers.has(prim.layer)) continue
+      if (prim.kind !== 'circle' && prim.kind !== 'arc') continue
+      for (const segIndex of segIndices) {
+        const layer = this.segmentLayers[segIndex]!
+        if (this.hiddenLayers.has(layer)) continue
+        const seg = this.segments[segIndex]!
+        const asLine: AcExOsnapPrimitive = {
+          kind: 'line',
+          layer,
+          x0: seg.x0,
+          y0: seg.y0,
+          x1: seg.x1,
+          y1: seg.y1
+        }
+        for (const point of intersectPrimitivePair(
+          prim,
+          asLine,
           paramTol,
           geomTol
         )) {

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
@@ -3,8 +3,9 @@
  *
  * Walks layout block table records recursively, expands `AcDbBlockReference`
  * (INSERT) with full insertion transforms, and emits compact analytic primitives
- * for the offline HTML viewer. This path preserves circle/arc/ellipse/spline
- * definitions that would otherwise be lost after tessellation into line batches.
+ * for the offline HTML viewer. Straight line edges are omitted (they duplicate
+ * display {@link AcExLineBatch} data); circle/arc/ellipse/spline/point remain so
+ * measurement-grade analytic snap survives tessellation.
  *
  * @packageDocumentation
  */
@@ -60,7 +61,6 @@ import type {
   AcExOsnapCatalog,
   AcExOsnapCirclePrimitive,
   AcExOsnapEllipsePrimitive,
-  AcExOsnapLinePrimitive,
   AcExOsnapPrimitive,
   AcExOsnapSplinePrimitive
 } from './AcExOsnapPrimitiveTypes'
@@ -109,9 +109,6 @@ function pushGeCircArc(
     normalSign
   })
 }
-
-/** Half-length used when exporting infinite rays/xlines as finite segments. @internal */
-const INFINITE_LINE_HALF_LENGTH = 1_000_000
 
 /** Applies a 4×4 layout/block matrix to a 3D point; returns XY. @internal */
 function transformPoint(
@@ -396,51 +393,43 @@ function isBlockReferenceEntity(
   )
 }
 
-/** Appends a WCS line primitive after transforming endpoints. @internal */
+/**
+ * Line primitives are intentionally not exported into the HTML OSNAP catalog.
+ *
+ * Straight edges duplicate {@link AcExLineBatch} geometry already shipped for
+ * display. The offline viewer rebuilds line snap from those batches after
+ * geometry loads (see {@link AcExOsnapIndex.rebuildAsync}).
+ *
+ * Curve entities (arc / circle / ellipse / spline) and points still go through
+ * dedicated push helpers so measurement-grade analytic snap is preserved.
+ *
+ * @internal
+ */
 function pushLine(
-  out: AcExOsnapPrimitive[],
-  layer: string,
-  matrix: THREE.Matrix4,
-  start: AcGePoint3dLike,
-  end: AcGePoint3dLike
+  _out: AcExOsnapPrimitive[],
+  _layer: string,
+  _matrix: THREE.Matrix4,
+  _start: AcGePoint3dLike,
+  _end: AcGePoint3dLike
 ) {
-  const a = transformPoint(matrix, start)
-  const b = transformPoint(matrix, end)
-  const prim: AcExOsnapLinePrimitive = {
-    kind: 'line',
-    layer,
-    x0: a.x,
-    y0: a.y,
-    x1: b.x,
-    y1: b.y
-  }
-  out.push(prim)
+  // no-op — see function doc
 }
 
 /**
- * Appends a long WCS line segment along a unit direction (ray or xline).
+ * Ray / xline extents are also omitted from the catalog; finite display
+ * segments in lineBatches cover practical endpoint / nearest snap.
  *
  * @internal
  */
 function pushDirectedLine(
-  out: AcExOsnapPrimitive[],
-  layer: string,
-  matrix: THREE.Matrix4,
-  base: AcGePoint3dLike,
-  unitDir: AcGeVector3dLike,
-  bidirectional: boolean
+  _out: AcExOsnapPrimitive[],
+  _layer: string,
+  _matrix: THREE.Matrix4,
+  _base: AcGePoint3dLike,
+  _unitDir: AcGeVector3dLike,
+  _bidirectional: boolean
 ) {
-  const origin = transformPoint(matrix, base)
-  const dir = transformVector(matrix, unitDir)
-  const len = Math.hypot(dir.x, dir.y) || 1
-  const ux = dir.x / len
-  const uy = dir.y / len
-  const half = INFINITE_LINE_HALF_LENGTH
-  const x0 = bidirectional ? origin.x - ux * half : origin.x
-  const y0 = bidirectional ? origin.y - uy * half : origin.y
-  const x1 = origin.x + ux * half
-  const y1 = origin.y + uy * half
-  out.push({ kind: 'line', layer, x0, y0, x1, y1 })
+  // no-op — see function doc
 }
 
 /**
@@ -1374,8 +1363,8 @@ function ellipseFromArc(entity: AcDbArc): AcDbEllipse {
  * @param database - Open drawing database (same instance used for HTML export).
  * @param layoutBtrId - Object id of the layout's owning block table record
  *   (e.g. model space BTR id from the renderer scene).
- * @returns Catalog with {@link AcExOsnapCatalog.primitives} in WCS; empty array
- *   when the BTR id is unknown or the layout has no snap-capable geometry.
+ * @returns Catalog of analytic curve/point primitives in WCS (no `line` kinds).
+ *   Empty when the BTR id is unknown or the layout has no snap-capable curves.
  *
  * @example
  * ```ts
@@ -1409,5 +1398,59 @@ export function buildOsnapCatalog(
     database,
     options.includeLayer
   )
-  return { primitives }
+  // Belt-and-suspenders: never ship line kinds (they duplicate lineBatches).
+  // Also drop non-finite coords so a single NaN polyline cannot poison the
+  // offline RBush index the way it did in the main viewer.
+  return {
+    primitives: primitives.filter(
+      primitive => primitive.kind !== 'line' && isFiniteOsnapPrimitive(primitive)
+    )
+  }
+}
+
+function isFiniteOsnapPrimitive(primitive: AcExOsnapPrimitive): boolean {
+  switch (primitive.kind) {
+    case 'line':
+      return (
+        Number.isFinite(primitive.x0) &&
+        Number.isFinite(primitive.y0) &&
+        Number.isFinite(primitive.x1) &&
+        Number.isFinite(primitive.y1)
+      )
+    case 'circle':
+      return (
+        Number.isFinite(primitive.cx) &&
+        Number.isFinite(primitive.cy) &&
+        Number.isFinite(primitive.r)
+      )
+    case 'arc':
+      return (
+        Number.isFinite(primitive.cx) &&
+        Number.isFinite(primitive.cy) &&
+        Number.isFinite(primitive.r) &&
+        Number.isFinite(primitive.startAngle) &&
+        Number.isFinite(primitive.endAngle)
+      )
+    case 'ellipse':
+      return (
+        Number.isFinite(primitive.cx) &&
+        Number.isFinite(primitive.cy) &&
+        Number.isFinite(primitive.majorX) &&
+        Number.isFinite(primitive.majorY) &&
+        Number.isFinite(primitive.majorR) &&
+        Number.isFinite(primitive.minorR) &&
+        Number.isFinite(primitive.startAngle) &&
+        Number.isFinite(primitive.endAngle)
+      )
+    case 'spline':
+      return (
+        primitive.controlPoints.every(value => Number.isFinite(value)) &&
+        primitive.knots.every(knot => Number.isFinite(knot)) &&
+        primitive.weights.every(weight => Number.isFinite(weight))
+      )
+    case 'point':
+      return Number.isFinite(primitive.x) && Number.isFinite(primitive.y)
+    default:
+      return false
+  }
 }

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
@@ -4,9 +4,10 @@
  * These definitions describe **analytic** geometry in world coordinates (WCS, XY plane).
  * All coordinate fields use IEEE-754 `number` (double precision) for measurement-grade
  * accuracy on large-coordinate drawings.
- * They are serialized per layout in {@link AcExLayoutSnapshot.osnap} at export time
- * (see {@link buildOsnapCatalog}) and consumed at runtime by {@link AcExOsnapIndex}
- * instead of tessellated render batches.
+ * Curve/point kinds are serialized per layout in {@link AcExLayoutSnapshot.osnap}
+ * at export time (see {@link buildOsnapCatalog}). Straight `line` edges are omitted
+ * from exported catalogs and rebuilt at runtime from {@link AcExLineBatch} display
+ * geometry by {@link AcExOsnapIndex} (self-contained HTML and multi-file packages).
  *
  * @packageDocumentation
  */
@@ -85,6 +86,9 @@ export interface AcExOsnapPrimitiveBase {
 
 /**
  * A straight line segment (`AcDbLine`, or a non-bulge polyline edge).
+ *
+ * Not written by {@link buildOsnapCatalog}; retained so runtime / tests can
+ * represent tessellated snap edges derived from {@link AcExLineBatch}.
  *
  * @see {@link AcExOsnapLinePrimitive.kind}
  */

--- a/packages/cad-html-plugin/src/AcExPackageBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExPackageBuilder.ts
@@ -297,8 +297,18 @@ function orderLayoutsForExport(
   return active ? [active, ...rest] : [...layouts]
 }
 
+/**
+ * File-name stem for package files (`{base}.acex.json`, zip-safe path segments).
+ * Keeps only `[A-Za-z0-9._-]`; spaces, `+`, parentheses, and other punctuation
+ * become underscores so {@link zipAcExPackageFiles} / package href checks pass.
+ * The browser download name for the `.zip` itself may still use the original
+ * drawing title via {@link resolveExportDownloadName}.
+ */
 function sanitizeBaseName(name: string): string {
-  const trimmed = name.trim().replace(/\.(dwg|dxf|html|zip)$/i, '')
-  const safe = trimmed.replace(/[^\w.\-()+ ]+/g, '_').replace(/\s+/g, '_')
+  const trimmed = name.trim().replace(/\.(dwg|dxf|html|zip|acex\.json)$/i, '')
+  const safe = trimmed
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^[_./-]+|[_./-]+$/g, '')
   return safe.length > 0 ? safe : 'drawing'
 }

--- a/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
+++ b/packages/cad-html-plugin/src/AcExSceneBatchCollector.ts
@@ -4,12 +4,12 @@ import {
   AcTrBatchedMesh,
   AcTrBatchedPoint,
   getMaterialMetadata,
+  getSceneDrawableUserData,
   isBatchGeometryActive,
   isBatchGeometryVisible,
   isHighlightCloneDrawable,
   isHighlightOverlayDescendant,
-  isObjectHierarchyVisible
-} from '@mlightcad/three-renderer'
+  isObjectHierarchyVisible} from '@mlightcad/three-renderer'
 import * as THREE from 'three'
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
@@ -155,6 +155,35 @@ type AcTrBatchedExportSource = {
 
 function shouldExportBatchedSlot(info: AcTrPackedGeometryInfo): boolean {
   return isBatchGeometryActive(info.flags) && isBatchGeometryVisible(info.flags)
+}
+
+/**
+ * Text/point glyph batches are bucketed with `bboxIntersectionCheck` so their
+ * stroke vertices are not used for CAD-style object snap.
+ */
+function batchedLineExcludesFromOsnap(
+  batch: AcTrBatchedExportSource
+): boolean {
+  const { count } = batch.mappingStats
+  for (let geometryId = 0; geometryId < count; geometryId++) {
+    let info: AcTrPackedGeometryInfo & { bboxIntersectionCheck?: boolean }
+    try {
+      info = batch.getGeometryRangeAt(geometryId) as AcTrPackedGeometryInfo & {
+        bboxIntersectionCheck?: boolean
+      }
+    } catch {
+      continue
+    }
+    if (!shouldExportBatchedSlot(info)) continue
+    if (info.bboxIntersectionCheck) {
+      return true
+    }
+  }
+  return false
+}
+
+function drawableExcludesFromOsnap(object: THREE.Object3D): boolean {
+  return getSceneDrawableUserData(object).bboxIntersectionCheck === true
 }
 
 /**
@@ -522,6 +551,9 @@ function exportBatchedLine2(
     lineWidth,
     ...slice
   }
+  if (batchedLineExcludesFromOsnap(batch)) {
+    exported.excludeFromOsnap = true
+  }
   assignRenderOrder(exported, batch, batch.material as THREE.Material)
   return exported
 }
@@ -544,6 +576,9 @@ function exportBatchedLine(batch: AcTrBatchedLine): AcExLineBatch | undefined {
     linePattern,
     lineDistances,
     ...slice
+  }
+  if (batchedLineExcludesFromOsnap(batch)) {
+    exported.excludeFromOsnap = true
   }
   assignRenderOrder(exported, batch, batch.material as THREE.Material)
   return exported
@@ -642,6 +677,9 @@ export function collectBatchesFromObject3D(
         lineWidth: readLineWidth(material),
         ...slice
       }
+      if (drawableExcludesFromOsnap(child)) {
+        exported.excludeFromOsnap = true
+      }
       assignRenderOrder(exported, child, material)
       lineBatches.push(exported)
     } else if (
@@ -664,6 +702,9 @@ export function collectBatchesFromObject3D(
         linePattern,
         lineDistances,
         ...slice
+      }
+      if (drawableExcludesFromOsnap(child)) {
+        exported.excludeFromOsnap = true
       }
       assignRenderOrder(exported, child, material)
       lineBatches.push(exported)

--- a/packages/cad-html-plugin/src/AcExSnapshotCompression.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotCompression.ts
@@ -6,11 +6,15 @@ export const ACEX_SNAPSHOT_COMPRESSION = 'gzip' as const
 /**
  * Hard cap on gunzip output for ACEX payloads (single-file snapshot or package
  * chunk). Rejects zip bombs after inflate; compressed input is also capped.
+ *
+ * Single-file HTML can exceed 64 MiB once geometry + analytic OSNAP are decoded
+ * (large site plans). Package ACEC/ACEO chunks stay far below this; the cap is
+ * sized for legitimate self-contained exports, not unbounded inflate.
  */
-export const ACEX_MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024
+export const ACEX_MAX_DECOMPRESSED_BYTES = 512 * 1024 * 1024
 
 /** Hard cap on compressed gzip bytes accepted before inflate. */
-export const ACEX_MAX_COMPRESSED_BYTES = 32 * 1024 * 1024
+export const ACEX_MAX_COMPRESSED_BYTES = 256 * 1024 * 1024
 
 export type AcExSnapshotCompression = typeof ACEX_SNAPSHOT_COMPRESSION
 

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -165,6 +165,13 @@ export interface AcExLineBatch {
    * Omitted when `0` (the default linework tier).
    */
   renderOrder?: number
+  /**
+   * When `true`, hybrid OSNAP must not index this batch's vertices.
+   * Set for text/point glyph stroke batches (`bboxIntersectionCheck` drawables)
+   * whose outlines flood snap without matching AutoCAD text snap behavior.
+   * Insertion/node snap for TEXT/MTEXT still comes from analytic ACEO points.
+   */
+  excludeFromOsnap?: boolean
 }
 
 /**
@@ -284,16 +291,16 @@ export interface AcExLayoutSnapshot {
   /**
    * Analytic geometry for object snap (OSNAP) in the offline viewer.
    *
-   * Populated at export time by {@link buildOsnapCatalog} from the drawing database
-   * (not from tessellated THREE batches). Includes lines, arcs, circles, ellipses,
-   * splines, and points in WCS, including entities inside block references.
+   * Populated at export time by {@link buildOsnapCatalog} from the drawing database.
+   * Contains **curve/point** primitives only (circle, arc, ellipse, spline, point,
+   * including polyline bulge arcs). Straight `line` edges are omitted because they
+   * duplicate {@link AcExLineBatch} display geometry; the offline viewer rebuilds
+   * line snap from those batches (self-contained HTML and multi-file packages).
    *
-   * Coordinates are stored as IEEE-754 `number` (double) in JSON for measurement-grade
-   * precision; they are not converted to {@link Float32Array}.
+   * Coordinates are IEEE-754 `number` (double) for measurement-grade precision.
    *
-   * When {@link AcExOsnapCatalog.primitives} is non-empty, {@link AcExOsnapIndex}
-   * uses these definitions exclusively and does **not** snap to discretized
-   * {@link AcExLineBatch} / {@link AcExMeshBatch} vertices.
+   * {@link AcExOsnapIndex} indexes ACEO curves together with tessellated line
+   * segments extracted from resident {@link AcExLineBatch} / mesh edges.
    */
   osnap?: AcExOsnapCatalog
   /**

--- a/packages/cad-html-plugin/src/AcExViewerMetadata.ts
+++ b/packages/cad-html-plugin/src/AcExViewerMetadata.ts
@@ -73,9 +73,9 @@ export interface AcExViewerMetadata {
  * Extracts viewer metadata from an open drawing database (units, extents).
  * Does not serialize entities or DXF/DWG content.
  *
- * Object-snap (OSNAP) curve and line definitions are **not** part of this
- * metadata object. They are stored per layout in
- * {@link AcExLayoutSnapshot.osnap}, built by {@link buildOsnapCatalog} at export time.
+ * Object-snap (OSNAP) curve/point definitions are **not** part of this metadata
+ * object. They are stored per layout in {@link AcExLayoutSnapshot.osnap}
+ * (curves/points only; straight lines come from `lineBatches` at runtime).
  *
  * @param database - Open `AcDbDatabase` to read sysvars and extents from.
  * @param options - Optional title override and background color (default `0x000000`).

--- a/packages/cad-simple-viewer/__tests__/AcTrRBushSpatialIndex.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcTrRBushSpatialIndex.spec.ts
@@ -1,0 +1,64 @@
+import { AcTrRBushSpatialIndex } from '../src/spatialIndex/AcTrRBushSpatialIndex'
+
+describe('AcTrRBushSpatialIndex', () => {
+  test('rejects NaN bboxes so one bad insert cannot poison all searches', () => {
+    const index = new AcTrRBushSpatialIndex()
+    for (let i = 0; i < 50; i++) {
+      index.insert({
+        minX: 360000 + i,
+        minY: 3535000,
+        maxX: 360000 + i + 10,
+        maxY: 3535010,
+        id: `ok-${i}`
+      })
+    }
+
+    expect(
+      index.search({
+        minX: 360000,
+        minY: 3535000,
+        maxX: 360100,
+        maxY: 3535200
+      }).length
+    ).toBeGreaterThan(0)
+
+    index.insert({
+      minX: NaN,
+      minY: NaN,
+      maxX: NaN,
+      maxY: NaN,
+      id: 'nan-box'
+    })
+    index.insert({
+      minX: Infinity,
+      minY: Infinity,
+      maxX: -Infinity,
+      maxY: -Infinity,
+      id: 'empty-inf'
+    })
+
+    const hits = index.search({
+      minX: 360000,
+      minY: 3535000,
+      maxX: 360100,
+      maxY: 3535200
+    })
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits.every(h => h.id.startsWith('ok-'))).toBe(true)
+    expect(index.all().some(h => h.id === 'nan-box')).toBe(false)
+  })
+
+  test('load filters non-finite items before bulk packing', () => {
+    const index = new AcTrRBushSpatialIndex()
+    index.load([
+      { minX: 0, minY: 0, maxX: 1, maxY: 1, id: 'a' },
+      { minX: NaN, minY: 0, maxX: 1, maxY: 1, id: 'bad' },
+      { minX: 10, minY: 10, maxX: 11, maxY: 11, id: 'b' }
+    ])
+
+    expect(index.all().map(item => item.id).sort()).toEqual(['a', 'b'])
+    expect(
+      index.search({ minX: -1, minY: -1, maxX: 12, maxY: 12 }).map(h => h.id)
+    ).toEqual(expect.arrayContaining(['a', 'b']))
+  })
+})

--- a/packages/cad-simple-viewer/src/spatialIndex/AcTrRBushSpatialIndex.ts
+++ b/packages/cad-simple-viewer/src/spatialIndex/AcTrRBushSpatialIndex.ts
@@ -2,6 +2,7 @@ import { AcDbObjectId } from '@mlightcad/data-model'
 import RBush from 'rbush'
 
 import { AcEdSpatialQueryResultItem } from '../editor/view'
+import { isFiniteSpatialBBox } from '../view/AcTrGroupWcsBboxAssert'
 import {
   AcTrSpatialIndex,
   AcTrSpatialIndexBBox,
@@ -26,6 +27,11 @@ export class AcTrRBushSpatialIndex implements AcTrSpatialIndex {
   }
 
   insert(item: AcEdSpatialQueryResultItem) {
+    // RBush parent-node bounds use Math.min/max; a single NaN bbox poisons the
+    // tree so every later search returns empty (pick / osnap fail globally).
+    if (!isFiniteSpatialBBox(item)) {
+      return
+    }
     const hasId = typeof item.id === 'string' && item.id.length > 0
     // Empty ids (hatch fill islands) must not share one Map slot — otherwise
     // later inserts overwrite earlier islands and only the last stays pickable.
@@ -51,8 +57,9 @@ export class AcTrRBushSpatialIndex implements AcTrSpatialIndex {
   }
 
   load(items: readonly AcEdSpatialQueryResultItem[]) {
-    this.tree.load(items)
-    for (const item of items) {
+    const finiteItems = items.filter(isFiniteSpatialBBox)
+    this.tree.load(finiteItems)
+    for (const item of finiteItems) {
       if (typeof item.id === 'string' && item.id.length > 0) {
         this.idMap.set(item.id, item)
       }

--- a/packages/cad-simple-viewer/src/view/AcTrLayout.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrLayout.ts
@@ -12,6 +12,7 @@ import { AcEdLayerInfo, AcEdSpatialQueryResultItem } from '../editor'
 import { unionSpatialQueryItems } from '../editor/view/AcEdSpatialQueryResult'
 import { AcTrHierarchicalSpatialIndex } from '../spatialIndex'
 import type { AcTrSpatialSearchOptions } from '../spatialIndex/AcTrSpatialIndex'
+import { isFiniteSpatialBBox } from './AcTrGroupWcsBboxAssert'
 import { AcTrLayer, AcTrLayerStats } from './AcTrLayer'
 
 /** Options for {@link AcTrLayout.createEntityPreviewRoot}. */
@@ -998,22 +999,28 @@ export class AcTrLayout {
       }
     }
 
-    this._spatialIndex.insert({
-      minX: rootBox.minX,
-      minY: rootBox.minY,
-      maxX: rootBox.maxX,
-      maxY: rootBox.maxY,
-      id: entity.objectId
-    })
+    // Skip non-finite roots (empty THREE.Box3 → ±Infinity, or NaN after a bad
+    // applyMatrix4). Inserting NaN into RBush poisons all spatial searches.
+    if (isFiniteSpatialBBox(rootBox)) {
+      this._spatialIndex.insert({
+        minX: rootBox.minX,
+        minY: rootBox.minY,
+        maxX: rootBox.maxX,
+        maxY: rootBox.maxY,
+        id: entity.objectId
+      })
 
-    if (spatialIndexChildBoxes && spatialIndexChildBoxes.length > 0) {
-      entity.wcsBbox.min.set(rootBox.minX, rootBox.minY, entity.wcsBbox.min.z)
-      entity.wcsBbox.max.set(rootBox.maxX, rootBox.maxY, entity.wcsBbox.max.z)
+      if (spatialIndexChildBoxes && spatialIndexChildBoxes.length > 0) {
+        entity.wcsBbox.min.set(rootBox.minX, rootBox.minY, entity.wcsBbox.min.z)
+        entity.wcsBbox.max.set(rootBox.maxX, rootBox.maxY, entity.wcsBbox.max.z)
+      }
     }
 
     // Some INSERT rendering paths split one block reference into multiple layer
     // groups (AcTrEntity instead of AcTrGroup). Keep child-box index via userData
     // so object snap can still resolve gsMark to sub-entities.
+    // ensureChildIndex may still register a finite root from child unions when
+    // the coarse root above was skipped.
     if (spatialIndexChildBoxes) {
       this._spatialIndex.ensureChildIndex(
         entity.objectId,
@@ -1029,12 +1036,16 @@ export class AcTrLayout {
    * Registers a simple axis-aligned WCS box in the spatial index by object id.
    */
   private registerSpatialIndexBox(objectId: AcDbObjectId, wcsBbox: THREE.Box3) {
-    this._spatialIndex.insert({
+    const box = {
       minX: wcsBbox.min.x,
       minY: wcsBbox.min.y,
       maxX: wcsBbox.max.x,
       maxY: wcsBbox.max.y,
       id: objectId
-    })
+    }
+    if (!isFiniteSpatialBBox(box)) {
+      return
+    }
+    this._spatialIndex.insert(box)
   }
 }


### PR DESCRIPTION
## Summary
- Hybrid HTML OSNAP: export ACEO curves/points only; rebuild straight-line snap from `lineBatches`, skip hatch meshes and glyph strokes (`excludeFromOsnap`), and keep circle/arc × line intersections across the split.
- Guard RBush against NaN/Inf segment and entity bboxes in both the offline viewer and `cad-simple-viewer`, so one bad insert cannot empty all pick/osnap searches.
- Yield OSNAP index rebuilds on a wall-clock budget instead of fixed tiny chunks, and cover the NaN / hybrid intersection paths with tests.

## Test plan
- [ ] `pnpm test -- --testPathPatterns="AcExOsnap|AcTrRBushSpatialIndex" --no-coverage`
- [ ] Export a drawing with lines + circles to HTML and confirm INT snap at crossings
- [ ] Confirm text/point glyph outlines do not flood endpoint snap
- [ ] Open a large-coordinate drawing and verify pick/osnap still work after entities with empty/NaN bounds