### PR TITLE
feat: lazy font catalog loading and per-session missed fonts

### DIFF
--- a/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApDocManagerFontUrl.spec.ts
@@ -4,6 +4,8 @@ class MockAcApFontLoader {
   private _baseUrl = ''
   load = jest.fn(() => Promise.resolve())
   avaiableFonts = []
+  fontLoader = {}
+  getAvaiableFonts = jest.fn(async () => [])
 
   constructor() {
     mockFontLoaderInstances.push(this)

--- a/packages/cad-simple-viewer/__tests__/AcApMTextCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApMTextCmd.spec.ts
@@ -5,6 +5,7 @@ jest.mock('../src/app', () => ({
   AcApDocManager: {
     instance: {
       avaiableFonts: [],
+      getAvaiableFonts: jest.fn(async () => []),
       editor: {
         getBox: mockGetBox
       }

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -85,7 +85,8 @@ import {
   AcEdCalculateSizeCallback,
   AcEdCommand,
   AcEdCommandStack,
-  AcEdOpenMode
+  AcEdOpenMode,
+  eventBus
 } from '../editor'
 import { AcApPluginManager } from '../plugin/AcApPluginManager'
 import { isScriptQuitCommand, parseScriptLines } from '../util/AcApScriptParser'
@@ -539,9 +540,10 @@ export class AcApDocManager {
     acapBindMarkupSession(this._activeSession.id)
 
     this._fontLoader = new AcApFontLoader()
+    // Share one DefaultFontLoader cache between UI catalog and on-demand draws.
+    FontManager.instance.setFontLoader(this._fontLoader.fontLoader)
     const fontsUrl = this.resolveFontsBaseUrl()
     this._fontLoader.baseUrl = fontsUrl
-    // On-demand loads go through FontManager's loader, not AcApFontLoader.
     FontManager.instance.baseUrl = fontsUrl
     acdbHostApplicationServices().workingDatabase = doc.database
 
@@ -1084,11 +1086,29 @@ export class AcApDocManager {
    * Gets the list of available fonts that can be loaded.
    *
    * Note: These fonts are available for loading but may not be loaded yet.
+   * Prefer {@link getAvaiableFonts} when the catalog may not have been fetched yet
+   * (lazy font loading no longer preloads metadata at viewer init).
    *
    * @returns Array of available font names
    */
   get avaiableFonts() {
     return this._fontLoader.avaiableFonts
+  }
+
+  /**
+   * Fetches font repository metadata (`fonts.json`) if not already cached.
+   * Emits `failed-to-get-avaiable-fonts` and returns `[]` when the catalog cannot
+   * be retrieved.
+   */
+  async getAvaiableFonts() {
+    try {
+      return await this._fontLoader.getAvaiableFonts()
+    } catch {
+      eventBus.emit('failed-to-get-avaiable-fonts', {
+        url: this._fontLoader.baseUrl
+      })
+      return []
+    }
   }
 
   /**

--- a/packages/cad-simple-viewer/src/app/AcApFontLoader.ts
+++ b/packages/cad-simple-viewer/src/app/AcApFontLoader.ts
@@ -86,6 +86,14 @@ export class AcApFontLoader {
   }
 
   /**
+   * Underlying mtext-renderer loader. Share with {@link FontManager.setFontLoader}
+   * so catalog fetches populate one cache for both drawing and UI.
+   */
+  get fontLoader(): AcTrFontLoader {
+    return this._loader
+  }
+
+  /**
    * Base URL to load fonts
    */
   get baseUrl() {

--- a/packages/cad-simple-viewer/src/command/draw/AcApMTextCmd.ts
+++ b/packages/cad-simple-viewer/src/command/draw/AcApMTextCmd.ts
@@ -37,9 +37,11 @@ export class AcApMTextCmd extends AcEdCommand {
     const view = context.view as AcTrView2d
     const textHeight = this.pixelsToWorldY(view, 24)
     const location = { x: box.min.x, y: box.max.y, z: 0 }
+    const availableFonts =
+      (await AcApDocManager.instance.getAvaiableFonts()) ?? []
     const toolbarFontFamilies = Array.from(
       new Set(
-        AcApDocManager.instance.avaiableFonts
+        availableFonts
           .flatMap(fontInfo => fontInfo.name)
           .map(fontName => fontName.trim())
           .filter(fontName => fontName.length > 0)

--- a/packages/cad-simple-viewer/src/view/AcTrView2d.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrView2d.ts
@@ -344,6 +344,10 @@ export class AcTrView2d extends AcEdBaseView {
         count: args.count ?? 0
       })
     })
+    this._renderer.events.fontLoaded.addEventListener(() => {
+      // Lazy load success clears FontManager.missedFonts; refresh status-bar state.
+      eventBus.emit('missed-data-changed', {})
+    })
 
     this._scene = this.createScene()
     this._layerAppearance = new AcTrLayerAppearanceController(
@@ -1509,7 +1513,7 @@ export class AcTrView2d extends AcEdBaseView {
         textHeight: this.resolveMTextEditorTextHeight(mtext),
         initialText: mtext.contents,
         initialAttachmentPoint: mtext.attachmentPoint,
-        toolbarFontFamilies: this.getMTextToolbarFontFamilies()
+        toolbarFontFamilies: await this.getMTextToolbarFontFamilies()
       })
       if (!result) return
 
@@ -1550,10 +1554,12 @@ export class AcTrView2d extends AcEdBaseView {
     return Math.max(Math.abs(p1.y - p0.y), 1e-4)
   }
 
-  private getMTextToolbarFontFamilies() {
+  private async getMTextToolbarFontFamilies() {
+    const availableFonts =
+      (await AcApDocManager.instance.getAvaiableFonts()) ?? []
     return Array.from(
       new Set(
-        AcApDocManager.instance.avaiableFonts
+        availableFonts
           .flatMap(fontInfo => fontInfo.name)
           .map(fontName => fontName.trim())
           .filter(fontName => fontName.length > 0)
@@ -2162,6 +2168,7 @@ export class AcTrView2d extends AcEdBaseView {
     this._externallyFramedLayouts.clear()
     this._loadingLayouts.clear()
     this._renderer.dispose()
+    eventBus.emit('missed-data-changed', {})
   }
 
   /**
@@ -2177,6 +2184,7 @@ export class AcTrView2d extends AcEdBaseView {
       externallyFramedLayouts: this._externallyFramedLayouts,
       loadingLayouts: this._loadingLayouts,
       missedImages: this._missedImages,
+      missedFonts: this._renderer.snapshotMissedFonts(),
       selectionIds: this.selectionSet.ids
     }
   }
@@ -2197,6 +2205,7 @@ export class AcTrView2d extends AcEdBaseView {
     this._externallyFramedLayouts = state.externallyFramedLayouts
     this._loadingLayouts = state.loadingLayouts
     this._missedImages = state.missedImages
+    this._renderer.replaceMissedFonts(state.missedFonts ?? {})
     this.rebindLayerAppearance()
     this._layoutViewManager.resize(this.width, this.height)
     this.selectionSet.clear()
@@ -2204,6 +2213,7 @@ export class AcTrView2d extends AcEdBaseView {
       this.selectionSet.add(state.selectionIds)
     }
     this._isDirty = true
+    eventBus.emit('missed-data-changed', {})
   }
 
   /**
@@ -2223,9 +2233,11 @@ export class AcTrView2d extends AcEdBaseView {
     this._externallyFramedLayouts = new Set()
     this._loadingLayouts = new Set()
     this._missedImages = new Map()
+    this._renderer.clearMissedFonts()
     this.rebindLayerAppearance()
     this.selectionSet.clear()
     this._isDirty = true
+    eventBus.emit('missed-data-changed', {})
     return parked
   }
 
@@ -2241,6 +2253,7 @@ export class AcTrView2d extends AcEdBaseView {
     state.externallyFramedLayouts.clear()
     state.loadingLayouts.clear()
     state.missedImages.clear()
+    state.missedFonts = {}
     state.selectionIds = []
   }
 

--- a/packages/cad-simple-viewer/src/view/AcTrViewSessionState.ts
+++ b/packages/cad-simple-viewer/src/view/AcTrViewSessionState.ts
@@ -22,6 +22,12 @@ export interface AcTrViewSessionState {
   loadingLayouts: Set<AcDbObjectId>
   /** Missing raster images keyed by entity id. */
   missedImages: Map<AcDbObjectId, string>
+  /**
+   * Missing fonts reported while this document was active.
+   * Parked with the session so FontManager's live map can track the active
+   * document only; restored when the session becomes active again.
+   */
+  missedFonts: Record<string, number>
   /** Selected entity ids at the moment the session was parked. */
   selectionIds: AcDbObjectId[]
 }

--- a/packages/cad-viewer/src/component/MlCadViewer.vue
+++ b/packages/cad-viewer/src/component/MlCadViewer.vue
@@ -586,16 +586,16 @@ eventBus.on('message', params => {
   // Also add to notification center
   switch (params.type) {
     case 'success':
-      success('System Message', params.message)
+      success(t('main.notification.title.systemMessage'), params.message)
       break
     case 'warning':
-      warning('System Warning', params.message)
+      warning(t('main.notification.title.systemWarning'), params.message)
       break
     case 'error':
-      error('System Error', params.message)
+      error(t('main.notification.title.systemError'), params.message)
       break
     default:
-      info('System Info', params.message)
+      info(t('main.notification.title.systemInfo'), params.message)
       break
   }
 })

--- a/packages/cad-viewer/src/component/palette/MlMissingResources.vue
+++ b/packages/cad-viewer/src/component/palette/MlMissingResources.vue
@@ -188,18 +188,19 @@ const canApply = computed(() => {
   return false
 })
 
-const refreshAvailableFonts = () => {
-  availableFontInfos.value = AcApDocManager.instance.avaiableFonts
+const refreshAvailableFonts = async () => {
+  availableFontInfos.value =
+    (await AcApDocManager.instance.getAvaiableFonts()) ?? []
 }
 
 onMounted(() => {
-  refreshAvailableFonts()
+  void refreshAvailableFonts()
 })
 
 watch(
   () => store.dialogs.activeMissingResourceTab,
   tab => {
-    if (tab === 'font') refreshAvailableFonts()
+    if (tab === 'font') void refreshAvailableFonts()
   }
 )
 

--- a/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
+++ b/packages/cad-viewer/src/component/ribbon/useMTextContextualRibbon.ts
@@ -2,6 +2,7 @@ import { CircleClose } from '@element-plus/icons-vue'
 import type { AcEdCommandEventArgs } from '@mlightcad/cad-simple-viewer'
 import {
   AcApDocManager,
+  type AcApFontInfo,
   AcApFontUtil,
   AcEdMTextEditor,
   AcGiTextParagraphAlignment
@@ -725,6 +726,7 @@ export function useMTextContextualRibbon({
     const bridge = getMTextEditorBridge()
     bridge.addActiveInputBoxChangeListener?.(handleActiveInputBoxChanged)
     bindEditorEvents(bridge.getActiveInputBox?.() ?? null)
+    void ensureAvailableFontsLoaded()
   })
 
   onUnmounted(() => {
@@ -843,6 +845,9 @@ export function useMTextContextualRibbon({
     applyCurrentFormat(nextFormat)
   }
 
+  /** Remote font catalog for MText pickers (filled asynchronously). */
+  const availableFontCatalog = ref<AcApFontInfo[]>([])
+
   /**
    * Builds the font dropdown options for the current editor context.
    *
@@ -850,7 +855,10 @@ export function useMTextContextualRibbon({
    * available system fonts, and the default fallback.
    */
   const getFontOptions = () => {
-    const availableFonts = AcApDocManager.instance?.avaiableFonts ?? []
+    const availableFonts =
+      availableFontCatalog.value.length > 0
+        ? availableFontCatalog.value
+        : (AcApDocManager.instance?.avaiableFonts ?? [])
     const fontNames = availableFonts.flatMap(fontInfo => fontInfo.name)
     const styleFonts = getTextStyleRecords().map(
       record => record.textStyle.font
@@ -861,6 +869,14 @@ export function useMTextContextualRibbon({
       ...fontNames,
       DEFAULT_MTEXT_FORMAT.fontFamily
     ])
+  }
+
+  /** Ensures the remote font catalog is loaded before MText font pickers open. */
+  const ensureAvailableFontsLoaded = async () => {
+    const fonts = await AcApDocManager.instance?.getAvaiableFonts()
+    if (fonts) {
+      availableFontCatalog.value = fonts
+    }
   }
 
   /**

--- a/packages/cad-viewer/src/composable/useMissedData.ts
+++ b/packages/cad-viewer/src/composable/useMissedData.ts
@@ -183,7 +183,10 @@ function ensureInitialized(): void {
   AcApDocManager.instance.events.documentActivated.addEventListener(() => {
     xrefOverlays.clear()
     imageData.clear()
+    fontMapping.clear()
     syncFromCurrentView()
+    // Refresh notification center (font-missed) for the newly active document.
+    eventBus.emit('missed-data-changed', {})
   })
 
   eventBus.on('font-not-found', () => {

--- a/packages/cad-viewer/src/composable/useTextStyle.ts
+++ b/packages/cad-viewer/src/composable/useTextStyle.ts
@@ -533,9 +533,9 @@ export function useTextStyle(editor: AcApDocManager = AcApDocManager.instance) {
    * Refreshes the font catalog, style list, and selects the drawing's current
    * TEXTSTYLE (or the first available style).
    */
-  function openDialog() {
+  async function openDialog() {
     const db = getDatabase()
-    fontInfos.value = editor.avaiableFonts ?? []
+    fontInfos.value = (await editor.getAvaiableFonts()) ?? []
     refreshStyleList(db)
     const initial = db?.textstyle || styleNames.value[0] || ''
     selectStyle(initial)

--- a/packages/cad-viewer/src/locale/ar/main.ts
+++ b/packages/cad-viewer/src/locale/ar/main.ts
@@ -1530,7 +1530,11 @@ export default {
       fontNotFound: 'الخط غير موجود',
       fontNotLoaded: 'لم يتم تحميل الخط',
 
-      parsingWarning: 'مشكلات أثناء تحليل الرسم'
+      parsingWarning: 'مشكلات أثناء تحليل الرسم',
+      systemMessage: 'رسالة النظام',
+      systemWarning: 'تحذير النظام',
+      systemError: 'خطأ النظام',
+      systemInfo: 'معلومات النظام'
     }
   }
 

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -1025,7 +1025,11 @@ export default {
       failedToOpenFileLicenseInvalid: 'Neplatná licence',
       fontNotFound: 'Font nenalezen',
       fontNotLoaded: 'Font nenačten',
-      parsingWarning: 'Problémy při načítání výkresu'
+      parsingWarning: 'Problémy při načítání výkresu',
+      systemMessage: 'Systémová zpráva',
+      systemWarning: 'Systémové varování',
+      systemError: 'Systémová chyba',
+      systemInfo: 'Systémové informace'
     }
   }
 }

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -1038,7 +1038,11 @@ export default {
       failedToOpenFileLicenseInvalid: 'Invalid License',
       fontNotFound: 'Font Not Found',
       fontNotLoaded: 'Font Not Loaded',
-      parsingWarning: 'Issues on Parsing Drawing'
+      parsingWarning: 'Issues on Parsing Drawing',
+      systemMessage: 'System Message',
+      systemWarning: 'System Warning',
+      systemError: 'System Error',
+      systemInfo: 'System Info'
     }
   }
 }

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -1039,7 +1039,11 @@ export default {
       failedToOpenFileLicenseInvalid: 'Geçersiz Lisans',
       fontNotFound: 'Yazı Tipi Bulunamadı',
       fontNotLoaded: 'Yazı Tipi Yüklenemedi',
-      parsingWarning: 'Çizim Ayrıştırma Sorunları'
+      parsingWarning: 'Çizim Ayrıştırma Sorunları',
+      systemMessage: 'Sistem Mesajı',
+      systemWarning: 'Sistem Uyarısı',
+      systemError: 'Sistem Hatası',
+      systemInfo: 'Sistem Bilgisi'
     }
   }
 }

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -993,7 +993,11 @@ export default {
       failedToOpenFileLicenseInvalid: '许可证无效',
       fontNotFound: '找不到字体',
       fontNotLoaded: '无法加载字体',
-      parsingWarning: '解析图纸问题'
+      parsingWarning: '解析图纸问题',
+      systemMessage: '系统消息',
+      systemWarning: '系统警告',
+      systemError: '系统错误',
+      systemInfo: '系统信息'
     }
   }
 }

--- a/packages/three-renderer/src/renderer/AcTrMTextRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrMTextRenderer.ts
@@ -143,6 +143,22 @@ export class AcTrMTextRenderer {
   }
 
   /**
+   * Replaces session-scoped missed-font bookkeeping on the main thread and workers.
+   */
+  async replaceMissedFonts(fonts: Record<string, number>): Promise<void> {
+    if (this._renderer) {
+      await this._renderer.replaceMissedFonts(fonts)
+      return
+    }
+    FontManager.instance.replaceMissedFonts(fonts)
+  }
+
+  /** Clears session-scoped missed-font bookkeeping on the main thread and workers. */
+  async clearMissedFonts(): Promise<void> {
+    await this.replaceMissedFonts({})
+  }
+
+  /**
    * Render MText using the current mode asynchronously
    */
   async asyncRenderMText(

--- a/packages/three-renderer/src/renderer/AcTrRenderer.ts
+++ b/packages/three-renderer/src/renderer/AcTrRenderer.ts
@@ -437,6 +437,29 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
   }
 
   /**
+   * Snapshot of session-scoped missed fonts for park/restore.
+   */
+  snapshotMissedFonts(): Record<string, number> {
+    return { ...FontManager.instance.missedFonts }
+  }
+
+  /**
+   * Restores or clears session-scoped missed fonts (main + MText workers).
+   * Fire-and-forget worker sync so document switches stay synchronous.
+   */
+  replaceMissedFonts(fonts: Record<string, number>): void {
+    FontManager.instance.replaceMissedFonts(fonts)
+    void AcTrMTextRenderer.getInstance().replaceMissedFonts(
+      FontManager.instance.missedFonts
+    )
+  }
+
+  /** Clears session-scoped missed fonts for the active document. */
+  clearMissedFonts(): void {
+    this.replaceMissedFonts({})
+  }
+
+  /**
    * Gets whether entity lineweights are displayed.
    */
   get showLineWeight() {
@@ -666,7 +689,7 @@ export class AcTrRenderer implements AcGiRenderer<AcTrEntity> {
    */
   dispose() {
     this._context.styleManager.dispose()
-    FontManager.instance.missedFonts = {}
+    this.clearMissedFonts()
   }
 
   private linePoints(points: AcGePoint3dLike[]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 overrides:
   '@mlightcad/data-model': ^1.14.4
   '@mlightcad/libredwg-converter': ^3.14.4
-  '@mlightcad/mtext-input-box': ^0.2.24
-  '@mlightcad/mtext-renderer': ^0.12.5
+  '@mlightcad/mtext-input-box': ^0.2.25
+  '@mlightcad/mtext-renderer': ^0.12.7
   '@mlightcad/ribbon': ^0.1.13
   '@mlightcad/ui-components': ^0.1.11
   element-plus: ^2.12.0
@@ -171,8 +171,8 @@ importers:
         specifier: ^3.14.4
         version: 3.14.4(@mlightcad/data-model@1.14.4)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.12.5
-        version: 0.12.5(three@0.172.0)
+        specifier: ^0.12.7
+        version: 0.12.7(three@0.172.0)
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -246,11 +246,11 @@ importers:
         specifier: ^1.14.4
         version: 1.14.4
       '@mlightcad/mtext-input-box':
-        specifier: ^0.2.24
-        version: 0.2.24(@mlightcad/mtext-renderer@0.12.5(three@0.172.0))(three@0.172.0)
+        specifier: ^0.2.25
+        version: 0.2.25(@mlightcad/mtext-renderer@0.12.7(three@0.172.0))(three@0.172.0)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.12.5
-        version: 0.12.5(three@0.172.0)
+        specifier: ^0.12.7
+        version: 0.12.7(three@0.172.0)
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -300,8 +300,8 @@ importers:
         specifier: ^3.14.4
         version: 3.14.4(@mlightcad/data-model@1.14.4)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.12.5
-        version: 0.12.5(three@0.172.0)
+        specifier: ^0.12.7
+        version: 0.12.7(three@0.172.0)
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -349,8 +349,8 @@ importers:
         specifier: ^3.14.4
         version: 3.14.4(@mlightcad/data-model@1.14.4)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.12.5
-        version: 0.12.5(three@0.172.0)
+        specifier: ^0.12.7
+        version: 0.12.7(three@0.172.0)
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -380,8 +380,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       '@mlightcad/mtext-renderer':
-        specifier: ^0.12.5
-        version: 0.12.5(three@0.172.0)
+        specifier: ^0.12.7
+        version: 0.12.7(three@0.172.0)
 
   packages/cad-viewer:
     devDependencies:
@@ -485,8 +485,8 @@ importers:
         specifier: ^3.14.4
         version: 3.14.4(@mlightcad/data-model@1.14.4)
       '@mlightcad/mtext-renderer':
-        specifier: ^0.12.5
-        version: 0.12.5(three@0.172.0)
+        specifier: ^0.12.7
+        version: 0.12.7(three@0.172.0)
       '@mlightcad/three-renderer':
         specifier: workspace:*
         version: link:../three-renderer
@@ -562,8 +562,8 @@ importers:
         specifier: ^1.14.4
         version: 1.14.4
       '@mlightcad/mtext-renderer':
-        specifier: ^0.12.5
-        version: 0.12.5(three@0.172.0)
+        specifier: ^0.12.7
+        version: 0.12.7(three@0.172.0)
       '@types/three':
         specifier: ^0.172.0
         version: 0.172.0
@@ -2084,20 +2084,20 @@ packages:
     resolution: {integrity: sha512-L9wnwQn8cgHIr6I5El/8TgKSXaRacW9vytSpsU19xufmrnAAqEEGcW0MU92PgEiDKuQtU4GBenERIDfSrbY99g==}
     engines: {node: '>=20'}
 
-  '@mlightcad/mtext-input-box@0.2.24':
-    resolution: {integrity: sha512-stp0lP8NyaDKawGHO27cZPE39hAmKO7PEBd3e/HenxLtKBEvhqGSTbwQIkjizNvqF2rqfo5CGE7GvvNlZTiLOQ==}
+  '@mlightcad/mtext-input-box@0.2.25':
+    resolution: {integrity: sha512-0pafjV0FJxG+w8+pBmyCOABUhyk45q1+x5LEUD2dZBQsK7DfzbTIpvWDj2Q964ia4j3Ce2n1MQD5itzjjRqN7g==}
     peerDependencies:
-      '@mlightcad/mtext-renderer': ^0.12.5
+      '@mlightcad/mtext-renderer': ^0.12.7
       three: ^0.172.0
 
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
-  '@mlightcad/mtext-parser@1.5.0':
-    resolution: {integrity: sha512-Yl/IQmSIGV1UUl/TyUptoOpNBunywcEE7yh4k9SFDXljHDTTI92VmqkVFxf4eYzhoWF4MNXIl4qgQV1P1Rbn6g==}
+  '@mlightcad/mtext-parser@1.5.1':
+    resolution: {integrity: sha512-fOs7Qi54YwKtcyPe1VzVeFxveDWpvDnzwonZijsG3bBxohYxrX+Q2p3XvqaUBIkVNQbnHBFEU/TDOfjIPGy0gw==}
 
-  '@mlightcad/mtext-renderer@0.12.5':
-    resolution: {integrity: sha512-8e4PHWZigsgJR3EdF5ciniWi1Nr9SkaUuEQACarIU8IzBnbxm9hL6ficTcq8mzbgOW/ZNwxAM+tKUCGCv60GWA==}
+  '@mlightcad/mtext-renderer@0.12.7':
+    resolution: {integrity: sha512-DgbmlvhFUTW+w+QMcbjmvbzokqv9Sx3Jv3dglebQDSDV30ZJ+XNuXh7UpCLrKne2nAzDlaZoYpKpLi+Cs+pyaA==}
     peerDependencies:
       three: ^0.172.0
 
@@ -8029,19 +8029,19 @@ snapshots:
 
   '@mlightcad/libredwg-web@0.7.10': {}
 
-  '@mlightcad/mtext-input-box@0.2.24(@mlightcad/mtext-renderer@0.12.5(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/mtext-input-box@0.2.25(@mlightcad/mtext-renderer@0.12.7(three@0.172.0))(three@0.172.0)':
     dependencies:
-      '@mlightcad/mtext-renderer': 0.12.5(three@0.172.0)
+      '@mlightcad/mtext-renderer': 0.12.7(three@0.172.0)
       '@mlightcad/text-box-cursor': 0.1.1(three@0.172.0)
       three: 0.172.0
 
   '@mlightcad/mtext-parser@1.4.1': {}
 
-  '@mlightcad/mtext-parser@1.5.0': {}
+  '@mlightcad/mtext-parser@1.5.1': {}
 
-  '@mlightcad/mtext-renderer@0.12.5(three@0.172.0)':
+  '@mlightcad/mtext-renderer@0.12.7(three@0.172.0)':
     dependencies:
-      '@mlightcad/mtext-parser': 1.5.0
+      '@mlightcad/mtext-parser': 1.5.1
       '@mlightcad/shx-parser': 1.4.5
       iconv-lite: 0.7.2
       idb: 8.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,8 @@ allowBuilds:
 overrides:
   '@mlightcad/data-model': '^1.14.4'
   '@mlightcad/libredwg-converter': '^3.14.4'
-  '@mlightcad/mtext-input-box': '^0.2.24'
-  '@mlightcad/mtext-renderer': '^0.12.5'
+  '@mlightcad/mtext-input-box': '^0.2.25'
+  '@mlightcad/mtext-renderer': '^0.12.7'
   '@mlightcad/ribbon': '^0.1.13'
   '@mlightcad/ui-components': '^0.1.11'
   element-plus: '^2.12.0'


### PR DESCRIPTION
## Summary
- Bump `@mlightcad/mtext-renderer` / `mtext-input-box` and share one `DefaultFontLoader` cache between UI catalog fetches and on-demand drawing.
- Fetch `fonts.json` lazily via `getAvaiableFonts()` for missing-resources, text style, and MText UI (including create/edit toolbar font lists).
- Park/restore `missedFonts` with document sessions and refresh status-bar/notification state when fonts load or the active document changes; i18n system notification titles.

## Test plan
- [ ] Open a drawing with missing fonts; confirm status-bar / Missing Resources updates, then load fonts and confirm the warning clears.
- [ ] Switch between two documents with different missing fonts; confirm each session restores the correct missed-font list.
- [ ] Open Missing Resources / Text Style / MText ribbon and verify the remote font catalog populates without a startup preload.
- [ ] Create and edit MText; confirm toolbar font families are available on a cold start (before other UI fetched the catalog).
- [ ] Switch UI language and trigger a system notification; confirm titles are localized.