### PR TITLE
feat: reading-mode toggle and disable switch-bg while active

### DIFF
--- a/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
+++ b/packages/cad-simple-ui-plugin/__tests__/resolveToolbarItems.spec.ts
@@ -2,7 +2,14 @@
 jest.mock('@mlightcad/cad-simple-viewer', () => ({
   AcApDocManager: {
     instance: {
-      curDocument: undefined
+      curDocument: undefined,
+      isReadingModeEnabled: () => false
+    }
+  },
+  AcApSettingManager: {
+    instance: {
+      get: () => true,
+      toggle: jest.fn()
     }
   },
   /** Minimal mock used by {@link acuiCreateDefaultToolbarItems} markup visibility toggle. */
@@ -233,6 +240,25 @@ describe('default toolbar items', () => {
     expect(childIds).toContain('theme')
     expect(childIds).toContain('locale')
     expect(childIds).toContain('toolbar-placement')
+  })
+
+  it('exposes reading mode as a toggle and disables switch-bg while reading mode is on', () => {
+    const items = acuiCreateDefaultToolbarItems()
+    const settings = items.find(item => item.id === 'settings')
+    const readingMode = settings?.children?.find(
+      child => child.id === 'reading-mode'
+    )
+    const switchBg = settings?.children?.find(child => child.id === 'switch-bg')
+
+    expect(readingMode?.toggle?.getValue).toEqual(expect.any(Function))
+    expect(readingMode?.toggle?.on.command).toBe('readingmode')
+    expect(readingMode?.toggle?.off.command).toBe('readingmode')
+    expect(readingMode?.toggle?.getValue()).toBe(false)
+
+    expect(switchBg?.disabled).toEqual(expect.any(Function))
+    expect(typeof switchBg?.disabled === 'function' && switchBg.disabled()).toBe(
+      false
+    )
   })
 
   it('places toolbar placement before theme inside settings', () => {

--- a/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
@@ -1,6 +1,6 @@
 import {
-  type AcApLocale,
   AcApDocManager,
+  type AcApLocale,
   AcApSettingManager,
   AcEdOpenMode,
   type AcEdUiTheme,

--- a/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
+++ b/packages/cad-simple-ui-plugin/src/config/defaultToolbarItems.ts
@@ -1,5 +1,6 @@
 import {
   type AcApLocale,
+  AcApDocManager,
   AcApSettingManager,
   AcEdOpenMode,
   type AcEdUiTheme,
@@ -207,6 +208,40 @@ function acuiCreateSimulatedMouseToolbarItem(): AcUiToolbarItem {
         label: 'toolbar.simulatedMouseOff',
         icon: ICON_SIMULATED_MOUSE,
         action: toggle
+      }
+    }
+  }
+}
+
+/** Whether transient reading mode is active on the current view. */
+function acuiIsReadingModeEnabled(): boolean {
+  try {
+    return AcApDocManager.instance.isReadingModeEnabled()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Builds the reading-mode toggle (black linework on a white canvas).
+ *
+ * @returns Toggle toolbar item bound to the `readingmode` command.
+ */
+function acuiCreateReadingModeToolbarItem(): AcUiToolbarItem {
+  return {
+    id: 'reading-mode',
+    requiresDocument: true,
+    toggle: {
+      getValue: acuiIsReadingModeEnabled,
+      on: {
+        label: 'toolbar.readingMode',
+        icon: ICON_READING_MODE,
+        command: 'readingmode'
+      },
+      off: {
+        label: 'toolbar.readingMode',
+        icon: ICON_READING_MODE,
+        command: 'readingmode'
       }
     }
   }
@@ -460,15 +495,12 @@ export function acuiCreateSettingsToolbarItem(
         id: 'switch-bg',
         label: 'toolbar.switchBg',
         icon: ICON_SWITCH_BG,
-        command: 'switchbg'
+        command: 'switchbg',
+        // Reading mode forces a white canvas; switching background has no
+        // visible effect until reading mode is turned off.
+        disabled: acuiIsReadingModeEnabled
       },
-      {
-        id: 'reading-mode',
-        label: 'toolbar.readingMode',
-        icon: ICON_READING_MODE,
-        requiresDocument: true,
-        command: 'readingmode'
-      },
+      acuiCreateReadingModeToolbarItem(),
       acuiCreateToolbarLocaleItem(context)
     ]
   }

--- a/packages/cad-simple-viewer/__tests__/AcApSwitchBgCmd.spec.ts
+++ b/packages/cad-simple-viewer/__tests__/AcApSwitchBgCmd.spec.ts
@@ -1,0 +1,72 @@
+jest.mock('../src/app', () => ({}))
+
+jest.mock('../src/editor', () => {
+  class AcEdCommand {}
+
+  return {
+    AcEdCommand
+  }
+})
+
+const setVar = jest.fn()
+const getVar = jest.fn(() => ({ red: 0, green: 0, blue: 0 }))
+const getDescriptor = jest.fn(() => ({}))
+
+jest.mock('@mlightcad/data-model', () => ({
+  AcCmColor: class {},
+  AcDbSysVarManager: {
+    instance: () => ({
+      getDescriptor,
+      getVar,
+      setVar
+    })
+  }
+}))
+
+jest.mock('../src/editor/global/AcEdUiColor', () => ({
+  layoutBackgroundSysVar: jest.fn(() => 'MODELBKCOLOR'),
+  toggleBlackWhiteBackgroundColor: jest.fn(color => ({
+    ...color,
+    toggled: true
+  }))
+}))
+
+import { AcApSwitchBgCmd } from '../src/command/AcApSwitchBgCmd'
+
+describe('AcApSwitchBgCmd', () => {
+  beforeEach(() => {
+    setVar.mockClear()
+    getVar.mockClear()
+    getDescriptor.mockClear()
+  })
+
+  it('no-ops when reading mode is enabled', async () => {
+    const cmd = new AcApSwitchBgCmd()
+    await cmd.execute({
+      doc: { database: {} },
+      view: {
+        readingModeEnabled: true,
+        activeLayoutBtrId: 'model',
+        modelSpaceBtrId: 'model'
+      }
+    } as never)
+
+    expect(setVar).not.toHaveBeenCalled()
+  })
+
+  it('toggles the layout background sysvar when reading mode is off', async () => {
+    const cmd = new AcApSwitchBgCmd()
+    const database = {}
+    await cmd.execute({
+      doc: { database },
+      view: {
+        readingModeEnabled: false,
+        activeLayoutBtrId: 'model',
+        modelSpaceBtrId: 'model'
+      }
+    } as never)
+
+    expect(getDescriptor).toHaveBeenCalledWith('MODELBKCOLOR')
+    expect(setVar).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/cad-simple-viewer/src/command/AcApSwitchBgCmd.ts
+++ b/packages/cad-simple-viewer/src/command/AcApSwitchBgCmd.ts
@@ -21,8 +21,14 @@ export class AcApSwitchBgCmd extends AcEdCommand {
    * @param context - The application context containing the view
    */
   async execute(context: AcApContext) {
-    const db = context.doc.database
     const view = context.view as AcTrView2d
+    // Reading mode owns the clear colour (white) and linework; switching the
+    // layout background would not be visible until reading mode is disabled.
+    if (view.readingModeEnabled) {
+      return
+    }
+
+    const db = context.doc.database
     const isModelSpace = view.activeLayoutBtrId === view.modelSpaceBtrId
     const variableName = layoutBackgroundSysVar(isModelSpace)
     const sysVarManager = AcDbSysVarManager.instance()

--- a/packages/cad-viewer/src/component/layout/MlToolBars.vue
+++ b/packages/cad-viewer/src/component/layout/MlToolBars.vue
@@ -6,7 +6,15 @@ import {
   isMeasurementVisible
 } from '@mlightcad/cad-simple-viewer'
 import { MlButtonData, MlToolBar } from '@mlightcad/ui-components'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import {
+  type Component,
+  computed,
+  defineComponent,
+  h,
+  onMounted,
+  onUnmounted,
+  ref
+} from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useDocument, useSettings } from '../../composable'
@@ -50,6 +58,23 @@ const { isDocumentOpening, openMode: docOpenMode } = useDocument()
 const isToolbarDisabled = computed(() => isDocumentOpening.value)
 const markupVisible = ref(isMarkupVisible())
 const measurementVisible = ref(isMeasurementVisible())
+const readingModeEnabled = ref(false)
+
+/** Marks the reading-mode "on" icon so toolbar CSS can highlight the button. */
+const readingModeOnIcon: Component = defineComponent({
+  name: 'IconReadingModeOn',
+  setup() {
+    return () => h(readingMode, { 'data-reading-mode-on': '' })
+  }
+})
+
+/** Marks switch-bg as visually disabled while reading mode owns the canvas. */
+const switchBgDisabledIcon: Component = defineComponent({
+  name: 'IconSwitchBgDisabled',
+  setup() {
+    return () => h(switchBg, { 'data-toolbar-disabled': '' })
+  }
+})
 
 const syncMarkupVisibility = () => {
   markupVisible.value = isMarkupVisible()
@@ -59,22 +84,35 @@ const syncMeasurementVisibility = () => {
   measurementVisible.value = isMeasurementVisible()
 }
 
+const syncReadingMode = () => {
+  try {
+    readingModeEnabled.value = AcApDocManager.instance.isReadingModeEnabled()
+  } catch {
+    readingModeEnabled.value = false
+  }
+}
+
 onMounted(() => {
   const docs = AcApDocManager.instance
   docs.editor.events.commandEnded.addEventListener(syncMarkupVisibility)
   docs.editor.events.commandEnded.addEventListener(syncMeasurementVisibility)
+  docs.editor.events.commandEnded.addEventListener(syncReadingMode)
   docs.events.documentActivated.addEventListener(syncMarkupVisibility)
   docs.events.documentActivated.addEventListener(syncMeasurementVisibility)
+  docs.events.documentActivated.addEventListener(syncReadingMode)
   syncMarkupVisibility()
   syncMeasurementVisibility()
+  syncReadingMode()
 })
 
 onUnmounted(() => {
   const docs = AcApDocManager.instance
   docs.editor.events.commandEnded.removeEventListener(syncMarkupVisibility)
   docs.editor.events.commandEnded.removeEventListener(syncMeasurementVisibility)
+  docs.editor.events.commandEnded.removeEventListener(syncReadingMode)
   docs.events.documentActivated.removeEventListener(syncMarkupVisibility)
   docs.events.documentActivated.removeEventListener(syncMeasurementVisibility)
+  docs.events.documentActivated.removeEventListener(syncReadingMode)
 })
 
 const toolbarSeparator = { type: 'separator' } as MlButtonData
@@ -102,6 +140,7 @@ const visibilityToggle = (
 })
 
 const verticalToolbarData = computed(() => {
+  const readingOn = readingModeEnabled.value
   const items: MlButtonData[] = [
     {
       icon: select,
@@ -134,16 +173,28 @@ const verticalToolbarData = computed(() => {
       description: t('main.verticalToolbar.layer.description')
     },
     {
-      icon: switchBg,
+      icon: readingOn ? switchBgDisabledIcon : switchBg,
       text: t('main.verticalToolbar.switchBg.text'),
       command: 'switchbg',
-      description: t('main.verticalToolbar.switchBg.description')
+      description: readingOn
+        ? t('main.verticalToolbar.switchBg.disabledInReadingMode')
+        : t('main.verticalToolbar.switchBg.description')
     },
     {
-      icon: readingMode,
-      text: t('main.verticalToolbar.readingMode.text'),
       command: 'readingmode',
-      description: t('main.verticalToolbar.readingMode.description')
+      toggle: {
+        value: readingOn,
+        on: {
+          icon: readingModeOnIcon,
+          text: t('main.verticalToolbar.readingMode.text'),
+          description: t('main.verticalToolbar.readingMode.description')
+        },
+        off: {
+          icon: readingMode,
+          text: t('main.verticalToolbar.readingMode.text'),
+          description: t('main.verticalToolbar.readingMode.description')
+        }
+      }
     },
     {
       icon: measure,
@@ -325,6 +376,7 @@ const verticalToolbarData = computed(() => {
 
 const handleCommand = (command?: string) => {
   if (isToolbarDisabled.value || !command) return
+  if (command === 'switchbg' && readingModeEnabled.value) return
   AcApDocManager.instance.sendStringToExecute(command)
 }
 
@@ -365,6 +417,19 @@ const handleToggle = (command: string) => {
   opacity: 0.6;
   pointer-events: none;
   user-select: none;
+}
+
+/* MlToolBar toggles do not apply is-selected; highlight reading mode via icon mark. */
+.ml-vertical-toolbar-container .ml-toolbar-button:has([data-reading-mode-on]) {
+  color: var(--el-button-hover-text-color);
+  background-color: var(--el-button-hover-bg-color);
+  border-color: var(--el-button-hover-border-color);
+}
+
+.ml-vertical-toolbar-container .ml-toolbar-button:has([data-toolbar-disabled]) {
+  opacity: 0.45;
+  pointer-events: none;
+  cursor: not-allowed;
 }
 
 .acap-svg-icon {

--- a/packages/cad-viewer/src/locale/ar/main.ts
+++ b/packages/cad-viewer/src/locale/ar/main.ts
@@ -807,7 +807,8 @@ export default {
     switchBg: {
       ...enMain.verticalToolbar.switchBg,
       text: 'تبديل',
-      description: 'التبديل بين خلفية الرسم السوداء والبيضاء'
+      description: 'التبديل بين خلفية الرسم السوداء والبيضاء',
+      disabledInReadingMode: 'غير متاح أثناء وضع القراءة (اللوحة البيضاء ثابتة)'
     },
 
     zoomToExtent: {

--- a/packages/cad-viewer/src/locale/cs/main.ts
+++ b/packages/cad-viewer/src/locale/cs/main.ts
@@ -566,7 +566,9 @@ export default {
     },
     switchBg: {
       text: 'Pozadí',
-      description: 'Přepne pozadí výkresu mezi bílým a černým'
+      description: 'Přepne pozadí výkresu mezi bílým a černým',
+      disabledInReadingMode:
+        'Nedostupné v režimu čtení (bílé plátno je pevné)'
     },
     zoomToExtent: {
       text: 'Zoom vše',

--- a/packages/cad-viewer/src/locale/en/main.ts
+++ b/packages/cad-viewer/src/locale/en/main.ts
@@ -574,7 +574,9 @@ export default {
     },
     switchBg: {
       text: 'Switch',
-      description: 'Switches the drawing background between white and black'
+      description: 'Switches the drawing background between white and black',
+      disabledInReadingMode:
+        'Unavailable while reading mode is on (white canvas is fixed)'
     },
     readingMode: {
       text: 'Reading',

--- a/packages/cad-viewer/src/locale/tr/main.ts
+++ b/packages/cad-viewer/src/locale/tr/main.ts
@@ -576,7 +576,9 @@ export default {
     },
     switchBg: {
       text: 'Değiştir',
-      description: 'Çizim arka planını beyaz ve siyah arasında değiştirir'
+      description: 'Çizim arka planını beyaz ve siyah arasında değiştirir',
+      disabledInReadingMode:
+        'Okuma modundayken kullanılamaz (beyaz tuval sabittir)'
     },
     zoomToExtent: {
       text: 'Tümünü Yakınlaştır',

--- a/packages/cad-viewer/src/locale/zh/main.ts
+++ b/packages/cad-viewer/src/locale/zh/main.ts
@@ -532,11 +532,12 @@ export default {
     },
     switchBg: {
       text: '切换背景色',
-      description: '在白色与黑色之间切换绘图背景色'
+      description: '在白色与黑色之间切换绘图背景色',
+      disabledInReadingMode: '阅读模式下不可用（白底固定）'
     },
     readingMode: {
       text: '阅读模式',
-      description: '切换阅读模式：白底黑线，便于阅读复杂图纸'
+      description: '切换阅读模式（白底黑线，便于审阅）'
     },
     zoomToExtent: {
       text: '范围缩放',

--- a/packages/cad-viewer/src/style/index.scss
+++ b/packages/cad-viewer/src/style/index.scss
@@ -5,12 +5,29 @@
   --ml-status-bar-height: 30px;
 }
 
+html,
+body {
+  // Teleported tooltips (e.g. right-docked toolbar) must not grow page width.
+  overflow-x: hidden;
+}
+
 body {
   font-family: Inter, system-ui, Avenir, "Helvetica Neue", Helvetica, "PingFang SC", "Hiragino Sans GB",
     "Microsoft YaHei", "微软雅黑", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
+}
+
+/**
+ * Constrain Element Plus tooltips so long CJK descriptions wrap instead of
+ * extending past the right edge of a right-docked toolbar.
+ */
+.el-popper[role='tooltip'] {
+  max-width: min(280px, calc(100vw - 24px));
+  box-sizing: border-box;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 a {


### PR DESCRIPTION
## Summary
- Surface reading mode as a proper toolbar toggle (simple-ui + vertical toolbar) and keep switch-background disabled/no-op while reading mode owns the white canvas.
- Guard `AcApSwitchBgCmd` when reading mode is on, with unit coverage for both paths.
- Constrain Element Plus tooltip width / page overflow so long CJK descriptions do not stretch a right-docked toolbar.

## Test plan
- [ ] Open a drawing, enable reading mode from settings and vertical toolbar; confirm toggle highlights and canvas is white linework.
- [ ] With reading mode on, confirm switch-bg is visually disabled and does not change background (command and UI).
- [ ] Turn reading mode off; confirm switch-bg works again between black/white.
- [ ] Hover switch-bg while reading mode is on; confirm disabled tooltip in en/zh (and other locales if available).
- [ ] Right-docked toolbar: long Chinese tooltips wrap within viewport without horizontal page scroll.
- [ ] Run unit tests for `cad-simple-ui-plugin` and `cad-simple-viewer` related specs.
