### PR TITLE
feat: allow choosing paper-space background when opening drawings

### DIFF
--- a/packages/cad-simple-viewer-example/index.html
+++ b/packages/cad-simple-viewer-example/index.html
@@ -434,14 +434,64 @@
         position: absolute;
         inset: 0;
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
+        gap: 1rem;
         z-index: 20;
         pointer-events: none;
       }
 
       .empty-state.hidden {
         display: none;
+      }
+
+      .empty-open-options {
+        pointer-events: auto;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.45rem;
+      }
+
+      .empty-open-options-label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #9ca3af;
+      }
+
+      .empty-open-options-pills {
+        display: flex;
+        border: 1px solid #4b5563;
+        border-radius: 8px;
+        overflow: hidden;
+        background: #1f2937;
+      }
+
+      .empty-open-options-pills button {
+        border: none;
+        background: transparent;
+        color: #9ca3af;
+        font-size: 0.82rem;
+        font-weight: 600;
+        padding: 0.4rem 0.85rem;
+        cursor: pointer;
+      }
+
+      .empty-open-options-pills button:not(:last-child) {
+        border-right: 1px solid #4b5563;
+      }
+
+      .empty-open-options-pills button:hover:not(.is-active) {
+        color: #e5e7eb;
+        background: #273447;
+      }
+
+      .empty-open-options-pills button.is-active {
+        background: #2563eb;
+        color: #ffffff;
       }
 
       .open-main-button {
@@ -662,6 +712,30 @@
         </div>
         <section class="viewer-canvas-area">
           <div class="empty-state" id="emptyState">
+            <div class="empty-open-options" role="group" aria-label="Paper space background">
+              <span class="empty-open-options-label">Paper space background</span>
+              <div class="empty-open-options-pills" role="radiogroup" aria-label="Paper space background">
+                <button
+                  type="button"
+                  id="paperSpaceBgWhite"
+                  class="is-active"
+                  role="radio"
+                  aria-checked="true"
+                  title="Desktop CAD / print preview"
+                >
+                  White
+                </button>
+                <button
+                  type="button"
+                  id="paperSpaceBgBlack"
+                  role="radio"
+                  aria-checked="false"
+                  title="Web viewer preference"
+                >
+                  Black
+                </button>
+              </div>
+            </div>
             <button type="button" class="open-main-button" id="centerOpenButton">Open File</button>
           </div>
           <input type="file" id="fileInputElement" accept=".dxf,.dwg" />

--- a/packages/cad-simple-viewer-example/src/main.ts
+++ b/packages/cad-simple-viewer-example/src/main.ts
@@ -9,12 +9,14 @@ import {
   AcApDocManager,
   acapFormatOpenFileErrorMessage,
   AcApOpenDatabaseOptions,
-  AcApQNewCmd,
   AcApSettingManager,
   acedApplyUiTheme,
   acedIsCompactUiLayout,
   AcEdOpenMode,
+  ACGI_MODEL_SPACE_BACKGROUND,
+  ACGI_PAPER_SPACE_BACKGROUND,
   eventBus,
+  layoutBackgroundColorFromRgb,
   LIBREDWG_PARSER_WORKER_FILE,
   MTEXT_RENDERER_WORKER_FILE
 } from '@mlightcad/cad-simple-viewer'
@@ -133,6 +135,9 @@ class CadViewerApp {
   private documentEventsRegistered = false
   private hasOpenedFile = false
   private isLoadingFile = false
+  private paperSpaceBackground = ACGI_PAPER_SPACE_BACKGROUND
+  private paperSpaceBgWhiteButton: HTMLButtonElement
+  private paperSpaceBgBlackButton: HTMLButtonElement
 
   constructor() {
     this.container = document.getElementById('cad-container') as HTMLDivElement
@@ -144,6 +149,12 @@ class CadViewerApp {
     ) as HTMLButtonElement
     this.viewerPane = document.getElementById('viewerPane') as HTMLElement
     this.emptyState = document.getElementById('emptyState') as HTMLDivElement
+    this.paperSpaceBgWhiteButton = document.getElementById(
+      'paperSpaceBgWhite'
+    ) as HTMLButtonElement
+    this.paperSpaceBgBlackButton = document.getElementById(
+      'paperSpaceBgBlack'
+    ) as HTMLButtonElement
     this.predefinedButtons = document.querySelectorAll(
       '#predefinedFileList .file-list-item'
     ) as NodeListOf<HTMLButtonElement>
@@ -218,6 +229,7 @@ class CadViewerApp {
     ) as HTMLButtonElement
 
     this.setupFileHandling()
+    this.setupPaperSpaceBackgroundOption()
     this.setupPredefinedFileActions()
     this.setupMobileSidebar()
     const fileSidebarResizeHandle = document.getElementById(
@@ -231,6 +243,50 @@ class CadViewerApp {
     this.setupDockMenu()
     this.setupViewerToolbarMenu()
     this.updateEmptyStateVisibility()
+  }
+
+  private setupPaperSpaceBackgroundOption() {
+    const setBackground = (rgb: number) => {
+      this.paperSpaceBackground = rgb
+      const isWhite = rgb === ACGI_PAPER_SPACE_BACKGROUND
+      this.paperSpaceBgWhiteButton.classList.toggle('is-active', isWhite)
+      this.paperSpaceBgBlackButton.classList.toggle('is-active', !isWhite)
+      this.paperSpaceBgWhiteButton.setAttribute(
+        'aria-checked',
+        isWhite ? 'true' : 'false'
+      )
+      this.paperSpaceBgBlackButton.setAttribute(
+        'aria-checked',
+        isWhite ? 'false' : 'true'
+      )
+      if (this.isInitialized) {
+        AcApDocManager.instance.setOpenDocumentDefaults(() =>
+          this.buildOpenOptions()
+        )
+      }
+    }
+
+    this.paperSpaceBgWhiteButton.addEventListener('click', () => {
+      setBackground(ACGI_PAPER_SPACE_BACKGROUND)
+    })
+    this.paperSpaceBgBlackButton.addEventListener('click', () => {
+      setBackground(ACGI_MODEL_SPACE_BACKGROUND)
+    })
+  }
+
+  private buildOpenOptions(
+    overrides: Partial<AcApOpenDatabaseOptions> = {}
+  ): AcApOpenDatabaseOptions {
+    return {
+      minimumChunkSize: 1000,
+      mode: AcEdOpenMode.Write,
+      progressiveRendering: isProgressiveOpenMode(),
+      sysVars: {
+        lwdisplay: false,
+        paperbkcolor: layoutBackgroundColorFromRgb(this.paperSpaceBackground)
+      },
+      ...overrides
+    }
   }
 
   private setupDisplayMenu() {
@@ -844,14 +900,9 @@ class CadViewerApp {
         commandAliases: EXAMPLE_COMMAND_ALIASES,
         // OPENPROF default: main-thread MTEXT (skip worker transfer cost).
         useMainThreadDraw: openProf ? !useWorkers : false,
-        openDocumentDefaults: {
-          minimumChunkSize: 1000,
-          mode: AcEdOpenMode.Write,
-          progressiveRendering: false,
-          sysVars: {
-            lwdisplay: false
-          }
-        },
+        openDocumentDefaults: () => this.buildOpenOptions({
+          progressiveRendering: false
+        }),
         webworkerFileUrls: {
           mtextRender: `./workers/${MTEXT_RENDERER_WORKER_FILE}`,
           dwgParser: dwgParserUrl
@@ -1037,8 +1088,12 @@ class CadViewerApp {
     this.setLoadingState(true)
 
     try {
-      const cmd = new AcApQNewCmd()
-      await cmd.execute(AcApDocManager.instance.context)
+      const success = await AcApDocManager.instance.newDocument(
+        this.buildOpenOptions({ progressiveRendering: false })
+      )
+      if (!success) {
+        throw new Error('Failed to create new drawing')
+      }
       this.onFileOpened()
       this.predefinedButtons.forEach(item => item.classList.remove('active'))
       this.updateFileSidebarSubtitle('Tap to browse sample files')
@@ -1076,14 +1131,7 @@ class CadViewerApp {
           AcApDocManager.instance.curDocument.database
         )
       }
-      const options: AcApOpenDatabaseOptions = {
-        minimumChunkSize: 1000,
-        mode: AcEdOpenMode.Write,
-        progressiveRendering: isProgressiveOpenMode(),
-        sysVars: {
-          lwdisplay: false
-        }
-      }
+      const options: AcApOpenDatabaseOptions = this.buildOpenOptions()
 
       const openStartedAt = performance.now()
       const success = await AcApDocManager.instance.openDocument(
@@ -1141,10 +1189,9 @@ class CadViewerApp {
     this.clearMessages()
 
     try {
-      const options: AcApOpenDatabaseOptions = {
-        minimumChunkSize: 1000,
-        mode: AcEdOpenMode.Write
-      }
+      const options: AcApOpenDatabaseOptions = this.buildOpenOptions({
+        progressiveRendering: false
+      })
 
       const success = await AcApDocManager.instance.openUrl(url, options)
 

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -104,6 +104,10 @@ import {
 import { AcApDocument } from './AcApDocument'
 import { AcApFontLoader } from './AcApFontLoader'
 import {
+  AcApOpenDatabaseOptions,
+  AcApOpenViewMode
+} from './AcApOpenDatabaseOptions'
+import {
   acapInstallOpenFileDialog,
   type AcApOpenDocumentDefaultsResolver,
   acapUninstallOpenFileDialog,
@@ -117,10 +121,6 @@ import {
   resetWebworkerReadinessCache
 } from './AcApWebworkerReadiness'
 import { AcApXrefManager } from './AcApXrefManager'
-import {
-  AcApOpenDatabaseOptions,
-  AcApOpenViewMode
-} from './AcDbOpenDatabaseOptions'
 
 const DEFAULT_BASE_URL = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data'
 /** Default ISO drawing template loaded by {@link AcApDocManager.newDocument}. */

--- a/packages/cad-simple-viewer/src/app/AcApDocument.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocument.ts
@@ -24,7 +24,7 @@ import type {
 } from '../service/types'
 import { LAYER_LOCKED_FLAG } from '../service/types'
 import type { AcApLayerPreviousSnapshot } from './AcApLayerSessionState'
-import { AcApOpenDatabaseOptions } from './AcDbOpenDatabaseOptions'
+import { AcApOpenDatabaseOptions } from './AcApOpenDatabaseOptions'
 
 /** Sentinel stored in {@link AcApDocument.docTitle} for unsaved documents. */
 export const ACAP_UNTITLED_DOC_TITLE = 'Untitled'
@@ -94,11 +94,14 @@ export class AcApDocument {
     const openErrorBefore = this._database.lastOpenError
     let isSuccess = true
     try {
-      // Convert to base options for database method
-      const baseOptions: AcDbOpenDatabaseOptions = {
+      // Convert to base options for database method. Viewer-only fields
+      // (`mode`, `progressiveRendering`, `openViewMode`) are ignored by
+      // `AcDbDatabase`; `sysVars` may include `AcCmColor` values that the
+      // published data-model type omits but `setVar` accepts at runtime.
+      const baseOptions = {
         ...options,
         readOnly: this._openMode === AcEdOpenMode.Read
-      }
+      } as AcDbOpenDatabaseOptions
       await this._database.openUri(uri, baseOptions)
       this.docTitle = this._fileName
     } catch {
@@ -135,11 +138,14 @@ export class AcApDocument {
     const openErrorBefore = this._database.lastOpenError
     try {
       const fileExtension = fileName.split('.').pop()?.toLocaleLowerCase()
-      // Convert to base options for database method
-      const baseOptions: AcDbOpenDatabaseOptions = {
+      // Convert to base options for database method. Viewer-only fields
+      // (`mode`, `progressiveRendering`, `openViewMode`) are ignored by
+      // `AcDbDatabase`; `sysVars` may include `AcCmColor` values that the
+      // published data-model type omits but `setVar` accepts at runtime.
+      const baseOptions = {
         ...options,
         readOnly: this._openMode === AcEdOpenMode.Read
-      }
+      } as AcDbOpenDatabaseOptions
       await this._database.read(
         content,
         baseOptions,

--- a/packages/cad-simple-viewer/src/app/AcApOpenDatabaseOptions.ts
+++ b/packages/cad-simple-viewer/src/app/AcApOpenDatabaseOptions.ts
@@ -1,4 +1,7 @@
-import { AcDbOpenDatabaseOptions } from '@mlightcad/data-model'
+import {
+  AcCmColor,
+  AcDbOpenDatabaseOptions
+} from '@mlightcad/data-model'
 
 import { AcEdOpenMode } from '../editor/view'
 
@@ -13,6 +16,18 @@ export enum AcApOpenViewMode {
 }
 
 /**
+ * Open-time system-variable overrides.
+ *
+ * Extends {@link AcDbOpenDatabaseOptions.sysVars} so colour sysvars such as
+ * `PAPERBKCOLOR` / `MODELBKCOLOR` can take an {@link AcCmColor} (for example
+ * from {@link layoutBackgroundColorFromRgb}), not only number/boolean/string.
+ */
+export type AcApOpenSysVars = Record<
+  string,
+  number | boolean | string | AcCmColor
+>
+
+/**
  * Options for opening a CAD database.
  *
  * This interface extends the base options from the data model but replaces
@@ -25,6 +40,10 @@ export enum AcApOpenViewMode {
  * (web viewer semantics) when omitted. When `circleSides` is omitted,
  * the data model uses draft quality (50).
  *
+ * Use {@link sysVars} to override session/database system variables at open
+ * time (for example `paperbkcolor` for the paper-space canvas background, or
+ * `lwdisplay: false` to hide lineweights).
+ *
  * Fonts are not loaded during database open. They are fetched on demand by
  * `@mlightcad/mtext-renderer` (`FontManager.lazyFontLoading`) while text is
  * drawn. Legacy open options `fontLoader` and `failOnFontLoadError` are no
@@ -33,14 +52,20 @@ export enum AcApOpenViewMode {
  *
  * @example
  * ```typescript
+ * import { layoutBackgroundColorFromRgb } from '@mlightcad/cad-simple-viewer'
+ *
  * const options: AcApOpenDatabaseOptions = {
- *   mode: AcEdOpenMode.Write
- * };
+ *   mode: AcEdOpenMode.Write,
+ *   sysVars: {
+ *     lwdisplay: false,
+ *     paperbkcolor: layoutBackgroundColorFromRgb(0x000000)
+ *   }
+ * }
  * ```
  */
 export interface AcApOpenDatabaseOptions extends Omit<
   AcDbOpenDatabaseOptions,
-  'readOnly'
+  'readOnly' | 'sysVars'
 > {
   /**
    * The access mode for opening the database.
@@ -68,4 +93,12 @@ export interface AcApOpenDatabaseOptions extends Omit<
    * Write mode uses {@link AcApOpenViewMode.Saved} (AutoCAD VPORT behavior).
    */
   openViewMode?: AcApOpenViewMode
+
+  /**
+   * System variables to override when the database opens.
+   *
+   * Keys are system variable names (case-insensitive). Colour sysvars such as
+   * `PAPERBKCOLOR` accept {@link AcCmColor}; see {@link AcApOpenSysVars}.
+   */
+  sysVars?: AcApOpenSysVars
 }

--- a/packages/cad-simple-viewer/src/app/AcApOpenFileDialog.ts
+++ b/packages/cad-simple-viewer/src/app/AcApOpenFileDialog.ts
@@ -2,7 +2,7 @@ import { log } from '@mlightcad/data-model'
 
 import { eventBus } from '../editor/global/eventBus'
 import { AcEdOpenMode } from '../editor/view/AcEdOpenMode'
-import type { AcApOpenDatabaseOptions } from './AcDbOpenDatabaseOptions'
+import type { AcApOpenDatabaseOptions } from './AcApOpenDatabaseOptions'
 
 /** File extensions accepted by the built-in OPEN file dialog. */
 const SUPPORTED_EXTENSIONS = ['.dxf', '.dwg'] as const

--- a/packages/cad-simple-viewer/src/app/index.ts
+++ b/packages/cad-simple-viewer/src/app/index.ts
@@ -14,8 +14,11 @@ export * from './AcApProgress'
 export * from './openFileProgress'
 export * from './AcApSettingManager'
 export * from './AcApLayerSessionState'
-export type { AcApOpenDatabaseOptions } from './AcDbOpenDatabaseOptions'
-export { AcApOpenViewMode } from './AcDbOpenDatabaseOptions'
+export type {
+  AcApOpenDatabaseOptions,
+  AcApOpenSysVars
+} from './AcApOpenDatabaseOptions'
+export { AcApOpenViewMode } from './AcApOpenDatabaseOptions'
 export type {
   AcApOpenDocumentDefaultsResolver,
   AcApOpenFileDialogOptions

--- a/packages/cad-simple-viewer/src/editor/global/AcEdUiColor.ts
+++ b/packages/cad-simple-viewer/src/editor/global/AcEdUiColor.ts
@@ -237,6 +237,21 @@ export function toggleBlackWhiteBackgroundColor(color: AcCmColor): AcCmColor {
 }
 
 /**
+ * Builds an {@link AcCmColor} for a packed 24-bit RGB layout background.
+ *
+ * Used when open options or hosts set `MODELBKCOLOR` / `PAPERBKCOLOR` from a
+ * numeric clear colour (e.g. `0xffffff`).
+ *
+ * @param rgb - Packed `0xRRGGBB` colour; only the low 24 bits are used.
+ * @returns `AcCmColor` with `ByColor` method and the given RGB.
+ */
+export function layoutBackgroundColorFromRgb(rgb: number): AcCmColor {
+  const color = new AcCmColor(AcCmColorMethod.ByColor)
+  color.setRGBValue(rgb & 0xffffff)
+  return color
+}
+
+/**
  * Chooses a CSS cursor colour that contrasts with the canvas background.
  *
  * Returns `'black'` on light backgrounds and `'white'` on dark backgrounds so

--- a/packages/cad-viewer-example/src/App.vue
+++ b/packages/cad-viewer-example/src/App.vue
@@ -19,6 +19,7 @@
         :progressive-rendering="progressiveRendering"
         :open-view-mode="openViewMode"
         :circle-sides="circleSides"
+        :paper-space-background="paperSpaceBackground"
         @create="onViewerCreate"
         :base-url="BASE_URL"
       />
@@ -32,10 +33,11 @@ import {
   AcApOpenViewMode,
   AcApSettingManager,
   AcEdCommandStack,
-  AcEdOpenMode
+  AcEdOpenMode,
+  layoutBackgroundColorFromRgb
 } from '@mlightcad/cad-simple-viewer'
 import { MlCadViewer } from '@mlightcad/cad-viewer'
-import { ACDB_DRAW_CIRCLE_SIDES_DRAFT, log } from '@mlightcad/data-model'
+import { ACDB_DRAW_CIRCLE_SIDES_DRAFT, ACGI_PAPER_SPACE_BACKGROUND, log } from '@mlightcad/data-model'
 import { computed, nextTick, ref } from 'vue'
 
 import { AcApQuitCmd } from './commands'
@@ -94,6 +96,7 @@ const drawNoPlotLayers = ref(false)
 const progressiveRendering = ref(false)
 const openViewMode = ref<AcApOpenViewMode | undefined>(undefined)
 const circleSides = ref(ACDB_DRAW_CIRCLE_SIDES_DRAFT)
+const paperSpaceBackground = ref(ACGI_PAPER_SPACE_BACKGROUND)
 
 const createNewDrawing = async () => {
   const success = await AcApDocManager.instance.newDocument({
@@ -101,6 +104,9 @@ const createNewDrawing = async () => {
     drawNoPlotLayers: drawNoPlotLayers.value,
     progressiveRendering: progressiveRendering.value,
     circleSides: circleSides.value,
+    sysVars: {
+      paperbkcolor: layoutBackgroundColorFromRgb(paperSpaceBackground.value)
+    },
     ...(openViewMode.value != null ? { openViewMode: openViewMode.value } : {})
   })
   if (!success) {
@@ -122,7 +128,8 @@ const applyOpenOptions = (
   showNoPlotLayers: boolean,
   enableProgressiveRendering: boolean,
   viewMode: AcApOpenViewMode | undefined,
-  sides: number
+  sides: number,
+  paperBg: number
 ) => {
   selectedMode.value = mode
   useMainThreadDraw.value = mainThreadDraw
@@ -130,6 +137,7 @@ const applyOpenOptions = (
   progressiveRendering.value = enableProgressiveRendering
   openViewMode.value = viewMode
   circleSides.value = sides
+  paperSpaceBackground.value = paperBg
 }
 
 // Handle file selection from upload component
@@ -140,7 +148,8 @@ const handleFileSelect = (
   showNoPlotLayers: boolean,
   enableProgressiveRendering: boolean,
   viewMode: AcApOpenViewMode | undefined,
-  sides: number
+  sides: number,
+  paperBg: number
 ) => {
   store.isNewDrawing = false
   store.selectedFile = file
@@ -150,7 +159,8 @@ const handleFileSelect = (
     showNoPlotLayers,
     enableProgressiveRendering,
     viewMode,
-    sides
+    sides,
+    paperBg
   )
 }
 
@@ -160,7 +170,8 @@ const handleNewDrawing = (
   showNoPlotLayers: boolean,
   enableProgressiveRendering: boolean,
   viewMode: AcApOpenViewMode | undefined,
-  sides: number
+  sides: number,
+  paperBg: number
 ) => {
   store.selectedFile = null
   store.isNewDrawing = true
@@ -170,7 +181,8 @@ const handleNewDrawing = (
     showNoPlotLayers,
     enableProgressiveRendering,
     viewMode,
-    sides
+    sides,
+    paperBg
   )
 }
 </script>

--- a/packages/cad-viewer-example/src/components/FileUpload.vue
+++ b/packages/cad-viewer-example/src/components/FileUpload.vue
@@ -239,6 +239,40 @@
               </button>
             </div>
           </div>
+
+          <div class="setting-block setting-block--full">
+            <h3 class="setting-label">
+              {{ t('example.fileUpload.paperSpaceBackground') }}
+            </h3>
+            <div
+              class="pill-segment"
+              role="radiogroup"
+              :aria-label="t('example.fileUpload.paperSpaceBackground')"
+            >
+              <button
+                type="button"
+                class="pill-option"
+                :class="{ 'is-active': paperSpaceBackground === ACGI_PAPER_SPACE_BACKGROUND }"
+                role="radio"
+                :aria-checked="paperSpaceBackground === ACGI_PAPER_SPACE_BACKGROUND"
+                :title="t('example.fileUpload.paperSpaceWhiteHint')"
+                @click="paperSpaceBackground = ACGI_PAPER_SPACE_BACKGROUND"
+              >
+                {{ t('example.fileUpload.paperSpaceWhite') }}
+              </button>
+              <button
+                type="button"
+                class="pill-option"
+                :class="{ 'is-active': paperSpaceBackground === ACGI_MODEL_SPACE_BACKGROUND }"
+                role="radio"
+                :aria-checked="paperSpaceBackground === ACGI_MODEL_SPACE_BACKGROUND"
+                :title="t('example.fileUpload.paperSpaceBlackHint')"
+                @click="paperSpaceBackground = ACGI_MODEL_SPACE_BACKGROUND"
+              >
+                {{ t('example.fileUpload.paperSpaceBlack') }}
+              </button>
+            </div>
+          </div>
         </div>
       </section>
     </div>
@@ -252,6 +286,8 @@ import {
   ACDB_DRAW_CIRCLE_SIDES_DRAFT,
   ACDB_DRAW_CIRCLE_SIDES_HIGH,
   ACDB_DRAW_CIRCLE_SIDES_STANDARD,
+  ACGI_MODEL_SPACE_BACKGROUND,
+  ACGI_PAPER_SPACE_BACKGROUND,
   log
 } from '@mlightcad/data-model'
 import type { UploadFile, UploadProps } from 'element-plus'
@@ -267,7 +303,8 @@ interface Props {
     drawNoPlotLayers: boolean,
     progressiveRendering: boolean,
     openViewMode: AcApOpenViewMode | undefined,
-    circleSides: number
+    circleSides: number,
+    paperSpaceBackground: number
   ) => void
   onNewDrawing?: (
     mode: AcEdOpenMode,
@@ -275,7 +312,8 @@ interface Props {
     drawNoPlotLayers: boolean,
     progressiveRendering: boolean,
     openViewMode: AcApOpenViewMode | undefined,
-    circleSides: number
+    circleSides: number,
+    paperSpaceBackground: number
   ) => void
 }
 
@@ -290,6 +328,7 @@ const selectedCircleSides = ref(ACDB_DRAW_CIRCLE_SIDES_DRAFT)
 const useMainThreadDraw = ref(false)
 const drawNoPlotLayers = ref(false)
 const progressiveRendering = ref(false)
+const paperSpaceBackground = ref(ACGI_PAPER_SPACE_BACKGROUND)
 
 const openViewModes = computed(() => [
   {
@@ -358,7 +397,8 @@ const handleFileChange: UploadProps['onChange'] = (uploadFile: UploadFile) => {
         drawNoPlotLayers.value,
         progressiveRendering.value,
         resolveOpenViewMode(),
-        selectedCircleSides.value
+        selectedCircleSides.value,
+        paperSpaceBackground.value
       )
     }
   }
@@ -371,7 +411,8 @@ const handleNewDrawing = () => {
     drawNoPlotLayers.value,
     progressiveRendering.value,
     resolveOpenViewMode(),
-    selectedCircleSides.value
+    selectedCircleSides.value,
+    paperSpaceBackground.value
   )
 }
 
@@ -416,7 +457,7 @@ const isValidFile = (file: File): boolean => {
 .upload-main {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  min-height: 0;
   padding: 18px 20px;
 }
 
@@ -462,7 +503,9 @@ const isValidFile = (file: File): boolean => {
 
 .upload-actions {
   display: flex;
+  flex: 1;
   flex-direction: column;
+  min-height: 0;
   gap: 0;
 }
 
@@ -515,20 +558,29 @@ const isValidFile = (file: File): boolean => {
 }
 
 .upload-dropzone {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
   width: 100%;
+  min-height: 120px;
   box-sizing: border-box;
 }
 
 .upload-dropzone :deep(.el-upload) {
-  display: block;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
   width: 100%;
+  height: 100%;
 }
 
 .upload-dropzone :deep(.el-upload-dragger) {
   display: flex;
+  flex: 1;
   align-items: center;
   justify-content: center;
   width: 100%;
+  height: 100%;
   box-sizing: border-box;
   padding: 14px 12px;
   border: 1.5px dashed #c7d2fe;

--- a/packages/cad-viewer-example/src/locale/ar.ts
+++ b/packages/cad-viewer-example/src/locale/ar.ts
@@ -65,6 +65,12 @@ export default {
       curveHigh: 'جودة',
       curveHighHint: 'منحنيات أنعم وذاكرة أكبر',
 
+      paperSpaceBackground: 'خلفية مساحة الورق',
+      paperSpaceWhite: 'أبيض',
+      paperSpaceWhiteHint: 'سطح المكتب CAD / معاينة الطباعة',
+      paperSpaceBlack: 'أسود',
+      paperSpaceBlackHint: 'تفضيل عارض الويب',
+
       invalidFileType:
         'نوع الملف غير صالح. يرجى اختيار ملف DWG أو DXF.'
     }

--- a/packages/cad-viewer-example/src/locale/cs.ts
+++ b/packages/cad-viewer-example/src/locale/cs.ts
@@ -65,6 +65,12 @@ export default {
       curveHigh: 'Kvalita',
       curveHighHint: 'Hladší křivky, více paměti',
 
+      paperSpaceBackground: 'Pozadí výkresového prostoru',
+      paperSpaceWhite: 'Bílé',
+      paperSpaceWhiteHint: 'Desktop CAD / náhled tisku',
+      paperSpaceBlack: 'Černé',
+      paperSpaceBlackHint: 'Preferované pro webový prohlížeč',
+
       invalidFileType:
         'Neplatný typ souboru. Nahrajte soubory DWG nebo DXF.'
     }

--- a/packages/cad-viewer-example/src/locale/en.ts
+++ b/packages/cad-viewer-example/src/locale/en.ts
@@ -65,6 +65,12 @@ export default {
       curveHigh: 'Quality',
       curveHighHint: 'Smoother curves, more memory',
 
+      paperSpaceBackground: 'Paper space background',
+      paperSpaceWhite: 'White',
+      paperSpaceWhiteHint: 'Desktop CAD / print preview',
+      paperSpaceBlack: 'Black',
+      paperSpaceBlackHint: 'Web viewer preference',
+
       invalidFileType:
         'Invalid file type. Please upload DWG or DXF files.'
     }

--- a/packages/cad-viewer-example/src/locale/tr.ts
+++ b/packages/cad-viewer-example/src/locale/tr.ts
@@ -65,6 +65,12 @@ export default {
       curveHigh: 'Kalite',
       curveHighHint: 'Daha pürüzsüz eğriler, daha fazla bellek',
 
+      paperSpaceBackground: 'Kağıt alanı arka planı',
+      paperSpaceWhite: 'Beyaz',
+      paperSpaceWhiteHint: 'Masaüstü CAD / yazdırma önizlemesi',
+      paperSpaceBlack: 'Siyah',
+      paperSpaceBlackHint: 'Web görüntüleyici tercihi',
+
       invalidFileType:
         'Geçersiz dosya türü. Lütfen DWG veya DXF dosyaları yükleyin.'
     }

--- a/packages/cad-viewer-example/src/locale/zh.ts
+++ b/packages/cad-viewer-example/src/locale/zh.ts
@@ -65,6 +65,12 @@ export default {
       curveHigh: '高精度',
       curveHighHint: '曲线更光滑，占用更多内存',
 
+      paperSpaceBackground: '图纸空间背景',
+      paperSpaceWhite: '白色',
+      paperSpaceWhiteHint: '桌面 CAD / 打印预览',
+      paperSpaceBlack: '黑色',
+      paperSpaceBlackHint: 'Web 查看器常用',
+
       invalidFileType: '文件类型无效，请上传 DWG 或 DXF 文件。'
     }
   }

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -94,9 +94,10 @@ import {
   AcApOpenViewMode,
   AcEdMTextEditor,
   AcEdOpenMode,
-  eventBus
+  eventBus,
+  layoutBackgroundColorFromRgb
 } from '@mlightcad/cad-simple-viewer'
-import { ACDB_DRAW_CIRCLE_SIDES_DRAFT, log } from '@mlightcad/data-model'
+import { ACDB_DRAW_CIRCLE_SIDES_DRAFT, ACGI_PAPER_SPACE_BACKGROUND, log } from '@mlightcad/data-model'
 import { provideLocale } from '@mlightcad/ui-components'
 import { ElConfigProvider, ElMessage } from 'element-plus'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
@@ -201,6 +202,12 @@ interface Props {
    * matching the data-model default for {@link AcApOpenDatabaseOptions.circleSides}.
    */
   circleSides?: number
+  /**
+   * Paper-space (layout) canvas background as packed 24-bit RGB
+   * (e.g. `0xffffff` white, `0x000000` black). Defaults to white.
+   * Mapped to open options as `sysVars.paperbkcolor`.
+   */
+  paperSpaceBackground?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -216,7 +223,8 @@ const props = withDefaults(defineProps<Props>(), {
   mode: AcEdOpenMode.Write,
   progressiveRendering: false,
   openViewMode: undefined,
-  circleSides: ACDB_DRAW_CIRCLE_SIDES_DRAFT
+  circleSides: ACDB_DRAW_CIRCLE_SIDES_DRAFT,
+  paperSpaceBackground: ACGI_PAPER_SPACE_BACKGROUND
 })
 
 const buildOpenOptions = (): AcApOpenDatabaseOptions => ({
@@ -225,6 +233,9 @@ const buildOpenOptions = (): AcApOpenDatabaseOptions => ({
   drawNoPlotLayers: props.drawNoPlotLayers,
   progressiveRendering: props.progressiveRendering,
   circleSides: props.circleSides,
+  sysVars: {
+    paperbkcolor: layoutBackgroundColorFromRgb(props.paperSpaceBackground)
+  },
   ...(props.openViewMode != null ? { openViewMode: props.openViewMode } : {})
 })
 
@@ -458,7 +469,8 @@ watch(
     props.drawNoPlotLayers,
     props.progressiveRendering,
     props.openViewMode,
-    props.circleSides
+    props.circleSides,
+    props.paperSpaceBackground
   ],
   () => {
     if (editorRef.value) {


### PR DESCRIPTION
## Summary
- Rename open-database options to `AcApOpenDatabaseOptions` and widen `sysVars` so colour vars like `paperbkcolor` accept `AcCmColor`
- Add `layoutBackgroundColorFromRgb` helper and `MlCadViewer.paperSpaceBackground` prop mapped to open defaults
- Surface White/Black paper-space background controls in cad-viewer-example and cad-simple-viewer-example empty states

## Test plan
- [ ] Open a paper-space drawing in cad-viewer-example with White vs Black background and confirm canvas clear colour
- [ ] Create a new drawing with each background option and verify layout background sticks
- [ ] In cad-simple-viewer-example, toggle Paper space background before Open File / sample open
- [ ] Confirm existing open options (progressive rendering, circle sides, mode) still apply
- [ ] Wait for GitHub CI to pass