### PR TITLE
fix: answer new -chtml format prompt in HTML demo script

### DIFF
--- a/packages/cad-simple-viewer-cli/examples/export-html.scr
+++ b/packages/cad-simple-viewer-cli/examples/export-html.scr
@@ -1,8 +1,10 @@
 ; Export a self-contained offline HTML viewer (-chtml).
-; Prompts: export invisible layers / export layouts / initial view / viewer mode.
+; Prompts: export format / export invisible layers / export layouts /
+; initial view / viewer mode.
 ; Usage:
 ;   cad-simple-viewer-cli -i drawing.dwg -s examples/export-html.scr -o ./out
 -chtml
+Single
 Yes
 Yes
 Extents


### PR DESCRIPTION
## Summary
- Main CI has been failing since #605 on **Export self-contained HTML demo**.
- `-chtml` now prompts for export format (`Single` / `Multi`) first, but `export-html.scr` still sent `Yes`, causing `Invalid scripted input 'Yes'`.
- Answer `Single` so the GitHub Pages demo still writes `canteen.html`.

## Test plan
- [ ] Merge and confirm the `Export self-contained HTML demo` step on `main` succeeds
- [ ] Confirm the demo still produces `packages/examples/public/self-contained-html/canteen.html`