### PR TITLE
feat: ribbon text-height entry and overlay style fixes

### DIFF
--- a/packages/cad-html-plugin/src/AcExMarkup.ts
+++ b/packages/cad-html-plugin/src/AcExMarkup.ts
@@ -426,17 +426,20 @@ export class AcExMarkupController {
     if (selectedId) {
       const record = this._findRecord(selectedId)
       if (record) {
-        const mode = record.style.textHeightMode ?? 'adaptive'
+        const fontSize = record.style.fontSize ?? this._drawFontSize
+        const wcsToScreen = (p: { x: number; y: number }) =>
+          this._wcsToScreenPoint(p)
+        const textHeightWcs =
+          record.style.textHeightWcs != null && record.style.textHeightWcs > 0
+            ? record.style.textHeightWcs
+            : acexScreenPxToWcs(fontSize, wcsToScreen)
         return {
           color: record.style.color || this._drawColor,
           lineWeight: ACEX_MARKUP_LINE_WEIGHT,
-          fontSize: record.style.fontSize ?? this._drawFontSize,
-          textHeightMode: mode,
-          ...(mode === 'custom' &&
-          record.style.textHeightWcs != null &&
-          record.style.textHeightWcs > 0
-            ? { textHeightWcs: record.style.textHeightWcs }
-            : {})
+          fontSize,
+          // Editing a committed overlay always presents Custom + world height.
+          textHeightMode: 'custom',
+          textHeightWcs
         }
       }
     }

--- a/packages/cad-html-plugin/src/AcExMeasurement.ts
+++ b/packages/cad-html-plugin/src/AcExMeasurement.ts
@@ -1236,17 +1236,21 @@ export class AcExMeasureController {
     if (selectedId) {
       const measure = this._committed.find(m => m.id === selectedId)
       if (measure) {
-        const mode = measure.record.style.textHeightMode ?? 'adaptive'
+        const fontSize = measure.record.style.fontSize || this._drawFontSize
+        const wcsToScreen = (p: { x: number; y: number }) =>
+          this._wcsToScreenPoint(p)
+        const textHeightWcs =
+          measure.record.style.textHeightWcs != null &&
+          measure.record.style.textHeightWcs > 0
+            ? measure.record.style.textHeightWcs
+            : acexScreenPxToWcs(fontSize, wcsToScreen)
         return {
           color: measure.record.style.color || this._measureCss(),
           lineWeight: ACEX_MEASUREMENT_LINE_WEIGHT,
-          fontSize: measure.record.style.fontSize || this._drawFontSize,
-          textHeightMode: mode,
-          ...(mode === 'custom' &&
-          measure.record.style.textHeightWcs != null &&
-          measure.record.style.textHeightWcs > 0
-            ? { textHeightWcs: measure.record.style.textHeightWcs }
-            : {})
+          fontSize,
+          // Editing a committed overlay always presents Custom + world height.
+          textHeightMode: 'custom',
+          textHeightWcs
         }
       }
     }
@@ -4384,8 +4388,14 @@ export class AcExMeasureController {
       }
       // Keep selection highlight on DOM; canvas redraws pick up color.
       for (const el of measure.parts.dom) {
-        if (el.classList.contains('mlcad-measure-badge') && style.fontSize) {
-          el.style.fontSize = `${style.fontSize}px`
+        if (el.classList.contains('mlcad-measure-badge')) {
+          if (style.color) {
+            el.style.color = style.color
+            el.style.borderColor = style.color
+          }
+          if (style.fontSize) {
+            el.style.fontSize = `${style.fontSize}px`
+          }
         } else if (el.classList.contains('mlcad-measure-dot') && style.color) {
           el.style.background = style.color
         }

--- a/packages/cad-simple-viewer/src/command/AcApShortCutSelectionAccessory.ts
+++ b/packages/cad-simple-viewer/src/command/AcApShortCutSelectionAccessory.ts
@@ -15,6 +15,7 @@ import type { AcUiShortCutToolbar } from '../ui/AcUiShortCutToolbar'
 import type { AcUiSimpleToolbarItem } from '../ui/AcUiSimpleToolbar'
 import {
   acuiOpenTextHeightDialog,
+  acuiResolveTextHeightDialogInitials,
   acuiResolveTextHeightPatch
 } from '../ui/AcUiTextHeightDialogHelpers'
 import { ICON_TEXT_HEIGHT } from '../ui/icons'
@@ -40,6 +41,7 @@ import {
 import {
   applyMeasurementStyleToSelection,
   getActiveMeasurementStyle,
+  getMeasurementSnapshot,
   getSelectedMeasurementId
 } from './measure/AcApMeasurementStore'
 
@@ -174,36 +176,52 @@ export function acapBindShortCutSelectionAccessory(
     try {
       const selectedMeasure =
         kind === 'measure' ? getActiveMeasurementStyle() : undefined
+      const markupSelectedId = getMarkupStore().selectedId
       const selectedMarkup =
-        kind === 'markup' && getMarkupStore().selectedId
-          ? getMarkupStore().get(getMarkupStore().selectedId!)
+        kind === 'markup' && markupSelectedId
+          ? getMarkupStore().get(markupSelectedId)
           : undefined
-      const initialMode =
+      const hasSelection =
+        selectedMeasure != null || selectedMarkup != null
+      const sessionMode =
         kind === 'measure'
           ? selectedMeasure?.textHeightMode ??
             acapGetMeasurementTextHeightMode()
           : selectedMarkup?.style.textHeightMode ?? getMarkupTextHeightMode()
-      const initialFontSizePx =
+      const fontSizePx =
         kind === 'measure'
           ? selectedMeasure?.fontSize ?? acapGetMeasurementFontSize()
           : selectedMarkup?.style.fontSize ?? getMarkupFontSize()
-      const initialTextHeightWcs =
+      const measureId = getSelectedMeasurementId()
+      const selectedTextHeightWcs =
         kind === 'measure'
-          ? selectedMeasure?.textHeightWcs ??
-            acapGetMeasurementCustomTextHeightWcs()
-          : selectedMarkup?.style.textHeightWcs ?? getMarkupCustomTextHeightWcs()
+          ? hasSelection
+            ? selectedMeasure?.textHeightWcs ??
+              (measureId
+                ? getMeasurementSnapshot(measureId)?.style.textHeightWcs
+                : undefined)
+            : acapGetMeasurementCustomTextHeightWcs()
+          : hasSelection
+            ? selectedMarkup?.style.textHeightWcs
+            : getMarkupCustomTextHeightWcs()
+
+      const initials = acuiResolveTextHeightDialogInitials({
+        hasSelection,
+        sessionMode: sessionMode ?? 'adaptive',
+        fontSizePx,
+        selectedTextHeightWcs,
+        view
+      })
 
       const result = await acuiOpenTextHeightDialog({
         view,
-        initialMode,
-        initialFontSizePx,
-        initialTextHeightWcs
+        ...initials
       })
       if (!result) return
       const patch = acuiResolveTextHeightPatch(
         view,
         result,
-        initialFontSizePx
+        initials.initialFontSizePx
       )
       if (kind === 'measure') {
         acapSetMeasurementTextHeight(

--- a/packages/cad-simple-viewer/src/ui/AcUiDrawStyleSessionAccessory.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiDrawStyleSessionAccessory.ts
@@ -17,7 +17,9 @@ import {
 } from '../command/markup/AcApMarkupUtil'
 import {
   applyMeasurementStyleToSelection,
-  getActiveMeasurementStyle
+  getActiveMeasurementStyle,
+  getMeasurementSnapshot,
+  getSelectedMeasurementId
 } from '../command/measure/AcApMeasurementStore'
 import {
   ACED_DRAW_STYLE_SESSION_PROVIDER_ID,
@@ -47,6 +49,7 @@ import {
 } from './AcUiDrawStyle'
 import {
   acuiOpenTextHeightDialog,
+  acuiResolveTextHeightDialogInitials,
   acuiResolveTextHeightPatch
 } from './AcUiTextHeightDialogHelpers'
 import { createIconElement, ICON_TEXT_HEIGHT } from './icons'
@@ -497,33 +500,52 @@ export class AcUiDrawStyleSessionAccessory {
     this.hideColorPanel()
     try {
       const isMeasure = this.kind === 'measure'
-      const selectedMeasure = isMeasure ? getActiveMeasurementStyle() : undefined
+      const selectedMeasure = isMeasure
+        ? getActiveMeasurementStyle()
+        : undefined
+      const markupSelectedId = getMarkupStore().selectedId
       const selectedMarkup =
-        !isMeasure && getMarkupStore().selectedId
-          ? getMarkupStore().get(getMarkupStore().selectedId!)
+        !isMeasure && markupSelectedId
+          ? getMarkupStore().get(markupSelectedId)
           : undefined
-      const initialMode = isMeasure
-        ? selectedMeasure?.textHeightMode ?? acapGetMeasurementTextHeightMode()
+      const hasSelection =
+        selectedMeasure != null || selectedMarkup != null
+      const sessionMode = isMeasure
+        ? selectedMeasure?.textHeightMode ??
+          acapGetMeasurementTextHeightMode()
         : selectedMarkup?.style.textHeightMode ?? getMarkupTextHeightMode()
-      const initialFontSizePx = isMeasure
+      const fontSizePx = isMeasure
         ? selectedMeasure?.fontSize ?? acapGetMeasurementFontSize()
         : selectedMarkup?.style.fontSize ?? getMarkupFontSize()
-      const initialTextHeightWcs = isMeasure
-        ? selectedMeasure?.textHeightWcs ??
-          acapGetMeasurementCustomTextHeightWcs()
-        : selectedMarkup?.style.textHeightWcs ?? getMarkupCustomTextHeightWcs()
+      const measureId = getSelectedMeasurementId()
+      const selectedTextHeightWcs = isMeasure
+        ? hasSelection
+          ? selectedMeasure?.textHeightWcs ??
+            (measureId
+              ? getMeasurementSnapshot(measureId)?.style.textHeightWcs
+              : undefined)
+          : acapGetMeasurementCustomTextHeightWcs()
+        : hasSelection
+          ? selectedMarkup?.style.textHeightWcs
+          : getMarkupCustomTextHeightWcs()
+
+      const initials = acuiResolveTextHeightDialogInitials({
+        hasSelection,
+        sessionMode: sessionMode ?? 'adaptive',
+        fontSizePx,
+        selectedTextHeightWcs,
+        view: this.view
+      })
 
       const result = await acuiOpenTextHeightDialog({
         view: this.view,
-        initialMode,
-        initialFontSizePx,
-        initialTextHeightWcs
+        ...initials
       })
       if (!result) return
       const patch = acuiResolveTextHeightPatch(
         this.view,
         result,
-        initialFontSizePx
+        initials.initialFontSizePx
       )
       if (isMeasure) {
         acapSetMeasurementTextHeight(

--- a/packages/cad-simple-viewer/src/ui/AcUiTextHeightDialogHelpers.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiTextHeightDialogHelpers.ts
@@ -23,6 +23,20 @@ export interface AcUiOpenTextHeightDialogOptions {
   initialTextHeightWcs?: number
 }
 
+/** Input for {@link acuiResolveTextHeightDialogInitials}. */
+export interface AcUiTextHeightDialogInitialsInput {
+  /** True when a measure/markup overlay is selected. */
+  hasSelection: boolean
+  /** Session or selected authoring mode. */
+  sessionMode: AcUiTextHeightMode
+  /** Screen font size (CSS px) for adaptive / calculator seed. */
+  fontSizePx: number
+  /** Known world height from the selected overlay, or session custom when idle. */
+  selectedTextHeightWcs?: number
+  /** View used to derive WCS from {@link fontSizePx} when needed. */
+  view: AcTrView2d
+}
+
 /**
  * Opens the shared text-height dialog with i18n labels and screen→WCS conversion.
  */
@@ -51,6 +65,52 @@ export async function acuiOpenTextHeightDialog(
       convert: AcApI18n.t('main.textHeight.convert')
     }
   })
+}
+
+/**
+ * Resolves dialog seeds when editing a selection vs the session draw style.
+ *
+ * Selected overlays always open on Custom with the first element's world
+ * height (baking Fit-to-screen size from {@link fontSizePx} when the overlay
+ * has no stored WCS). Do not pass the session custom WCS while a selection is
+ * active — that would leak draw defaults into the selected element.
+ */
+export function acuiResolveTextHeightDialogInitials(
+  input: AcUiTextHeightDialogInitialsInput
+): {
+  initialMode: AcUiTextHeightMode
+  initialFontSizePx: number
+  initialTextHeightWcs?: number
+} {
+  const fontSizePx =
+    input.fontSizePx > 0 && Number.isFinite(input.fontSizePx)
+      ? input.fontSizePx
+      : 13
+  if (input.hasSelection) {
+    const wcs =
+      input.selectedTextHeightWcs != null &&
+      input.selectedTextHeightWcs > 0
+        ? input.selectedTextHeightWcs
+        : acapScreenPxToWcs(fontSizePx, input.view)
+    return {
+      initialMode: 'custom',
+      initialFontSizePx: Math.max(
+        1,
+        Math.round(acapWcsToScreenPx(wcs, input.view))
+      ),
+      initialTextHeightWcs: wcs
+    }
+  }
+  return {
+    initialMode: input.sessionMode,
+    initialFontSizePx: fontSizePx,
+    initialTextHeightWcs:
+      input.sessionMode === 'custom' &&
+      input.selectedTextHeightWcs != null &&
+      input.selectedTextHeightWcs > 0
+        ? input.selectedTextHeightWcs
+        : undefined
+  }
 }
 
 /**

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonCommands.vue
@@ -19,23 +19,32 @@ import {
   AcApDocManager,
   acapDrawStyleKindForCommand,
   acapGetMeasurementColor,
+  acapGetMeasurementCustomTextHeightWcs,
   acapGetMeasurementFontSize,
+  acapGetMeasurementTextHeightMode,
   AcApOpenCmd,
   AcApQNewCmd,
   acapRunDatabaseEdit,
+  acapScreenPxToWcs,
   acapSetMeasurementDrawColor,
-  acapSetMeasurementDrawFontSize,
+  acapSetMeasurementTextHeight,
   type AcEdCommandEventArgs,
   AcEdOpenMode,
   type AcTrView2d,
+  acuiOpenTextHeightDialog,
+  acuiResolveTextHeightDialogInitials,
+  acuiResolveTextHeightPatch,
   applyMarkupStyleToSelection,
   applyMeasurementStyleToSelection,
   cssToMarkupColor,
   defaultMarkupColor,
   getActiveMeasurementStyle,
   getEffectiveMeasurementUnits,
+  getMarkupCustomTextHeightWcs,
   getMarkupFontSize,
   getMarkupStore,
+  getMarkupTextHeightMode,
+  getMeasurementSnapshot,
   getSelectedMeasurementId,
   isMarkupVisible,
   isMeasurementVisible,
@@ -43,7 +52,7 @@ import {
   MEASUREMENT_LENGTH_UNIT_FOLLOW_DRAWING,
   refreshMeasurementValueLabels,
   setMarkupDrawColor,
-  setMarkupDrawFontSize,
+  setMarkupTextHeight,
   setMeasurementUnitOverride,
   subscribeMeasurementSelection
 } from '@mlightcad/cad-simple-viewer'
@@ -159,17 +168,20 @@ import MlLayerSelect from '../common/MlLayerSelect.vue'
 import MlCharacterMapDialog from '../dialog/MlCharacterMapDialog.vue'
 import MlRibbonFileName from './MlRibbonFileName.vue'
 import MlRibbonLanguageSelector from './MlRibbonLanguageSelector.vue'
-import MlRibbonMarkupFontSizeSelect from './MlRibbonMarkupFontSizeSelect.vue'
 import MlRibbonMeasurementUnitsPanel from './MlRibbonMeasurementUnitsPanel.vue'
 import MlRibbonPropertyColorDropdown from './MlRibbonPropertyColorDropdown.vue'
 import MlRibbonPropertyLineTypeSelect from './MlRibbonPropertyLineTypeSelect.vue'
 import MlRibbonPropertyLineWeightSelect from './MlRibbonPropertyLineWeightSelect.vue'
+import MlRibbonTextHeightButton from './MlRibbonTextHeightButton.vue'
 import { classifyOverlaySelection } from './overlaySelectionKind'
 import { useHatchContextualRibbon } from './useHatchContextualRibbon'
 import { useMTextContextualRibbon } from './useMTextContextualRibbon'
 
-/** Shared dropdown width for color / line-weight / font-size in overlay Style panels. */
+/** Shared control width for color / text-height in overlay Style panels. */
 const OVERLAY_STYLE_CONTROL_WIDTH = '120px'
+
+/** Authoring mode for overlay text height (Fit to screen vs world height). */
+type OverlayTextHeightMode = 'adaptive' | 'custom'
 
 interface Props {
   currentLocale?: LocaleProp
@@ -198,10 +210,19 @@ const isMarkupOverlayVisible = ref(true)
 const isMeasurementOverlayVisible = ref(true)
 const markupDrawColor = shallowRef(defaultMarkupColor())
 const markupDrawColorDisplay = ref(markupColorToCss(markupDrawColor.value))
-const markupDrawFontSize = ref(getMarkupFontSize())
+const markupTextHeightMode = ref<OverlayTextHeightMode>(getMarkupTextHeightMode())
+const markupTextHeightWcs = ref<number | undefined>(
+  getMarkupCustomTextHeightWcs()
+)
 const measurementDrawColor = shallowRef(new AcCmColor())
 const measurementDrawColorDisplay = ref('#7b8794')
-const measurementDrawFontSize = ref(acapGetMeasurementFontSize())
+const measurementTextHeightMode = ref<OverlayTextHeightMode>(
+  acapGetMeasurementTextHeightMode()
+)
+const measurementTextHeightWcs = ref<number | undefined>(
+  acapGetMeasurementCustomTextHeightWcs()
+)
+let textHeightDialogOpen = false
 const measurementLunits = ref(AcDbLinearUnits.Decimal)
 const measurementLuprec = ref(4)
 const measurementAunits = ref(AcDbAngleUnits.DecimalDegrees)
@@ -629,7 +650,7 @@ const scheduleActivateRibbonTabForOverlaySelection = () => {
 
 /**
  * Switches to Measurement or Review while a drawing command is active so
- * color / lineweight / font-size can be changed before the overlay is committed.
+ * color / text-height can be changed before the overlay is committed.
  */
 const activateRibbonTabForDrawCommand = (args: AcEdCommandEventArgs) => {
   const kind = acapDrawStyleKindForCommand(args.command?.globalName)
@@ -782,14 +803,29 @@ const syncMarkupStyleControls = () => {
     const color = cssToMarkupColor(selected.style.color)
     markupDrawColor.value = color
     markupDrawColorDisplay.value = selected.style.color
-    markupDrawFontSize.value =
+    const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
+    const fontSize =
       selected.style.fontSize != null && selected.style.fontSize > 0
         ? selected.style.fontSize
         : getMarkupFontSize()
+    const wcs =
+      selected.style.textHeightWcs != null &&
+      selected.style.textHeightWcs > 0
+        ? selected.style.textHeightWcs
+        : view
+          ? acapScreenPxToWcs(fontSize, view)
+          : undefined
+    // Selected overlays always summarize as Custom + first-element WCS.
+    markupTextHeightMode.value = 'custom'
+    markupTextHeightWcs.value = wcs
   } else {
     markupDrawColor.value = defaultMarkupColor()
     markupDrawColorDisplay.value = markupColorToCss(markupDrawColor.value)
-    markupDrawFontSize.value = getMarkupFontSize()
+    markupTextHeightMode.value = getMarkupTextHeightMode()
+    markupTextHeightWcs.value =
+      markupTextHeightMode.value === 'custom'
+        ? getMarkupCustomTextHeightWcs()
+        : undefined
   }
   scheduleActivateRibbonTabForOverlaySelection()
 }
@@ -798,7 +834,12 @@ const syncMarkupStyleControls = () => {
  * Apply a style patch to the currently selected markup and republish it.
  */
 const patchSelectedMarkupStyle = (
-  patch: Partial<{ color: string; fontSize: number }>
+  patch: Partial<{
+    color: string
+    fontSize: number
+    textHeightMode: OverlayTextHeightMode
+    textHeightWcs: number
+  }>
 ) => {
   const view = AcApDocManager.instance?.curView
   if (view) applyMarkupStyleToSelection(view, patch)
@@ -817,13 +858,56 @@ const handleMarkupDrawColorChange = (value?: AcCmColor) => {
 }
 
 /**
- * Updates the session markup draw font size used by text / callout markups.
- * When a markup is selected, also updates that markup's font size.
+ * Opens the shared text-height dialog for Review markups.
  */
-const handleMarkupDrawFontSizeChange = (value: number) => {
-  setMarkupDrawFontSize(value)
-  markupDrawFontSize.value = getMarkupFontSize()
-  patchSelectedMarkupStyle({ fontSize: getMarkupFontSize() })
+const handleMarkupTextHeightClick = async () => {
+  if (textHeightDialogOpen) return
+  const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
+  if (!view) return
+  textHeightDialogOpen = true
+  try {
+    const store = getMarkupStore()
+    const selected = store.selectedId
+      ? store.get(store.selectedId)
+      : undefined
+    const hasSelection = selected != null
+    const fontSizePx =
+      selected?.style.fontSize != null && selected.style.fontSize > 0
+        ? selected.style.fontSize
+        : getMarkupFontSize()
+    const selectedTextHeightWcs = hasSelection
+      ? selected?.style.textHeightWcs
+      : getMarkupCustomTextHeightWcs()
+    const initials = acuiResolveTextHeightDialogInitials({
+      hasSelection,
+      sessionMode: hasSelection
+        ? 'custom'
+        : getMarkupTextHeightMode(),
+      fontSizePx,
+      selectedTextHeightWcs,
+      view
+    })
+    const result = await acuiOpenTextHeightDialog({
+      view,
+      ...initials
+    })
+    if (!result) return
+    const patch = acuiResolveTextHeightPatch(
+      view,
+      result,
+      initials.initialFontSizePx
+    )
+    setMarkupTextHeight(
+      patch.textHeightMode,
+      patch.textHeightMode === 'custom'
+        ? (patch.textHeightWcs ?? patch.fontSize)
+        : patch.fontSize
+    )
+    applyMarkupStyleToSelection(view, patch)
+    syncMarkupStyleControls()
+  } finally {
+    textHeightDialogOpen = false
+  }
 }
 
 const syncMeasurementStyleControls = () => {
@@ -831,7 +915,22 @@ const syncMeasurementStyleControls = () => {
   if (selected) {
     measurementDrawColor.value = selected.color.clone()
     measurementDrawColorDisplay.value = acapCssColor(selected.color)
-    measurementDrawFontSize.value = selected.fontSize
+    const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
+    const measureId = getSelectedMeasurementId()
+    const wcs =
+      selected.textHeightWcs != null && selected.textHeightWcs > 0
+        ? selected.textHeightWcs
+        : measureId
+          ? getMeasurementSnapshot(measureId)?.style.textHeightWcs
+          : undefined
+    const resolvedWcs =
+      wcs != null && wcs > 0
+        ? wcs
+        : view
+          ? acapScreenPxToWcs(selected.fontSize, view)
+          : undefined
+    measurementTextHeightMode.value = 'custom'
+    measurementTextHeightWcs.value = resolvedWcs
   } else {
     const db = getCurrentDatabase()
     if (db) {
@@ -839,7 +938,11 @@ const syncMeasurementStyleControls = () => {
       measurementDrawColor.value = color.clone()
       measurementDrawColorDisplay.value = acapCssColor(color)
     }
-    measurementDrawFontSize.value = acapGetMeasurementFontSize()
+    measurementTextHeightMode.value = acapGetMeasurementTextHeightMode()
+    measurementTextHeightWcs.value =
+      measurementTextHeightMode.value === 'custom'
+        ? acapGetMeasurementCustomTextHeightWcs()
+        : undefined
   }
   scheduleActivateRibbonTabForOverlaySelection()
 }
@@ -853,12 +956,55 @@ const handleMeasurementDrawColorChange = (value?: AcCmColor) => {
   if (view) applyMeasurementStyleToSelection(view, { color: value })
 }
 
-const handleMeasurementDrawFontSizeChange = (value: number) => {
-  acapSetMeasurementDrawFontSize(value)
-  measurementDrawFontSize.value = acapGetMeasurementFontSize()
+/**
+ * Opens the shared text-height dialog for Measurement overlays.
+ */
+const handleMeasurementTextHeightClick = async () => {
+  if (textHeightDialogOpen) return
   const view = AcApDocManager.instance?.curView as AcTrView2d | undefined
-  if (view) {
-    applyMeasurementStyleToSelection(view, { fontSize: acapGetMeasurementFontSize() })
+  if (!view) return
+  textHeightDialogOpen = true
+  try {
+    const selected = getActiveMeasurementStyle()
+    const hasSelection = selected != null
+    const measureId = getSelectedMeasurementId()
+    const fontSizePx =
+      selected?.fontSize ?? acapGetMeasurementFontSize()
+    const selectedTextHeightWcs = hasSelection
+      ? selected?.textHeightWcs ??
+        (measureId
+          ? getMeasurementSnapshot(measureId)?.style.textHeightWcs
+          : undefined)
+      : acapGetMeasurementCustomTextHeightWcs()
+    const initials = acuiResolveTextHeightDialogInitials({
+      hasSelection,
+      sessionMode: hasSelection
+        ? 'custom'
+        : acapGetMeasurementTextHeightMode(),
+      fontSizePx,
+      selectedTextHeightWcs,
+      view
+    })
+    const result = await acuiOpenTextHeightDialog({
+      view,
+      ...initials
+    })
+    if (!result) return
+    const patch = acuiResolveTextHeightPatch(
+      view,
+      result,
+      initials.initialFontSizePx
+    )
+    acapSetMeasurementTextHeight(
+      patch.textHeightMode,
+      patch.textHeightMode === 'custom'
+        ? (patch.textHeightWcs ?? patch.fontSize)
+        : patch.fontSize
+    )
+    applyMeasurementStyleToSelection(view, patch)
+    syncMeasurementStyleControls()
+  } finally {
+    textHeightDialogOpen = false
   }
 }
 
@@ -1254,18 +1400,21 @@ const buildBaseTabs = (
       }
     },
     {
-      id: 'markup-draw-font-size',
+      id: 'markup-draw-text-height',
       type: 'custom',
       size: 'small',
       tooltip: t('main.verticalToolbar.markupFontSize.description'),
       props: {
-        component: MlRibbonMarkupFontSizeSelect,
+        component: MlRibbonTextHeightButton,
         componentProps: {
-          modelValue: markupDrawFontSize.value,
-          options: [10, 12, 14, 16, 18, 20, 24, 28, 32],
+          mode: markupTextHeightMode.value,
+          textHeightWcs: markupTextHeightWcs.value,
+          fitLabel: t('main.verticalToolbar.markupFontSize.fit'),
+          wcsLabel: t('main.verticalToolbar.markupFontSize.wcs'),
           placeholder: t('main.verticalToolbar.markupFontSize.text'),
+          ariaLabel: t('main.verticalToolbar.markupFontSize.description'),
           controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
-          'onUpdate:modelValue': handleMarkupDrawFontSizeChange
+          onClick: handleMarkupTextHeightClick
         }
       }
     }
@@ -1439,18 +1588,21 @@ const buildBaseTabs = (
       }
     },
     {
-      id: 'measurement-draw-font-size',
+      id: 'measurement-draw-text-height',
       type: 'custom',
       size: 'small',
       tooltip: t('main.verticalToolbar.measurementFontSize.description'),
       props: {
-        component: MlRibbonMarkupFontSizeSelect,
+        component: MlRibbonTextHeightButton,
         componentProps: {
-          modelValue: measurementDrawFontSize.value,
-          options: [10, 12, 13, 14, 16, 18, 20, 24, 28, 32],
+          mode: measurementTextHeightMode.value,
+          textHeightWcs: measurementTextHeightWcs.value,
+          fitLabel: t('main.verticalToolbar.measurementFontSize.fit'),
+          wcsLabel: t('main.verticalToolbar.measurementFontSize.wcs'),
           placeholder: t('main.verticalToolbar.measurementFontSize.text'),
+          ariaLabel: t('main.verticalToolbar.measurementFontSize.description'),
           controlWidth: OVERLAY_STYLE_CONTROL_WIDTH,
-          'onUpdate:modelValue': handleMeasurementDrawFontSizeChange
+          onClick: handleMeasurementTextHeightClick
         }
       }
     }
@@ -2354,14 +2506,16 @@ const ribbonData = computed(() => {
   const openMode = docOpenMode.value
   const markupVisible = isMarkupOverlayVisible.value
   const measurementVisible = isMeasurementOverlayVisible.value
-  // Track markup draw style so Review ribbon color / font controls refresh.
+  // Track markup draw style so Review ribbon color / text-height controls refresh.
   markupDrawColor.value
   markupDrawColorDisplay.value
-  markupDrawFontSize.value
+  markupTextHeightMode.value
+  markupTextHeightWcs.value
   // Track measurement draw style so Measurement ribbon controls refresh.
   measurementDrawColor.value
   measurementDrawColorDisplay.value
-  measurementDrawFontSize.value
+  measurementTextHeightMode.value
+  measurementTextHeightWcs.value
   measurementLunits.value
   measurementLuprec.value
   measurementAunits.value

--- a/packages/cad-viewer/src/component/ribbon/MlRibbonTextHeightButton.vue
+++ b/packages/cad-viewer/src/component/ribbon/MlRibbonTextHeightButton.vue
@@ -1,0 +1,139 @@
+<template>
+  <ml-ribbon-property-field
+    :icon="textHeightIcon"
+    :disabled="disabled"
+    :control-width="controlWidth"
+    variant="line-weight"
+  >
+    <button
+      type="button"
+      class="ml-ribbon-text-height-button"
+      :disabled="disabled"
+      :aria-label="ariaLabel || placeholder"
+      @click="emit('click')"
+    >
+      <template v-if="mode === 'custom'">
+        <span class="ml-ribbon-text-height-button__mode">{{ wcsLabel }}</span>
+        <span class="ml-ribbon-text-height-button__value">{{
+          formattedWcs || '-'
+        }}</span>
+      </template>
+      <span v-else class="ml-ribbon-text-height-button__value">{{ fitLabel }}</span>
+    </button>
+  </ml-ribbon-property-field>
+</template>
+
+<script setup lang="ts">
+import { ICON_TEXT_HEIGHT } from '@mlightcad/cad-simple-viewer'
+import { computed, defineComponent, h } from 'vue'
+
+import MlRibbonPropertyField from './MlRibbonPropertyField.vue'
+
+/**
+ * Compact ribbon control that shows Fit / WCS text-height status and opens
+ * the shared dialog on click (dialog is not embedded in the ribbon).
+ */
+interface RibbonTextHeightButtonProps {
+  /** Current authoring mode shown in the summary. */
+  mode?: 'adaptive' | 'custom'
+  /** World-space height when {@link mode} is `'custom'`. */
+  textHeightWcs?: number
+  /** Short label for Fit-to-screen (e.g. `Fit`). */
+  fitLabel?: string
+  /** Short prefix for custom height (e.g. `WCS`). */
+  wcsLabel?: string
+  /** Accessible name / tooltip fallback. */
+  placeholder?: string
+  /** Optional explicit aria-label. */
+  ariaLabel?: string
+  disabled?: boolean
+  controlWidth?: string
+}
+
+const props = withDefaults(defineProps<RibbonTextHeightButtonProps>(), {
+  mode: 'adaptive',
+  textHeightWcs: undefined,
+  fitLabel: 'Fit',
+  wcsLabel: 'WCS',
+  placeholder: '',
+  ariaLabel: '',
+  disabled: false,
+  controlWidth: '120px'
+})
+
+const emit = defineEmits<{
+  (e: 'click'): void
+}>()
+
+const textHeightIcon = defineComponent({
+  name: 'MlRibbonTextHeightIcon',
+  setup() {
+    return () =>
+      h('span', {
+        class: 'ml-ribbon-text-height-icon',
+        innerHTML: ICON_TEXT_HEIGHT
+      })
+  }
+})
+
+const formattedWcs = computed(() => {
+  const value = props.textHeightWcs
+  if (value == null || !Number.isFinite(value) || value <= 0) return ''
+  const rounded = Math.round(value * 1000) / 1000
+  return Number.isInteger(rounded) ? String(rounded) : String(rounded)
+})
+</script>
+
+<style scoped>
+.ml-ribbon-text-height-button {
+  --ml-ribbon-text-height-scale: var(--ml-rb-scale, 1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: calc(6px * var(--ml-ribbon-text-height-scale));
+  width: 100%;
+  min-height: var(--ml-rb-compact-height, 28px);
+  padding: 0 calc(8px * var(--ml-ribbon-text-height-scale));
+  border: 1px solid var(--el-border-color, #dcdfe6);
+  border-radius: var(--el-border-radius-base, 4px);
+  background: var(--el-fill-color-blank, #fff);
+  color: var(--el-text-color-regular, #606266);
+  font-size: calc(12px * var(--ml-ribbon-text-height-scale));
+  line-height: 1.2;
+  cursor: pointer;
+  text-align: left;
+}
+
+.ml-ribbon-text-height-button:hover:not(:disabled) {
+  border-color: var(--el-color-primary, #409eff);
+  color: var(--el-color-primary, #409eff);
+}
+
+.ml-ribbon-text-height-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.ml-ribbon-text-height-button__mode {
+  flex: 0 0 auto;
+  color: var(--el-text-color-secondary, #909399);
+  font-weight: 500;
+}
+
+.ml-ribbon-text-height-button__value {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--el-text-color-primary, #303133);
+  font-variant-numeric: tabular-nums;
+}
+
+.ml-ribbon-text-height-button:hover:not(:disabled)
+  .ml-ribbon-text-height-button__value,
+.ml-ribbon-text-height-button:hover:not(:disabled)
+  .ml-ribbon-text-height-button__mode {
+  color: inherit;
+}
+</style>

--- a/packages/cad-viewer/src/locale/ar/main.ts
+++ b/packages/cad-viewer/src/locale/ar/main.ts
@@ -752,8 +752,8 @@ export default {
 
     markupFontSize: {
       ...enMain.verticalToolbar.markupFontSize,
-      text: 'حجم الخط',
-      description: 'تحديد حجم خط النصوص ووسائل الشرح'
+      text: 'ارتفاع النص',
+      description: 'فتح إعدادات ارتفاع النص لعلامات المراجعة'
     },
 
     measurementColor: {
@@ -764,8 +764,8 @@ export default {
 
     measurementFontSize: {
       ...enMain.verticalToolbar.measurementFontSize,
-      text: 'حجم الخط',
-      description: 'تحديد حجم خط القياس المحدد أو القياسات الجديدة'
+      text: 'ارتفاع النص',
+      description: 'فتح إعدادات ارتفاع النص للقياس المحدد أو القياسات الجديدة'
     },
 
     showMarkup: {

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -522,8 +522,11 @@ export default {
       description: 'Nastaví barvu nových poznámek'
     },
     markupFontSize: {
-      text: 'Velikost písma',
-      description: 'Nastaví velikost písma textových a odkazových poznámek'
+      text: 'Výška textu',
+      description:
+        'Otevře nastavení výšky textu poznámek (přizpůsobit obrazovce nebo světová výška)',
+      fit: 'Fit',
+      wcs: 'WCS'
     },
     measurementColor: {
       text: 'Barva',
@@ -531,9 +534,11 @@ export default {
         'Nastaví barvu vybraného měření, nebo měření, která přidáte příště'
     },
     measurementFontSize: {
-      text: 'Velikost písma',
+      text: 'Výška textu',
       description:
-        'Nastaví velikost písma vybraného měření, nebo měření, která přidáte příště'
+        'Otevře nastavení výšky textu vybraného měření, nebo měření, která přidáte příště',
+      fit: 'Fit',
+      wcs: 'WCS'
     },
     showMarkup: {
       text: 'Zobrazit',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -530,8 +530,11 @@ export default {
       description: 'Set the color for new markup drawings'
     },
     markupFontSize: {
-      text: 'Font size',
-      description: 'Set the font size for text and callout markups'
+      text: 'Text height',
+      description:
+        'Open text height settings for markups (Fit to screen or world height)',
+      fit: 'Fit',
+      wcs: 'WCS'
     },
     measurementColor: {
       text: 'Color',
@@ -539,9 +542,11 @@ export default {
         'Set the color for the selected measurement, or for measurements you add next'
     },
     measurementFontSize: {
-      text: 'Font size',
+      text: 'Text height',
       description:
-        'Set the font size for the selected measurement, or for measurements you add next'
+        'Open text height settings for the selected measurement, or for measurements you add next',
+      fit: 'Fit',
+      wcs: 'WCS'
     },
     showMarkup: {
       text: 'Show',

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -533,17 +533,22 @@ export default {
       description: 'Yeni işaret çizimleri için rengi ayarlar'
     },
     markupFontSize: {
-      text: 'Yazı Boyutu',
-      description: 'Metin ve çağrı işaretleri için yazı boyutunu ayarlar'
+      text: 'Yazı yüksekliği',
+      description:
+        'İşaretler için yazı yüksekliği ayarlarını açar (ekrana sığdır veya dünya yüksekliği)',
+      fit: 'Fit',
+      wcs: 'WCS'
     },
     measurementColor: {
       text: 'Renk',
       description: 'Seçili ölçümün veya sonraki ölçümlerin rengini ayarlar'
     },
     measurementFontSize: {
-      text: 'Yazı Boyutu',
+      text: 'Yazı yüksekliği',
       description:
-        'Seçili ölçümün veya sonraki ölçümlerin yazı boyutunu ayarlar'
+        'Seçili ölçümün veya sonraki ölçümlerin yazı yüksekliği ayarlarını açar',
+      fit: 'Fit',
+      wcs: 'WCS'
     },
     showMarkup: {
       text: 'Göster',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -491,16 +491,20 @@ export default {
       description: '设置新建批注的颜色'
     },
     markupFontSize: {
-      text: '字号',
-      description: '设置文字与标注文本框的字号'
+      text: '字高',
+      description: '打开字高设置（适应屏幕或世界坐标高度）',
+      fit: '适应',
+      wcs: 'WCS'
     },
     measurementColor: {
       text: '颜色',
       description: '有选中测量标注时修改其颜色；未选中时用于后续添加的测量标注'
     },
     measurementFontSize: {
-      text: '字号',
-      description: '有选中测量标注时修改其字号；未选中时用于后续添加的测量标注'
+      text: '字高',
+      description: '有选中测量标注时修改其字高；未选中时用于后续添加的测量标注',
+      fit: '适应',
+      wcs: 'WCS'
     },
     showMarkup: {
       text: '显示批注',

--- a/packages/three-renderer/__tests__/AcTrHtmlTransientManager.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrHtmlTransientManager.spec.ts
@@ -96,6 +96,33 @@ describe('AcTrHtmlTransientManager', () => {
     manager.dispose()
   })
 
+  it('preserves authored baseZoom when the overlay is moved', () => {
+    const scene = new THREE.Scene()
+    const manager = new AcTrHtmlTransientManager(scene)
+    const element = document.createElement('div')
+    element.style.transform = 'translate(-50%, -50%)'
+
+    manager.add(
+      new AcTrHtmlElement(element, {
+        id: 'wcs-label',
+        worldPosition: { x: 0, y: 0 },
+        scaleWithView: true
+      })
+    )
+
+    const entry = getEntry(manager, 'wcs-label')
+    entry.baseZoom = 1
+    entry.setPosition({ x: 10, y: 20 })
+    expect(entry.baseZoom).toBe(1)
+
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 1000)
+    camera.zoom = 2
+    entry.object.onAfterRender(null!, null!, camera)
+    expect(element.style.transform).toContain('scale(2, 2)')
+
+    manager.dispose()
+  })
+
   it('adds a selectable group and selects it on child click', () => {
     const scene = new THREE.Scene()
     const manager = new AcTrHtmlTransientManager(scene)

--- a/packages/three-renderer/src/html/AcTrHtmlColorUtil.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlColorUtil.ts
@@ -2,7 +2,16 @@ import { AcCmColor } from '@mlightcad/data-model'
 
 /** Converts an AcCmColor to a CSS color string, with rgb() fallback. */
 export function acTrHtmlCssColor(c: AcCmColor): string {
-  return c.cssColor ?? `rgb(${c.red}, ${c.green}, ${c.blue})`
+  // Prefer live RGB channels so palette edits are reflected immediately.
+  // `cssColor` can lag behind ACI/index mutations on some AcCmColor builds.
+  if (
+    Number.isFinite(c.red) &&
+    Number.isFinite(c.green) &&
+    Number.isFinite(c.blue)
+  ) {
+    return `rgb(${c.red}, ${c.green}, ${c.blue})`
+  }
+  return c.cssColor ?? '#ffffff'
 }
 
 /** Converts an AcCmColor to a CSS rgba() string. */

--- a/packages/three-renderer/src/html/AcTrHtmlElement.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlElement.ts
@@ -104,6 +104,10 @@ export class AcTrHtmlElement {
 
   /**
    * Update the world-space anchor position.
+   *
+   * Preserves {@link baseZoom} so WCS-sized overlays (live draw previews and
+   * committed capsules) keep their world height while moving. Callers that
+   * intentionally re-anchor view scale should clear {@link baseZoom} themselves.
    */
   setPosition(worldPosition: { x: number; y: number; z?: number }): void {
     this.object.position.set(
@@ -114,8 +118,6 @@ export class AcTrHtmlElement {
     this.object.matrixAutoUpdate = true
     this.object.updateMatrix()
     this.object.updateMatrixWorld(true)
-    // Re-anchor view scale so the next zoom is relative to this placement.
-    this.baseZoom = undefined
   }
 
   /**

--- a/packages/three-renderer/src/html/AcTrHtmlGrip.ts
+++ b/packages/three-renderer/src/html/AcTrHtmlGrip.ts
@@ -116,20 +116,6 @@ export class AcTrHtmlGrip extends AcTrHtmlElement {
     })
   }
 
-  /**
-   * Keep the WCS diameter when the grip is moved (do not re-anchor zoom).
-   */
-  override setPosition(worldPosition: { x: number; y: number; z?: number }): void {
-    this.object.position.set(
-      worldPosition.x,
-      worldPosition.y,
-      worldPosition.z ?? 0
-    )
-    this.object.matrixAutoUpdate = true
-    this.object.updateMatrix()
-    this.object.updateMatrixWorld(true)
-  }
-
   /** Update the marker fill color. */
   setColor(color: AcCmColor): void {
     this.element.style.background = acTrHtmlCssColor(color)


### PR DESCRIPTION
## Summary
- Replace Review/Measurement ribbon Style font-size dropdowns with Fit/WCS status buttons that open the shared text-height dialog
- Seed selection text-height dialogs from the first overlay WCS (bake from screen px when missing); do not leak session custom WCS into selection
- Refresh selected measurement capsule colors while selected (HTML + Vue `acTrHtmlCssColor`)
- Preserve `baseZoom` on HTML overlay move so custom WCS sizing applies during live draw, not only after commit

## Test plan
- [ ] Ribbon Review/Measurement Style: button shows Fit or WCS n; click opens dialog; OK updates session/selection
- [ ] With overlay selected, dialog opens on Custom with that element WCS (not session default)
- [ ] Set custom WCS via ribbon, start measure/markup draw: preview size matches WCS while drawing and after commit
- [ ] Change color while measure/markup selected: capsule updates immediately
- [ ] Zoom after custom-WCS commit: capsules scale with view

EOF