### PR TITLE
feat: make ACEX viewer.html generic with fixed drawing.acex.json

### DIFF
--- a/packages/cad-html-plugin/README.md
+++ b/packages/cad-html-plugin/README.md
@@ -16,7 +16,7 @@ The plugin path is designed for **lazy loading** so the export bundle is only do
 
 - **Display-only snapshot** — layers, layouts, line/mesh batches, extents, and drawing units (no editable DXF/DWG payload)
 - **Self-contained HTML** — gzip/base64 snapshot + inline viewer runtime; opens offline in any modern browser
-- **Multi-file ACEX package** — shell HTML + versioned `*.acex.json` + per-chunk `*.acex.gz`; export downloads a zip (unzip before hosting for progressive load)
+- **Multi-file ACEX package** — generic `viewer.html` + fixed `drawing.acex.json` + per-chunk `*.acex.gz`; export downloads a zip (unzip before hosting for progressive load). The shell does not hard-code a drawing-specific data path: it probes sibling `drawing.acex.json`, supports `?manifest=` / `?acex=` URLs, and can open a local package folder or a pasted manifest URL when the default file is missing
 - **Offline viewer** — select / pan / zoom (extents, window, original view), layer panel, layout switching, measurement, Design Review markup annotations, object snap (OSNAP). Select, pan, and zoom tools exit any active measurement or review drawing tool.
 - **i18n** — embedded English / Chinese / Czech / Turkish UI; initial language follows the browser (`zh*` → Chinese, `cs*` → Czech, `tr*` → Turkish, otherwise English); the toolbar language button opens a strip to pick a locale, and the choice persists in `localStorage`
 - **Plugin API** — implements `AcApPlugin`; register once with `registerLazyHtmlPlugin`
