### PR TITLE
feat: add ACEO path osnap and split oversized geometry batches

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExGeometryBatchSplit.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExGeometryBatchSplit.spec.ts
@@ -1,0 +1,201 @@
+import { estimateLineBatchBytes, estimateMeshBatchBytes } from '../src/AcExBatchBinaryCodec'
+import {
+  splitLineBatch,
+  splitMeshBatch
+} from '../src/AcExGeometryBatchSplit'
+import { splitLayoutIntoSlices } from '../src/AcExPackageBuilder'
+import {
+  ACEX_DEFAULT_CHUNK_MAX_BYTES,
+  ACEX_MAX_GEOMETRY_BATCH_BYTES
+} from '../src/AcExPackageTypes'
+import type { AcExLayoutSnapshot, AcExLineBatch, AcExMeshBatch } from '../src/AcExSnapshotTypes'
+
+function sequentialLinePositions(segmentCount: number): Float32Array {
+  const positions = new Float32Array(segmentCount * 6)
+  for (let i = 0; i < segmentCount; i++) {
+    positions[i * 6] = i
+    positions[i * 6 + 3] = i + 1
+  }
+  return positions
+}
+
+function lineSegmentKeys(batch: AcExLineBatch): string[] {
+  const keys: string[] = []
+  const pos = batch.positions
+  if (batch.indices && batch.indices.length >= 2) {
+    for (let i = 0; i + 1 < batch.indices.length; i += 2) {
+      const a = batch.indices[i]! * 3
+      const b = batch.indices[i + 1]! * 3
+      keys.push(
+        `${pos[a]},${pos[a + 1]},${pos[a + 2]}|${pos[b]},${pos[b + 1]},${pos[b + 2]}`
+      )
+    }
+    return keys
+  }
+  for (let i = 0; i + 5 < pos.length; i += 6) {
+    keys.push(
+      `${pos[i]},${pos[i + 1]},${pos[i + 2]}|${pos[i + 3]},${pos[i + 4]},${pos[i + 5]}`
+    )
+  }
+  return keys
+}
+
+function triangleKeys(batch: AcExMeshBatch): string[] {
+  const keys: string[] = []
+  const pos = batch.positions
+  const idx = batch.indices!
+  for (let i = 0; i + 2 < idx.length; i += 3) {
+    const verts = [idx[i]!, idx[i + 1]!, idx[i + 2]!].map(vi => {
+      const o = vi * 3
+      return `${pos[o]},${pos[o + 1]},${pos[o + 2]}`
+    })
+    keys.push(verts.join('|'))
+  }
+  return keys
+}
+
+describe('AcExGeometryBatchSplit', () => {
+  it('exports a tunable max batch size constant', () => {
+    expect(ACEX_MAX_GEOMETRY_BATCH_BYTES).toBe(2 * 1024 * 1024)
+    expect(ACEX_MAX_GEOMETRY_BATCH_BYTES).toBe(ACEX_DEFAULT_CHUNK_MAX_BYTES)
+  })
+
+  it('leaves small line batches intact', () => {
+    const batch: AcExLineBatch = {
+      layer: '0',
+      color: 0xff0000,
+      offset: [1, 2, 3],
+      positions: sequentialLinePositions(2)
+    }
+    expect(splitLineBatch(batch, ACEX_MAX_GEOMETRY_BATCH_BYTES)).toEqual([batch])
+  })
+
+  it('splits a large sequential line batch and keeps every segment', () => {
+    const batch: AcExLineBatch = {
+      layer: 'WALL',
+      color: 0x00ff00,
+      offset: [10, 20, 0],
+      positions: sequentialLinePositions(400),
+      lineWidth: 2,
+      renderOrder: -1,
+      excludeFromOsnap: true,
+      lineDistances: Float32Array.from({ length: 800 }, (_, i) => i)
+    }
+    const pieces = splitLineBatch(batch, 2000)
+    expect(pieces.length).toBeGreaterThan(1)
+    expect(pieces.every(piece => estimateLineBatchBytes(piece) <= 2000 + 24)).toBe(
+      true
+    )
+    expect(pieces.flatMap(lineSegmentKeys).sort()).toEqual(
+      lineSegmentKeys(batch).sort()
+    )
+    expect(pieces.every(piece => piece.layer === 'WALL')).toBe(true)
+    expect(pieces.every(piece => piece.lineWidth === 2)).toBe(true)
+    expect(pieces.every(piece => piece.excludeFromOsnap === true)).toBe(true)
+    expect(
+      pieces.reduce((n, piece) => n + (piece.lineDistances?.length ?? 0), 0)
+    ).toBe(800)
+  })
+
+  it('splits an indexed line batch without dropping segments', () => {
+    const positions = sequentialLinePositions(80)
+    const indices = new Uint32Array(80 * 2)
+    for (let i = 0; i < 80; i++) {
+      indices[i * 2] = i * 2
+      indices[i * 2 + 1] = i * 2 + 1
+    }
+    const batch: AcExLineBatch = {
+      layer: '0',
+      color: 1,
+      offset: [0, 0, 0],
+      positions,
+      indices,
+      lineDistances: Float32Array.from({ length: 160 }, (_, i) => i * 0.5)
+    }
+    const pieces = splitLineBatch(batch, 1500)
+    expect(pieces.length).toBeGreaterThan(1)
+    expect(pieces.flatMap(lineSegmentKeys).sort()).toEqual(
+      lineSegmentKeys(batch).sort()
+    )
+    expect(pieces.every(piece => piece.indices && piece.indices.length >= 2)).toBe(
+      true
+    )
+  })
+
+  it('splits an indexed mesh and preserves every triangle', () => {
+    const positions = new Float32Array(21)
+    for (let i = 0; i < 7; i++) {
+      positions[i * 3] = i
+      positions[i * 3 + 1] = i * 2
+    }
+    const indices = new Uint32Array(90)
+    for (let t = 0; t < 30; t++) {
+      indices[t * 3] = t % 7
+      indices[t * 3 + 1] = (t + 1) % 7
+      indices[t * 3 + 2] = (t + 2) % 7
+    }
+    const batch: AcExMeshBatch = {
+      layer: 'HATCH',
+      color: 0x0000ff,
+      offset: [0, 0, 0],
+      positions,
+      indices,
+      hatchPattern: {
+        patternAngle: 0,
+        patternLines: []
+      },
+      renderOrder: -1
+    }
+    const pieces = splitMeshBatch(batch, 500)
+    expect(pieces.length).toBeGreaterThan(1)
+    expect(pieces.flatMap(triangleKeys).sort()).toEqual(triangleKeys(batch).sort())
+    expect(pieces.every(piece => piece.hatchPattern?.patternAngle === 0)).toBe(
+      true
+    )
+    expect(pieces.every(piece => piece.renderOrder === -1)).toBe(true)
+  })
+
+  it('does not split textured IMAGE/OLE mesh batches', () => {
+    const batch: AcExMeshBatch = {
+      layer: '0',
+      color: 0xffffff,
+      offset: [0, 0, 0],
+      positions: new Float32Array(3000),
+      indices: Uint32Array.from({ length: 3000 }, (_, i) => i),
+      uvs: new Float32Array(2000),
+      texture: { mimeType: 'image/png', bytes: new Uint8Array(80_000) }
+    }
+    expect(estimateMeshBatchBytes(batch)).toBeGreaterThan(2000)
+    expect(splitMeshBatch(batch, 2000)).toEqual([batch])
+  })
+
+  it('turns one oversized layer batch into multiple layout slices', () => {
+    const layout: AcExLayoutSnapshot = {
+      btrId: 'ms',
+      name: '*Model_Space',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xff0000,
+          offset: [0, 0, 0],
+          positions: sequentialLinePositions(400)
+        }
+      ],
+      meshBatches: []
+    }
+    const slices = splitLayoutIntoSlices(layout, 2000, 2000)
+    expect(slices.length).toBeGreaterThan(1)
+    const totalSegments = slices.reduce(
+      (n, slice) =>
+        n +
+        slice.lineBatches.reduce(
+          (m, batch) => m + ((batch.positions.length / 6) | 0),
+          0
+        ),
+      0
+    )
+    expect(totalSegments).toBe(400)
+    expect(slices.every(slice => slice.estimatedBytes <= 2000 + 256)).toBe(true)
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts
@@ -337,7 +337,7 @@ describe('AcExOsnapIndex', () => {
     expect(snap?.mode).toBe('center')
   })
 
-  it('merges patterned line batch segments before endpoint snap', () => {
+  it('walks patterned line batch edges so intermediate vertices stay snappable', () => {
     const batch = {
       layer: '0',
       color: 0xffffff,
@@ -351,7 +351,8 @@ describe('AcExOsnapIndex', () => {
       }
     }
     expect(extractLineBatchSnapSegments(batch)).toEqual([
-      { x0: 0, y0: 0, x1: 10, y1: 0 }
+      { x0: 0, y0: 0, x1: 5, y1: 0 },
+      { x0: 5, y0: 0, x1: 10, y1: 0 }
     ])
 
     const patternedLayout = {
@@ -360,11 +361,16 @@ describe('AcExOsnapIndex', () => {
     }
     const index = new AcExOsnapIndex(['endpoint'])
     index.rebuild(patternedLayout)
+    expect(index.findSnap(5.1, 0.1, 1)).toEqual({
+      x: 5,
+      y: 0,
+      mode: 'endpoint'
+    })
     const snap = index.findSnap(9.8, 0.1, 1)
     expect(snap).toEqual({ x: 10, y: 0, mode: 'endpoint' })
   })
 
-  it('prefers analytic line endpoints over patterned render segments', () => {
+  it('snaps patterned intermediate vertices even when an ACEO line shares the chain', () => {
     const hybridLayout = {
       ...layout,
       lineBatches: [
@@ -396,8 +402,16 @@ describe('AcExOsnapIndex', () => {
     }
     const index = new AcExOsnapIndex(['endpoint'])
     index.rebuild(hybridLayout)
-    const snap = index.findSnap(1.5, 0.2, 2)
-    expect(snap).toEqual({ x: 0, y: 0, mode: 'endpoint' })
+    expect(index.findSnap(1.5, 0.2, 2)).toEqual({
+      x: 2,
+      y: 0,
+      mode: 'endpoint'
+    })
+    expect(index.findSnap(0.2, 0.1, 1)).toEqual({
+      x: 0,
+      y: 0,
+      mode: 'endpoint'
+    })
   })
 
   it('snaps to T-junction where stem ends on crossbar interior', () => {
@@ -740,6 +754,60 @@ describe('AcExOsnapIndex', () => {
     index.rebuild(hybridLayout)
     const snap = index.findSnap(10.1, 0.1, 1)
     expect(snap).toEqual({ x: 10, y: 0, mode: 'intersection' })
+  })
+
+  it('snaps to path-edge × lineBatch intersection', () => {
+    const hybridLayout = {
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [
+        {
+          layer: '0',
+          color: 0xffffff,
+          offset: [0, 0, 0] as [number, number, number],
+          positions: f32([5, -5, 0, 5, 15, 0])
+        }
+      ],
+      meshBatches: [],
+      osnap: {
+        primitives: [
+          {
+            kind: 'path' as const,
+            layer: '0',
+            closed: true,
+            vertices: [0, 0, 0, 10, 0, 0, 10, 10, 0, 0, 10, 0]
+          }
+        ]
+      }
+    }
+    const index = new AcExOsnapIndex(['intersection'])
+    index.rebuild(hybridLayout)
+    const snap = index.findSnap(5.1, 0.1, 1)
+    expect(snap).toEqual({ x: 5, y: 0, mode: 'intersection' })
+  })
+
+  it('snaps to fill-path endpoints', () => {
+    const index = new AcExOsnapIndex(['endpoint'])
+    index.rebuild({
+      btrId: 'model',
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [],
+      meshBatches: [],
+      osnap: {
+        primitives: [
+          {
+            kind: 'path',
+            layer: '0',
+            closed: true,
+            vertices: [0, 0, 0, 20, 0, 0, 20, 10, 0, 0, 10, 0]
+          }
+        ]
+      }
+    })
+    const snap = index.findSnap(0.2, 0.1, 1)
+    expect(snap).toEqual({ x: 0, y: 0, mode: 'endpoint' })
   })
 
   it('rebuilds large tessellated layouts without blowing the call stack', () => {

--- a/packages/cad-html-plugin/__tests__/AcExOsnapCatalogCodec.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapCatalogCodec.spec.ts
@@ -46,7 +46,13 @@ describe('AcExOsnapCatalogCodec', () => {
           closed: false,
           fitPoints: [0, 0, 2, 0]
         },
-        { kind: 'point', layer: '0', x: 9, y: 8 }
+        { kind: 'point', layer: '0', x: 9, y: 8 },
+        {
+          kind: 'path',
+          layer: 'H',
+          closed: true,
+          vertices: [0, 0, 0, 10, 0, 0, 10, 10, 0, 0, 10, 0]
+        }
       ]
     }
 
@@ -91,7 +97,7 @@ describe('AcExOsnapCatalogCodec', () => {
 describe('AcExOsnapIndex.rebuildAsync', () => {
   it('bulk-loads RBush after building entries and yields on wall-clock budget', async () => {
     const { AcExOsnapIndex } = await import('../src/AcExOsnap')
-    // Must exceed OSNAP_INDEX_YIELD_CHECK_EVERY (8192) so the scheduler samples
+    // Must exceed OSNAP_INDEX_YIELD_CHECK_EVERY (1024) so the scheduler samples
     // the wall-clock budget at least once.
     const primitiveCount = 9000
     const primitives = Array.from({ length: primitiveCount }, (_, i) => ({

--- a/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
@@ -1,5 +1,6 @@
 import {
   AcDbAlignedDimension,
+  AcDbAttribute,
   AcDbBlockReference,
   AcDbBlockTableRecord,
   AcDbDatabase,
@@ -11,10 +12,12 @@ import {
   AcDbMLeader,
   AcDbMLeaderContentType,
   AcDbMLine,
+  AcDbOle2Frame,
   AcDbPoint,
   AcDbPolyline,
   AcDbRasterImage,
   AcDbRay,
+  AcDbSolid,
   AcDbTable,
   AcDbText,
   AcDbTrace,
@@ -107,6 +110,76 @@ describe('buildOsnapCatalog', () => {
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
     expect(catalog.primitives.filter(p => p.kind === 'line').length).toBe(0)
+    expect(catalog.primitives.filter(p => p.kind === 'path').length).toBe(0)
+  })
+
+  it('exports a wide LWPOLYLINE centerline as one path (mesh, not lineBatches)', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+    const polyline = new AcDbPolyline()
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0), 0, 2, 1)
+    polyline.addVertexAt(1, new AcGePoint2d(10, 0), 0, 1, 2)
+    polyline.addVertexAt(2, new AcGePoint2d(10, 10), 0, 2, 2)
+    modelSpace.appendEntity(polyline)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
+    const paths = catalog.primitives.filter(p => p.kind === 'path')
+    expect(paths).toHaveLength(1)
+    expect(paths[0]).toMatchObject({
+      kind: 'path',
+      closed: false,
+      vertices: [0, 0, 0, 10, 0, 0, 10, 10, 0]
+    })
+
+    const index = new AcExOsnapIndex(['endpoint', 'midpoint', 'nearest'])
+    index.rebuild({
+      btrId: modelSpace.objectId,
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [],
+      meshBatches: [],
+      osnap: catalog
+    })
+    expect(index.findSnap(10.1, 0.1, 1)).toEqual({
+      x: 10,
+      y: 0,
+      mode: 'endpoint'
+    })
+    expect(index.findSnap(5, 0.1, 1)?.mode).toBe('midpoint')
+    expect(index.findSnap(5, 0.1, 1)?.x).toBeCloseTo(5, 5)
+  })
+
+  it('keeps bulge on a wide LWPOLYLINE path so arc nearest still works', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+    const polyline = new AcDbPolyline()
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0), 1, 2, 2)
+    polyline.addVertexAt(1, new AcGePoint2d(10, 0), 0, 2, 2)
+    modelSpace.appendEntity(polyline)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const path = catalog.primitives.find(p => p.kind === 'path')
+    expect(path?.kind).toBe('path')
+    if (path?.kind === 'path') {
+      expect(path.vertices[2]).toBe(1)
+    }
+
+    const arc = new AcGeCircArc2d({ x: 0, y: 0 }, { x: 10, y: 0 }, 1)
+    const index = new AcExOsnapIndex(['nearest'])
+    index.rebuild({
+      btrId: modelSpace.objectId,
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [],
+      meshBatches: [],
+      osnap: catalog
+    })
+    const mid = arc.midPoint
+    const snap = index.findSnap(mid.x, mid.y, 1)
+    expect(snap?.mode).toBe('nearest')
+    expect(snap?.x).toBeCloseTo(mid.x, 5)
+    expect(snap?.y).toBeCloseTo(mid.y, 5)
   })
 
   it('snaps nearest on both CCW and CW polyline bulge segments', () => {
@@ -229,10 +302,9 @@ describe('buildOsnapCatalog', () => {
     const blockName = '*DIM_TEST'
     db.tables.blockTable.add(dimension.createDimBlock(blockName))
     dimension.dimBlockId = blockName
-    modelSpace.appendEntity(dimension)
-
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
     expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
+    expect(catalog.primitives.filter(p => p.kind === 'path')).toHaveLength(0)
   })
 
   it('exports points for text/point and omits ray/xline/trace/leader lines', () => {
@@ -253,8 +325,8 @@ describe('buildOsnapCatalog', () => {
     const trace = new AcDbTrace()
     trace.setPointAt(0, new AcGePoint3d(20, 0, 0))
     trace.setPointAt(1, new AcGePoint3d(30, 0, 0))
-    trace.setPointAt(2, new AcGePoint3d(30, 10, 0))
-    trace.setPointAt(3, new AcGePoint3d(20, 10, 0))
+    trace.setPointAt(2, new AcGePoint3d(20, 10, 0))
+    trace.setPointAt(3, new AcGePoint3d(30, 10, 0))
     modelSpace.appendEntity(trace)
 
     const leader = new AcDbLeader()
@@ -272,6 +344,14 @@ describe('buildOsnapCatalog', () => {
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
     expect(catalog.primitives.some(p => p.kind === 'line')).toBe(false)
+    const tracePath = catalog.primitives.find(p => p.kind === 'path')
+    expect(tracePath?.kind).toBe('path')
+    if (tracePath?.kind === 'path') {
+      expect(tracePath.closed).toBe(true)
+      expect(tracePath.vertices).toEqual([
+        20, 0, 0, 30, 0, 0, 30, 10, 0, 20, 10, 0
+      ])
+    }
     expect(catalog.primitives.some(p => p.kind === 'point' && p.x === 60)).toBe(
       true
     )
@@ -367,7 +447,7 @@ describe('buildOsnapCatalog', () => {
     expect(snap?.y).toBeCloseTo(0, 5)
   })
 
-  it('omits hatch polyline boundary lines from the catalog', () => {
+  it('exports hatch polyline boundary as one path', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -387,9 +467,16 @@ describe('buildOsnapCatalog', () => {
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
     expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
+    const paths = catalog.primitives.filter(p => p.kind === 'path')
+    expect(paths).toHaveLength(1)
+    expect(paths[0]).toMatchObject({
+      kind: 'path',
+      closed: true,
+      vertices: [0, 0, 0, 20, 0, 0, 20, 10, 0, 0, 10, 0]
+    })
   })
 
-  it('omits hatch edge-loop lines from the catalog', () => {
+  it('exports hatch edge-loop lines as one path', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -404,9 +491,16 @@ describe('buildOsnapCatalog', () => {
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
     expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
+    const paths = catalog.primitives.filter(p => p.kind === 'path')
+    expect(paths).toHaveLength(1)
+    expect(paths[0]?.kind).toBe('path')
+    if (paths[0]?.kind === 'path') {
+      expect(paths[0].closed).toBe(true)
+      expect(paths[0].vertices.length).toBe(12)
+    }
   })
 
-  it('exports raster image insertion points and omits frame lines', () => {
+  it('exports raster image insertion points and clip-frame path', () => {
     const db = new AcDbDatabase()
     const modelSpace = db.tables.blockTable.modelSpace
 
@@ -421,6 +515,12 @@ describe('buildOsnapCatalog', () => {
     expect(
       catalog.primitives.some(p => p.kind === 'point' && p.x === 5 && p.y === 5)
     ).toBe(true)
+    const frame = catalog.primitives.find(p => p.kind === 'path')
+    expect(frame?.kind).toBe('path')
+    if (frame?.kind === 'path') {
+      expect(frame.closed).toBe(true)
+      expect(frame.vertices).toEqual([5, 5, 0, 25, 5, 0, 25, 15, 0, 5, 15, 0])
+    }
   })
 
   it('exports table insertion points and omits grid lines', () => {
@@ -497,5 +597,237 @@ describe('buildOsnapCatalog', () => {
     const center = index.findSnap(5.1, 5.1, 2)
     expect(center?.mode).toBe('center')
     expect(center?.x).toBeCloseTo(5, 5)
+  })
+
+  it('transforms hatch paths inside INSERT and emits INS points', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'HATCH_BLOCK'
+    db.tables.blockTable.add(blockRecord)
+    const hatch = new AcDbHatch()
+    hatch.add(
+      new AcGePolyline2d(
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 10, y: 4 },
+          { x: 0, y: 4 }
+        ],
+        true
+      )
+    )
+    blockRecord.appendEntity(hatch)
+
+    const insert = new AcDbBlockReference('HATCH_BLOCK')
+    insert.position = new AcGePoint3d(100, 50, 0)
+    modelSpace.appendEntity(insert)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    expect(
+      catalog.primitives.some(
+        p => p.kind === 'point' && p.x === 100 && p.y === 50
+      )
+    ).toBe(true)
+    const path = catalog.primitives.find(p => p.kind === 'path')
+    expect(path?.kind).toBe('path')
+    if (path?.kind === 'path') {
+      expect(path.vertices[0]).toBeCloseTo(100, 5)
+      expect(path.vertices[1]).toBeCloseTo(50, 5)
+      expect(path.vertices[3]).toBeCloseTo(110, 5)
+    }
+  })
+
+  it('zeros path bulge under non-uniform INSERT scale (circular → chord)', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'HATCH_BULGE_NU'
+    db.tables.blockTable.add(blockRecord)
+    const hatch = new AcDbHatch()
+    hatch.add(
+      new AcGePolyline2d(
+        [
+          { x: 0, y: 0, bulge: 1 },
+          { x: 10, y: 0 },
+          { x: 10, y: 4 },
+          { x: 0, y: 4 }
+        ],
+        true
+      )
+    )
+    blockRecord.appendEntity(hatch)
+
+    const insert = new AcDbBlockReference('HATCH_BULGE_NU')
+    insert.position = new AcGePoint3d(0, 0, 0)
+    insert.scaleFactors = new AcGePoint3d(2, 1, 1)
+    modelSpace.appendEntity(insert)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const path = catalog.primitives.find(p => p.kind === 'path')
+    expect(path?.kind).toBe('path')
+    if (path?.kind === 'path') {
+      expect(path.vertices[0]).toBeCloseTo(0, 5)
+      expect(path.vertices[3]).toBeCloseTo(20, 5)
+      expect(path.vertices[2]).toBe(0)
+    }
+  })
+
+  it('flips path bulge under mirrored INSERT', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'HATCH_BULGE_MIRROR'
+    db.tables.blockTable.add(blockRecord)
+    const hatch = new AcDbHatch()
+    hatch.add(
+      new AcGePolyline2d(
+        [
+          { x: 0, y: 0, bulge: 1 },
+          { x: 10, y: 0 },
+          { x: 10, y: 4 },
+          { x: 0, y: 4 }
+        ],
+        true
+      )
+    )
+    blockRecord.appendEntity(hatch)
+
+    const insert = new AcDbBlockReference('HATCH_BULGE_MIRROR')
+    insert.position = new AcGePoint3d(0, 0, 0)
+    insert.scaleFactors = new AcGePoint3d(-1, 1, 1)
+    modelSpace.appendEntity(insert)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const path = catalog.primitives.find(p => p.kind === 'path')
+    expect(path?.kind).toBe('path')
+    if (path?.kind === 'path') {
+      expect(path.vertices[2]).toBeCloseTo(-1, 5)
+    }
+  })
+
+  it('emits one INS point per MINSERT instance', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'MINSERT_BLOCK'
+    db.tables.blockTable.add(blockRecord)
+    blockRecord.appendEntity(new AcDbPoint())
+
+    const insert = new AcDbBlockReference('MINSERT_BLOCK')
+    insert.position = new AcGePoint3d(0, 0, 0)
+    insert.columnCount = 2
+    insert.rowCount = 2
+    insert.columnSpacing = 30
+    insert.rowSpacing = 20
+    modelSpace.appendEntity(insert)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const points = catalog.primitives.filter(p => p.kind === 'point')
+    expect(points).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'point', x: 0, y: 0 }),
+        expect.objectContaining({ kind: 'point', x: 30, y: 0 }),
+        expect.objectContaining({ kind: 'point', x: 0, y: 20 }),
+        expect.objectContaining({ kind: 'point', x: 30, y: 20 })
+      ])
+    )
+  })
+
+  it('exports ATTRIB text points in parent space', () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'ATTR_BLOCK'
+    db.tables.blockTable.add(blockRecord)
+
+    const insert = new AcDbBlockReference('ATTR_BLOCK')
+    insert.position = new AcGePoint3d(40, 10, 0)
+    modelSpace.appendEntity(insert)
+
+    const attrib = new AcDbAttribute()
+    attrib.position = new AcGePoint3d(45, 12, 0)
+    insert.appendAttributes(attrib)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    expect(
+      catalog.primitives.some(
+        p => p.kind === 'point' && p.x === 45 && p.y === 12
+      )
+    ).toBe(true)
+  })
+
+  it('snaps IMAGE clip vertices rather than the unclipped rectangle', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+
+    const image = new AcDbRasterImage()
+    image.position = new AcGePoint3d(5, 5, 0)
+    image.width = 20
+    image.height = 10
+    image.isClipped = true
+    image.clipBoundary = [
+      new AcGePoint2d(0, 0),
+      new AcGePoint2d(1, 0),
+      new AcGePoint2d(0.5, 1),
+      new AcGePoint2d(0, 0)
+    ]
+    modelSpace.appendEntity(image)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const path = catalog.primitives.find(p => p.kind === 'path')
+    expect(path?.kind).toBe('path')
+    if (path?.kind === 'path') {
+      expect(path.vertices).toEqual([5, 5, 0, 25, 5, 0, 15, 15, 0])
+    }
+
+    const index = new AcExOsnapIndex(['endpoint'])
+    index.rebuild({
+      btrId: modelSpace.objectId,
+      name: 'Model',
+      isModelSpace: true,
+      lineBatches: [],
+      meshBatches: [],
+      osnap: catalog
+    })
+    const snap = index.findSnap(15.1, 14.9, 1)
+    expect(snap).toEqual({ x: 15, y: 15, mode: 'endpoint' })
+  })
+
+  it('skips SOLID fills inside dimension blocks but keeps layout SOLID paths', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+    const solid = new AcDbSolid()
+    solid.setPointAt(0, new AcGePoint3d(0, 0, 0))
+    solid.setPointAt(1, new AcGePoint3d(2, 0, 0))
+    solid.setPointAt(2, new AcGePoint3d(0, 1, 0))
+    solid.setPointAt(3, new AcGePoint3d(2, 1, 0))
+    modelSpace.appendEntity(solid)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    expect(catalog.primitives.filter(p => p.kind === 'path')).toHaveLength(1)
+  })
+
+  it('exports OLE frame corners as a path', () => {
+    const db = new AcDbDatabase()
+    const modelSpace = db.tables.blockTable.modelSpace
+    const ole = new AcDbOle2Frame()
+    ole.setLocation(new AcGePoint3d(0, 10, 0))
+    ole.setWcsWidth(8)
+    ole.setWcsHeight(4)
+    modelSpace.appendEntity(ole)
+
+    const catalog = buildOsnapCatalog(db, modelSpace.objectId)
+    const path = catalog.primitives.find(p => p.kind === 'path')
+    expect(path?.kind).toBe('path')
+    expect(
+      catalog.primitives.some(p => p.kind === 'point' && p.x === 0 && p.y === 10)
+    ).toBe(true)
   })
 })

--- a/packages/cad-html-plugin/docs/acex-package-format.md
+++ b/packages/cad-html-plugin/docs/acex-package-format.md
@@ -132,20 +132,36 @@ Batch records reuse the ACEX feature-flag scheme (`F_LINE_*`, `F_MESH_*`):
 ### Geometry chunking rules
 
 1. Split primarily **by layout**.
-2. If a layout’s estimated uncompressed size exceeds ~512 KiB, split further by
-   batch groups into `L{layoutIndex}-{slice:000}`.
-3. Empty layouts still emit one empty chunk so the layout remains addressable.
+2. If a layout’s estimated uncompressed size exceeds
+   `ACEX_DEFAULT_CHUNK_MAX_BYTES` (~2 MiB), split further by batch groups into
+   `L{layoutIndex}-{slice:000}`. Gzip typically compresses a 2 MiB slice to well
+   under 200 KiB; smaller slices add inflate round-trips and slow first open.
+3. Scene collection packs geometry **by layer** (and material). A single busy
+   layer can therefore be tens of megabytes in one line/mesh batch. Before
+   grouping into chunks, any batch larger than `ACEX_MAX_GEOMETRY_BATCH_BYTES`
+   (~2 MiB, same default as the chunk budget) is split into smaller batches of
+   the same layer and style. Hosts can then fetch, inflate, and paint those
+   pieces independently instead of waiting on the whole layer.
+4. Textured IMAGE/OLE mesh batches are **not** split (the bitmap cannot be
+   painted in fragments without duplicating the texture in every chunk).
+5. Empty layouts still emit one empty chunk so the layout remains addressable.
 
 ## OSNAP chunk (`*-osnap-*.osnap.gz`)
 
 Each file is **raw gzip** of one **ACEO** binary payload (measure-mode exports).
 Coordinates are IEEE-754 **float64**; layer names are dictionary-compressed.
 
-**Straight `line` primitives are not stored in ACEO.** They duplicate display
-`lineBatches` already downloaded for rendering. After geometry loads (and before
-CPU batch buffers are released), the viewer extracts snap segments from those
-batches and indexes them together with analytic ACEO curves (circle / arc /
-ellipse / spline / point, including polyline bulge arcs and hatch curve edges).
+**Straight drawing `line` primitives are not stored in ACEO.** They duplicate
+display `lineBatches` already downloaded for rendering. After geometry loads (and
+before CPU batch buffers are released), the viewer extracts snap segments from
+those batches and indexes them together with analytic ACEO curves (circle / arc /
+ellipse / spline / point, including polyline bulge arcs) **and compact `path`
+records** for mesh-drawn fill/frame boundaries (hatch loops, TRACE/SOLID,
+IMAGE/WIPEOUT clip polygons, OLE frames) and **wide LWPOLYLINE centerlines**
+(start/end width; drawn as `area` meshes, not `lineBatches`).
+
+Kind `7` (`path`) is part of ACEO **version 1**. The schema has not had a formal
+release, so adding this kind does not bump the version byte.
 
 Large curve catalogs are still split (~512 KiB estimated uncompressed per file)
 so hosts can fetch snap slices after the drawing is already visible.
@@ -155,14 +171,14 @@ so hosts can fetch snap slices after the drawing is already visible.
 | Field | Type | Description |
 |-------|------|-------------|
 | magic | `u32` | `0x4F454341` (`ACEO`) |
-| version | `u8` | Currently **1** |
+| version | `u8` | Currently **1** (includes kind `7` `path`) |
 | reserved | `u8` × 3 | Must be `0` |
 | layerCount | `u32` | |
 | layers | strings | Length-prefixed UTF-8 dictionary |
 | primitiveCount | `u32` | |
 | primitives | … | kind `u8` + layer index `u32` + kind-specific f64 fields |
 
-Kind codes: `1` line (legacy / unused on export), `2` circle, `3` arc, `4` ellipse, `5` spline, `6` point.
+Kind codes: `1` line (legacy / unused on export), `2` circle, `3` arc, `4` ellipse, `5` spline, `6` point, `7` path (`closed` `u8` + `f64` vertex pack `[x,y,bulge,…]`).
 
 ### OSNAP chunking rules
 
@@ -189,7 +205,7 @@ Kind codes: `1` line (legacy / unused on export), `2` circle, `3` arc, `4` ellip
 Self-contained HTML embeds one gzip+base64 **ACEX** snapshot
 (`magic 0x58454341`). The **same** snapshot builder is used as for multi-file
 packages: measure-mode OSNAP catalogs omit straight `line` primitives and keep
-only analytic curves/points. The offline runtime rebuilds line snap from the
+only analytic curves/points/paths. The offline runtime rebuilds line snap from the
 embedded `lineBatches` before releasing CPU buffers, so single-file HTML is
 smaller for line-heavy drawings without losing endpoint/midpoint snap.
 

--- a/packages/cad-html-plugin/src/AcExGeometryBatchSplit.ts
+++ b/packages/cad-html-plugin/src/AcExGeometryBatchSplit.ts
@@ -1,0 +1,378 @@
+/**
+ * Splits oversized layer line/mesh batches so HTML package chunks stay under
+ * {@link ACEX_MAX_GEOMETRY_BATCH_BYTES} and can paint progressively.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  estimateLineBatchBytes,
+  estimateMeshBatchBytes
+} from './AcExBatchBinaryCodec'
+import { ACEX_MAX_GEOMETRY_BATCH_BYTES } from './AcExPackageTypes'
+import type { AcExLineBatch, AcExMeshBatch } from './AcExSnapshotTypes'
+
+/** Fixed per-batch header allowance used when budgeting piece size. */
+const BATCH_HEADER_BYTES = 256
+
+/**
+ * Splits one line batch into pieces that each stay near `maxBytes`.
+ *
+ * Small batches are returned unchanged. Indexed and non-indexed layouts are
+ * both preserved; vertex attributes (`lineDistances`) are remapped with the
+ * vertices they belong to.
+ */
+export function splitLineBatch(
+  batch: AcExLineBatch,
+  maxBytes: number = ACEX_MAX_GEOMETRY_BATCH_BYTES
+): AcExLineBatch[] {
+  if (!(maxBytes > 0) || estimateLineBatchBytes(batch) <= maxBytes) {
+    return [batch]
+  }
+
+  if (batch.indices && batch.indices.length >= 2) {
+    return splitIndexedLineBatch(batch, maxBytes)
+  }
+  return splitSequentialLineBatch(batch, maxBytes)
+}
+
+/**
+ * Splits one mesh/point batch into pieces that each stay near `maxBytes`.
+ *
+ * Textured IMAGE/OLE batches are not split (the bitmap cannot be painted in
+ * fragments without duplicating the texture in every chunk).
+ */
+export function splitMeshBatch(
+  batch: AcExMeshBatch,
+  maxBytes: number = ACEX_MAX_GEOMETRY_BATCH_BYTES
+): AcExMeshBatch[] {
+  if (batch.texture) {
+    return [batch]
+  }
+  if (!(maxBytes > 0) || estimateMeshBatchBytes(batch) <= maxBytes) {
+    return [batch]
+  }
+
+  if (batch.points) {
+    return splitPointMeshBatch(batch, maxBytes)
+  }
+  if (!batch.indices || batch.indices.length < 3) {
+    return splitPointOrUnindexedMeshBatch(batch, maxBytes)
+  }
+  return splitIndexedMeshBatch(batch, maxBytes)
+}
+
+function linePatternOverhead(batch: AcExLineBatch): number {
+  return batch.linePattern ? 64 + batch.linePattern.pattern.length * 8 : 0
+}
+
+function meshStyleOverhead(batch: AcExMeshBatch): number {
+  return (batch.hatchPattern ? 128 : 0) + (batch.gradientFill ? 64 : 0)
+}
+
+function maxPrimitivesPerPiece(
+  maxBytes: number,
+  extraBytes: number,
+  bytesPerPrimitive: number
+): number {
+  const budget = maxBytes - BATCH_HEADER_BYTES - extraBytes
+  if (budget < bytesPerPrimitive) {
+    return 1
+  }
+  return Math.max(1, Math.floor(budget / bytesPerPrimitive))
+}
+
+function splitSequentialLineBatch(
+  batch: AcExLineBatch,
+  maxBytes: number
+): AcExLineBatch[] {
+  const hasDistances = (batch.lineDistances?.length ?? 0) >= 2
+  const bytesPerSegment = 24 + (hasDistances ? 8 : 0)
+  const maxSegments = maxPrimitivesPerPiece(
+    maxBytes,
+    linePatternOverhead(batch),
+    bytesPerSegment
+  )
+  const totalSegments = (batch.positions.length / 6) | 0
+  if (totalSegments <= 1) {
+    return [batch]
+  }
+
+  const pieces: AcExLineBatch[] = []
+  for (let start = 0; start < totalSegments; start += maxSegments) {
+    const count = Math.min(maxSegments, totalSegments - start)
+    const posStart = start * 6
+    const piece: AcExLineBatch = {
+      layer: batch.layer,
+      color: batch.color,
+      offset: batch.offset,
+      positions: batch.positions.slice(posStart, posStart + count * 6)
+    }
+    copyLineStyle(batch, piece)
+    if (hasDistances && batch.lineDistances) {
+      const distStart = start * 2
+      piece.lineDistances = batch.lineDistances.slice(
+        distStart,
+        distStart + count * 2
+      )
+    }
+    pieces.push(piece)
+  }
+  return pieces.length > 0 ? pieces : [batch]
+}
+
+function splitIndexedLineBatch(
+  batch: AcExLineBatch,
+  maxBytes: number
+): AcExLineBatch[] {
+  const indices = batch.indices!
+  const hasDistances = (batch.lineDistances?.length ?? 0) > 0
+  // Worst case: two unique vertices per segment (no sharing).
+  const bytesPerSegment = 24 + 8 + (hasDistances ? 8 : 0)
+  const maxSegments = maxPrimitivesPerPiece(
+    maxBytes,
+    linePatternOverhead(batch),
+    bytesPerSegment
+  )
+  const pieces: AcExLineBatch[] = []
+  for (let i = 0; i + 1 < indices.length; ) {
+    const indexCount = Math.min(maxSegments * 2, indices.length - i)
+    const aligned = indexCount - (indexCount % 2)
+    if (aligned < 2) break
+    pieces.push(remapLineSlice(batch, i, aligned))
+    i += aligned
+  }
+  return pieces.length > 0 ? pieces : [batch]
+}
+
+function remapLineSlice(
+  batch: AcExLineBatch,
+  indexStart: number,
+  indexCount: number
+): AcExLineBatch {
+  const mapped = remapIndexedVertices(
+    batch.positions,
+    batch.indices!.subarray(indexStart, indexStart + indexCount),
+    batch.lineDistances ? [batch.lineDistances] : [],
+    [1]
+  )
+  const piece: AcExLineBatch = {
+    layer: batch.layer,
+    color: batch.color,
+    offset: batch.offset,
+    positions: mapped.positions,
+    indices: mapped.indices
+  }
+  copyLineStyle(batch, piece)
+  if (mapped.attributes[0] && mapped.attributes[0].length > 0) {
+    piece.lineDistances = mapped.attributes[0]
+  }
+  return piece
+}
+
+function splitPointMeshBatch(
+  batch: AcExMeshBatch,
+  maxBytes: number
+): AcExMeshBatch[] {
+  if (batch.indices && batch.indices.length > 0) {
+    return splitIndexedPointMeshBatch(batch, maxBytes)
+  }
+  return splitPointOrUnindexedMeshBatch(batch, maxBytes)
+}
+
+function splitIndexedPointMeshBatch(
+  batch: AcExMeshBatch,
+  maxBytes: number
+): AcExMeshBatch[] {
+  const indices = batch.indices!
+  const bytesPerPoint =
+    12 + 4 + (batch.uvs ? 8 : 0) + (batch.gradientPositions ? 8 : 0)
+  const maxPoints = maxPrimitivesPerPiece(
+    maxBytes,
+    meshStyleOverhead(batch),
+    bytesPerPoint
+  )
+  const pieces: AcExMeshBatch[] = []
+  for (let i = 0; i < indices.length; ) {
+    const count = Math.min(maxPoints, indices.length - i)
+    if (count < 1) break
+    pieces.push(remapMeshSlice(batch, i, count))
+    i += count
+  }
+  return pieces.length > 0 ? pieces : [batch]
+}
+
+function splitPointOrUnindexedMeshBatch(
+  batch: AcExMeshBatch,
+  maxBytes: number
+): AcExMeshBatch[] {
+  const vertexCount = (batch.positions.length / 3) | 0
+  if (vertexCount <= 1) {
+    return [batch]
+  }
+  const bytesPerVertex =
+    12 + (batch.uvs ? 8 : 0) + (batch.gradientPositions ? 8 : 0)
+  const maxVertices = maxPrimitivesPerPiece(
+    maxBytes,
+    meshStyleOverhead(batch),
+    bytesPerVertex
+  )
+  const group = batch.points ? 1 : 3
+  const alignedMax = Math.max(group, maxVertices - (maxVertices % group))
+  const pieces: AcExMeshBatch[] = []
+  for (let start = 0; start < vertexCount; start += alignedMax) {
+    const count = Math.min(alignedMax, vertexCount - start)
+    const alignedCount = count - (count % group)
+    if (alignedCount < group) break
+    pieces.push(sliceMeshVertices(batch, start, alignedCount))
+  }
+  return pieces.length > 0 ? pieces : [batch]
+}
+
+function splitIndexedMeshBatch(
+  batch: AcExMeshBatch,
+  maxBytes: number
+): AcExMeshBatch[] {
+  const indices = batch.indices!
+  const bytesPerTriangle =
+    36 + 12 + (batch.uvs ? 24 : 0) + (batch.gradientPositions ? 24 : 0)
+  const maxTriangles = maxPrimitivesPerPiece(
+    maxBytes,
+    meshStyleOverhead(batch),
+    bytesPerTriangle
+  )
+  const pieces: AcExMeshBatch[] = []
+  for (let i = 0; i + 2 < indices.length; ) {
+    const indexCount = Math.min(maxTriangles * 3, indices.length - i)
+    const aligned = indexCount - (indexCount % 3)
+    if (aligned < 3) break
+    pieces.push(remapMeshSlice(batch, i, aligned))
+    i += aligned
+  }
+  return pieces.length > 0 ? pieces : [batch]
+}
+
+function sliceMeshVertices(
+  batch: AcExMeshBatch,
+  vertexStart: number,
+  vertexCount: number
+): AcExMeshBatch {
+  const posStart = vertexStart * 3
+  const piece: AcExMeshBatch = {
+    layer: batch.layer,
+    color: batch.color,
+    offset: batch.offset,
+    positions: batch.positions.slice(posStart, posStart + vertexCount * 3)
+  }
+    copyMeshStyle(batch, piece)
+    if (batch.uvs) {
+    piece.uvs = batch.uvs.slice(vertexStart * 2, (vertexStart + vertexCount) * 2)
+  }
+  if (batch.gradientPositions) {
+    piece.gradientPositions = batch.gradientPositions.slice(
+      vertexStart * 2,
+      (vertexStart + vertexCount) * 2
+    )
+  }
+  return piece
+}
+
+function remapMeshSlice(
+  batch: AcExMeshBatch,
+  indexStart: number,
+  indexCount: number
+): AcExMeshBatch {
+  const extras: Float32Array[] = []
+  const strides: number[] = []
+  if (batch.uvs) {
+    extras.push(batch.uvs)
+    strides.push(2)
+  }
+  if (batch.gradientPositions) {
+    extras.push(batch.gradientPositions)
+    strides.push(2)
+  }
+  const mapped = remapIndexedVertices(
+    batch.positions,
+    batch.indices!.subarray(indexStart, indexStart + indexCount),
+    extras,
+    strides
+  )
+  const piece: AcExMeshBatch = {
+    layer: batch.layer,
+    color: batch.color,
+    offset: batch.offset,
+    positions: mapped.positions,
+    indices: mapped.indices
+  }
+  copyMeshStyle(batch, piece)
+  let attr = 0
+  if (batch.uvs) {
+    piece.uvs = mapped.attributes[attr++]
+  }
+  if (batch.gradientPositions) {
+    piece.gradientPositions = mapped.attributes[attr]
+  }
+  return piece
+}
+
+function remapIndexedVertices(
+  positions: Float32Array,
+  indices: Uint32Array,
+  extras: Float32Array[],
+  strides: number[]
+): {
+  positions: Float32Array
+  indices: Uint32Array
+  attributes: Float32Array[]
+} {
+  const remap = new Map<number, number>()
+  const newPositions: number[] = []
+  const newIndices = new Uint32Array(indices.length)
+  const newExtras: number[][] = extras.map(() => [])
+
+  for (let i = 0; i < indices.length; i++) {
+    const oldIndex = indices[i]!
+    let mapped = remap.get(oldIndex)
+    if (mapped == null) {
+      mapped = remap.size
+      remap.set(oldIndex, mapped)
+      const src = oldIndex * 3
+      newPositions.push(
+        positions[src] ?? 0,
+        positions[src + 1] ?? 0,
+        positions[src + 2] ?? 0
+      )
+      for (let a = 0; a < extras.length; a++) {
+        const stride = strides[a]!
+        const extra = extras[a]!
+        const base = oldIndex * stride
+        for (let k = 0; k < stride; k++) {
+          newExtras[a]!.push(extra[base + k] ?? 0)
+        }
+      }
+    }
+    newIndices[i] = mapped
+  }
+
+  return {
+    positions: Float32Array.from(newPositions),
+    indices: newIndices,
+    attributes: newExtras.map(values => Float32Array.from(values))
+  }
+}
+
+function copyLineStyle(from: AcExLineBatch, to: AcExLineBatch): void {
+  if (from.linePattern) to.linePattern = from.linePattern
+  if (from.lineWidth != null) to.lineWidth = from.lineWidth
+  if (from.renderOrder != null) to.renderOrder = from.renderOrder
+  if (from.excludeFromOsnap) to.excludeFromOsnap = true
+}
+
+function copyMeshStyle(from: AcExMeshBatch, to: AcExMeshBatch): void {
+  if (from.hatchPattern) to.hatchPattern = from.hatchPattern
+  if (from.gradientFill) to.gradientFill = from.gradientFill
+  if (from.side != null) to.side = from.side
+  if (from.renderOrder != null) to.renderOrder = from.renderOrder
+  if (from.points) to.points = true
+}

--- a/packages/cad-html-plugin/src/AcExOsnap.ts
+++ b/packages/cad-html-plugin/src/AcExOsnap.ts
@@ -17,6 +17,12 @@ import {
   intersectPrimitivePair,
   isIntersectionCapablePrimitive
 } from './AcExOsnapIntersections'
+import {
+  expandOsnapPath,
+  isOsnapPathPrimitive,
+  pathEdgeNearAperture,
+  pathPrimitiveBounds
+} from './AcExOsnapPath'
 import { primitiveToAcGeCurve } from './AcExOsnapPrimitiveToAcGe'
 import type {
   AcExOsnapMode,
@@ -33,14 +39,23 @@ export type { AcExOsnapMode, AcExOsnapPoint } from './AcExOsnapPrimitiveTypes'
 export { ACEX_DEFAULT_OSNAP_MODES } from './AcExOsnapPrimitiveTypes'
 
 /**
- * How often to check the wall-clock budget while walking segments / building
- * RBush entries. Checking every item is wasteful; yielding every ~1000 items via
- * `requestAnimationFrame` made million-edge indexes take minutes of idle waits.
+ * How often to sample the wall-clock budget while walking segments / building
+ * RBush entries. `performance.now()` is cheap; checking only every 8192 items
+ * let a single batch overshoot the slice by tens of milliseconds.
  */
-const OSNAP_INDEX_YIELD_CHECK_EVERY = 8192
+const OSNAP_INDEX_YIELD_CHECK_EVERY = 1024
 
-/** Target main-thread slice length before yielding to the event loop. */
-const OSNAP_INDEX_YIELD_BUDGET_MS = 200
+/**
+ * Target main-thread slice before yielding.
+ *
+ * 200ms is already a Chrome "long task" (~12 frames at 60Hz). 100ms still
+ * hitchs slightly but keeps million-edge indexes from turning into a rAF
+ * wait-per-chunk slog.
+ */
+const OSNAP_INDEX_YIELD_BUDGET_MS = 100
+
+/** Bulk-load this many RBush entries per slice so `load()` itself can yield. */
+const OSNAP_RBUSH_LOAD_CHUNK = 32_768
 
 function yieldToBrowser(): Promise<void> {
   return new Promise(resolve => {
@@ -75,6 +90,50 @@ function createOsnapYieldScheduler(
       return yieldFn().then(() => {
         sliceStart = performance.now()
       })
+    }
+  }
+}
+
+function searchRbushForest(
+  tree: RBush<AcExRbushEntry>,
+  extras: RBush<AcExRbushEntry>[],
+  box: { minX: number; minY: number; maxX: number; maxY: number }
+): AcExRbushEntry[] {
+  if (extras.length === 0) {
+    return tree.search(box)
+  }
+  const hits = tree.search(box).slice()
+  for (const extra of extras) {
+    const part = extra.search(box)
+    for (let i = 0; i < part.length; i++) {
+      hits.push(part[i]!)
+    }
+  }
+  return hits
+}
+
+async function bulkLoadRbush(
+  tree: RBush<AcExRbushEntry>,
+  extras: RBush<AcExRbushEntry>[],
+  entries: AcExRbushEntry[],
+  yieldFn: () => Promise<void>
+): Promise<void> {
+  extras.length = 0
+  tree.clear()
+  if (entries.length === 0) {
+    return
+  }
+  for (let offset = 0; offset < entries.length; offset += OSNAP_RBUSH_LOAD_CHUNK) {
+    const chunk = entries.slice(offset, offset + OSNAP_RBUSH_LOAD_CHUNK)
+    if (offset === 0) {
+      tree.load(chunk)
+    } else {
+      const extra = new RBush<AcExRbushEntry>()
+      extra.load(chunk)
+      extras.push(extra)
+    }
+    if (offset + OSNAP_RBUSH_LOAD_CHUNK < entries.length) {
+      await yieldFn()
     }
   }
 }
@@ -277,152 +336,12 @@ export function mergeConnectedSegments(
 }
 
 /**
- * Reads one vertex from a line batch in WCS (XY).
- *
- * Applies {@link AcExLineBatch.offset} after indexing into the flat
- * {@link AcExLineBatch.positions} buffer (`vertexIndex * 3` stride).
- *
- * @param batch - Exported line batch from the HTML snapshot.
- * @param vertexIndex - Zero-based vertex index referenced by the batch index buffer.
- * @returns Transformed XY coordinates in drawing units.
- * @internal
- */
-function readBatchVertex(
-  batch: AcExLineBatch,
-  vertexIndex: number
-): { x: number; y: number } {
-  const [ox, oy] = batch.offset
-  const base = vertexIndex * 3
-  return {
-    x: toWcsCoord(batch.positions[base]!, ox),
-    y: toWcsCoord(batch.positions[base + 1]!, oy)
-  }
-}
-
-/**
- * Derives logical snap segments from a patterned ({@link AcExLineBatch.linePattern}) line batch.
- *
- * Dashed and dotted lines are drawn with a GPU shader on top of a continuous vertex
- * chain. The snapshot index buffer encodes that chain as shared-vertex edges
- * (`0-1`, `1-2`, …). {@link iterLineSegments} treats every index pair as a separate
- * edge, which makes endpoint snap land on internal tessellation vertices instead of
- * the entity's true ends; unlike AutoCAD, linetype gaps are visual only.
- *
- * This function walks the index graph, traces open chains from endpoints (vertices
- * whose degree is not two), and emits one {@link AcExOsnapSegment} per chain spanning
- * the first and last vertex positions. Closed loops and isolated edges are handled
- * as separate chains.
- *
- * When the batch has no index buffer, falls back to {@link mergeConnectedSegments}
- * over {@link iterLineSegments} output (non-indexed pair storage).
- *
- * @param batch - Line batch with {@link AcExLineBatch.linePattern} set.
- * @returns Logical WCS segments suitable for endpoint / midpoint / nearest snap.
- * @internal
- */
-function extractPatternLineSnapSegments(
-  batch: AcExLineBatch
-): AcExOsnapSegment[] {
-  if (!batch.indices || batch.indices.length < 2) {
-    return mergeConnectedSegments(segmentsFromIterable(iterLineSegments(batch)))
-  }
-
-  const edges: Array<{ a: number; b: number }> = []
-
-  for (let i = 0; i + 1 < batch.indices.length; i += 2) {
-    edges.push({ a: batch.indices[i]!, b: batch.indices[i + 1]! })
-  }
-
-  const adjacency = new Map<number, number[]>()
-  const addEdge = (a: number, b: number) => {
-    if (a === b) return
-    let listA = adjacency.get(a)
-    if (!listA) {
-      listA = []
-      adjacency.set(a, listA)
-    }
-    listA.push(b)
-    let listB = adjacency.get(b)
-    if (!listB) {
-      listB = []
-      adjacency.set(b, listB)
-    }
-    listB.push(a)
-  }
-
-  for (const edge of edges) {
-    addEdge(edge.a, edge.b)
-  }
-
-  const visitedEdges = new Set<string>()
-  const edgeKey = (a: number, b: number) => (a < b ? `${a}:${b}` : `${b}:${a}`)
-  const logical: AcExOsnapSegment[] = []
-
-  const tracePath = (start: number, next: number): number[] => {
-    const path = [start]
-    let prev = start
-    let current = next
-    while (true) {
-      visitedEdges.add(edgeKey(prev, current))
-      path.push(current)
-      const neighbors = adjacency.get(current) ?? []
-      const candidates = neighbors.filter(
-        neighbor =>
-          neighbor !== prev && !visitedEdges.has(edgeKey(current, neighbor))
-      )
-      if (candidates.length !== 1) {
-        break
-      }
-      prev = current
-      current = candidates[0]!
-    }
-    return path
-  }
-
-  for (const edge of edges) {
-    const key = edgeKey(edge.a, edge.b)
-    if (visitedEdges.has(key)) continue
-
-    const degreeA = adjacency.get(edge.a)?.length ?? 0
-    const degreeB = adjacency.get(edge.b)?.length ?? 0
-    let path: number[]
-
-    if (degreeA !== 2) {
-      path = tracePath(edge.a, edge.b)
-    } else if (degreeB !== 2) {
-      path = tracePath(edge.b, edge.a)
-    } else {
-      path = tracePath(edge.a, edge.b)
-    }
-
-    const first = readBatchVertex(batch, path[0]!)
-    const last = readBatchVertex(batch, path[path.length - 1]!)
-    logical.push({
-      x0: first.x,
-      y0: first.y,
-      x1: last.x,
-      y1: last.y
-    })
-  }
-
-  return logical.length > 0
-    ? logical
-    : segmentsFromIterable(iterLineSegments(batch))
-}
-
-/**
  * Extracts WCS snap segments from one exported {@link AcExLineBatch}.
  *
- * Chooses the extraction strategy from batch metadata:
- *
- * - **Patterned lines** (`linePattern` present): delegates to
- *   {@link extractPatternLineSnapSegments} so snap follows entity geometry rather
- *   than shader dash boundaries or per-edge tessellation.
- * - **Solid lines**: yields one segment per index pair / vertex pair via
- *   {@link iterLineSegments} without merging.
- *
- * Used by {@link collectBatchSegments} when building the tessellated fallback
- * path of {@link AcExOsnapIndex}.
+ * Always walks stored segment pairs / index edges via {@link iterLineSegments}.
+ * Patterned (dashed) batches are **not** collapsed to first/last chain ends —
+ * that dropped intermediate WidePolyline / LWPOLYLINE vertices. Linetype gaps
+ * are shader-only; the vertex chain is the entity geometry AutoCAD snaps to.
  *
  * @param batch - One line batch from {@link AcExLayoutSnapshot.lineBatches}.
  * @returns Snap segments in WCS; may be empty when the batch has no geometry.
@@ -430,9 +349,6 @@ function extractPatternLineSnapSegments(
 export function extractLineBatchSnapSegments(
   batch: AcExLineBatch
 ): AcExOsnapSegment[] {
-  if (batch.linePattern) {
-    return extractPatternLineSnapSegments(batch)
-  }
   return segmentsFromIterable(iterLineSegments(batch))
 }
 
@@ -501,9 +417,7 @@ async function collectBatchSegmentsAsync(
     if (batch.excludeFromOsnap) continue
     // Stream solid batches via the generator; avoid materializing the whole
     // batch into an intermediate array before the first yield can run.
-    const source = batch.linePattern
-      ? extractLineBatchSnapSegments(batch)
-      : iterLineSegments(batch)
+    const source = iterLineSegments(batch)
     for (const seg of source) {
       if (!isFiniteSegment(seg)) continue
       segments.push(seg)
@@ -635,6 +549,8 @@ function primitiveBounds(prim: AcExOsnapPrimitive): {
       }
       return { minX, minY, maxX, maxY }
     }
+    case 'path':
+      return pathPrimitiveBounds(prim)
     case 'point':
       return { minX: prim.x, minY: prim.y, maxX: prim.x, maxY: prim.y }
   }
@@ -653,6 +569,9 @@ export class AcExOsnapIndex {
   private primitives: AcExOsnapPrimitive[] = []
   private primitiveTree = new RBush<AcExRbushEntry>()
   private segmentTree = new RBush<AcExRbushEntry>()
+  /** Extra bulk-loaded trees when async rebuild splits {@link OSNAP_RBUSH_LOAD_CHUNK}. */
+  private primitiveTreeExtras: RBush<AcExRbushEntry>[] = []
+  private segmentTreeExtras: RBush<AcExRbushEntry>[] = []
   private modes: Set<AcExOsnapMode>
   private hiddenLayers = new Set<string>()
 
@@ -714,9 +633,8 @@ export class AcExOsnapIndex {
   }
 
   /**
-   * Like {@link rebuild}, but yields while collecting batch segments and while
-   * preparing RBush entries. Entries are still passed to RBush via a single bulk
-   * {@link RBush.load} (not per-item `insert`).
+   * Like {@link rebuild}, but yields while collecting batch segments, filtering
+   * primitives, preparing RBush entries, and bulk-loading the trees in chunks.
    *
    * @param layout - Active layout snapshot.
    * @param yieldFn - Called between work batches (defaults to a macrotask yield).
@@ -725,24 +643,52 @@ export class AcExOsnapIndex {
     layout: AcExLayoutSnapshot,
     yieldFn: () => Promise<void> = yieldToBrowser
   ): Promise<void> {
-    this.resetFromLayout(layout)
+    this.resetIndexState()
+    await this.filterPrimitivesAsync(
+      layout.osnap?.primitives ?? [],
+      yieldFn
+    )
     await this.collectSegmentsFromLayoutAsync(layout, yieldFn)
     await this.loadPrimitiveTreeAsync(yieldFn)
     await this.loadSegmentTreeAsync(yieldFn)
   }
 
-  private resetFromLayout(layout: AcExLayoutSnapshot): void {
+  private resetIndexState(): void {
     this.primitiveTree.clear()
     this.segmentTree.clear()
+    this.primitiveTreeExtras = []
+    this.segmentTreeExtras = []
     this.hiddenLayers.clear()
     this.segments = []
     this.segmentLayers = []
-    // Drop non-finite analytic primitives up front (NaN polyline / bad arcs).
-    // Leaving them out of `this.primitives` avoids any query path that walks
-    // the array without going through the RBush finite filter.
+  }
+
+  private resetFromLayout(layout: AcExLayoutSnapshot): void {
+    this.resetIndexState()
     this.primitives = (layout.osnap?.primitives ?? []).filter(prim =>
       isFiniteBounds(primitiveBounds(prim))
     )
+  }
+
+  private async filterPrimitivesAsync(
+    source: readonly AcExOsnapPrimitive[],
+    yieldFn: () => Promise<void>
+  ): Promise<void> {
+    if (source.length === 0) {
+      this.primitives = []
+      return
+    }
+    const filtered: AcExOsnapPrimitive[] = []
+    const schedule = createOsnapYieldScheduler(yieldFn)
+    for (let i = 0; i < source.length; i++) {
+      const prim = source[i]!
+      if (isFiniteBounds(primitiveBounds(prim))) {
+        filtered.push(prim)
+      }
+      const wait = schedule.afterItem()
+      if (wait) await wait
+    }
+    this.primitives = filtered
   }
 
   private collectSegmentsFromLayout(layout: AcExLayoutSnapshot): void {
@@ -829,7 +775,12 @@ export class AcExOsnapIndex {
       if (wait) await wait
     }
     if (primitiveEntries.length > 0) {
-      this.primitiveTree.load(primitiveEntries)
+      await bulkLoadRbush(
+        this.primitiveTree,
+        this.primitiveTreeExtras,
+        primitiveEntries,
+        yieldFn
+      )
     }
   }
 
@@ -855,7 +806,12 @@ export class AcExOsnapIndex {
       if (wait) await wait
     }
     if (segmentEntries.length > 0) {
-      this.segmentTree.load(segmentEntries)
+      await bulkLoadRbush(
+        this.segmentTree,
+        this.segmentTreeExtras,
+        segmentEntries,
+        yieldFn
+      )
     }
   }
 
@@ -889,28 +845,37 @@ export class AcExOsnapIndex {
       | undefined
 
     const mouse = { x: px, y: py }
-    for (const hit of this.primitiveTree.search(box)) {
+    for (const hit of searchRbushForest(
+      this.primitiveTree,
+      this.primitiveTreeExtras,
+      box
+    )) {
       const prim = this.primitives[hit.index]!
       if (this.hiddenLayers.has(prim.layer)) continue
-      if (prim.kind !== 'circle' && prim.kind !== 'arc') continue
-      const geo = primitiveToAcGeCurve(prim)
-      if (geo.kind !== 'circArc') continue
-      const nearest = geo.curve.nearestPoint({ x: px, y: py })
-      const d2 = distSq(px, py, nearest.x, nearest.y)
-      if (d2 > threshSq) continue
-      const align = inwardArcAlignment(geo.curve, nearest, mouse)
-      if (
-        !best ||
-        isBetterArcLock(d2, align, bestDistSq, bestAlign)
-      ) {
-        bestDistSq = d2
-        bestAlign = align
-        best = {
-          cx: prim.cx,
-          cy: prim.cy,
-          r: prim.r,
-          x: nearest.x,
-          y: nearest.y
+      const arcs =
+        prim.kind === 'path'
+          ? expandOsnapPath(prim).filter(edge => edge.kind === 'arc')
+          : prim.kind === 'circle' || prim.kind === 'arc'
+            ? [prim]
+            : []
+      for (const arcPrim of arcs) {
+        if (arcPrim.kind !== 'circle' && arcPrim.kind !== 'arc') continue
+        const geo = primitiveToAcGeCurve(arcPrim)
+        if (geo.kind !== 'circArc') continue
+        const nearest = geo.curve.nearestPoint({ x: px, y: py })
+        const d2 = distSq(px, py, nearest.x, nearest.y)
+        if (d2 > threshSq) continue
+        const align = inwardArcAlignment(geo.curve, nearest, mouse)
+        if (!best || isBetterArcLock(d2, align, bestDistSq, bestAlign)) {
+          bestDistSq = d2
+          bestAlign = align
+          best = {
+            cx: arcPrim.cx,
+            cy: arcPrim.cy,
+            r: arcPrim.r,
+            x: nearest.x,
+            y: nearest.y
+          }
         }
       }
     }
@@ -1001,8 +966,16 @@ export class AcExOsnapIndex {
     threshold: number
   ): AcExOsnapPoint | undefined {
     const box = searchBox(px, py, threshold)
-    const primHits = this.primitiveTree.search(box)
-    const segHits = this.segmentTree.search(box)
+    const primHits = searchRbushForest(
+      this.primitiveTree,
+      this.primitiveTreeExtras,
+      box
+    )
+    const segHits = searchRbushForest(
+      this.segmentTree,
+      this.segmentTreeExtras,
+      box
+    )
     if (primHits.length === 0 && segHits.length === 0) return undefined
 
     const threshSq = threshold * threshold
@@ -1010,19 +983,27 @@ export class AcExOsnapIndex {
     const paramTol = intersectionToleranceForExtent(extent)
     const geomTol = intersectionGeomToleranceForSnap(extent, threshold)
 
-    const primIndices: number[] = []
     const segIndices: number[] = []
     const primSeen = new Set<number>()
     const segSeen = new Set<number>()
+    const workPrims: AcExOsnapPrimitive[] = []
 
     for (const hit of primHits) {
       const prim = this.primitives[hit.index]!
       if (this.hiddenLayers.has(prim.layer)) continue
-      if (!isIntersectionCapablePrimitive(prim)) continue
       if (primSeen.has(hit.index)) continue
-      if (primIndices.length >= ACEX_MAX_INTERSECTION_SOURCES) continue
       primSeen.add(hit.index)
-      primIndices.push(hit.index)
+      if (isOsnapPathPrimitive(prim)) {
+        for (const edge of expandOsnapPath(prim)) {
+          if (!pathEdgeNearAperture(edge, px, py, threshold)) continue
+          if (workPrims.length >= ACEX_MAX_INTERSECTION_SOURCES) break
+          workPrims.push(edge)
+        }
+        continue
+      }
+      if (!isIntersectionCapablePrimitive(prim)) continue
+      if (workPrims.length >= ACEX_MAX_INTERSECTION_SOURCES) continue
+      workPrims.push(prim)
     }
 
     for (const hit of segHits) {
@@ -1037,12 +1018,10 @@ export class AcExOsnapIndex {
     let bestDistSq = threshSq
     let best: AcExOsnapPoint | undefined
 
-    for (let i = 0; i < primIndices.length; i++) {
-      const indexA = primIndices[i]!
-      const primA = this.primitives[indexA]!
-      for (let j = i + 1; j < primIndices.length; j++) {
-        const indexB = primIndices[j]!
-        const primB = this.primitives[indexB]!
+    for (let i = 0; i < workPrims.length; i++) {
+      const primA = workPrims[i]!
+      for (let j = i + 1; j < workPrims.length; j++) {
+        const primB = workPrims[j]!
         if (
           this.hiddenLayers.has(primA.layer) ||
           this.hiddenLayers.has(primB.layer)
@@ -1090,12 +1069,16 @@ export class AcExOsnapIndex {
       }
     }
 
-    // Hybrid exports keep curves in ACEO and straight edges in line batches.
-    // Without prim×seg pairs, circle/arc ∩ line intersections would disappear.
-    for (const primIndex of primIndices) {
-      const prim = this.primitives[primIndex]!
+    // Hybrid: ACEO curves/path edges × display lineBatches.
+    for (const prim of workPrims) {
       if (this.hiddenLayers.has(prim.layer)) continue
-      if (prim.kind !== 'circle' && prim.kind !== 'arc') continue
+      if (
+        prim.kind !== 'circle' &&
+        prim.kind !== 'arc' &&
+        prim.kind !== 'line'
+      ) {
+        continue
+      }
       for (const segIndex of segIndices) {
         const layer = this.segmentLayers[segIndex]!
         if (this.hiddenLayers.has(layer)) continue
@@ -1177,7 +1160,11 @@ export class AcExOsnapIndex {
       best: undefined as AcExOsnapPoint | undefined
     }
 
-    for (const hit of this.primitiveTree.search(box)) {
+    for (const hit of searchRbushForest(
+      this.primitiveTree,
+      this.primitiveTreeExtras,
+      box
+    )) {
       const prim = this.primitives[hit.index]!
       for (const candidate of collectPrimitiveDiscreteSnapCandidates(
         prim,
@@ -1194,7 +1181,11 @@ export class AcExOsnapIndex {
       }
     }
 
-    for (const hit of this.segmentTree.search(box)) {
+    for (const hit of searchRbushForest(
+      this.segmentTree,
+      this.segmentTreeExtras,
+      box
+    )) {
       const seg = this.segments[hit.index]!
       const layer = this.segmentLayers[hit.index]!
       if (discreteModes.has('endpoint')) {
@@ -1244,7 +1235,11 @@ export class AcExOsnapIndex {
     let bestDistSq = Number.MAX_VALUE
     let best: AcExOsnapPoint | undefined
 
-    for (const hit of this.primitiveTree.search(box)) {
+    for (const hit of searchRbushForest(
+      this.primitiveTree,
+      this.primitiveTreeExtras,
+      box
+    )) {
       if (
         distSqToBounds(px, py, hit.minX, hit.minY, hit.maxX, hit.maxY) >
         threshSq
@@ -1256,8 +1251,15 @@ export class AcExOsnapIndex {
       if (this.hiddenLayers.has(prim.layer)) continue
       if (prim.kind === 'point') continue
 
-      const geo = primitiveToAcGeCurve(prim)
-      const nearest = collectPrimitiveNearestSnapCandidate(prim, px, py, geo)
+      const nearest =
+        prim.kind === 'path'
+          ? collectPrimitiveNearestSnapCandidate(prim, px, py)
+          : collectPrimitiveNearestSnapCandidate(
+              prim,
+              px,
+              py,
+              primitiveToAcGeCurve(prim)
+            )
       if (!nearest) continue
       const d2 = distSq(px, py, nearest.x, nearest.y)
       if (d2 <= threshSq && d2 < bestDistSq) {
@@ -1266,7 +1268,11 @@ export class AcExOsnapIndex {
       }
     }
 
-    for (const hit of this.segmentTree.search(box)) {
+    for (const hit of searchRbushForest(
+      this.segmentTree,
+      this.segmentTreeExtras,
+      box
+    )) {
       if (
         distSqToBounds(px, py, hit.minX, hit.minY, hit.maxX, hit.maxY) >
         threshSq

--- a/packages/cad-html-plugin/src/AcExOsnapCatalogCodec.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapCatalogCodec.ts
@@ -11,7 +11,12 @@ import {
 /** Magic for ACEO osnap catalog payloads (`ACEO` little-endian). */
 export const ACEO_OSNAP_MAGIC = 0x4f454341
 
-/** Current ACEO payload schema version. */
+/**
+ * Current ACEO payload schema version.
+ *
+ * Kind `7` (`path`) is included in version 1; the format has not had a formal
+ * release, so adding a kind does not require a version bump.
+ */
 export const ACEO_OSNAP_VERSION = 1 as const
 
 /** Hard cap on primitives inside one ACEO chunk. */
@@ -26,6 +31,7 @@ const KIND_ARC = 3
 const KIND_ELLIPSE = 4
 const KIND_SPLINE = 5
 const KIND_POINT = 6
+const KIND_PATH = 7
 
 /**
  * Rough uncompressed ACEO size estimate for one primitive (used when splitting
@@ -46,6 +52,8 @@ export function estimateOsnapPrimitiveBytes(
       return 1 + 4 + 64 + 1 + 1
     case 'point':
       return 1 + 4 + 16
+    case 'path':
+      return 1 + 4 + 1 + 4 + primitive.vertices.length * 8
     case 'spline': {
       const floats =
         primitive.controlPoints.length +
@@ -284,6 +292,12 @@ function writePrimitive(
       writer.writeF64(primitive.x)
       writer.writeF64(primitive.y)
       return
+    case 'path':
+      writer.writeU8(KIND_PATH)
+      writer.writeU32(layer)
+      writer.writeU8(primitive.closed ? 1 : 0)
+      writeF64Array(writer, primitive.vertices)
+      return
     default: {
       const _exhaustive: never = primitive
       throw new Error(`Unsupported osnap primitive: ${String(_exhaustive)}`)
@@ -372,6 +386,16 @@ function readPrimitive(
         x: reader.readF64(),
         y: reader.readF64()
       }
+    case KIND_PATH: {
+      const closed = reader.readU8() !== 0
+      const vertices = readF64Array(reader)
+      return {
+        kind: 'path',
+        layer,
+        closed,
+        vertices
+      }
+    }
     default:
       throw new Error(`Unsupported osnap primitive kind: ${kind}`)
   }

--- a/packages/cad-html-plugin/src/AcExOsnapGeometry.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapGeometry.ts
@@ -12,6 +12,10 @@
 import { AcGeCircArc2d, type AcGePoint2dLike } from '@mlightcad/data-model'
 
 import {
+  expandOsnapPath,
+  pathEdgeNearAperture
+} from './AcExOsnapPath'
+import {
   type AcExOsnapAcGeCurve,
   ellipsePointAtNormalized,
   primitiveToAcGeCurve
@@ -109,6 +113,14 @@ export function collectPrimitiveDiscreteSnapCandidates(
   modes: Set<AcExOsnapMode>,
   geo?: AcExOsnapAcGeCurve
 ): AcExOsnapCandidate[] {
+  if (prim.kind === 'path') {
+    const out: AcExOsnapCandidate[] = []
+    for (const edge of expandOsnapPath(prim)) {
+      out.push(...collectPrimitiveDiscreteSnapCandidates(edge, modes))
+    }
+    return out
+  }
+
   const out: AcExOsnapCandidate[] = []
   const resolved = geo ?? primitiveToAcGeCurve(prim)
 
@@ -210,6 +222,23 @@ export function collectPrimitiveNearestSnapCandidate(
   py: number,
   geo?: AcExOsnapAcGeCurve
 ): AcExOsnapCandidate | undefined {
+  if (prim.kind === 'path') {
+    let best: AcExOsnapCandidate | undefined
+    let bestDist = Infinity
+    const threshold = Number.POSITIVE_INFINITY
+    for (const edge of expandOsnapPath(prim)) {
+      if (!pathEdgeNearAperture(edge, px, py, threshold)) continue
+      const candidate = collectPrimitiveNearestSnapCandidate(edge, px, py)
+      if (!candidate) continue
+      const d = distSq(px, py, candidate.x, candidate.y)
+      if (d < bestDist) {
+        bestDist = d
+        best = candidate
+      }
+    }
+    return best
+  }
+
   const pick = { x: px, y: py, z: 0 }
   const resolved = geo ?? primitiveToAcGeCurve(prim)
 

--- a/packages/cad-html-plugin/src/AcExOsnapPath.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPath.ts
@@ -1,0 +1,176 @@
+/**
+ * Expands compact ACEO {@link AcExOsnapPathPrimitive} records into line/arc
+ * edges for query-time snap (entity-bbox index, not per-edge export).
+ *
+ * @packageDocumentation
+ */
+
+import { AcGeCircArc2d, AcGeTol } from '@mlightcad/data-model'
+
+import { wcsPointToOcsArcAngle } from './AcExOsnapPrimitiveToAcGe'
+import type {
+  AcExOsnapArcPrimitive,
+  AcExOsnapLinePrimitive,
+  AcExOsnapPathPrimitive,
+  AcExOsnapPrimitive
+} from './AcExOsnapPrimitiveTypes'
+
+/** Line or bulge-arc edge produced by {@link expandOsnapPath}. */
+export type AcExOsnapPathEdge = AcExOsnapLinePrimitive | AcExOsnapArcPrimitive
+
+/**
+ * Axis-aligned bounds of a fill/frame path in WCS.
+ */
+export function pathPrimitiveBounds(path: AcExOsnapPathPrimitive): {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+} {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  const verts = path.vertices
+  const count = (verts.length / 3) | 0
+  for (let i = 0; i < count; i++) {
+    const x = verts[i * 3]!
+    const y = verts[i * 3 + 1]!
+    minX = Math.min(minX, x)
+    minY = Math.min(minY, y)
+    maxX = Math.max(maxX, x)
+    maxY = Math.max(maxY, y)
+  }
+  const segmentCount = path.closed ? count : count - 1
+  for (let i = 0; i < segmentCount; i++) {
+    const bulge = verts[i * 3 + 2]!
+    if (!AcGeTol.isPositive(Math.abs(bulge))) continue
+    const i1 = ((i + 1) % count) * 3
+    const arc = new AcGeCircArc2d(
+      { x: verts[i * 3]!, y: verts[i * 3 + 1]! },
+      { x: verts[i1]!, y: verts[i1 + 1]! },
+      bulge
+    )
+    if (!(arc.radius > 0) || !Number.isFinite(arc.radius)) continue
+    minX = Math.min(minX, arc.center.x - arc.radius)
+    minY = Math.min(minY, arc.center.y - arc.radius)
+    maxX = Math.max(maxX, arc.center.x + arc.radius)
+    maxY = Math.max(maxY, arc.center.y + arc.radius)
+  }
+  return { minX, minY, maxX, maxY }
+}
+
+/**
+ * Turns one path into straight segments and circular-arc edges (WCS).
+ *
+ * Bulge vertices use {@link AcGeCircArc2d} the same way hatch/polyline export
+ * does, so endpoint / midpoint / center snap matches the live viewer.
+ */
+export function expandOsnapPath(
+  path: AcExOsnapPathPrimitive
+): AcExOsnapPathEdge[] {
+  const verts = path.vertices
+  const count = (verts.length / 3) | 0
+  if (count < 2 || verts.length !== count * 3) {
+    return []
+  }
+
+  const segmentCount = path.closed ? count : count - 1
+  const out: AcExOsnapPathEdge[] = []
+  for (let i = 0; i < segmentCount; i++) {
+    const i0 = i * 3
+    const i1 = ((i + 1) % count) * 3
+    const x0 = verts[i0]!
+    const y0 = verts[i0 + 1]!
+    const bulge = verts[i0 + 2]!
+    const x1 = verts[i1]!
+    const y1 = verts[i1 + 1]!
+    if (!Number.isFinite(x0) || !Number.isFinite(y0)) continue
+    if (!Number.isFinite(x1) || !Number.isFinite(y1)) continue
+
+    if (AcGeTol.isPositive(Math.abs(bulge))) {
+      const arc = pathEdgeFromBulge(path.layer, x0, y0, x1, y1, bulge)
+      if (arc) out.push(arc)
+    } else {
+      out.push({
+        kind: 'line',
+        layer: path.layer,
+        x0,
+        y0,
+        x1,
+        y1
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * True when an edge bbox is within `threshold` of `(px, py)`.
+ */
+export function pathEdgeNearAperture(
+  edge: AcExOsnapPathEdge,
+  px: number,
+  py: number,
+  threshold: number
+): boolean {
+  if (edge.kind === 'line') {
+    const minX = Math.min(edge.x0, edge.x1) - threshold
+    const maxX = Math.max(edge.x0, edge.x1) + threshold
+    const minY = Math.min(edge.y0, edge.y1) - threshold
+    const maxY = Math.max(edge.y0, edge.y1) + threshold
+    return px >= minX && px <= maxX && py >= minY && py <= maxY
+  }
+  return (
+    px >= edge.cx - edge.r - threshold &&
+    px <= edge.cx + edge.r + threshold &&
+    py >= edge.cy - edge.r - threshold &&
+    py <= edge.cy + edge.r + threshold
+  )
+}
+
+function pathEdgeFromBulge(
+  layer: string,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  bulge: number
+): AcExOsnapArcPrimitive | undefined {
+  const arc = new AcGeCircArc2d({ x: x0, y: y0 }, { x: x1, y: y1 }, bulge)
+  if (!(arc.radius > 0) || !Number.isFinite(arc.radius)) {
+    return undefined
+  }
+  const normalSign: 1 | -1 = arc.clockwise ? -1 : 1
+  const cx = arc.center.x
+  const cy = arc.center.y
+  return {
+    kind: 'arc',
+    layer,
+    cx,
+    cy,
+    r: arc.radius,
+    startAngle: wcsPointToOcsArcAngle(
+      cx,
+      cy,
+      arc.startPoint.x,
+      arc.startPoint.y,
+      normalSign
+    ),
+    endAngle: wcsPointToOcsArcAngle(
+      cx,
+      cy,
+      arc.endPoint.x,
+      arc.endPoint.y,
+      normalSign
+    ),
+    normalSign
+  }
+}
+
+/** Type guard used when walking mixed ACEO catalogs. */
+export function isOsnapPathPrimitive(
+  prim: AcExOsnapPrimitive
+): prim is AcExOsnapPathPrimitive {
+  return prim.kind === 'path'
+}

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
@@ -3,9 +3,12 @@
  *
  * Walks layout block table records recursively, expands `AcDbBlockReference`
  * (INSERT) with full insertion transforms, and emits compact analytic primitives
- * for the offline HTML viewer. Straight line edges are omitted (they duplicate
- * display {@link AcExLineBatch} data); circle/arc/ellipse/spline/point remain so
- * measurement-grade analytic snap survives tessellation.
+ * for the offline HTML viewer. Straight drawing-line edges are omitted (they
+ * duplicate display {@link AcExLineBatch} data). Circle/arc/ellipse/spline/point
+ * remain so measurement-grade analytic snap survives tessellation. Fill/frame
+ * boundaries that are drawn as meshes (hatch, TRACE/SOLID, IMAGE clip, OLE,
+ * and wide LWPOLYLINE centerlines) are stored as compact
+ * {@link AcExOsnapPathPrimitive} records.
  *
  * @packageDocumentation
  */
@@ -14,6 +17,7 @@ import {
   AcDb2dPolyline,
   AcDb3dPolyline,
   AcDbArc,
+  AcDbAttribute,
   AcDbBlockReference,
   type AcDbBlockTableRecord,
   AcDbCircle,
@@ -31,6 +35,7 @@ import {
   AcDbMLine,
   AcDbMText,
   type AcDbObjectId,
+  AcDbOle2Frame,
   AcDbPoint,
   AcDbPolyline,
   AcDbRasterImage,
@@ -64,6 +69,9 @@ import type {
   AcExOsnapPrimitive,
   AcExOsnapSplinePrimitive
 } from './AcExOsnapPrimitiveTypes'
+
+/** Vertex used when packing a fill/frame {@link AcExOsnapPathPrimitive}. */
+type AcExOsnapPathVertex = AcGePoint3dLike & { bulge?: number }
 
 /** Maps entity extrusion normal to arc/circle winding sign. @internal */
 function normalSignFromVector(normal: AcGeVector3dLike): 1 | -1 {
@@ -292,6 +300,13 @@ type AcExBlockReferenceLike = AcDbEntity & {
   blockTableRecord: AcDbBlockTableRecord | undefined
   blockName?: string
   getFullInsertionTransform(): AcGeMatrix3d
+  columnCount?: number
+  rowCount?: number
+  columnSpacing?: number
+  rowSpacing?: number
+  attributeIterator?: () => Iterable<AcDbEntity> & {
+    toArray?: () => AcDbEntity[]
+  }
 }
 
 /** Dimension entity shape whose geometry lives in an anonymous block. @internal */
@@ -430,6 +445,84 @@ function pushDirectedLine(
   _bidirectional: boolean
 ) {
   // no-op — see function doc
+}
+
+/**
+ * Packs a fill/frame boundary as one {@link AcExOsnapPathPrimitive}.
+ *
+ * Mesh-drawn entities (hatch, TRACE/SOLID, IMAGE clip, OLE, wide LWPOLYLINE)
+ * have no edges in {@link AcExLineBatch}; this keeps their outline / centerline
+ * in ACEO without exploding every edge into a `line` primitive.
+ *
+ * Bulge is invariant only under similarity. Vertices are transformed first;
+ * under reflection the bulge sign flips (`det2d < 0`). Under non-uniform
+ * scale/shear a circular bulge becomes elliptical, so the edge degrades to a
+ * chord — matching the former hatch circular-arc boundary fallback.
+ *
+ * @internal
+ */
+function pushCatalogPath(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  vertices: AcExOsnapPathVertex[],
+  closed: boolean
+) {
+  if (vertices.length < 2) return
+  const uniform = scaleIsUniform(matrix)
+  const det2d =
+    matrix.elements[0]! * matrix.elements[5]! -
+    matrix.elements[4]! * matrix.elements[1]!
+  const bulgeSign = det2d < 0 ? -1 : 1
+  const packed: number[] = []
+  for (const vertex of vertices) {
+    const p = transformPoint(matrix, vertex)
+    let bulge = vertex.bulge ?? 0
+    if (AcGeTol.isPositive(Math.abs(bulge))) {
+      bulge = uniform ? bulge * bulgeSign : 0
+    }
+    packed.push(p.x, p.y, bulge)
+  }
+  out.push({ kind: 'path', layer, closed, vertices: packed })
+}
+
+function samePoint2d(a: AcGePoint3dLike, b: AcGePoint3dLike): boolean {
+  return AcGeTol.equal(a.x, b.x) && AcGeTol.equal(a.y, b.y)
+}
+
+function circArc2dBulge(arc: AcGeCircArc2d): number {
+  return (arc.clockwise ? -1 : 1) * Math.tan(arc.deltaAngle / 4)
+}
+
+function appendPathEdge(
+  verts: AcExOsnapPathVertex[],
+  start: AcGePoint3dLike,
+  end: AcGePoint3dLike,
+  bulge: number
+) {
+  if (verts.length === 0) {
+    verts.push({ x: start.x, y: start.y, z: start.z ?? 0, bulge })
+    verts.push({ x: end.x, y: end.y, z: end.z ?? 0, bulge: 0 })
+    return
+  }
+  const last = verts[verts.length - 1]!
+  if (samePoint2d(last, start)) {
+    last.bulge = bulge
+  } else {
+    last.bulge = 0
+    verts.push({ x: start.x, y: start.y, z: start.z ?? 0, bulge })
+  }
+  verts.push({ x: end.x, y: end.y, z: end.z ?? 0, bulge: 0 })
+}
+
+function finalizePathVertices(verts: AcExOsnapPathVertex[]): AcExOsnapPathVertex[] {
+  if (
+    verts.length >= 2 &&
+    samePoint2d(verts[0]!, verts[verts.length - 1]!)
+  ) {
+    verts.pop()
+  }
+  return verts
 }
 
 /**
@@ -723,11 +816,72 @@ function pushSpline(
 }
 
 /**
- * Decomposes `AcDbPolyline` into line and arc primitives.
+ * Matches `AcDbPolyline` `WIDTH_EPSILON`: any start/end width above this
+ * draws the whole LWPOLYLINE as a solid `area` mesh, not a `lineStrip`.
+ */
+const POLYLINE_WIDTH_EPSILON = 1e-6
+
+type AcExLwPolylineVertex = AcExOsnapPathVertex & {
+  startWidth?: number
+  endWidth?: number
+}
+
+function readLwPolylineVertices(entity: AcDbPolyline): AcExLwPolylineVertex[] {
+  const elevation = entity.elevation
+  const runtimeVertices = (
+    entity as unknown as {
+      _geo?: {
+        vertices?: Array<{
+          x: number
+          y: number
+          bulge?: number
+          startWidth?: number
+          endWidth?: number
+        }>
+      }
+    }
+  )._geo?.vertices
+
+  if (runtimeVertices && runtimeVertices.length > 1) {
+    return runtimeVertices.map(vertex => ({
+      x: vertex.x,
+      y: vertex.y,
+      z: elevation,
+      bulge: vertex.bulge,
+      startWidth: vertex.startWidth,
+      endWidth: vertex.endWidth
+    }))
+  }
+
+  return Array.from({ length: entity.numberOfVertices }, (_, i) => {
+    const p = entity.getPoint2dAt(i)
+    return { x: p.x, y: p.y, z: elevation, bulge: 0 as number | undefined }
+  })
+}
+
+/**
+ * True when the LWPOLYLINE is drawn as a wide mesh (`directBatchPrimitive`
+ * `'area'`), matching {@link AcDbPolyline} `hasRenderableWidth`.
+ */
+function polylineHasRenderableWidth(vertices: AcExLwPolylineVertex[]): boolean {
+  return vertices.some(vertex => {
+    const startWidth = Math.max(0, vertex.startWidth ?? 0)
+    const endWidth = Math.max(0, vertex.endWidth ?? 0)
+    return (
+      startWidth > POLYLINE_WIDTH_EPSILON || endWidth > POLYLINE_WIDTH_EPSILON
+    )
+  })
+}
+
+/**
+ * Decomposes `AcDbPolyline` into ACEO primitives.
  *
- * Straight segments become {@link AcExOsnapLinePrimitive}; bulge segments are
- * converted with {@link AcGeCircArc2d} in WCS (endpoints transformed first so
- * rotation/translation of INSERT is respected; bulge is invariant under similarity).
+ * Thin polylines (`lineStrip`) keep bulge arcs in ACEO and omit straight
+ * edges (those duplicate {@link AcExLineBatch}). Wide polylines are drawn as
+ * a filled mesh from the width profile, so they never appear in lineBatches —
+ * their **centerline** (vertices + bulge, the same geometry
+ * {@link AcDbPolyline.subGetOsnapPoints} snaps to) is stored as one
+ * {@link AcExOsnapPathPrimitive}.
  *
  * @internal
  */
@@ -737,22 +891,14 @@ function pushPolyline(
   matrix: THREE.Matrix4,
   entity: AcDbPolyline
 ) {
-  const runtimeVertices = (
-    entity as unknown as {
-      _geo?: { vertices?: Array<{ x: number; y: number; bulge?: number }> }
-    }
-  )._geo?.vertices
-
-  const vertices =
-    runtimeVertices && runtimeVertices.length > 1
-      ? runtimeVertices.map(v => ({ x: v.x, y: v.y, bulge: v.bulge }))
-      : Array.from({ length: entity.numberOfVertices }, (_, i) => {
-          const p = entity.getPoint2dAt(i)
-          return { x: p.x, y: p.y, bulge: 0 as number | undefined }
-        })
-
+  const vertices = readLwPolylineVertices(entity)
   const count = vertices.length
   if (count < 2) return
+
+  if (polylineHasRenderableWidth(vertices)) {
+    pushCatalogPath(out, layer, matrix, vertices, entity.closed)
+    return
+  }
 
   const segmentCount = entity.closed ? count : count - 1
   for (let i = 0; i < segmentCount; i++) {
@@ -760,58 +906,13 @@ function pushPolyline(
     const end = vertices[(i + 1) % count]!
     const bulge = start.bulge ?? 0
     if (AcGeTol.isPositive(Math.abs(bulge))) {
-      const startW = transformPoint(matrix, { x: start.x, y: start.y, z: 0 })
-      const endW = transformPoint(matrix, { x: end.x, y: end.y, z: 0 })
+      const startW = transformPoint(matrix, start)
+      const endW = transformPoint(matrix, end)
       pushGeCircArc(out, layer, new AcGeCircArc2d(startW, endW, bulge))
     } else {
-      pushLine(
-        out,
-        layer,
-        matrix,
-        { x: start.x, y: start.y, z: 0 },
-        { x: end.x, y: end.y, z: 0 }
-      )
+      pushLine(out, layer, matrix, start, end)
     }
   }
-}
-
-/** Appends a WCS arc from a 2D circular arc at a fixed elevation. @internal */
-function pushCircArc2dBoundary(
-  out: AcExOsnapPrimitive[],
-  layer: string,
-  matrix: THREE.Matrix4,
-  arc: AcGeCircArc2d,
-  elevation: number
-) {
-  if (scaleIsUniform(matrix)) {
-    const startW = transformPoint(matrix, {
-      x: arc.startPoint.x,
-      y: arc.startPoint.y,
-      z: elevation
-    })
-    const endW = transformPoint(matrix, {
-      x: arc.endPoint.x,
-      y: arc.endPoint.y,
-      z: elevation
-    })
-    const det2d =
-      matrix.elements[0]! * matrix.elements[5]! -
-      matrix.elements[4]! * matrix.elements[1]!
-    const bulge =
-      (arc.clockwise ? -1 : 1) *
-      Math.tan(arc.deltaAngle / 4) *
-      (det2d < 0 ? -1 : 1)
-    pushGeCircArc(out, layer, new AcGeCircArc2d(startW, endW, bulge))
-    return
-  }
-
-  pushLine(
-    out,
-    layer,
-    matrix,
-    { x: arc.startPoint.x, y: arc.startPoint.y, z: elevation },
-    { x: arc.endPoint.x, y: arc.endPoint.y, z: elevation }
-  )
 }
 
 /** Appends a WCS ellipse arc from a 2D ellipse arc at a fixed elevation. @internal */
@@ -876,21 +977,17 @@ function pushHatchPolyline2d(
   const vertexCount = polyline.numberOfVertices
   if (vertexCount < 2) return
 
-  const segmentCount = polyline.closed ? vertexCount : vertexCount - 1
-  for (let index = 0; index < segmentCount; index++) {
-    const start = polyline.getPointAt(index)
-    const end = polyline.getPointAt((index + 1) % vertexCount)
-    const bulge = polyline.vertices[index]?.bulge ?? 0
-    const start3 = { x: start.x, y: start.y, z: elevation }
-    const end3 = { x: end.x, y: end.y, z: elevation }
-    if (AcGeTol.isPositive(Math.abs(bulge))) {
-      const startW = transformPoint(matrix, start3)
-      const endW = transformPoint(matrix, end3)
-      pushGeCircArc(out, layer, new AcGeCircArc2d(startW, endW, bulge))
-    } else {
-      pushLine(out, layer, matrix, start3, end3)
-    }
+  const vertices: AcExOsnapPathVertex[] = []
+  for (let index = 0; index < vertexCount; index++) {
+    const point = polyline.getPointAt(index)
+    vertices.push({
+      x: point.x,
+      y: point.y,
+      z: elevation,
+      bulge: polyline.vertices[index]?.bulge ?? 0
+    })
   }
+  pushCatalogPath(out, layer, matrix, vertices, polyline.closed)
 }
 
 /** Exports one hatch boundary loop (polyline or edge loop). @internal */
@@ -906,35 +1003,64 @@ function pushHatchLoop(
     return
   }
 
-  if (loop instanceof AcGeLoop2d) {
-    for (const curve of loop.curves) {
-      if (curve instanceof AcGeLine2d) {
-        pushLine(
-          out,
-          layer,
-          matrix,
-          {
-            x: curve.startPoint.x,
-            y: curve.startPoint.y,
-            z: elevation
-          },
-          {
-            x: curve.endPoint.x,
-            y: curve.endPoint.y,
-            z: elevation
-          }
-        )
-      } else if (curve instanceof AcGeCircArc2d) {
-        pushCircArc2dBoundary(out, layer, matrix, curve, elevation)
-      } else if (curve instanceof AcGeEllipseArc2d) {
-        pushEllipseArc2dBoundary(out, layer, matrix, curve, elevation)
-      }
+  if (!(loop instanceof AcGeLoop2d)) return
+
+  const verts: AcExOsnapPathVertex[] = []
+  let splitByEllipse = false
+  const flushOpen = () => {
+    const packed = finalizePathVertices(verts)
+    if (packed.length >= 2) {
+      pushCatalogPath(out, layer, matrix, packed, false)
     }
+    verts.length = 0
+  }
+
+  for (const curve of loop.curves) {
+    if (curve instanceof AcGeLine2d) {
+      appendPathEdge(
+        verts,
+        {
+          x: curve.startPoint.x,
+          y: curve.startPoint.y,
+          z: elevation
+        },
+        {
+          x: curve.endPoint.x,
+          y: curve.endPoint.y,
+          z: elevation
+        },
+        0
+      )
+    } else if (curve instanceof AcGeCircArc2d) {
+      appendPathEdge(
+        verts,
+        {
+          x: curve.startPoint.x,
+          y: curve.startPoint.y,
+          z: elevation
+        },
+        {
+          x: curve.endPoint.x,
+          y: curve.endPoint.y,
+          z: elevation
+        },
+        circArc2dBulge(curve)
+      )
+    } else if (curve instanceof AcGeEllipseArc2d) {
+      splitByEllipse = true
+      flushOpen()
+      pushEllipseArc2dBoundary(out, layer, matrix, curve, elevation)
+    }
+  }
+
+  const packed = finalizePathVertices(verts)
+  if (packed.length >= 2) {
+    pushCatalogPath(out, layer, matrix, packed, !splitByEllipse)
   }
 }
 
 /**
- * Exports hatch boundary loops as line/arc/ellipse primitives.
+ * Exports hatch boundary loops as compact path primitives (plus ellipse edges).
  *
  * Reads internal `_geo.loops` from the data model, mirroring
  * {@link AcDbHatch.subGetOsnapPoints}.
@@ -1021,7 +1147,8 @@ function visitTableEntity(
   out: AcExOsnapPrimitive[],
   blockStack: Set<AcDbObjectId>,
   database: AcDbDatabase,
-  includeLayer?: (layerName: string) => boolean
+  includeLayer?: (layerName: string) => boolean,
+  exportFillBoundaries = true
 ) {
   const layer = effectiveLayer(entity.layer, insertLayer)
   if (includeLayer && !includeLayer(layer)) {
@@ -1031,7 +1158,16 @@ function visitTableEntity(
   if (block && !blockStack.has(block.objectId) && blockHasEntities(block)) {
     blockStack.add(block.objectId)
     const nested = composeTransforms(matrix, blockInsertTransform(entity))
-    visitBlock(block, nested, layer, out, blockStack, database, includeLayer)
+    visitBlock(
+      block,
+      nested,
+      layer,
+      out,
+      blockStack,
+      database,
+      includeLayer,
+      exportFillBoundaries
+    )
     blockStack.delete(block.objectId)
     return
   }
@@ -1067,11 +1203,43 @@ function pushRasterImage(
     }
   }
   if (boundary.length >= 2) {
-    pushVertexPath(out, layer, matrix, boundary, true)
+    pushCatalogPath(out, layer, matrix, boundary, true)
   }
 
   const insertion = transformPoint(matrix, entity.position)
   out.push({ kind: 'point', layer, x: insertion.x, y: insertion.y })
+}
+
+/**
+ * Exports OLE2FRAME rectangle corners and insertion (upper-left) point.
+ *
+ * @internal
+ */
+function pushOle2Frame(
+  out: AcExOsnapPrimitive[],
+  layer: string,
+  matrix: THREE.Matrix4,
+  entity: AcDbOle2Frame
+) {
+  const rect = entity.position()
+  pushCatalogPath(
+    out,
+    layer,
+    matrix,
+    [rect.upperLeft, rect.upperRight, rect.lowerRight, rect.lowerLeft],
+    true
+  )
+  const insertion = transformPoint(matrix, entity.getLocation())
+  out.push({ kind: 'point', layer, x: insertion.x, y: insertion.y })
+}
+
+function iterInsertAttributes(entity: AcExBlockReferenceLike): AcDbEntity[] {
+  const iterator = entity.attributeIterator?.()
+  if (!iterator) return []
+  if (typeof iterator.toArray === 'function') {
+    return iterator.toArray()
+  }
+  return [...iterator]
 }
 
 /**
@@ -1101,7 +1269,8 @@ function visitEntity(
   out: AcExOsnapPrimitive[],
   blockStack: Set<AcDbObjectId>,
   database: AcDbDatabase,
-  includeLayer?: (layerName: string) => boolean
+  includeLayer?: (layerName: string) => boolean,
+  exportFillBoundaries = true
 ) {
   if (!entity.visibility) return
 
@@ -1118,7 +1287,8 @@ function visitEntity(
       out,
       blockStack,
       database,
-      includeLayer
+      includeLayer,
+      exportFillBoundaries
     )
     return
   }
@@ -1127,17 +1297,58 @@ function visitEntity(
     const block = resolveBlockReferenceBlock(entity, database)
     if (!block || blockStack.has(block.objectId)) return
     blockStack.add(block.objectId)
-    const nested = composeTransforms(matrix, entity.getFullInsertionTransform())
+    const insertXform = entity.getFullInsertionTransform()
+    const cols = Math.max(1, entity.columnCount ?? 1)
+    const rows = Math.max(1, entity.rowCount ?? 1)
+    const colSp = entity.columnSpacing ?? 0
+    const rowSp = entity.rowSpacing ?? 0
     const blockInsertLayer = effectiveLayer(entity.layer, insertLayer)
-    visitBlock(
-      block,
-      nested,
-      blockInsertLayer,
-      out,
-      blockStack,
-      database,
-      includeLayer
-    )
+    for (let row = 0; row < rows; row++) {
+      for (let col = 0; col < cols; col++) {
+        const nested = composeTransforms(matrix, insertXform)
+        if (col !== 0 || row !== 0) {
+          nested.multiply(
+            new THREE.Matrix4().makeTranslation(col * colSp, row * rowSp, 0)
+          )
+        }
+        const ins = transformPoint(nested, { x: 0, y: 0, z: 0 })
+        out.push({
+          kind: 'point',
+          layer: blockInsertLayer,
+          x: ins.x,
+          y: ins.y
+        })
+        visitBlock(
+          block,
+          nested,
+          blockInsertLayer,
+          out,
+          blockStack,
+          database,
+          includeLayer,
+          exportFillBoundaries
+        )
+      }
+    }
+    for (const attrib of iterInsertAttributes(entity)) {
+      if (
+        attrib instanceof AcDbAttribute
+          ? attrib.isInvisible
+          : Boolean((attrib as { isInvisible?: boolean }).isInvisible)
+      ) {
+        continue
+      }
+      visitEntity(
+        attrib,
+        matrix,
+        blockInsertLayer,
+        out,
+        blockStack,
+        database,
+        includeLayer,
+        exportFillBoundaries
+      )
+    }
     blockStack.delete(block.objectId)
     return
   }
@@ -1151,7 +1362,16 @@ function visitEntity(
       matrix,
       dimension.getFullDimBlockTransform()
     )
-    visitBlock(block, nested, layer, out, blockStack, database, includeLayer)
+    visitBlock(
+      block,
+      nested,
+      layer,
+      out,
+      blockStack,
+      database,
+      includeLayer,
+      false
+    )
     blockStack.delete(block.objectId)
     return
   }
@@ -1216,7 +1436,9 @@ function visitEntity(
   }
 
   if (entity instanceof AcDbHatch) {
-    pushHatch(out, layer, matrix, entity)
+    if (exportFillBoundaries) {
+      pushHatch(out, layer, matrix, entity)
+    }
     return
   }
 
@@ -1238,13 +1460,20 @@ function visitEntity(
   }
 
   if (entity instanceof AcDbTrace) {
-    const vertices = [
-      entity.getPointAt(0),
-      entity.getPointAt(1),
-      entity.getPointAt(2),
-      entity.getPointAt(3)
-    ]
-    pushVertexPath(out, layer, matrix, vertices, true)
+    if (exportFillBoundaries) {
+      pushCatalogPath(
+        out,
+        layer,
+        matrix,
+        [
+          entity.getPointAt(0),
+          entity.getPointAt(1),
+          entity.getPointAt(3),
+          entity.getPointAt(2)
+        ],
+        true
+      )
+    }
     return
   }
 
@@ -1286,8 +1515,17 @@ function visitEntity(
     return
   }
 
+  if (entity instanceof AcDbOle2Frame) {
+    if (exportFillBoundaries) {
+      pushOle2Frame(out, layer, matrix, entity)
+    }
+    return
+  }
+
   if (entity instanceof AcDbRasterImage) {
-    pushRasterImage(out, layer, matrix, entity)
+    if (exportFillBoundaries) {
+      pushRasterImage(out, layer, matrix, entity)
+    }
     return
   }
 
@@ -1305,7 +1543,8 @@ function visitBlock(
   out: AcExOsnapPrimitive[],
   blockStack: Set<AcDbObjectId>,
   database: AcDbDatabase,
-  includeLayer?: (layerName: string) => boolean
+  includeLayer?: (layerName: string) => boolean,
+  exportFillBoundaries = true
 ) {
   for (const entity of block.newIterator()) {
     visitEntity(
@@ -1315,7 +1554,8 @@ function visitBlock(
       out,
       blockStack,
       database,
-      includeLayer
+      includeLayer,
+      exportFillBoundaries
     )
   }
 }
@@ -1357,13 +1597,15 @@ function ellipseFromArc(entity: AcDbArc): AcDbEllipse {
  * `AcDbSpline`, `AcDbPolyline`, `AcDb2dPolyline`, `AcDb3dPolyline`, `AcDbHatch`,
  * `AcDbRay`, `AcDbXline`, `AcDbTrace`, `AcDbFace`, `AcDbLeader`, `AcDbMLine`,
  * `AcDbMLeader`, `AcDbText`, `AcDbMText`, `AcDbPoint`, `AcDbRasterImage`,
- * `AcDbTable`, INSERT, and dimension entities (`AcDbDimension` and subclasses
- * via anonymous dim blocks).
+ * `AcDbOle2Frame`, `AcDbTable`, INSERT / MINSERT (with ATTRIB), and dimension
+ * entities (`AcDbDimension` and subclasses via anonymous dim blocks). Hatch /
+ * TRACE / SOLID / IMAGE / OLE fills are stored as `path` primitives except
+ * inside dimension blocks (arrow solids are skipped).
  *
  * @param database - Open drawing database (same instance used for HTML export).
  * @param layoutBtrId - Object id of the layout's owning block table record
  *   (e.g. model space BTR id from the renderer scene).
- * @returns Catalog of analytic curve/point primitives in WCS (no `line` kinds).
+ * @returns Catalog of analytic curve/point/path primitives in WCS (no `line` kinds).
  *   Empty when the BTR id is unknown or the layout has no snap-capable curves.
  *
  * @example
@@ -1450,7 +1692,15 @@ function isFiniteOsnapPrimitive(primitive: AcExOsnapPrimitive): boolean {
       )
     case 'point':
       return Number.isFinite(primitive.x) && Number.isFinite(primitive.y)
-    default:
-      return false
+    case 'path':
+      return (
+        primitive.vertices.length >= 6 &&
+        primitive.vertices.length % 3 === 0 &&
+        primitive.vertices.every(value => Number.isFinite(value))
+      )
+    default: {
+      const _exhaustive: never = primitive
+      return _exhaustive
+    }
   }
 }

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveToAcGe.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveToAcGe.ts
@@ -220,5 +220,7 @@ export function primitiveToAcGeCurve(
       return { kind: 'spline', curve: splineToAcGe(prim) }
     case 'point':
       return { kind: 'point', point: new AcGePoint2d(prim.x, prim.y) }
+    case 'path':
+      throw new Error('path primitives must be expanded before curve conversion')
   }
 }

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveTypes.ts
@@ -4,10 +4,13 @@
  * These definitions describe **analytic** geometry in world coordinates (WCS, XY plane).
  * All coordinate fields use IEEE-754 `number` (double precision) for measurement-grade
  * accuracy on large-coordinate drawings.
- * Curve/point kinds are serialized per layout in {@link AcExLayoutSnapshot.osnap}
- * at export time (see {@link buildOsnapCatalog}). Straight `line` edges are omitted
- * from exported catalogs and rebuilt at runtime from {@link AcExLineBatch} display
- * geometry by {@link AcExOsnapIndex} (self-contained HTML and multi-file packages).
+ * Curve/point/path kinds are serialized per layout in {@link AcExLayoutSnapshot.osnap}
+ * at export time (see {@link buildOsnapCatalog}). Ordinary drawing `line` strokes are
+ * omitted from exported catalogs and rebuilt at runtime from {@link AcExLineBatch}
+ * display geometry. Fill/frame boundaries (hatch, TRACE/SOLID, IMAGE clip, …) are
+ * stored as compact {@link AcExOsnapPathPrimitive} records, not exploded line edges.
+ * Wide LWPOLYLINE entities (start/end width) are also stored as a centerline
+ * `path` because they render as meshes and never appear in {@link AcExLineBatch}.
  *
  * @packageDocumentation
  */
@@ -242,6 +245,27 @@ export interface AcExOsnapPointPrimitive extends AcExOsnapPrimitiveBase {
 }
 
 /**
+ * One fill/frame/centerline stored as a vertex chain (hatch loop, TRACE/SOLID,
+ * IMAGE clip path, OLE frame, wide LWPOLYLINE centerline).
+ *
+ * Packed as `[x0, y0, bulge0, x1, y1, bulge1, …]`. A non-zero bulge is the
+ * AutoCAD polyline bulge for the outgoing segment (same as `AcGeCircArc2d`
+ * from start/end/bulge). Indexed by the whole-path bbox at query time so a
+ * 200-edge hatch is one RBush entry, not 200 ACEO lines.
+ */
+export interface AcExOsnapPathPrimitive extends AcExOsnapPrimitiveBase {
+  /** Discriminator for {@link AcExOsnapPrimitive}. */
+  kind: 'path'
+  /**
+   * Vertex pack: three numbers per vertex (`x`, `y`, outgoing `bulge`).
+   * Length is always a multiple of 3 and at least 6 (two vertices).
+   */
+  vertices: number[]
+  /** When `true`, the last vertex connects back to the first. */
+  closed: boolean
+}
+
+/**
  * Discriminated union of all analytic primitives stored in a layout snapshot.
  *
  * Select on {@link AcExOsnapPrimitive.kind} before reading geometry fields.
@@ -253,14 +277,14 @@ export type AcExOsnapPrimitive =
   | AcExOsnapEllipsePrimitive
   | AcExOsnapSplinePrimitive
   | AcExOsnapPointPrimitive
+  | AcExOsnapPathPrimitive
 
 /**
  * Per-layout catalog of analytic geometry used for object snap.
  *
- * Embedded on {@link AcExLayoutSnapshot.osnap} when exporting HTML. When
- * {@link AcExOsnapCatalog.primitives} is non-empty, {@link AcExOsnapIndex}
- * ignores tessellated `lineBatches` / `meshBatches` for snapping and derives
- * discrete snap points from primitives at query time.
+ * Embedded on {@link AcExLayoutSnapshot.osnap} when exporting HTML.
+ * {@link AcExOsnapIndex} indexes ACEO curves/paths together with tessellated
+ * line segments from {@link AcExLineBatch}.
  */
 export interface AcExOsnapCatalog {
   /** Analytic OSNAP geometry serialized into the HTML snapshot. */

--- a/packages/cad-html-plugin/src/AcExPackageBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExPackageBuilder.ts
@@ -6,7 +6,12 @@ import {
 } from './AcExBatchBinaryCodec'
 import {
   type AcExGeometryChunk,
-  encodeChunkGzip} from './AcExChunkBinaryCodec'
+  encodeChunkGzip
+} from './AcExChunkBinaryCodec'
+import {
+  splitLineBatch,
+  splitMeshBatch
+} from './AcExGeometryBatchSplit'
 import { packHtmlPackage } from './AcExHtmlPackager'
 import {
   encodeOsnapCatalogGzip,
@@ -15,6 +20,7 @@ import {
 import {
   ACEX_DEFAULT_CHUNK_MAX_BYTES,
   ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES,
+  ACEX_MAX_GEOMETRY_BATCH_BYTES,
   ACEX_PACKAGE_VERSION,
   ACEX_SNAPSHOT_VERSION,
   type AcExPackageChunkRef,
@@ -37,6 +43,12 @@ export interface AcExBuildPackageOptions {
   baseName?: string
   /** Max uncompressed ACEC bytes per geometry chunk. */
   maxChunkBytes?: number
+  /**
+   * Max uncompressed bytes of one line/mesh batch piece.
+   * Oversized layer batches are split so chunks can paint progressively.
+   * Defaults to {@link ACEX_MAX_GEOMETRY_BATCH_BYTES}.
+   */
+  maxBatchBytes?: number
   /** Max estimated uncompressed ACEO bytes per OSNAP chunk. */
   maxOsnapChunkBytes?: number
   /**
@@ -54,11 +66,15 @@ interface GeometrySlice {
 
 /**
  * Splits a layout's batches into slices that stay under `maxChunkBytes`.
+ *
+ * Oversized single-layer batches are first cut at `maxBatchBytes` so a busy
+ * layer can download, inflate, and paint in pieces instead of one long task.
  * Empty layouts still produce one empty slice so the layout remains addressable.
  */
 export function splitLayoutIntoSlices(
   layout: AcExLayoutSnapshot,
-  maxChunkBytes: number
+  maxChunkBytes: number,
+  maxBatchBytes: number = ACEX_MAX_GEOMETRY_BATCH_BYTES
 ): GeometrySlice[] {
   const slices: GeometrySlice[] = []
   let current: GeometrySlice = {
@@ -103,11 +119,17 @@ export function splitLayoutIntoSlices(
     current.estimatedBytes += size
   }
 
+  const batchBudget = Math.min(maxChunkBytes, maxBatchBytes)
+
   for (const batch of layout.lineBatches) {
-    pushLine(batch)
+    for (const piece of splitLineBatch(batch, batchBudget)) {
+      pushLine(piece)
+    }
   }
   for (const batch of layout.meshBatches) {
-    pushMesh(batch)
+    for (const piece of splitMeshBatch(batch, batchBudget)) {
+      pushMesh(piece)
+    }
   }
 
   if (
@@ -141,6 +163,7 @@ export function buildAcExPackage(
     options.baseName ?? snapshot.meta.title ?? 'drawing'
   )
   const maxChunkBytes = options.maxChunkBytes ?? ACEX_DEFAULT_CHUNK_MAX_BYTES
+  const maxBatchBytes = options.maxBatchBytes ?? ACEX_MAX_GEOMETRY_BATCH_BYTES
   const maxOsnapChunkBytes =
     options.maxOsnapChunkBytes ?? ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES
   const manifestFileName = `${baseName}.acex.json`
@@ -159,7 +182,7 @@ export function buildAcExPackage(
 
   orderedLayouts.forEach((layout, layoutIndex) => {
     layoutIndexByBtrId.set(layout.btrId, layoutIndex)
-    const slices = splitLayoutIntoSlices(layout, maxChunkBytes)
+    const slices = splitLayoutIntoSlices(layout, maxChunkBytes, maxBatchBytes)
     const chunkIds: string[] = []
 
     slices.forEach((slice, sliceIndex) => {

--- a/packages/cad-html-plugin/src/AcExPackageTypes.ts
+++ b/packages/cad-html-plugin/src/AcExPackageTypes.ts
@@ -1,134 +1,150 @@
-import {
-  ACEX_SNAPSHOT_VERSION,
-  type AcExLayerSnapshot,
-  type AcExSnapshot,
-  type AcExSnapshotVersion,
-  type AcExViewportSnapshot
-} from './AcExSnapshotTypes'
-
-/** Current multi-file package / manifest protocol version. */
-export const ACEX_PACKAGE_VERSION = 1 as const
-
-export type AcExPackageVersion = typeof ACEX_PACKAGE_VERSION
-
-/** Snapshot schema version embedded in package manifests (matches ACEX batches). */
-export type AcExPackageSnapshotVersion = AcExSnapshotVersion
-
-/** One gzip-compressed geometry chunk listed in the package manifest. */
-export interface AcExPackageChunkRef {
-  /** Stable chunk id (also used in the default file name). */
-  id: string
-  /** Relative URL from the manifest file (e.g. `chunks/L0-000.acex.gz`). */
-  href: string
-  /** Layout BTR id this chunk belongs to. */
-  layoutBtrId: string
-  /** Uncompressed ACEC byte length. */
-  byteLength: number
-  /** Gzip-compressed byte length. */
-  compressedByteLength: number
-  /** Number of line batches in this chunk. */
-  lineBatchCount: number
-  /** Number of mesh batches in this chunk. */
-  meshBatchCount: number
-  /** Optional content hash (hex SHA-256). Not required by the loader. */
-  sha256?: string
-}
-
-/**
- * One gzip-compressed ACEO OSNAP chunk (measure mode).
- * Loaded after geometry so viewing does not wait on snap catalogs.
- */
-export interface AcExPackageOsnapChunkRef {
-  /** Stable chunk id (also used in the default file name). */
-  id: string
-  /** Relative URL from the manifest (e.g. `chunks/L0-osnap-000.osnap.gz`). */
-  href: string
-  /** Layout BTR id this chunk belongs to. */
-  layoutBtrId: string
-  /** Uncompressed ACEO byte length. */
-  byteLength: number
-  /** Gzip-compressed byte length. */
-  compressedByteLength: number
-  /** Number of analytic primitives in this chunk. */
-  primitiveCount: number
-  /** Optional content hash (hex SHA-256). Not required by the loader. */
-  sha256?: string
-}
-
-/**
- * Layout directory entry in the package manifest.
- * Geometry and OSNAP catalogs live in referenced files, not inline.
- */
-export interface AcExPackageLayoutRef {
-  btrId: string
-  name: string
-  isModelSpace: boolean
-  /** Paper-space viewports (model space omits this). */
-  viewports?: AcExViewportSnapshot[]
-  /** Geometry chunks for this layout, in paint order. */
-  chunkIds: string[]
-  /**
-   * OSNAP chunk ids for this layout (measure mode).
-   * Omitted when the layout has no analytic snap data.
-   */
-  osnapChunkIds?: string[]
-}
-
-/**
- * Versioned package manifest (`*.acex.json`).
- * Small JSON fetched first; geometry is loaded progressively from chunks.
- */
-export interface AcExPackageManifest {
-  /** Discriminator for package manifests. */
-  format: 'acex-package'
-  /** Package protocol version ({@link ACEX_PACKAGE_VERSION}). */
-  packageVersion: AcExPackageVersion
-  /** Batch / snapshot schema version ({@link ACEX_SNAPSHOT_VERSION}). */
-  snapshotVersion: AcExPackageSnapshotVersion
-  /** Document-level metadata (same shape as {@link AcExSnapshot.meta}). */
-  meta: AcExSnapshot['meta']
-  layers: AcExLayerSnapshot[]
-  activeLayoutBtrId: string
-  layouts: AcExPackageLayoutRef[]
-  /** Flat geometry chunk list; layouts reference ids via {@link AcExPackageLayoutRef.chunkIds}. */
-  chunks: AcExPackageChunkRef[]
-  /**
-   * Flat OSNAP chunk list (measure mode). Layouts reference ids via
-   * {@link AcExPackageLayoutRef.osnapChunkIds}. Omitted or empty for view-only.
-   */
-  osnapChunks?: AcExPackageOsnapChunkRef[]
-}
-
-/** One file in a multi-file package before zipping for download. */
-export interface AcExPackageFile {
-  /** Path relative to the package root (forward slashes). */
-  path: string
-  /** File bytes (UTF-8 for text, raw for binary). */
-  bytes: Uint8Array
-}
-
-/**
- * Complete multi-file package ready to zip or write to disk.
- */
-export interface AcExPackageFiles {
-  /** Shell HTML (`viewer.html`) with `#mlcad-package` config. */
-  html: string
-  /** Manifest object (also serialized as `*.acex.json`). */
-  manifest: AcExPackageManifest
-  /** Manifest file name at package root (e.g. `drawing.acex.json`). */
-  manifestFileName: string
-  /** All package files including HTML, manifest, and chunk `.acex.gz` files. */
-  files: AcExPackageFile[]
-}
-
-/** Default max uncompressed ACEC size per geometry chunk (~512 KiB). */
-export const ACEX_DEFAULT_CHUNK_MAX_BYTES = 512 * 1024
-
-/**
- * Default max estimated uncompressed ACEO size per OSNAP chunk (~512 KiB).
- * Large measure catalogs are split so hosts can fetch snap data in parallel.
- */
-export const ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES = 512 * 1024
-
-export { ACEX_SNAPSHOT_VERSION }
-
+import {
+  ACEX_SNAPSHOT_VERSION,
+  type AcExLayerSnapshot,
+  type AcExSnapshot,
+  type AcExSnapshotVersion,
+  type AcExViewportSnapshot
+} from './AcExSnapshotTypes'
+
+/** Current multi-file package / manifest protocol version. */
+export const ACEX_PACKAGE_VERSION = 1 as const
+
+export type AcExPackageVersion = typeof ACEX_PACKAGE_VERSION
+
+/** Snapshot schema version embedded in package manifests (matches ACEX batches). */
+export type AcExPackageSnapshotVersion = AcExSnapshotVersion
+
+/** One gzip-compressed geometry chunk listed in the package manifest. */
+export interface AcExPackageChunkRef {
+  /** Stable chunk id (also used in the default file name). */
+  id: string
+  /** Relative URL from the manifest file (e.g. `chunks/L0-000.acex.gz`). */
+  href: string
+  /** Layout BTR id this chunk belongs to. */
+  layoutBtrId: string
+  /** Uncompressed ACEC byte length. */
+  byteLength: number
+  /** Gzip-compressed byte length. */
+  compressedByteLength: number
+  /** Number of line batches in this chunk. */
+  lineBatchCount: number
+  /** Number of mesh batches in this chunk. */
+  meshBatchCount: number
+  /** Optional content hash (hex SHA-256). Not required by the loader. */
+  sha256?: string
+}
+
+/**
+ * One gzip-compressed ACEO OSNAP chunk (measure mode).
+ * Loaded after geometry so viewing does not wait on snap catalogs.
+ */
+export interface AcExPackageOsnapChunkRef {
+  /** Stable chunk id (also used in the default file name). */
+  id: string
+  /** Relative URL from the manifest (e.g. `chunks/L0-osnap-000.osnap.gz`). */
+  href: string
+  /** Layout BTR id this chunk belongs to. */
+  layoutBtrId: string
+  /** Uncompressed ACEO byte length. */
+  byteLength: number
+  /** Gzip-compressed byte length. */
+  compressedByteLength: number
+  /** Number of analytic primitives in this chunk. */
+  primitiveCount: number
+  /** Optional content hash (hex SHA-256). Not required by the loader. */
+  sha256?: string
+}
+
+/**
+ * Layout directory entry in the package manifest.
+ * Geometry and OSNAP catalogs live in referenced files, not inline.
+ */
+export interface AcExPackageLayoutRef {
+  btrId: string
+  name: string
+  isModelSpace: boolean
+  /** Paper-space viewports (model space omits this). */
+  viewports?: AcExViewportSnapshot[]
+  /** Geometry chunks for this layout, in paint order. */
+  chunkIds: string[]
+  /**
+   * OSNAP chunk ids for this layout (measure mode).
+   * Omitted when the layout has no analytic snap data.
+   */
+  osnapChunkIds?: string[]
+}
+
+/**
+ * Versioned package manifest (`*.acex.json`).
+ * Small JSON fetched first; geometry is loaded progressively from chunks.
+ */
+export interface AcExPackageManifest {
+  /** Discriminator for package manifests. */
+  format: 'acex-package'
+  /** Package protocol version ({@link ACEX_PACKAGE_VERSION}). */
+  packageVersion: AcExPackageVersion
+  /** Batch / snapshot schema version ({@link ACEX_SNAPSHOT_VERSION}). */
+  snapshotVersion: AcExPackageSnapshotVersion
+  /** Document-level metadata (same shape as {@link AcExSnapshot.meta}). */
+  meta: AcExSnapshot['meta']
+  layers: AcExLayerSnapshot[]
+  activeLayoutBtrId: string
+  layouts: AcExPackageLayoutRef[]
+  /** Flat geometry chunk list; layouts reference ids via {@link AcExPackageLayoutRef.chunkIds}. */
+  chunks: AcExPackageChunkRef[]
+  /**
+   * Flat OSNAP chunk list (measure mode). Layouts reference ids via
+   * {@link AcExPackageLayoutRef.osnapChunkIds}. Omitted or empty for view-only.
+   */
+  osnapChunks?: AcExPackageOsnapChunkRef[]
+}
+
+/** One file in a multi-file package before zipping for download. */
+export interface AcExPackageFile {
+  /** Path relative to the package root (forward slashes). */
+  path: string
+  /** File bytes (UTF-8 for text, raw for binary). */
+  bytes: Uint8Array
+}
+
+/**
+ * Complete multi-file package ready to zip or write to disk.
+ */
+export interface AcExPackageFiles {
+  /** Shell HTML (`viewer.html`) with `#mlcad-package` config. */
+  html: string
+  /** Manifest object (also serialized as `*.acex.json`). */
+  manifest: AcExPackageManifest
+  /** Manifest file name at package root (e.g. `drawing.acex.json`). */
+  manifestFileName: string
+  /** All package files including HTML, manifest, and chunk `.acex.gz` files. */
+  files: AcExPackageFile[]
+}
+
+/**
+ * Default max uncompressed ACEC size per geometry chunk (~2 MiB).
+ *
+ * Gzip typically brings a 2 MiB slice down to well under 200 KiB. Smaller
+ * slices cause too many inflate round-trips and slow first open.
+ */
+export const ACEX_DEFAULT_CHUNK_MAX_BYTES = 2 * 1024 * 1024
+
+/**
+ * Max uncompressed size of one line/mesh batch piece (~2 MiB).
+ *
+ * Scene collection packs by layer (and material), so a busy layer can be tens
+ * of megabytes in a single batch. The packager splits those batches at this
+ * threshold so each package chunk can download, inflate, and paint independently.
+ * Kept in sync with {@link ACEX_DEFAULT_CHUNK_MAX_BYTES} so pieces are not cut
+ * smaller than a chunk and then packed back together.
+ */
+export const ACEX_MAX_GEOMETRY_BATCH_BYTES = 2 * 1024 * 1024
+
+/**
+ * Default max estimated uncompressed ACEO size per OSNAP chunk (~512 KiB).
+ * Large measure catalogs are split so hosts can fetch snap data in parallel.
+ */
+export const ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES = 512 * 1024
+
+export { ACEX_SNAPSHOT_VERSION }
+

--- a/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
+++ b/packages/cad-html-plugin/src/AcExSnapshotTypes.ts
@@ -292,14 +292,18 @@ export interface AcExLayoutSnapshot {
    * Analytic geometry for object snap (OSNAP) in the offline viewer.
    *
    * Populated at export time by {@link buildOsnapCatalog} from the drawing database.
-   * Contains **curve/point** primitives only (circle, arc, ellipse, spline, point,
-   * including polyline bulge arcs). Straight `line` edges are omitted because they
-   * duplicate {@link AcExLineBatch} display geometry; the offline viewer rebuilds
-   * line snap from those batches (self-contained HTML and multi-file packages).
+   * Contains **curve/point/path** primitives (circle, arc, ellipse, spline, point,
+   * polyline bulge arcs, fill/frame `path` records, and wide LWPOLYLINE
+   * centerline `path` records). Straight drawing-line
+   * edges are omitted because they duplicate {@link AcExLineBatch} display
+   * geometry; the offline viewer rebuilds line snap from those batches
+   * (self-contained HTML and multi-file packages). Hatch / TRACE / SOLID / IMAGE
+   * clip / OLE boundaries are stored as compact `path` primitives, not exploded
+   * ACEO lines.
    *
    * Coordinates are IEEE-754 `number` (double) for measurement-grade precision.
    *
-   * {@link AcExOsnapIndex} indexes ACEO curves together with tessellated line
+   * {@link AcExOsnapIndex} indexes ACEO curves/paths together with tessellated line
    * segments extracted from resident {@link AcExLineBatch} / mesh edges.
    */
   osnap?: AcExOsnapCatalog

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -66,6 +66,7 @@ export {
 export {
   ACEX_PACKAGE_VERSION,
   ACEX_DEFAULT_CHUNK_MAX_BYTES,
+  ACEX_MAX_GEOMETRY_BATCH_BYTES,
   ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES,
   type AcExPackageVersion,
   type AcExPackageChunkRef,


### PR DESCRIPTION
## Summary
- Add ACEO `path` (kind 7) primitives for hatch/TRACE/SOLID/IMAGE/OLE boundaries and wide LWPOLYLINE centerlines, so mesh-drawn geometry stays snappable without exploding edges into ACEO lines.
- Split oversized per-layer line/mesh batches (~2 MiB) before packaging, raise default geometry chunk budget to ~2 MiB, and tighten OSNAP index yielding (RBush forest + shorter slices) for progressive paint.
- Correct path bulge under INSERT transforms: flip on mirrors, degrade to chord under non-uniform scale.

## Test plan
- [x] `pnpm test -- packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts packages/cad-html-plugin/__tests__/AcExGeometryBatchSplit.spec.ts packages/cad-html-plugin/__tests__/AcExOsnap.spec.ts packages/cad-html-plugin/__tests__/AcExOsnapCatalogCodec.spec.ts`
- [ ] Export a measure-mode ACEX package with hatch + wide LWPOLYLINE and confirm path osnap (endpoint/nearest)
- [ ] Open a layer-heavy drawing package and confirm geometry paints in progressive chunks
- [ ] Verify mirrored / non-uniform INSERT hatch bulge arcs match expected chord/flip behavior