@@ -107,22 +107,34 @@ await new AcApHtmlConvertor().convert('my-drawing.dwg', {
 
 ### Multi-file package (low-level)
 
-See **[docs/acex-package-format.md](./docs/acex-package-format.md)** for the on-disk format, and **[docs/acex-web-hosting-guide.md](./docs/acex-web-hosting-guide.md)** for static hosting / CDN deployment.
+See **[docs/acex-package-format.md](./docs/acex-package-format.md)** for the on-disk format, and **[docs/acex-web-hosting-guide.md](./docs/acex-web-hosting-guide.md)** for static hosting / CDN deployment (includes a live progressive demo).
 
 ```typescript
 import {
+  ACEX_DEFAULT_MANIFEST_FILE,
   buildAcExPackage,
   zipAcExPackageFiles,
   packHtmlPackage
 } from '@mlightcad/cad-html-plugin'
 
+// Always writes viewer.html + drawing.acex.json + chunks/
+// (baseName is retained for API compatibility; it does not rename the manifest).
 const pkg = buildAcExPackage(snapshot, {
   viewerRuntime: runtime,
   baseName: 'my-drawing'
 })
+// pkg.manifestFileName === ACEX_DEFAULT_MANIFEST_FILE ('drawing.acex.json')
 const zipBytes = zipAcExPackageFiles(pkg)
 // Or serve pkg.files as a static directory after unzip
 ```
+
+**How generic `viewer.html` finds data** (in order):
+
+1. Query string — `?manifest=<url>` or `?acex=<url>` (relative or absolute `http(s)`)
+2. Sibling file — `./drawing.acex.json` next to the HTML
+3. If missing — UI to pick a local package folder (must contain `drawing.acex.json`) or paste a manifest URL
+
+Unsupported package / snapshot versions surface as an on-page error.
 
 ### Low-level snapshot assembly
 
@@ -191,6 +203,7 @@ import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.j
 | `AcApHtmlSnapshotBuilder` | Live Three.js scene → `AcExSnapshotV1` |
 | `packHtml`, `AcExPackHtmlOptions` | Assemble self-contained HTML from snapshot + runtime |
 | `packHtmlPackage`, `buildAcExPackage`, `zipAcExPackageFiles` | Multi-file package shell, builder, and export zip |
+| `ACEX_DEFAULT_MANIFEST_FILE`, `ACEX_DEFAULT_MANIFEST_HREF`, package bootstrap helpers | Canonical `drawing.acex.json` name and generic viewer resolve / probe / directory-fetch helpers |
 | `HTML_VIEWER_RUNTIME_FILE` | Default runtime filename (`viewer-runtime.iife.js`) |
 | `AcExSnapshot`, `ACEX_SNAPSHOT_VERSION`, batch/layer types | Snapshot schema |
 | Package format doc | [`docs/acex-package-format.md`](./docs/acex-package-format.md) |
@@ -213,7 +226,10 @@ import '@mlightcad/cad-html-plugin/viewer-runtime' // dist/viewer-runtime.iife.j
 | `src/AcExSnapshotTypes.ts` | Snapshot schema (v1) |
 | `src/AcExSnapshotCodec.ts` | Encode/decode embedded snapshot script tag |
 | `src/AcExSceneBatchCollector.ts` | THREE.js traversal → export batches |
-| `src/AcExHtmlPackager.ts` | `packHtml` — shell + snapshot + runtime |
+| `src/AcExHtmlPackager.ts` | `packHtml` / `packHtmlPackage` — shell + snapshot or package marker + runtime |
+| `src/AcExPackageBuilder.ts` | Multi-file package builder (`viewer.html` + `drawing.acex.json` + chunks) |
+| `src/AcExHtmlPackageBootstrap.ts` | Generic package resolve (query / sibling / probe / local directory fetch) |
+| `src/AcExHtmlPackageSourceGate.ts` | Folder / URL picker when sibling `drawing.acex.json` is missing |
 | `src/AcExHtmlViewerRuntime.ts` | Offline viewer (built as IIFE) |
 | `src/AcExHtmlShell.ts` | Static HTML/CSS shell markup |
 | `src/AcExOsnap*.ts` | Object snap index and primitives |

--- a/packages/cad-html-plugin/__tests__/AcExHtmlPackageBootstrap.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExHtmlPackageBootstrap.spec.ts
@@ -1,0 +1,262 @@
+import { strToU8 } from 'fflate'
+
+import {
+  ACEX_DEFAULT_MANIFEST_FILE,
+  ACEX_DEFAULT_MANIFEST_HREF,
+  ACEX_PACKAGE_DIRECTORY_ORIGIN,
+  acexGlobalFetch,
+  buildPackageDirectoryFileMap,
+  canOpenLocalPackageFolder,
+  chooseInitialManifestHref,
+  createPackageDirectoryFetch,
+  detectLocalFolderOpenSupport,
+  detectSharedDirectoryRoot,
+  isAbsoluteHttpUrl,
+  normalizePackageDirectoryPath,
+  probePackageManifest,
+  readManifestUrlFromSearchParams,
+  resolveViewerManifestUrl
+} from '../src/AcExHtmlPackageBootstrap'
+import { ACEX_PACKAGE_VERSION } from '../src/AcExPackageTypes'
+import { ACEX_SNAPSHOT_VERSION } from '../src/AcExSnapshotTypes'
+
+function validManifestJson(overrides?: Record<string, unknown>): string {
+  return JSON.stringify({
+    format: 'acex-package',
+    packageVersion: ACEX_PACKAGE_VERSION,
+    snapshotVersion: ACEX_SNAPSHOT_VERSION,
+    meta: {
+      title: 'demo',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      extents: { minX: 0, minY: 0, maxX: 1, maxY: 1 },
+      viewExtents: { minX: 0, minY: 0, maxX: 1, maxY: 1 },
+      units: {
+        insunits: 4,
+        lunits: 2,
+        luprec: 4,
+        aunits: 0,
+        auprec: 0,
+        measurement: 1,
+        ltscale: 1,
+        angbase: 0,
+        angdir: 0
+      },
+      background: 0,
+      viewerMode: 'view',
+      exportLayouts: true
+    },
+    layers: [{ name: '0', color: 0xffffff, visible: true }],
+    activeLayoutBtrId: 'ms',
+    layouts: [
+      {
+        btrId: 'ms',
+        name: '*Model_Space',
+        isModelSpace: true,
+        chunkIds: []
+      }
+    ],
+    chunks: [],
+    ...overrides
+  })
+}
+
+describe('AcExHtmlPackageBootstrap', () => {
+  it('exposes a fetch wrapper that can be called without a Window receiver', async () => {
+    const original = globalThis.fetch
+    const calls: unknown[] = []
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      calls.push(String(input))
+      return Promise.resolve(new Response('ok', { status: 200 }))
+    }) as typeof fetch
+    try {
+      const detached = acexGlobalFetch
+      const response = await detached('https://cdn.example/drawing.acex.json')
+      expect(response.status).toBe(200)
+      expect(calls).toEqual(['https://cdn.example/drawing.acex.json'])
+    } finally {
+      globalThis.fetch = original
+    }
+  })
+
+  it('detects local folder open support with secure-context and webkitdirectory fallbacks', () => {
+    expect(
+      detectLocalFolderOpenSupport({
+        hasDirectoryPicker: true,
+        isSecureContext: true,
+        supportsWebkitDirectoryAttribute: false
+      })
+    ).toEqual({ directoryPicker: true, webkitDirectory: false })
+
+    expect(
+      detectLocalFolderOpenSupport({
+        hasDirectoryPicker: true,
+        isSecureContext: false,
+        supportsWebkitDirectoryAttribute: true
+      })
+    ).toEqual({ directoryPicker: false, webkitDirectory: true })
+
+    expect(
+      detectLocalFolderOpenSupport({
+        hasDirectoryPicker: false,
+        isSecureContext: true,
+        supportsWebkitDirectoryAttribute: false
+      })
+    ).toEqual({ directoryPicker: false, webkitDirectory: false })
+
+    expect(
+      canOpenLocalPackageFolder({
+        directoryPicker: false,
+        webkitDirectory: true
+      })
+    ).toBe(true)
+    expect(
+      canOpenLocalPackageFolder({
+        directoryPicker: false,
+        webkitDirectory: false
+      })
+    ).toBe(false)
+  })
+
+  it('reads manifest URL from query parameters', () => {
+    expect(
+      readManifestUrlFromSearchParams(
+        '?manifest=https://cdn.example/pkg/drawing.acex.json'
+      )
+    ).toBe('https://cdn.example/pkg/drawing.acex.json')
+    expect(
+      readManifestUrlFromSearchParams('?acex=./other.acex.json&x=1')
+    ).toBe('./other.acex.json')
+    expect(readManifestUrlFromSearchParams('?foo=bar')).toBeNull()
+  })
+
+  it('prefers query over config over sibling default', () => {
+    expect(
+      chooseInitialManifestHref({
+        search: '?manifest=https://cdn.example/a.acex.json',
+        configManifestUrl: './legacy.acex.json'
+      })
+    ).toEqual({
+      href: 'https://cdn.example/a.acex.json',
+      fromQuery: true
+    })
+    expect(
+      chooseInitialManifestHref({
+        search: '',
+        configManifestUrl: './legacy.acex.json'
+      })
+    ).toEqual({ href: './legacy.acex.json', fromQuery: false })
+    expect(chooseInitialManifestHref({})).toEqual({
+      href: ACEX_DEFAULT_MANIFEST_HREF,
+      fromQuery: false
+    })
+  })
+
+  it('resolves absolute and relative viewer manifest URLs', () => {
+    expect(isAbsoluteHttpUrl('https://cdn.example/drawing.acex.json')).toBe(
+      true
+    )
+    expect(
+      resolveViewerManifestUrl(
+        'https://cdn.example/pkg/drawing.acex.json',
+        'https://viewer.example/app/viewer.html'
+      )
+    ).toBe('https://cdn.example/pkg/drawing.acex.json')
+    expect(
+      resolveViewerManifestUrl(
+        ACEX_DEFAULT_MANIFEST_HREF,
+        'https://cdn.example/pkg/viewer.html'
+      )
+    ).toBe('https://cdn.example/pkg/drawing.acex.json')
+    expect(() =>
+      resolveViewerManifestUrl(
+        'https://evil.example/x',
+        'https://cdn.example/pkg/viewer.html'
+      )
+    ).not.toThrow()
+  })
+
+  it('probes manifest success, not-found, and unsupported version', async () => {
+    const okFetch: typeof fetch = async () =>
+      new Response(validManifestJson(), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    const ok = await probePackageManifest(
+      'https://cdn.example/drawing.acex.json',
+      okFetch
+    )
+    expect(ok.ok).toBe(true)
+    if (ok.ok) {
+      expect(ok.manifest.format).toBe('acex-package')
+    }
+
+    const missing = await probePackageManifest(
+      'https://cdn.example/drawing.acex.json',
+      async () => new Response(null, { status: 404 })
+    )
+    expect(missing).toMatchObject({ ok: false, reason: 'not-found' })
+
+    const badVersion = await probePackageManifest(
+      'https://cdn.example/drawing.acex.json',
+      async () =>
+        new Response(validManifestJson({ packageVersion: 999 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+    )
+    expect(badVersion).toMatchObject({ ok: false, reason: 'invalid' })
+    if (!badVersion.ok) {
+      expect(badVersion.error.message).toMatch(/package version/i)
+    }
+  })
+
+  it('normalizes webkitdirectory paths and serves via directory fetch', async () => {
+    expect(
+      detectSharedDirectoryRoot([
+        'canteen/drawing.acex.json',
+        'canteen/chunks/L0-000.acex.gz'
+      ])
+    ).toBe('canteen')
+    expect(
+      normalizePackageDirectoryPath(
+        'canteen/chunks/L0-000.acex.gz',
+        'canteen'
+      )
+    ).toBe('chunks/L0-000.acex.gz')
+
+    const files = buildPackageDirectoryFileMap([
+      {
+        relativePath: 'pkg/drawing.acex.json',
+        bytes: strToU8(validManifestJson())
+      },
+      {
+        relativePath: 'pkg/chunks/L0-000.acex.gz',
+        bytes: new Uint8Array([1, 2, 3])
+      }
+    ])
+    expect(files.has(ACEX_DEFAULT_MANIFEST_FILE)).toBe(true)
+    expect(files.has('chunks/L0-000.acex.gz')).toBe(true)
+
+    const { manifestUrl, fetchImpl } = createPackageDirectoryFetch(files)
+    expect(manifestUrl.startsWith(ACEX_PACKAGE_DIRECTORY_ORIGIN)).toBe(true)
+
+    const probed = await probePackageManifest(manifestUrl, fetchImpl)
+    expect(probed.ok).toBe(true)
+
+    const chunk = await fetchImpl(
+      new URL('chunks/L0-000.acex.gz', ACEX_PACKAGE_DIRECTORY_ORIGIN).toString()
+    )
+    expect(chunk.status).toBe(200)
+    expect(new Uint8Array(await chunk.arrayBuffer())).toEqual(
+      new Uint8Array([1, 2, 3])
+    )
+  })
+
+  it('rejects a folder map without drawing.acex.json', () => {
+    expect(() =>
+      createPackageDirectoryFetch(
+        new Map([['readme.txt', strToU8('hi')]])
+      )
+    ).toThrow(/drawing\.acex\.json/)
+  })
+})

--- a/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts
@@ -287,7 +287,7 @@ describe('buildOsnapCatalog', () => {
     ).toBeCloseTo(second.radius, 5)
   })
 
-  it('omits dimension extension lines from the catalog (derived from batches at runtime)', () => {
+  it('omits dimension extension lines but keeps arrow SOLID paths', () => {
     const db = new AcDbDatabase()
     acdbHostApplicationServices().workingDatabase = db
     const modelSpace = db.tables.blockTable.modelSpace
@@ -302,9 +302,17 @@ describe('buildOsnapCatalog', () => {
     const blockName = '*DIM_TEST'
     db.tables.blockTable.add(dimension.createDimBlock(blockName))
     dimension.dimBlockId = blockName
+    modelSpace.appendEntity(dimension)
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
     expect(catalog.primitives.filter(p => p.kind === 'line')).toHaveLength(0)
-    expect(catalog.primitives.filter(p => p.kind === 'path')).toHaveLength(0)
+    const arrowPaths = catalog.primitives.filter(p => p.kind === 'path')
+    expect(arrowPaths.length).toBeGreaterThan(0)
+    for (const path of arrowPaths) {
+      if (path.kind !== 'path') continue
+      expect(path.closed).toBe(true)
+      expect(path.vertices.length).toBeGreaterThanOrEqual(9)
+      expect(path.vertices.length % 3).toBe(0)
+    }
   })
 
   it('exports points for text/point and omits ray/xline/trace/leader lines', () => {
@@ -800,18 +808,56 @@ describe('buildOsnapCatalog', () => {
     expect(snap).toEqual({ x: 15, y: 15, mode: 'endpoint' })
   })
 
-  it('skips SOLID fills inside dimension blocks but keeps layout SOLID paths', () => {
+  it('exports SOLID arrow vertices and layout SOLID paths', () => {
     const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
     const modelSpace = db.tables.blockTable.modelSpace
-    const solid = new AcDbSolid()
-    solid.setPointAt(0, new AcGePoint3d(0, 0, 0))
-    solid.setPointAt(1, new AcGePoint3d(2, 0, 0))
-    solid.setPointAt(2, new AcGePoint3d(0, 1, 0))
-    solid.setPointAt(3, new AcGePoint3d(2, 1, 0))
-    modelSpace.appendEntity(solid)
+
+    const layoutSolid = new AcDbSolid()
+    layoutSolid.setPointAt(0, new AcGePoint3d(0, 0, 0))
+    layoutSolid.setPointAt(1, new AcGePoint3d(2, 0, 0))
+    layoutSolid.setPointAt(2, new AcGePoint3d(0, 1, 0))
+    layoutSolid.setPointAt(3, new AcGePoint3d(2, 1, 0))
+    modelSpace.appendEntity(layoutSolid)
+
+    // Mimic a dimension arrow authored as SOLID inside an anonymous dim block.
+    const arrowSolid = new AcDbSolid()
+    arrowSolid.setPointAt(0, new AcGePoint3d(10, 0, 0))
+    arrowSolid.setPointAt(1, new AcGePoint3d(9, 0.25, 0))
+    arrowSolid.setPointAt(2, new AcGePoint3d(9, -0.25, 0))
+    arrowSolid.setPointAt(3, new AcGePoint3d(9, -0.25, 0))
+    const dimBlock = new AcDbBlockTableRecord()
+    dimBlock.name = '*D_ARROW'
+    dimBlock.appendEntity(arrowSolid)
+    db.tables.blockTable.add(dimBlock)
+
+    const dimension = new AcDbAlignedDimension(
+      new AcGePoint3d(10, 0, 0),
+      new AcGePoint3d(20, 0, 0),
+      new AcGePoint3d(15, 2, 0)
+    )
+    dimension.dimBlockId = dimBlock.name
+    modelSpace.appendEntity(dimension)
 
     const catalog = buildOsnapCatalog(db, modelSpace.objectId)
-    expect(catalog.primitives.filter(p => p.kind === 'path')).toHaveLength(1)
+    const paths = catalog.primitives.filter(p => p.kind === 'path')
+    expect(paths.length).toBeGreaterThanOrEqual(2)
+    expect(
+      paths.some(
+        p =>
+          p.kind === 'path' &&
+          p.vertices[0] === 0 &&
+          p.vertices[1] === 0 &&
+          p.vertices[3] === 2
+      )
+    ).toBe(true)
+    expect(
+      paths.some(
+        p =>
+          p.kind === 'path' &&
+          p.vertices.some((v, i) => i % 3 === 0 && v === 10)
+      )
+    ).toBe(true)
   })
 
   it('exports OLE frame corners as a path', () => {

--- a/packages/cad-html-plugin/__tests__/AcExPackage.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPackage.spec.ts
@@ -138,9 +138,11 @@ describe('AcEx package format', () => {
     expect(pkg.manifest.format).toBe('acex-package')
     expect(pkg.manifest.packageVersion).toBe(1)
     expect(pkg.html).toContain('id="mlcad-package"')
-    expect(pkg.html).toContain('demo.acex.json')
+    expect(pkg.html).not.toContain('demo.acex.json')
+    expect(pkg.html).toContain('{}')
     expect(pkg.files.some(f => f.path === 'viewer.html')).toBe(true)
-    expect(pkg.files.some(f => f.path === 'demo.acex.json')).toBe(true)
+    expect(pkg.files.some(f => f.path === 'drawing.acex.json')).toBe(true)
+    expect(pkg.manifestFileName).toBe('drawing.acex.json')
     expect(pkg.manifest.chunks.length).toBeGreaterThan(1)
 
     const fileMap = new Map(pkg.files.map(f => [f.path, f.bytes]))
@@ -168,7 +170,7 @@ describe('AcEx package format', () => {
 
     const progresses: number[] = []
     const loaded = await loadAcExPackage({
-      manifestUrl: 'https://cdn.example/demo.acex.json',
+      manifestUrl: 'https://cdn.example/drawing.acex.json',
       fetchImpl,
       onChunk: (_layout, _chunk, progress) => {
         progresses.push(progress.loadedChunks)
@@ -213,12 +215,12 @@ describe('AcEx package format', () => {
     expect(skeleton.activeLayoutBtrId).toBe('ms')
   })
 
-  it('sanitizes drawing titles with spaces and plus signs for zip-safe paths', () => {
+  it('always names the package manifest drawing.acex.json', () => {
     const pkg = buildAcExPackage(makeSnapshot(), {
       viewerRuntime: '/* runtime */',
       baseName: 'FJP-898E-G-_-V01 + 1'
     })
-    expect(pkg.manifestFileName).toBe('FJP-898E-G-_-V01_1.acex.json')
+    expect(pkg.manifestFileName).toBe('drawing.acex.json')
     expect(isSafePackageHref(`./${pkg.manifestFileName}`)).toBe(true)
     expect(() => zipAcExPackageFiles(pkg)).not.toThrow()
   })
@@ -335,7 +337,7 @@ describe('AcEx package format', () => {
     }
 
     const geometryOnly = await loadAcExPackage({
-      manifestUrl: 'https://cdn.example/demo.acex.json',
+      manifestUrl: 'https://cdn.example/drawing.acex.json',
       fetchImpl,
       loadOsnap: false
     })
@@ -343,7 +345,7 @@ describe('AcEx package format', () => {
     expect(geometryOnly.layouts[0]?.lineBatches.length).toBeGreaterThan(0)
 
     const loaded = await loadAcExPackage({
-      manifestUrl: 'https://cdn.example/demo.acex.json',
+      manifestUrl: 'https://cdn.example/drawing.acex.json',
       fetchImpl
     })
     expect(loaded.layouts[0]?.osnap?.primitives).toEqual(

--- a/packages/cad-html-plugin/docs/acex-package-format.md
+++ b/packages/cad-html-plugin/docs/acex-package-format.md
@@ -28,7 +28,17 @@ drawing/
 
 ### Shell HTML
 
-Contains `#mlcad-package` (JSON) instead of an embedded snapshot:
+Contains `#mlcad-package` (JSON marker) instead of an embedded snapshot. By
+default the config is empty — the generic viewer probes sibling
+`drawing.acex.json`, then query / folder / URL pickers:
+
+```html
+<script id="mlcad-package" type="application/json">
+{}
+</script>
+```
+
+Optional override (legacy or custom hosts):
 
 ```html
 <script id="mlcad-package" type="application/json">
@@ -36,7 +46,10 @@ Contains `#mlcad-package` (JSON) instead of an embedded snapshot:
 </script>
 ```
 
-`manifestUrl` may be relative to the HTML file or an absolute CDN URL.
+Runtime resolution order: `?manifest=` / `?acex=` → `#mlcad-package.manifestUrl`
+→ `./drawing.acex.json` → local folder or pasted URL UI. Absolute `http(s)`
+manifest URLs are allowed from the query / picker; chunk hrefs must stay
+relative to that manifest and same-origin with it.
 
 ## Versioning
 

--- a/packages/cad-html-plugin/docs/acex-web-hosting-guide.md
+++ b/packages/cad-html-plugin/docs/acex-web-hosting-guide.md
@@ -44,14 +44,28 @@ DWG/DXF 文件 → 浏览器下载 → 解析实体（AcDb*）→ 细分/三角�
 
 ---
 
+## 在线体验
+
+如果你想先直观体验一下这种「预渲染 + 静态托管」的 DWG Web 看图方案，可以直接打开下面的在线 Demo：
+
+👉 [在线体验 DWG Web Viewer](https://mlightcad.github.io/cad-viewer/self-contained-html/canteen-progressive/viewer.html)
+
+这个 Demo 使用的就是本文介绍的预渲染方案。DWG 图纸在发布之前已经完成了解析和几何细分，用户打开网页后无需再解析原始 DWG 文件，而是直接加载预先生成的显示数据（`viewer.html` + `drawing.acex.json` + `chunks/`）。
+
+由于图纸资源会被浏览器缓存，第一次打开时可能需要等待资源下载；缓存建立之后，再次打开同一个页面会非常快。这也是这种「预渲染 + 静态托管」方案特别适合图纸发布、分享和反复查看场景的原因之一。
+
+可以先实际体验一下，再继续阅读下面的架构和实现细节。
+
+---
+
 ## 2. 产物：一个解压即用的静态目录
 
-multi 导出下载的是一个 `.zip`，但 **zip 仅用于分发**。查看器不会在浏览器里解 zip——它按顺序 `fetch` 清单和各个块文件。**托管前必须先解压**：
+multi 导出下载的是一个 `.zip`（下载文件名仍可按图纸名命名），但 **zip 仅用于分发**。查看器不会在浏览器里解 zip——它按顺序 `fetch` 清单和各个块文件。**托管前必须先解压**：
 
 ```text
 my-drawing/
-  viewer.html                 # 入口页面（HTML/CSS/JS 外壳 + 内联的离线查看器运行时）
-  my_drawing.acex.json        # 包清单（很小的元数据 + 索引）
+  viewer.html                 # 通用入口（HTML/CSS/JS 外壳 + 内联离线查看器；不硬编码图纸数据路径）
+  drawing.acex.json           # 包清单（固定文件名；很小的元数据 + 索引）
   chunks/
     L0-000.acex.gz            # gzip 压缩的几何块（ACEC 二进制，非 base64）
     L0-001.acex.gz
@@ -60,15 +74,24 @@ my-drawing/
     ...
 ```
 
-用户访问 `viewer.html` 后的加载顺序：
+`viewer.html` 是**通用壳**：同一份 HTML 可以配合任意一份 `drawing.acex.json` + `chunks/` 使用。用户访问后的加载顺序：
 
-1. 读取页面内的 `#mlcad-package` 配置，拿到清单地址（默认 `./{name}.acex.json`）；
-2. 下载清单（小 JSON），初始化图层、布局、范围等界面；
+1. 解析数据来源（按优先级）：
+   - URL query：`?manifest=<url>` 或 `?acex=<url>`（相对路径或绝对 `http(s)` URL）；
+   - 页面同级目录下的 `./drawing.acex.json`；
+   - 若默认清单不存在：界面上提供「选择本地文件夹」或「输入清单 URL」。
+2. 下载并校验清单（格式 / `packageVersion` / `snapshotVersion` 不对会显示错误）；
 3. **当前布局**的几何块逐块下载 → gunzip → 解码 → 上屏，画一块刷一块；
 4. 图纸已经可以平移缩放后，再下载 `*.osnap.gz` 捕捉数据（测量/对象捕捉用）；
 5. 其余布局在用户切换时才加载。
 
 查看器运行时已经内联在 `viewer.html` 里，目录中**没有任何额外 JS 依赖**，功能包含：选择 / 平移 / 缩放（范围、窗口、原图）、图层面板、布局切换、测量、批注（Design Review markup）、对象捕捉，以及内嵌的中/英/捷/土多语言界面。
+
+示例：用 query 打开别处托管的清单（块文件仍须与该清单同源、且位于清单所在目录下）：
+
+```text
+https://cdn.example/viewer.html?manifest=https://cdn.example/packages/floor-plan/drawing.acex.json
+```
 
 ---
 
@@ -85,7 +108,7 @@ my-drawing/
   ...
   ```
 
-  浏览器会下载一个 `.zip`。
+  浏览器会下载一个 `.zip`（解压后始终是 `viewer.html` + `drawing.acex.json` + `chunks/`）。
 
 ### 方式二：服务端 / CI 批量转换（云端架构推荐）
 
@@ -118,7 +141,7 @@ quit
 cad-simple-viewer-cli -i ./drawings/floor-plan.dwg \
   -s node_modules/@mlightcad/cad-simple-viewer-cli/examples/export-html-multi.scr \
   -o ./out
-# 输出：./out/floor-plan.zip
+# 输出：./out/floor-plan.zip（包内清单固定为 drawing.acex.json）
 ```
 
 批量目录转换、zip 解压与发布的完整自动化方案见第 6 节。
@@ -159,6 +182,7 @@ await new AcApHtmlConvertor({ viewerRuntimeUrl: './viewer-runtime.iife.js' })
 
 ```typescript
 import {
+  ACEX_DEFAULT_MANIFEST_FILE,
   buildAcExPackage,
   zipAcExPackageFiles,
   unzipAcExPackageFiles
@@ -166,9 +190,10 @@ import {
 
 // snapshot 由 AcApHtmlSnapshotBuilder 从 Three.js 场景构建
 const pkg = buildAcExPackage(snapshot, {
-  viewerRuntime,          // viewer-runtime.iife.js 的文本
-  baseName: 'floor-plan'
+  viewerRuntime // viewer-runtime.iife.js 的文本
+  // baseName 仅保留 API 兼容；清单文件名始终是 drawing.acex.json
 })
+// pkg.manifestFileName === ACEX_DEFAULT_MANIFEST_FILE
 
 const zipBytes = zipAcExPackageFiles(pkg)     // 打成 zip 供下载
 // 或者直接把 pkg.files（[{ path, bytes }, ...]）写到磁盘 / 上传对象存储，
@@ -193,12 +218,18 @@ unzip ./out/floor-plan.zip -d /var/www/cad-packages/floor-plan
 
 发布后把 `https://你的域名/cad-packages/floor-plan/viewer.html` 这个 URL 发给用户即可。建议按**图纸 ID / 版本号**划分目录（如 `/cad-packages/{drawingId}/{version}/`），图纸更新就发一个新版本目录，旧版本自然下线，也便于缓存。
 
+同一份通用 `viewer.html` 也可以单独托管，再用 query 指向各图纸的清单，例如：
+
+```text
+https://你的域名/viewer.html?manifest=https://你的域名/cad-packages/floor-plan/drawing.acex.json
+```
+
 ### 4.2 服务器要求
 
 任何能发静态文件的服务都可以：nginx、Apache、IIS、`npx serve`、Python `-m http.server`，以及阿里云 OSS / AWS S3 + CloudFront 等对象存储静态网站托管。要求只有几条：
 
-1. **必须通过 http(s) 访问**。查看器用 `fetch()` 加载清单和块文件，`file://` 协议下无法工作，不能双击 `viewer.html` 当本地文件用。
-2. **整包同源托管**。加载器出于安全限制会校验：`manifestUrl` 必须与页面同源，块文件必须与清单同源且位于包目录内（拒绝绝对 URL、`..` 跨目录）。所以请把 `viewer.html`、清单、`chunks/` 放在**同一个站点/同一个 CDN 域名**下，不要把块文件拆到另一个域。页面和块一起放在 CDN 域名上是完全没问题的。
+1. **必须通过 http(s) 访问**。查看器用 `fetch()` 加载清单和块文件，`file://` 协议下无法工作，不能双击 `viewer.html` 当本地文件用（若本地没有同级 `drawing.acex.json`，页面会提示选择文件夹或输入 URL）。
+2. **块文件与清单同源、且不得逃出包目录**。相对路径的清单默认相对 `viewer.html` 解析；通过 query / 用户粘贴的**绝对** `http(s)` 清单 URL 可以使用，但每个块仍须与**该清单**同源，并落在清单所在目录下（拒绝 `..` 跨目录）。最简单的做法仍是把 `viewer.html`、`drawing.acex.json`、`chunks/` 放在同一站点目录里一起发布。
 3. **`.gz` 文件按原始字节返回，不要附带 `Content-Encoding: gzip` 响应头**。
    `.acex.gz` / `.osnap.gz` 是 gzip 压缩过的字节，由查看器在 JavaScript 里自己 gunzip。如果 Web 服务器（典型如 Apache 的 `mod_mime` 默认对 `.gz` 后缀设置 `AddEncoding gzip gz`，或某些 CDN/对象存储元数据）给它们加上了 `Content-Encoding: gzip`，浏览器会先自动解压一次，查看器再解压就会报错。请确保这些文件以不透明二进制方式返回（`Content-Type: application/octet-stream` 即可，查看器按 `arrayBuffer` 读取，不依赖 MIME），清单 `.acex.json` 用 `application/json`。
 4. **缓存策略**。块文件内容不可变（同一版本目录内不会变），可以放心地给 `chunks/` 加长缓存（`Cache-Control: public, max-age=31536000, immutable`）；清单文件建议短缓存或 `no-cache`，以便重新导出同目录后客户端能尽快发现更新。按版本号分目录发布时则整目录都可以长缓存。
@@ -244,7 +275,11 @@ npx serve .
 # 打开 http://localhost:3000/viewer.html
 ```
 
-能正常显示图纸、切换布局、测量，即说明托管配置正确。
+能正常显示图纸、切换布局、测量，即说明托管配置正确。也可验证 query：
+
+```text
+http://localhost:3000/viewer.html?manifest=./drawing.acex.json
+```
 
 ---
 
@@ -308,16 +343,19 @@ console.log(`Published: https://drawings.example.com/${path.basename(target)}/vi
 ## 7. FAQ
 
 **Q：能不能直接把 zip 放到服务器上给个链接？**
-不能。zip 只是下载分发用的封装，查看器运行时 fetch 的是解压后的 `viewer.html` / `*.acex.json` / `chunks/*.gz`。要么服务器端解压后托管，要么在你自己的应用里用 `unzipAcExPackageFiles` 在前端解压（注意同源和内存问题，不推荐大图这么做）。
+不能。zip 只是下载分发用的封装，查看器运行时 fetch 的是解压后的 `viewer.html` / `drawing.acex.json` / `chunks/*.gz`。要么服务器端解压后托管，要么在你自己的应用里用 `unzipAcExPackageFiles` 在前端解压（注意同源和内存问题，不推荐大图这么做）。
 
-**Q：打开页面后块文件 404 / 加载失败？**
-检查：是否通过 http(s) 访问；`chunks/` 目录是否随 `viewer.html`、清单一起部署；块文件是否被改了名或路径（清单里的 `href` 是相对路径，需保持目录结构）。
+**Q：打开页面后提示找不到图纸 / 块文件 404？**
+检查：是否通过 http(s) 访问；同级是否有 `drawing.acex.json`；`chunks/` 是否随清单一起部署；query `manifest` 是否指向正确 URL。缺少默认清单时，页面会提供选文件夹或输入 URL 的入口。
+
+**Q：清单版本报错？**
+加载器会校验 `format`、`packageVersion`、`snapshotVersion`。用当前版本的 `cad-html-plugin` 重新导出即可；不要混用新旧协议的块文件。
 
 **Q：块文件下载回来解析报错？**
 多半是服务器对 `.gz` 文件加了 `Content-Encoding: gzip`（浏览器自动解了一次压），按 4.2 第 3 条检查响应头。
 
 **Q：可以把块文件放 CDN、页面放自己域名吗？**
-当前加载器要求页面、清单、块文件同源。把**整个包目录**发布到 CDN 域名、用户直接访问 CDN 上的 `viewer.html` 即可获得 CDN 加速。
+块必须与**清单**同源。可以把整包（含 `viewer.html`）放到 CDN；或单独托管通用 `viewer.html`，用 `?manifest=` 指向 CDN 上的 `drawing.acex.json`（此时块也须在该 CDN 清单目录下）。
 
 **Q：导出的文件名变成了 `floor-plan-2.zip`？**
 目标文件已存在时，导出命名会自动追加序号避免覆盖。重新导出前先删除输出目录里的旧产物（见第 6 节自动化示例中的清理步骤）。

--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -210,6 +210,18 @@ export type AcExHtmlMessageKey =
   | 'status.loadingChunks'
   | 'status.loadingOsnap'
   | 'status.buildingOsnap'
+  | 'package.title'
+  | 'package.hint'
+  | 'package.hintUrlOnly'
+  | 'package.chooseFolder'
+  | 'package.urlPlaceholder'
+  | 'package.openUrl'
+  | 'package.urlRequired'
+  | 'package.manifestNotFound'
+  | 'package.invalidManifest'
+  | 'package.folderMissingManifest'
+  | 'package.folderUnsupported'
+  | 'package.loadFailed'
   | 'access.title'
   | 'access.passwordPrompt'
   | 'access.passwordPlaceholder'
@@ -455,6 +467,24 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       loadingOsnap: 'Loading object snap… {loaded}/{total}',
       buildingOsnap: 'Building object snap index…'
     },
+    package: {
+      title: 'Open drawing package',
+      hint: 'No drawing.acex.json was found next to this page. Choose a local package folder or enter the manifest URL.',
+      hintUrlOnly:
+        'No drawing.acex.json was found next to this page. Enter the manifest URL to open the package.',
+      chooseFolder: 'Choose local folder',
+      urlPlaceholder: 'https://example.com/drawing.acex.json',
+      openUrl: 'Open URL',
+      urlRequired: 'Please enter a manifest URL.',
+      manifestNotFound: 'drawing.acex.json was not found next to this page.',
+      invalidManifest:
+        'The package manifest is invalid or uses an unsupported version: {error}',
+      folderMissingManifest:
+        'The selected folder must contain drawing.acex.json.',
+      folderUnsupported:
+        'This browser cannot open a local package folder. Paste a manifest URL instead.',
+      loadFailed: 'Failed to open package: {error}'
+    },
     access: {
       title: 'Protected drawing',
       passwordPrompt: 'Enter the password to open this file.',
@@ -687,6 +717,22 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       loadingChunks: '正在加载几何… {loaded}/{total}',
       loadingOsnap: '正在加载对象捕捉… {loaded}/{total}',
       buildingOsnap: '正在构建对象捕捉索引…'
+    },
+    package: {
+      title: '打开图纸包',
+      hint: '当前页面同级目录未找到 drawing.acex.json。请选择本地包文件夹，或输入清单 URL。',
+      hintUrlOnly:
+        '当前页面同级目录未找到 drawing.acex.json。请输入清单 URL 以打开图纸包。',
+      chooseFolder: '选择本地文件夹',
+      urlPlaceholder: 'https://example.com/drawing.acex.json',
+      openUrl: '打开 URL',
+      urlRequired: '请输入清单 URL。',
+      manifestNotFound: '当前页面同级目录未找到 drawing.acex.json。',
+      invalidManifest: '包清单无效或版本不受支持：{error}',
+      folderMissingManifest: '所选文件夹必须包含 drawing.acex.json。',
+      folderUnsupported:
+        '当前浏览器无法选择本地包文件夹，请改为输入清单 URL。',
+      loadFailed: '无法打开图纸包：{error}'
     },
     access: {
       title: '受保护的图纸',
@@ -924,6 +970,24 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       loadingChunks: 'Načítání geometrie… {loaded}/{total}',
       loadingOsnap: 'Načítání uchopování… {loaded}/{total}',
       buildingOsnap: 'Sestavování indexu uchopování…'
+    },
+    package: {
+      title: 'Otevřít balíček výkresu',
+      hint: 'Vedle této stránky nebyl nalezen drawing.acex.json. Vyberte místní složku balíčku nebo zadejte URL manifestu.',
+      hintUrlOnly:
+        'Vedle této stránky nebyl nalezen drawing.acex.json. Zadejte URL manifestu pro otevření balíčku.',
+      chooseFolder: 'Vybrat místní složku',
+      urlPlaceholder: 'https://example.com/drawing.acex.json',
+      openUrl: 'Otevřít URL',
+      urlRequired: 'Zadejte URL manifestu.',
+      manifestNotFound: 'drawing.acex.json nebyl vedle této stránky nalezen.',
+      invalidManifest:
+        'Manifest balíčku je neplatný nebo používá nepodporovanou verzi: {error}',
+      folderMissingManifest:
+        'Vybraná složka musí obsahovat drawing.acex.json.',
+      folderUnsupported:
+        'Tento prohlížeč neumí otevřít místní složku balíčku. Zadejte místo toho URL manifestu.',
+      loadFailed: 'Nepodařilo se otevřít balíček: {error}'
     },
     access: {
       title: 'Chráněný výkres',
@@ -1165,6 +1229,24 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       loadingOsnap: 'Nesne yakalama yükleniyor… {loaded}/{total}',
       buildingOsnap: 'Nesne yakalama dizini oluşturuluyor…'
     },
+    package: {
+      title: 'Çizim paketini aç',
+      hint: 'Bu sayfanın yanında drawing.acex.json bulunamadı. Yerel bir paket klasörü seçin veya manifesto URL’sini girin.',
+      hintUrlOnly:
+        'Bu sayfanın yanında drawing.acex.json bulunamadı. Paketi açmak için manifesto URL’sini girin.',
+      chooseFolder: 'Yerel klasör seç',
+      urlPlaceholder: 'https://example.com/drawing.acex.json',
+      openUrl: 'URL aç',
+      urlRequired: 'Lütfen bir manifesto URL’si girin.',
+      manifestNotFound: 'Bu sayfanın yanında drawing.acex.json bulunamadı.',
+      invalidManifest:
+        'Paket manifestosu geçersiz veya desteklenmeyen bir sürüm kullanıyor: {error}',
+      folderMissingManifest:
+        'Seçilen klasör drawing.acex.json içermelidir.',
+      folderUnsupported:
+        'Bu tarayıcı yerel paket klasörü açamıyor. Bunun yerine manifesto URL’si yapıştırın.',
+      loadFailed: 'Paket açılamadı: {error}'
+    },
     access: {
       title: 'Korumalı çizim',
       passwordPrompt: 'Bu dosyayı açmak için parolayı girin.',
@@ -1388,6 +1470,24 @@ const AR_MESSAGES: AcExMessageTree = {
     'loadingChunks': 'جاري تحميل الهندسة… {loaded}/{total}',
     'loadingOsnap': 'جاري تحميل الالتقاط… {loaded}/{total}',
     'buildingOsnap': 'جاري بناء فهرس الالتقاط…'
+  },
+  package: {
+    title: 'فتح حزمة الرسم',
+    hint: 'لم يتم العثور على drawing.acex.json بجانب هذه الصفحة. اختر مجلد الحزمة المحلي أو أدخل عنوان URL للقائمة.',
+    hintUrlOnly:
+      'لم يتم العثور على drawing.acex.json بجانب هذه الصفحة. أدخل عنوان URL للقائمة لفتح الحزمة.',
+    chooseFolder: 'اختيار مجلد محلي',
+    urlPlaceholder: 'https://example.com/drawing.acex.json',
+    openUrl: 'فتح الرابط',
+    urlRequired: 'يرجى إدخال عنوان URL للقائمة.',
+    manifestNotFound: 'لم يتم العثور على drawing.acex.json بجانب هذه الصفحة.',
+    invalidManifest:
+      'قائمة الحزمة غير صالحة أو تستخدم إصداراً غير مدعوم: {error}',
+    folderMissingManifest:
+      'يجب أن يحتوي المجلد المحدد على drawing.acex.json.',
+    folderUnsupported:
+      'لا يمكن لهذا المتصفح فتح مجلد حزمة محلي. الصق عنوان URL للقائمة بدلاً من ذلك.',
+    loadFailed: 'تعذر فتح الحزمة: {error}'
   },
   access: {
     title: 'رسم محمي',

--- a/packages/cad-html-plugin/src/AcExHtmlPackageBootstrap.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlPackageBootstrap.ts
@@ -1,0 +1,355 @@
+/**
+ * Resolves where a generic multi-file viewer.html should load its package
+ * (`drawing.acex.json` + chunks) from: query param, sibling default file,
+ * remote URL, or a local directory index.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  parseAcExPackageManifest,
+  resolvePackageManifestUrl
+} from './AcExPackageLoader'
+import type { AcExPackageManifest } from './AcExPackageTypes'
+
+/** Canonical package manifest file name next to `viewer.html`. */
+export const ACEX_DEFAULT_MANIFEST_FILE = 'drawing.acex.json'
+
+/** Relative href used when no query / config override is present. */
+export const ACEX_DEFAULT_MANIFEST_HREF = `./${ACEX_DEFAULT_MANIFEST_FILE}`
+
+/**
+ * Query parameter names that may carry a `drawing.acex.json` URL.
+ * First match wins (`manifest` preferred).
+ */
+export const ACEX_MANIFEST_QUERY_KEYS = ['manifest', 'acex'] as const
+
+/** Virtual origin used by {@link createPackageDirectoryFetch}. */
+export const ACEX_PACKAGE_DIRECTORY_ORIGIN = 'https://acex-package.invalid/'
+
+/**
+ * `window.fetch` wrapped so it is safe to store and call as `fetchImpl(...)`.
+ * Passing the bare `fetch` function loses the Window receiver and throws
+ * `TypeError: Illegal invocation` in browsers.
+ */
+export const acexGlobalFetch: typeof fetch = (input, init) =>
+  globalThis.fetch(input, init)
+
+/**
+ * Which local-folder APIs the current browser exposes for opening an ACEX
+ * package directory.
+ */
+export interface AcExLocalFolderOpenSupport {
+  /** File System Access API `showDirectoryPicker` (secure contexts). */
+  directoryPicker: boolean
+  /** Legacy `<input webkitdirectory>` / `directory` file input. */
+  webkitDirectory: boolean
+}
+
+/** True when at least one local-folder selection path is available. */
+export function canOpenLocalPackageFolder(
+  support: AcExLocalFolderOpenSupport
+): boolean {
+  return support.directoryPicker || support.webkitDirectory
+}
+
+/**
+ * Detects local folder open support for the package source gate.
+ *
+ * @param env - Optional stubs for unit tests (defaults to the current window / DOM).
+ */
+export function detectLocalFolderOpenSupport(env?: {
+  hasDirectoryPicker?: boolean
+  isSecureContext?: boolean
+  supportsWebkitDirectoryAttribute?: boolean
+}): AcExLocalFolderOpenSupport {
+  const hasDirectoryPicker =
+    env?.hasDirectoryPicker ??
+    typeof (
+      globalThis as { showDirectoryPicker?: unknown }
+    ).showDirectoryPicker === 'function'
+  const isSecureContext =
+    env?.isSecureContext ??
+    (typeof globalThis.isSecureContext === 'boolean'
+      ? globalThis.isSecureContext
+      : true)
+
+  let supportsWebkitDirectoryAttribute =
+    env?.supportsWebkitDirectoryAttribute
+  if (supportsWebkitDirectoryAttribute == null) {
+    supportsWebkitDirectoryAttribute = false
+    if (typeof document !== 'undefined') {
+      const input = document.createElement('input')
+      input.type = 'file'
+      supportsWebkitDirectoryAttribute =
+        'webkitdirectory' in input || 'directory' in input
+    }
+  }
+
+  return {
+    // showDirectoryPicker is defined in some engines outside secure contexts
+    // but rejects on call — only advertise it when the context is secure.
+    directoryPicker: hasDirectoryPicker && isSecureContext,
+    webkitDirectory: supportsWebkitDirectoryAttribute
+  }
+}
+
+export type AcExManifestProbeFailureReason =
+  | 'not-found'
+  | 'invalid'
+  | 'network'
+
+export type AcExManifestProbeResult =
+  | { ok: true; manifest: AcExPackageManifest }
+  | { ok: false; reason: AcExManifestProbeFailureReason; error: Error }
+
+/**
+ * Reads a manifest URL from `location.search` / a search string.
+ * Accepts absolute `http(s)` URLs or relative package paths.
+ */
+export function readManifestUrlFromSearchParams(
+  search: string
+): string | null {
+  const raw = search.startsWith('?') ? search.slice(1) : search
+  if (!raw) return null
+  let params: URLSearchParams
+  try {
+    params = new URLSearchParams(raw)
+  } catch {
+    return null
+  }
+  for (const key of ACEX_MANIFEST_QUERY_KEYS) {
+    const value = params.get(key)?.trim()
+    if (value) return value
+  }
+  return null
+}
+
+/**
+ * Chooses the initial manifest href before probing.
+ *
+ * Priority: query param → `#mlcad-package` config → sibling default.
+ */
+export function chooseInitialManifestHref(options: {
+  search?: string
+  configManifestUrl?: string | null
+}): { href: string; fromQuery: boolean } {
+  const fromQuery = readManifestUrlFromSearchParams(options.search ?? '')
+  if (fromQuery) {
+    return { href: fromQuery, fromQuery: true }
+  }
+  const fromConfig = options.configManifestUrl?.trim()
+  if (fromConfig) {
+    return { href: fromConfig, fromQuery: false }
+  }
+  return { href: ACEX_DEFAULT_MANIFEST_HREF, fromQuery: false }
+}
+
+/** Returns true for absolute `http:` / `https:` URLs. */
+export function isAbsoluteHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim())
+}
+
+/**
+ * Resolves a viewer manifest href against the page URL.
+ *
+ * Absolute `http(s)` URLs (query / user paste) are accepted as-is.
+ * Relative paths stay same-origin via {@link resolvePackageManifestUrl}.
+ */
+export function resolveViewerManifestUrl(
+  href: string,
+  pageUrl: string
+): string {
+  const trimmed = href.trim()
+  if (!trimmed) {
+    throw new Error('Missing manifest URL')
+  }
+  if (isAbsoluteHttpUrl(trimmed)) {
+    try {
+      return new URL(trimmed).toString()
+    } catch {
+      throw new Error('Invalid manifest URL')
+    }
+  }
+  return resolvePackageManifestUrl(trimmed, pageUrl)
+}
+
+/**
+ * Fetches and validates a package manifest. Distinguishes missing files from
+ * unsupported versions / malformed JSON so the UI can react accordingly.
+ */
+export async function probePackageManifest(
+  manifestUrl: string,
+  fetchImpl: typeof fetch = acexGlobalFetch
+): Promise<AcExManifestProbeResult> {
+  let response: Response
+  try {
+    response = await fetchImpl(manifestUrl)
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'network',
+      error: error instanceof Error ? error : new Error(String(error))
+    }
+  }
+  if (response.status === 404 || response.status === 410) {
+    return {
+      ok: false,
+      reason: 'not-found',
+      error: new Error(
+        `Failed to load package manifest (${response.status})`
+      )
+    }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      reason: 'network',
+      error: new Error(
+        `Failed to load package manifest (${response.status})`
+      )
+    }
+  }
+
+  let data: unknown
+  try {
+    data = await response.json()
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'invalid',
+      error:
+        error instanceof Error
+          ? error
+          : new Error('Invalid package manifest JSON')
+    }
+  }
+
+  try {
+    return { ok: true, manifest: parseAcExPackageManifest(data) }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'invalid',
+      error: error instanceof Error ? error : new Error(String(error))
+    }
+  }
+}
+
+/**
+ * Normalizes directory entry paths so `drawing.acex.json` and `chunks/…`
+ * sit at the package root (strips a shared top-level folder from
+ * `webkitdirectory` / folder-picker listings).
+ */
+export function normalizePackageDirectoryPath(
+  relativePath: string,
+  stripRootPrefix?: string | null
+): string {
+  let path = relativePath.replace(/\\/g, '/').replace(/^\/+/, '')
+  if (stripRootPrefix) {
+    const prefix = stripRootPrefix.replace(/\\/g, '/').replace(/\/+$/, '')
+    if (path === prefix) {
+      path = ''
+    } else if (path.startsWith(`${prefix}/`)) {
+      path = path.slice(prefix.length + 1)
+    }
+  }
+  return path.replace(/^\.\//, '')
+}
+
+/**
+ * Detects a shared root folder when every path starts with the same segment
+ * (typical of `<input webkitdirectory>` FileList entries).
+ */
+export function detectSharedDirectoryRoot(
+  relativePaths: Iterable<string>
+): string | null {
+  const normalized = [...relativePaths]
+    .map(p => p.replace(/\\/g, '/').replace(/^\/+/, ''))
+    .filter(Boolean)
+  if (normalized.length === 0) return null
+  const firstSeg = normalized[0]!.split('/')[0]
+  if (!firstSeg || firstSeg === ACEX_DEFAULT_MANIFEST_FILE) return null
+  const allShare = normalized.every(p => {
+    const seg = p.split('/')[0]
+    return seg === firstSeg
+  })
+  if (!allShare) return null
+  // Only strip when the root is a directory prefix (paths have nested files).
+  const hasNested = normalized.some(p => p.includes('/'))
+  return hasNested ? firstSeg : null
+}
+
+/**
+ * Builds a path → bytes map for local package loading.
+ */
+export function buildPackageDirectoryFileMap(
+  entries: Iterable<{ relativePath: string; bytes: Uint8Array }>
+): Map<string, Uint8Array> {
+  const list = [...entries]
+  const root = detectSharedDirectoryRoot(list.map(e => e.relativePath))
+  const out = new Map<string, Uint8Array>()
+  for (const entry of list) {
+    const path = normalizePackageDirectoryPath(entry.relativePath, root)
+    if (!path || path.endsWith('/')) continue
+    out.set(path, entry.bytes)
+  }
+  return out
+}
+
+/**
+ * Creates a `fetch` implementation that serves package files from an in-memory
+ * directory map. `manifestUrl` is a virtual absolute URL so
+ * {@link resolveChunkUrl} can resolve relative chunk hrefs.
+ */
+export function createPackageDirectoryFetch(
+  files: ReadonlyMap<string, Uint8Array>,
+  options?: { manifestFileName?: string }
+): { manifestUrl: string; fetchImpl: typeof fetch } {
+  const manifestFileName =
+    options?.manifestFileName ?? ACEX_DEFAULT_MANIFEST_FILE
+  if (!files.has(manifestFileName)) {
+    throw new Error(`Missing ${manifestFileName} in selected folder`)
+  }
+  const manifestUrl = new URL(
+    manifestFileName,
+    ACEX_PACKAGE_DIRECTORY_ORIGIN
+  ).toString()
+  const origin = new URL(ACEX_PACKAGE_DIRECTORY_ORIGIN).origin
+
+  const fetchImpl: typeof fetch = async input => {
+    const url = new URL(String(input))
+    if (url.origin !== origin) {
+      return new Response(null, { status: 404 })
+    }
+    const rel = decodeURIComponent(url.pathname.replace(/^\/+/, ''))
+    const bytes = files.get(rel)
+    if (!bytes) {
+      return new Response(null, { status: 404 })
+    }
+    if (rel.endsWith('.json')) {
+      const text = new TextDecoder().decode(bytes)
+      return new Response(text, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    }
+    const copy = new Uint8Array(bytes.byteLength)
+    copy.set(bytes)
+    return new Response(copy, { status: 200 })
+  }
+
+  return { manifestUrl, fetchImpl }
+}
+
+/**
+ * Locates `drawing.acex.json` in a directory file map (root only).
+ */
+export function findDefaultManifestInDirectory(
+  files: ReadonlyMap<string, Uint8Array>
+): string | null {
+  if (files.has(ACEX_DEFAULT_MANIFEST_FILE)) {
+    return ACEX_DEFAULT_MANIFEST_FILE
+  }
+  return null
+}

--- a/packages/cad-html-plugin/src/AcExHtmlPackageSourceGate.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlPackageSourceGate.ts
@@ -1,0 +1,481 @@
+/**
+ * Overlay that lets the user open a multi-file ACEX package when the sibling
+ * `drawing.acex.json` is missing: pick a local folder (when supported) or
+ * paste a manifest URL.
+ *
+ * @packageDocumentation
+ */
+
+import type { AcExHtmlI18n, AcExHtmlMessageKey } from './AcExHtmlI18n'
+import {
+  ACEX_DEFAULT_MANIFEST_FILE,
+  type AcExLocalFolderOpenSupport,
+  buildPackageDirectoryFileMap,
+  canOpenLocalPackageFolder,
+  createPackageDirectoryFetch,
+  detectLocalFolderOpenSupport} from './AcExHtmlPackageBootstrap'
+
+export type AcExHtmlPackageSourceChoice =
+  | { kind: 'url'; href: string }
+  | {
+      kind: 'directory'
+      manifestUrl: string
+      fetchImpl: typeof fetch
+    }
+
+/**
+ * Shows the package source picker and resolves when the user submits a URL or
+ * (when supported) selects a folder that contains {@link ACEX_DEFAULT_MANIFEST_FILE}.
+ */
+export function promptAcExHtmlPackageSource(
+  i18n: AcExHtmlI18n,
+  options?: {
+    errorKey?: Extract<
+      AcExHtmlMessageKey,
+      | 'package.manifestNotFound'
+      | 'package.invalidManifest'
+      | 'package.folderMissingManifest'
+      | 'package.loadFailed'
+    >
+    errorMessage?: string
+    /** Override capability detection (tests). */
+    folderSupport?: AcExLocalFolderOpenSupport
+  }
+): Promise<AcExHtmlPackageSourceChoice> {
+  const loading = document.getElementById('mlcad-loading')
+  loading?.classList.remove('mlcad-loading--done')
+  loading?.classList.add('mlcad-loading--gate')
+
+  const folderSupport =
+    options?.folderSupport ?? detectLocalFolderOpenSupport()
+  const folderAvailable = canOpenLocalPackageFolder(folderSupport)
+
+  ensurePackageSourceGateDom(folderSupport)
+  const gate = document.getElementById('mlcad-package-gate')
+  const form = document.getElementById(
+    'mlcad-package-url-form'
+  ) as HTMLFormElement | null
+  const input = document.getElementById(
+    'mlcad-package-url'
+  ) as HTMLInputElement | null
+  const folderBtn = document.getElementById('mlcad-package-folder-btn')
+  const folderInput = document.getElementById(
+    'mlcad-package-folder-input'
+  ) as HTMLInputElement | null
+  const hintEl = document.getElementById('mlcad-package-gate-hint')
+  const errorEl = document.getElementById('mlcad-package-gate-error')
+
+  if (!gate || !form || !input) {
+    return Promise.reject(new Error('Package source gate is not available.'))
+  }
+  if (folderAvailable && (!folderBtn || !folderInput)) {
+    return Promise.reject(new Error('Package source gate is not available.'))
+  }
+
+  if (hintEl) {
+    const hintKey = folderAvailable ? 'package.hint' : 'package.hintUrlOnly'
+    hintEl.setAttribute('data-i18n-key', hintKey)
+    hintEl.textContent = i18n.t(hintKey)
+  }
+  if (folderBtn) {
+    folderBtn.hidden = !folderAvailable
+  }
+  if (folderInput) {
+    folderInput.hidden = !folderAvailable
+    folderInput.disabled = !folderAvailable
+  }
+
+  i18n.applyToDocument()
+  gate.hidden = false
+  input.value = ''
+
+  if (errorEl) {
+    if (options?.errorMessage) {
+      errorEl.hidden = false
+      errorEl.textContent = options.errorMessage
+    } else if (options?.errorKey) {
+      errorEl.hidden = false
+      errorEl.textContent = i18n.t(options.errorKey)
+    } else {
+      errorEl.hidden = true
+      errorEl.textContent = ''
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const showError = (message: string) => {
+      if (!errorEl) return
+      errorEl.hidden = false
+      errorEl.textContent = message
+    }
+
+    const cleanup = () => {
+      form.removeEventListener('submit', onSubmit)
+      folderBtn?.removeEventListener('click', onFolderClick)
+      folderInput?.removeEventListener('change', onFolderChange)
+      gate.hidden = true
+      loading?.classList.remove('mlcad-loading--gate')
+    }
+
+    const finish = (choice: AcExHtmlPackageSourceChoice) => {
+      cleanup()
+      resolve(choice)
+    }
+
+    const onSubmit = (event: Event) => {
+      event.preventDefault()
+      const href = input.value.trim()
+      if (!href) {
+        showError(i18n.t('package.urlRequired'))
+        return
+      }
+      finish({ kind: 'url', href })
+    }
+
+    const ingestFileList = async (fileList: FileList | null) => {
+      if (!fileList || fileList.length === 0) {
+        showError(i18n.t('package.folderMissingManifest'))
+        return
+      }
+      try {
+        const entries: { relativePath: string; bytes: Uint8Array }[] = []
+        for (const file of Array.from(fileList)) {
+          const relativePath =
+            (file as File & { webkitRelativePath?: string }).webkitRelativePath ||
+            file.name
+          const buffer = new Uint8Array(await file.arrayBuffer())
+          entries.push({ relativePath, bytes: buffer })
+        }
+        const files = buildPackageDirectoryFileMap(entries)
+        if (!files.has(ACEX_DEFAULT_MANIFEST_FILE)) {
+          showError(i18n.t('package.folderMissingManifest'))
+          return
+        }
+        const { manifestUrl, fetchImpl } = createPackageDirectoryFetch(files)
+        finish({ kind: 'directory', manifestUrl, fetchImpl })
+      } catch (error) {
+        showError(
+          i18n.t('package.loadFailed', {
+            error: error instanceof Error ? error.message : String(error)
+          })
+        )
+      }
+    }
+
+    const openWebkitDirectoryInput = () => {
+      if (!folderSupport.webkitDirectory || !folderInput) {
+        showError(i18n.t('package.folderUnsupported'))
+        return
+      }
+      folderInput.click()
+    }
+
+    const onFolderChange = () => {
+      if (!folderInput) return
+      void ingestFileList(folderInput.files)
+      folderInput.value = ''
+    }
+
+    const onFolderClick = () => {
+      if (!folderAvailable) return
+
+      if (folderSupport.directoryPicker) {
+        const dirPicker = (
+          globalThis as {
+            showDirectoryPicker?: () => Promise<FileSystemDirectoryHandle>
+          }
+        ).showDirectoryPicker
+        if (typeof dirPicker !== 'function') {
+          openWebkitDirectoryInput()
+          return
+        }
+        void (async () => {
+          try {
+            const root = await dirPicker.call(globalThis)
+            const entries = await collectDirectoryEntries(root)
+            const files = buildPackageDirectoryFileMap(entries)
+            if (!files.has(ACEX_DEFAULT_MANIFEST_FILE)) {
+              showError(i18n.t('package.folderMissingManifest'))
+              return
+            }
+            const { manifestUrl, fetchImpl } = createPackageDirectoryFetch(files)
+            finish({ kind: 'directory', manifestUrl, fetchImpl })
+          } catch (error) {
+            // User cancel — keep the gate open.
+            if (
+              error instanceof DOMException &&
+              (error.name === 'AbortError' || error.name === 'NotAllowedError')
+            ) {
+              return
+            }
+            // Degrade to <input webkitdirectory> when the picker fails
+            // (SecurityError, missing async iteration, etc.).
+            if (folderSupport.webkitDirectory) {
+              openWebkitDirectoryInput()
+              return
+            }
+            showError(
+              i18n.t('package.loadFailed', {
+                error: error instanceof Error ? error.message : String(error)
+              })
+            )
+          }
+        })()
+        return
+      }
+
+      openWebkitDirectoryInput()
+    }
+
+    form.addEventListener('submit', onSubmit)
+    if (folderAvailable && folderBtn && folderInput) {
+      folderBtn.addEventListener('click', onFolderClick)
+      folderInput.addEventListener('change', onFolderChange)
+    }
+    window.setTimeout(() => input.focus(), 0)
+
+    gate.addEventListener(
+      'cancel',
+      () => {
+        cleanup()
+        reject(new Error('Package source selection cancelled.'))
+      },
+      { once: true }
+    )
+  })
+}
+
+async function collectDirectoryEntries(
+  root: FileSystemDirectoryHandle,
+  prefix = ''
+): Promise<{ relativePath: string; bytes: Uint8Array }[]> {
+  const out: { relativePath: string; bytes: Uint8Array }[] = []
+  const handles = await listDirectoryHandles(root)
+  for (const { name, handle } of handles) {
+    const relativePath = prefix ? `${prefix}/${name}` : name
+    if (handle.kind === 'file') {
+      const file = await (handle as FileSystemFileHandle).getFile()
+      out.push({
+        relativePath,
+        bytes: new Uint8Array(await file.arrayBuffer())
+      })
+    } else if (handle.kind === 'directory') {
+      out.push(
+        ...(await collectDirectoryEntries(
+          handle as FileSystemDirectoryHandle,
+          relativePath
+        ))
+      )
+    }
+  }
+  return out
+}
+
+/**
+ * Enumerates a directory handle across browsers that expose async iteration
+ * and those that only expose `.entries()` / `.values()`.
+ */
+async function listDirectoryHandles(
+  root: FileSystemDirectoryHandle
+): Promise<Array<{ name: string; handle: FileSystemHandle }>> {
+  const out: Array<{ name: string; handle: FileSystemHandle }> = []
+  const asEntries = root as FileSystemDirectoryHandle & {
+    entries?: () => AsyncIterableIterator<[string, FileSystemHandle]>
+    values?: () => AsyncIterableIterator<FileSystemHandle>
+  }
+
+  if (typeof asEntries.entries === 'function') {
+    for await (const [name, handle] of asEntries.entries()) {
+      out.push({ name, handle })
+    }
+    return out
+  }
+
+  if (
+    typeof (root as unknown as AsyncIterable<[string, FileSystemHandle]>)[
+      Symbol.asyncIterator
+    ] === 'function'
+  ) {
+    for await (const [name, handle] of root as unknown as AsyncIterable<
+      [string, FileSystemHandle]
+    >) {
+      out.push({ name, handle })
+    }
+    return out
+  }
+
+  if (typeof asEntries.values === 'function') {
+    for await (const handle of asEntries.values()) {
+      out.push({ name: handle.name, handle })
+    }
+    return out
+  }
+
+  throw new Error('Directory listing is not supported in this browser')
+}
+
+function ensurePackageSourceGateDom(
+  folderSupport: AcExLocalFolderOpenSupport
+): void {
+  const existing = document.getElementById('mlcad-package-gate')
+  if (existing) {
+    syncFolderControls(existing, folderSupport)
+    return
+  }
+
+  const styleId = 'mlcad-package-gate-style'
+  if (!document.getElementById(styleId)) {
+    const style = document.createElement('style')
+    style.id = styleId
+    style.textContent = `
+#mlcad-package-gate {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(12, 14, 18, 0.92);
+  color: #e8eaed;
+}
+#mlcad-package-gate[hidden] { display: none !important; }
+#mlcad-package-gate-card {
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 22px 20px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #1a1d24;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+#mlcad-package-gate-card h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+#mlcad-package-gate-card p {
+  margin: 0;
+  line-height: 1.45;
+  color: rgba(232, 234, 237, 0.82);
+  font-size: 0.92rem;
+}
+#mlcad-package-gate-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+#mlcad-package-folder-btn,
+#mlcad-package-url-form button {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: #2a3140;
+  color: inherit;
+  border-radius: 6px;
+  padding: 10px 12px;
+  cursor: pointer;
+  font: inherit;
+}
+#mlcad-package-folder-btn:hover,
+#mlcad-package-url-form button:hover {
+  background: #364052;
+}
+#mlcad-package-folder-btn[hidden] { display: none !important; }
+#mlcad-package-url-form {
+  display: flex;
+  gap: 8px;
+}
+#mlcad-package-url {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  background: #0f1218;
+  color: inherit;
+  padding: 10px 12px;
+  font: inherit;
+}
+#mlcad-package-gate-error {
+  color: #ff8a80;
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+#mlcad-package-folder-input { display: none; }
+`
+    document.head.appendChild(style)
+  }
+
+  const gate = document.createElement('div')
+  gate.id = 'mlcad-package-gate'
+  gate.hidden = true
+  gate.innerHTML = `
+    <div id="mlcad-package-gate-card" role="dialog" aria-modal="true" aria-labelledby="mlcad-package-gate-title">
+      <h2 id="mlcad-package-gate-title" data-i18n-key="package.title" data-i18n-text>Open drawing package</h2>
+      <p id="mlcad-package-gate-hint" data-i18n-key="package.hint" data-i18n-text>
+        No drawing.acex.json was found next to this page. Choose a local package folder or enter the manifest URL.
+      </p>
+      <div id="mlcad-package-gate-actions">
+        <button type="button" id="mlcad-package-folder-btn" data-i18n-key="package.chooseFolder" data-i18n-text>
+          Choose local folder
+        </button>
+        <form id="mlcad-package-url-form">
+          <input
+            id="mlcad-package-url"
+            type="text"
+            name="manifestUrl"
+            autocomplete="off"
+            spellcheck="false"
+            data-i18n-attr="placeholder"
+            data-i18n-key="package.urlPlaceholder"
+            placeholder="https://example.com/drawing.acex.json"
+          />
+          <button type="submit" data-i18n-key="package.openUrl" data-i18n-text>Open URL</button>
+        </form>
+      </div>
+      <div id="mlcad-package-gate-error" hidden></div>
+      <input id="mlcad-package-folder-input" type="file" multiple />
+    </div>
+  `
+
+  const folderInput = gate.querySelector(
+    '#mlcad-package-folder-input'
+  ) as HTMLInputElement | null
+  if (folderInput) {
+    // Chromium / Safari / Firefox: webkitdirectory. Some engines also accept
+    // the non-standard `directory` attribute.
+    folderInput.setAttribute('webkitdirectory', '')
+    folderInput.setAttribute('directory', '')
+  }
+
+  const host =
+    document.getElementById('mlcad-loading') ?? document.body
+  host.appendChild(gate)
+  syncFolderControls(gate, folderSupport)
+}
+
+function syncFolderControls(
+  gate: HTMLElement,
+  folderSupport: AcExLocalFolderOpenSupport
+): void {
+  const available = canOpenLocalPackageFolder(folderSupport)
+  const folderBtn = gate.querySelector(
+    '#mlcad-package-folder-btn'
+  ) as HTMLButtonElement | null
+  const folderInput = gate.querySelector(
+    '#mlcad-package-folder-input'
+  ) as HTMLInputElement | null
+  const hintEl = gate.querySelector('#mlcad-package-gate-hint')
+  if (folderBtn) folderBtn.hidden = !available
+  if (folderInput) {
+    folderInput.hidden = !available
+    folderInput.disabled = !available
+  }
+  if (hintEl) {
+    hintEl.setAttribute(
+      'data-i18n-key',
+      available ? 'package.hint' : 'package.hintUrlOnly'
+    )
+  }
+}

--- a/packages/cad-html-plugin/src/AcExHtmlPackager.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlPackager.ts
@@ -1,5 +1,6 @@
 import type { AcExHtmlAccessManifest } from './AcExHtmlAccess'
 import { resolveAcExHtmlLocale } from './AcExHtmlI18n'
+import { ACEX_DEFAULT_MANIFEST_HREF } from './AcExHtmlPackageBootstrap'
 import { ACEX_HTML_SHELL_CSS, buildAcExHtmlShellBody } from './AcExHtmlShell'
 import { encodeSnapshot, snapshotMimeType } from './AcExSnapshotCodec'
 import type { AcExEncodedSnapshot } from './AcExSnapshotCompression'
@@ -39,10 +40,11 @@ export interface AcExPackHtmlPackageOptions {
   /** Inline viewer bootstrap script (IIFE). */
   viewerRuntime: string
   /**
-   * URL of the `*.acex.json` manifest relative to the HTML file
-   * (or an absolute CDN URL).
+   * Optional URL of the `*.acex.json` manifest relative to the HTML file.
+   * When omitted, the generic viewer probes `./drawing.acex.json` (and query /
+   * folder / URL pickers) at runtime — no drawing-specific path is embedded.
    */
-  manifestUrl: string
+  manifestUrl?: string
 }
 
 /**
@@ -94,11 +96,12 @@ ${accessScript}  <script id="mlcad-snapshot" type="${snapshotType}">${encoded.pa
 }
 
 /**
- * Builds a shell HTML document that loads render data from a package manifest URL.
- * Contains only HTML/CSS/JS — no embedded geometry.
+ * Builds a shell HTML document that loads render data from a package manifest.
+ * Contains only HTML/CSS/JS — no embedded geometry and no drawing-specific
+ * data-file paths by default (see {@link ACEX_DEFAULT_MANIFEST_HREF}).
  *
  * @param snapshot - Used for title, locale, background, and viewer mode chrome.
- * @param options - Runtime source and manifest URL.
+ * @param options - Runtime source and optional manifest URL override.
  */
 export function packHtmlPackage(
   snapshot: AcExSnapshot,
@@ -110,9 +113,12 @@ export function packHtmlPackage(
   const htmlLang = resolveAcExHtmlLocale(snapshot.meta.locale) ?? 'en'
   const viewerMode = snapshot.meta.viewerMode ?? 'measure'
   const exportLayouts = snapshot.meta.exportLayouts !== false
-  const packageConfig = JSON.stringify({
-    manifestUrl: options.manifestUrl
-  })
+  const manifestUrl = options.manifestUrl?.trim()
+  const packageConfig = JSON.stringify(
+    manifestUrl && manifestUrl !== ACEX_DEFAULT_MANIFEST_HREF
+      ? { manifestUrl }
+      : {}
+  )
 
   return `<!DOCTYPE html>
 <html lang="${htmlLang}">

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -39,6 +39,13 @@ import { setupAcExHtmlLayoutMenu } from './AcExHtmlLayoutMenu'
 import { setupAcExHtmlMeasurePanel } from './AcExHtmlMeasurePanel'
 import { setupAcExHtmlMeasureSettings } from './AcExHtmlMeasureSettings'
 import { setupAcExHtmlNavTools } from './AcExHtmlNavTools'
+import {
+  acexGlobalFetch,
+  chooseInitialManifestHref,
+  probePackageManifest,
+  resolveViewerManifestUrl
+} from './AcExHtmlPackageBootstrap'
+import { promptAcExHtmlPackageSource } from './AcExHtmlPackageSourceGate'
 import { setupAcExHtmlReviewPanel } from './AcExHtmlReviewPanel'
 import { acexSyncHtmlShortCutSelection } from './AcExHtmlShortCutSelection'
 import { setupAcExHtmlShortCutToolbar } from './AcExHtmlShortCutToolbar'
@@ -66,9 +73,7 @@ import { AcExOsnapIndex, estimateOsnapRebuildWork } from './AcExOsnap'
 import { AcExOsnapMarker } from './AcExOsnapMarker'
 import {
   loadAcExPackageLayoutOsnap,
-  parseAcExPackageManifest,
   resolveChunkUrl,
-  resolvePackageManifestUrl,
   snapshotSkeletonFromManifest
 } from './AcExPackageLoader'
 import type { AcExPackageManifest } from './AcExPackageTypes'
@@ -300,6 +305,128 @@ function flipNearBlackWhiteMaterials(root: THREE.Object3D): void {
   })
 }
 
+/**
+ * Resolves a multi-file package session for generic `viewer.html`:
+ * query `?manifest=` / `?acex=` → config → sibling `drawing.acex.json` →
+ * folder / URL picker when the default file is missing.
+ */
+async function openAcExHtmlPackageSession(options: {
+  pageUrl: string
+  search: string
+  configManifestUrl?: string
+  i18n: AcExHtmlI18n
+}): Promise<{
+  manifest: AcExPackageManifest
+  manifestUrl: string
+  fetchImpl: typeof fetch
+} | null> {
+  const { i18n } = options
+  const initial = chooseInitialManifestHref({
+    search: options.search,
+    configManifestUrl: options.configManifestUrl
+  })
+
+  const tryUrl = async (
+    href: string,
+    fetchImpl: typeof fetch = acexGlobalFetch
+  ): Promise<
+    | { ok: true; manifest: AcExPackageManifest; manifestUrl: string }
+    | { ok: false; reason: 'not-found' | 'invalid' | 'network'; error: Error }
+  > => {
+    let manifestUrl: string
+    try {
+      manifestUrl = resolveViewerManifestUrl(href, options.pageUrl)
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'invalid',
+        error: error instanceof Error ? error : new Error(String(error))
+      }
+    }
+    const probed = await probePackageManifest(manifestUrl, fetchImpl)
+    if (!probed.ok) {
+      return { ok: false, reason: probed.reason, error: probed.error }
+    }
+    return { ok: true, manifest: probed.manifest, manifestUrl }
+  }
+
+  const first = await tryUrl(initial.href)
+  if (first.ok) {
+    return {
+      manifest: first.manifest,
+      manifestUrl: first.manifestUrl,
+      fetchImpl: acexGlobalFetch
+    }
+  }
+
+  // Query / explicit URL failures are fatal (show error, no picker).
+  if (initial.fromQuery || first.reason === 'invalid') {
+    const message =
+      first.reason === 'invalid'
+        ? i18n.t('package.invalidManifest', { error: first.error.message })
+        : i18n.t('package.loadFailed', { error: first.error.message })
+    showViewerError(message)
+    return null
+  }
+
+  // Sibling default missing → let the user pick a folder or paste a URL.
+  let gateErrorKey:
+    | 'package.manifestNotFound'
+    | 'package.invalidManifest'
+    | 'package.folderMissingManifest'
+    | 'package.loadFailed'
+    | undefined = 'package.manifestNotFound'
+  let gateErrorMessage: string | undefined
+
+  for (;;) {
+    let choice: Awaited<ReturnType<typeof promptAcExHtmlPackageSource>>
+    try {
+      choice = await promptAcExHtmlPackageSource(i18n, {
+        errorKey: gateErrorKey,
+        errorMessage: gateErrorMessage
+      })
+    } catch {
+      showViewerError(i18n.t('package.manifestNotFound'))
+      return null
+    }
+
+    if (choice.kind === 'url') {
+      const loaded = await tryUrl(choice.href)
+      if (loaded.ok) {
+        return {
+          manifest: loaded.manifest,
+          manifestUrl: loaded.manifestUrl,
+          fetchImpl: acexGlobalFetch
+        }
+      }
+      gateErrorKey =
+        loaded.reason === 'invalid'
+          ? 'package.invalidManifest'
+          : 'package.loadFailed'
+      gateErrorMessage = i18n.t(gateErrorKey, {
+        error: loaded.error.message
+      })
+      continue
+    }
+
+    const loaded = await tryUrl(choice.manifestUrl, choice.fetchImpl)
+    if (loaded.ok) {
+      return {
+        manifest: loaded.manifest,
+        manifestUrl: loaded.manifestUrl,
+        fetchImpl: choice.fetchImpl
+      }
+    }
+    gateErrorKey =
+      loaded.reason === 'invalid'
+        ? 'package.invalidManifest'
+        : 'package.loadFailed'
+    gateErrorMessage = i18n.t(gateErrorKey, {
+      error: loaded.error.message
+    })
+  }
+}
+
 function bootstrap(): void {
   void accmYieldForPaint().then(() => startViewer())
 }
@@ -386,6 +513,7 @@ async function startViewer(): Promise<void> {
   let packageSession: {
     manifest: AcExPackageManifest
     manifestUrl: string
+    fetchImpl: typeof fetch
     loadedLayouts: Set<string>
     loadedOsnapLayouts: Set<string>
   } | null = null
@@ -395,25 +523,20 @@ async function startViewer(): Promise<void> {
       const config = JSON.parse(packageEl.textContent?.trim() || '{}') as {
         manifestUrl?: string
       }
-      const manifestUrl = config.manifestUrl?.trim()
-      if (!manifestUrl) {
-        throw new Error('Missing manifestUrl in package config')
+      const opened = await openAcExHtmlPackageSession({
+        pageUrl: window.location.href,
+        search: window.location.search,
+        configManifestUrl: config.manifestUrl,
+        i18n
+      })
+      if (!opened) {
+        return
       }
-      const absoluteManifestUrl = resolvePackageManifestUrl(
-        manifestUrl,
-        window.location.href
-      )
-      const manifestResponse = await fetch(absoluteManifestUrl)
-      if (!manifestResponse.ok) {
-        throw new Error(
-          `Failed to load package manifest (${manifestResponse.status})`
-        )
-      }
-      const manifest = parseAcExPackageManifest(await manifestResponse.json())
-      snapshot = snapshotSkeletonFromManifest(manifest)
+      snapshot = snapshotSkeletonFromManifest(opened.manifest)
       packageSession = {
-        manifest,
-        manifestUrl: absoluteManifestUrl,
+        manifest: opened.manifest,
+        manifestUrl: opened.manifestUrl,
+        fetchImpl: opened.fetchImpl,
         loadedLayouts: new Set(),
         loadedOsnapLayouts: new Set()
       }
@@ -638,7 +761,7 @@ async function startViewer(): Promise<void> {
           total: String(chunks.length)
         })
         const url = resolveChunkUrl(packageSession.manifestUrl, chunkRef.href)
-        const response = await fetch(url)
+        const response = await packageSession.fetchImpl(url)
         if (!response.ok) {
           throw new Error(
             `Failed to load geometry chunk (${response.status})`
@@ -713,6 +836,7 @@ async function startViewer(): Promise<void> {
       target.btrId,
       target,
       {
+        fetchImpl: packageSession.fetchImpl,
         yieldFn: async () => {
           paintPackageChunk?.()
           await accmYieldForPaint()

--- a/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExOsnapPrimitiveBuilder.ts
@@ -40,6 +40,7 @@ import {
   AcDbPolyline,
   AcDbRasterImage,
   AcDbRay,
+  AcDbSolid,
   AcDbSpline,
   AcDbTable,
   AcDbText,
@@ -1362,6 +1363,8 @@ function visitEntity(
       matrix,
       dimension.getFullDimBlockTransform()
     )
+    // Keep arrowhead vertices (SOLID / solid-fill HATCH) for snap. Extension
+    // lines are still omitted because pushLine is a no-op for catalog export.
     visitBlock(
       block,
       nested,
@@ -1370,7 +1373,7 @@ function visitEntity(
       blockStack,
       database,
       includeLayer,
-      false
+      true
     )
     blockStack.delete(block.objectId)
     return
@@ -1456,6 +1459,26 @@ function visitEntity(
 
   if (entity instanceof AcDbXline) {
     pushDirectedLine(out, layer, matrix, entity.basePoint, entity.unitDir, true)
+    return
+  }
+
+  if (entity instanceof AcDbSolid) {
+    // Dimension arrowheads are SOLID entities inside anonymous dim blocks.
+    // Always keep their vertices for endpoint / nearest snap — even when
+    // visiting dim blocks with exportFillBoundaries=false (which skips TRACE
+    // fills and other mesh boundaries that are not useful for snapping).
+    pushCatalogPath(
+      out,
+      layer,
+      matrix,
+      [
+        entity.getPointAt(0),
+        entity.getPointAt(1),
+        entity.getPointAt(3),
+        entity.getPointAt(2)
+      ],
+      true
+    )
     return
   }
 
@@ -1599,8 +1622,9 @@ function ellipseFromArc(entity: AcDbArc): AcDbEllipse {
  * `AcDbMLeader`, `AcDbText`, `AcDbMText`, `AcDbPoint`, `AcDbRasterImage`,
  * `AcDbOle2Frame`, `AcDbTable`, INSERT / MINSERT (with ATTRIB), and dimension
  * entities (`AcDbDimension` and subclasses via anonymous dim blocks). Hatch /
- * TRACE / SOLID / IMAGE / OLE fills are stored as `path` primitives except
- * inside dimension blocks (arrow solids are skipped).
+ * TRACE / SOLID / IMAGE / OLE fills are stored as `path` primitives. Dimension
+ * arrowheads (SOLID entities or solid-fill HATCH inserts) keep their vertices
+ * so tips remain snappable; straight dim lines still omit `line` kinds.
  *
  * @param database - Open drawing database (same instance used for HTML export).
  * @param layoutBtrId - Object id of the layout's owning block table record

--- a/packages/cad-html-plugin/src/AcExPackageBuilder.ts
+++ b/packages/cad-html-plugin/src/AcExPackageBuilder.ts
@@ -12,6 +12,7 @@ import {
   splitLineBatch,
   splitMeshBatch
 } from './AcExGeometryBatchSplit'
+import { ACEX_DEFAULT_MANIFEST_FILE } from './AcExHtmlPackageBootstrap'
 import { packHtmlPackage } from './AcExHtmlPackager'
 import {
   encodeOsnapCatalogGzip,
@@ -39,7 +40,10 @@ import type {
 export interface AcExBuildPackageOptions {
   /** Inline viewer runtime IIFE source. */
   viewerRuntime: string
-  /** Base name for files (no extension), e.g. `drawing`. */
+  /**
+   * Optional stem retained for API compatibility. Multi-file packages always
+   * write {@link ACEX_DEFAULT_MANIFEST_FILE} so `viewer.html` stays generic.
+   */
   baseName?: string
   /** Max uncompressed ACEC bytes per geometry chunk. */
   maxChunkBytes?: number
@@ -52,8 +56,9 @@ export interface AcExBuildPackageOptions {
   /** Max estimated uncompressed ACEO bytes per OSNAP chunk. */
   maxOsnapChunkBytes?: number
   /**
-   * Relative or absolute manifest URL embedded in the shell HTML.
-   * Defaults to `./{baseName}.acex.json`.
+   * Optional relative or absolute manifest URL embedded in the shell HTML.
+   * When omitted, the shell stays generic and probes
+   * `./drawing.acex.json` at runtime.
    */
   manifestUrl?: string
 }
@@ -159,15 +164,14 @@ export function buildAcExPackage(
     throw new Error(`Unsupported snapshot version: ${snapshot.version}`)
   }
 
-  const baseName = sanitizeBaseName(
-    options.baseName ?? snapshot.meta.title ?? 'drawing'
-  )
   const maxChunkBytes = options.maxChunkBytes ?? ACEX_DEFAULT_CHUNK_MAX_BYTES
   const maxBatchBytes = options.maxBatchBytes ?? ACEX_MAX_GEOMETRY_BATCH_BYTES
   const maxOsnapChunkBytes =
     options.maxOsnapChunkBytes ?? ACEX_DEFAULT_OSNAP_CHUNK_MAX_BYTES
-  const manifestFileName = `${baseName}.acex.json`
-  const manifestUrl = options.manifestUrl ?? `./${manifestFileName}`
+  // Generic viewer.html always looks for this sibling name; keep zip contents
+  // aligned so hosting is drop-in (`viewer.html` + `drawing.acex.json`).
+  const manifestFileName = ACEX_DEFAULT_MANIFEST_FILE
+  const manifestUrl = options.manifestUrl
 
   const orderedLayouts = orderLayoutsForExport(
     snapshot.layouts,
@@ -296,7 +300,7 @@ export function buildAcExPackage(
   const html = packHtmlPackage(snapshot, {
     title: snapshot.meta.title,
     viewerRuntime: options.viewerRuntime,
-    manifestUrl
+    ...(manifestUrl ? { manifestUrl } : {})
   })
   files.unshift({
     path: 'viewer.html',
@@ -318,20 +322,4 @@ function orderLayoutsForExport(
   const active = layouts.find(l => l.btrId === activeLayoutBtrId)
   const rest = layouts.filter(l => l.btrId !== activeLayoutBtrId)
   return active ? [active, ...rest] : [...layouts]
-}
-
-/**
- * File-name stem for package files (`{base}.acex.json`, zip-safe path segments).
- * Keeps only `[A-Za-z0-9._-]`; spaces, `+`, parentheses, and other punctuation
- * become underscores so {@link zipAcExPackageFiles} / package href checks pass.
- * The browser download name for the `.zip` itself may still use the original
- * drawing title via {@link resolveExportDownloadName}.
- */
-function sanitizeBaseName(name: string): string {
-  const trimmed = name.trim().replace(/\.(dwg|dxf|html|zip|acex\.json)$/i, '')
-  const safe = trimmed
-    .replace(/[^A-Za-z0-9._-]+/g, '_')
-    .replace(/_+/g, '_')
-    .replace(/^[_./-]+|[_./-]+$/g, '')
-  return safe.length > 0 ? safe : 'drawing'
 }

--- a/packages/cad-html-plugin/src/AcExPackageLoader.ts
+++ b/packages/cad-html-plugin/src/AcExPackageLoader.ts
@@ -1,4 +1,5 @@
 import { decodeChunkGzip } from './AcExChunkBinaryCodec'
+import { acexGlobalFetch } from './AcExHtmlPackageBootstrap'
 import { decodeOsnapCatalogGzip } from './AcExOsnapCatalogCodec'
 import type { AcExOsnapPrimitive } from './AcExOsnapPrimitiveTypes'
 import {
@@ -234,7 +235,7 @@ async function fetchCompressedBytes(
 export async function loadAcExPackage(
   options: AcExPackageLoaderOptions
 ): Promise<AcExSnapshot> {
-  const fetchImpl = options.fetchImpl ?? fetch
+  const fetchImpl = options.fetchImpl ?? acexGlobalFetch
   const loadOsnap = options.loadOsnap !== false
   const manifestResponse = await fetchImpl(options.manifestUrl)
   if (!manifestResponse.ok) {
@@ -322,7 +323,7 @@ export async function loadAcExPackageLayout(
   layout: AcExLayoutSnapshot,
   options: Pick<AcExPackageLoaderOptions, 'fetchImpl' | 'onChunk'> = {}
 ): Promise<void> {
-  const fetchImpl = options.fetchImpl ?? fetch
+  const fetchImpl = options.fetchImpl ?? acexGlobalFetch
   const layoutRef = manifest.layouts.find(l => l.btrId === layoutBtrId)
   if (!layoutRef) {
     throw new Error(`Layout not found: ${layoutBtrId}`)
@@ -387,7 +388,7 @@ export async function loadAcExPackageLayoutOsnap(
     return
   }
 
-  const fetchImpl = options.fetchImpl ?? fetch
+  const fetchImpl = options.fetchImpl ?? acexGlobalFetch
   const yieldFn =
     options.yieldFn ??
     (() =>

--- a/packages/cad-html-plugin/src/AcExPackageTypes.ts
+++ b/packages/cad-html-plugin/src/AcExPackageTypes.ts
@@ -115,7 +115,7 @@ export interface AcExPackageFiles {
   html: string
   /** Manifest object (also serialized as `*.acex.json`). */
   manifest: AcExPackageManifest
-  /** Manifest file name at package root (e.g. `drawing.acex.json`). */
+  /** Manifest file name at package root (always `drawing.acex.json`). */
   manifestFileName: string
   /** All package files including HTML, manifest, and chunk `.acex.gz` files. */
   files: AcExPackageFile[]

--- a/packages/cad-html-plugin/src/index.ts
+++ b/packages/cad-html-plugin/src/index.ts
@@ -39,6 +39,27 @@ export {
 } from './AcExOsnapPrimitiveToAcGe'
 export { packHtml, packHtmlPackage, type AcExPackHtmlOptions, type AcExPackHtmlPackageOptions } from './AcExHtmlPackager'
 export {
+  ACEX_DEFAULT_MANIFEST_FILE,
+  ACEX_DEFAULT_MANIFEST_HREF,
+  ACEX_MANIFEST_QUERY_KEYS,
+  ACEX_PACKAGE_DIRECTORY_ORIGIN,
+  acexGlobalFetch,
+  buildPackageDirectoryFileMap,
+  canOpenLocalPackageFolder,
+  chooseInitialManifestHref,
+  createPackageDirectoryFetch,
+  detectLocalFolderOpenSupport,
+  detectSharedDirectoryRoot,
+  findDefaultManifestInDirectory,
+  isAbsoluteHttpUrl,
+  normalizePackageDirectoryPath,
+  probePackageManifest,
+  readManifestUrlFromSearchParams,
+  resolveViewerManifestUrl,
+  type AcExLocalFolderOpenSupport,
+  type AcExManifestProbeResult
+} from './AcExHtmlPackageBootstrap'
+export {
   type AcApHtmlExpiryDays,
   type AcExHtmlAccessManifest,
   ACEX_HTML_EXPIRY_COUNTDOWN_MS,


### PR DESCRIPTION
## Summary
- Make multi-file ACEX export use a generic `viewer.html` plus fixed `drawing.acex.json`, resolved via `?manifest=` / `?acex=`, sibling probe, or a folder/URL picker when the default file is missing.
- Keep dimension arrowhead SOLID / solid-fill HATCH vertices in the OSNAP catalog while still omitting extension lines.
- Update package format / hosting docs and add bootstrap unit coverage.

## Test plan
- [ ] `pnpm test -- packages/cad-html-plugin/__tests__/AcExHtmlPackageBootstrap.spec.ts packages/cad-html-plugin/__tests__/AcExPackage.spec.ts packages/cad-html-plugin/__tests__/AcExOsnapPrimitiveBuilder.spec.ts`
- [ ] Export a multi-file package and confirm zip contents are `viewer.html` + `drawing.acex.json` + `chunks/`
- [ ] Open hosted `viewer.html` with sibling manifest, with `?manifest=`, and with missing sibling (folder/URL gate)
- [ ] Confirm dimension arrow endpoints still snap in the offline viewer
