### PR TITLE
feat: notification bell placement and collapsible shortcut toolbar

### DIFF
--- a/packages/cad-html-plugin/src/AcExHtmlI18n.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlI18n.ts
@@ -96,6 +96,8 @@ export type AcExHtmlMessageKey =
   | 'shortCutToolbar.undo'
   | 'shortCutToolbar.redo'
   | 'shortCutToolbar.erase'
+  | 'shortCutToolbar.collapse'
+  | 'shortCutToolbar.expand'
   | 'textHeight.title'
   | 'textHeight.close'
   | 'textHeight.ok'
@@ -320,7 +322,9 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       more: 'More',
       undo: 'Undo',
       redo: 'Redo',
-      erase: 'Delete'
+      erase: 'Delete',
+      collapse: 'Collapse toolbar',
+      expand: 'Expand toolbar'
     },
     textHeight: {
       title: 'Text Height',
@@ -577,7 +581,9 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       more: '更多',
       undo: '撤销',
       redo: '重做',
-      erase: '删除'
+      erase: '删除',
+      collapse: '收起工具栏',
+      expand: '展开工具栏'
     },
     textHeight: {
       title: '字高设置',
@@ -824,7 +830,9 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       more: 'Více',
       undo: 'Zpět',
       redo: 'Znovu',
-      erase: 'Smazat'
+      erase: 'Smazat',
+      collapse: 'Sbalit panel nástrojů',
+      expand: 'Rozbalit panel nástrojů'
     },
     textHeight: {
       title: 'Výška textu',
@@ -1081,7 +1089,9 @@ const BASE_MESSAGES: Record<Exclude<AcExHtmlLocale, 'ar'>, AcExMessageTree> = {
       more: 'Daha fazla',
       undo: 'Geri al',
       redo: 'Yinele',
-      erase: 'Sil'
+      erase: 'Sil',
+      collapse: 'Araç çubuğunu daralt',
+      expand: 'Araç çubuğunu genişlet'
     },
     textHeight: {
       title: 'Yazı Yüksekliği',

--- a/packages/cad-html-plugin/src/AcExHtmlShortCutToolbar.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlShortCutToolbar.ts
@@ -65,7 +65,9 @@ export function setupAcExHtmlShortCutToolbar(
       more: ctx.i18n.t('shortCutToolbar.more'),
       undo: ctx.i18n.t('shortCutToolbar.undo'),
       redo: ctx.i18n.t('shortCutToolbar.redo'),
-      erase: ctx.i18n.t('shortCutToolbar.erase')
+      erase: ctx.i18n.t('shortCutToolbar.erase'),
+      collapse: ctx.i18n.t('shortCutToolbar.collapse'),
+      expand: ctx.i18n.t('shortCutToolbar.expand')
     }
   })
 

--- a/packages/cad-simple-viewer/docs/notification-center.md
+++ b/packages/cad-simple-viewer/docs/notification-center.md
@@ -74,11 +74,11 @@ acapSetNotificationCenter(null)     // restore built-in store + default UI (if e
 
 `AcUiDefaultNotificationUi` ties chrome visibility to the **active session’s** notification list:
 
-| State | Bell | Panel | Backdrop (phone) |
+| State | Bell | Panel | Backdrop (phone / pad) |
 |---|---|---|---|
 | `notifications.length === 0` | Hidden | Hidden | Hidden |
 | Has messages, panel closed | Visible (badge) | Hidden | Hidden |
-| Has messages, user tapped bell | Visible | Visible | Visible on phone |
+| Has messages, user tapped bell | Visible | Visible | Visible on phone / pad |
 
 Interaction rules:
 
@@ -111,14 +111,15 @@ Custom Centers should drive their own show/hide from `subscribe` / reactive `not
 ### Theme and layout
 
 - Styles use `--ml-ui-*` via `acedApplyUiTheme` / `resolveUiTheme` (same tokens as the shortcut toolbar and command line).
-- **Desktop (non-handheld):** bell at the **canvas** bottom-right; panel opens above the bell.
-- **Phone / Pad / handheld:** bell is placed **below** the measured shortcut toolbar (so it does not cover undo/redo/erase). On phone the panel is a top sheet + dimmed backdrop, both clipped to the canvas host.
+- **Desktop / pad:** bell at the **canvas** bottom-right by default. Pad opens a **top sheet** (with backdrop) whose width matches the pad session input panel (`ML_UI_SESSION_PANEL_WIDTH`, capped to the canvas host via `calc(100% - ML_UI_SESSION_PANEL_INSET)`).
+- **Phone:** bell is placed **below** the measured shortcut toolbar (so it does not cover undo/redo/erase). The panel is a full-width top sheet + dimmed backdrop, both clipped to the canvas host.
+- Override the bell corner with `notificationCenter.placement` or `acapSetNotificationUiPlacement` (`bottom-right` | `bottom-left` | `top-right` | `top-left`).
 - The bell is **not** merged into the shortcut toolbar: notifications are system alerts, not drawing shortcuts; toggling visibility would shift toolbar buttons, and the toolbar can be hidden in settings.
 
 ### Options
 
 ```ts
-import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { AcApDocManager, acapSetNotificationUiPlacement } from '@mlightcad/cad-simple-viewer'
 
 AcApDocManager.createInstance({
   container: document.getElementById('viewer')!,
@@ -126,9 +127,15 @@ AcApDocManager.createInstance({
     // Mount node for the bell; defaults to curView.container (canvas host)
     host: document.getElementById('viewer')!,
     // true (default): show built-in bell; false: bridge only, host supplies UI
-    showDefaultUi: true
+    showDefaultUi: true,
+    // Optional: override layout default (phone top-right, pad/desktop bottom-right)
+    placement: 'bottom-right'
   }
 })
+
+// Runtime (built-in DOM UI only)
+acapSetNotificationUiPlacement('bottom-left')
+acapSetNotificationUiPlacement(null) // restore layout defaults
 ```
 
 `cad-viewer` uses `showDefaultUi: false` and registers a Vue notification center.

--- a/packages/cad-simple-viewer/src/app/AcApDocManager.ts
+++ b/packages/cad-simple-viewer/src/app/AcApDocManager.ts
@@ -126,7 +126,8 @@ import {
 import { AcApXrefManager } from './AcApXrefManager'
 import {
   acapDisposeNotificationService,
-  acapInstallNotificationService
+  acapInstallNotificationService,
+  type AcUiNotificationBellPlacement
 } from './notification'
 
 const DEFAULT_BASE_URL = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data'
@@ -408,6 +409,13 @@ export interface AcApDocManagerOptions {
         host?: HTMLElement
         /** When false, skip the built-in DOM UI. Default true. */
         showDefaultUi?: boolean
+        /**
+         * Corner for the built-in notification bell.
+         *
+         * When omitted: phone `top-right`, pad / desktop `bottom-right`.
+         * Change later with {@link acapSetNotificationUiPlacement}.
+         */
+        placement?: AcUiNotificationBellPlacement
       }
 }
 
@@ -634,6 +642,7 @@ export class AcApDocManager {
       acapInstallNotificationService(this, {
         host: ncOptions.host,
         showDefaultUi: ncOptions.showDefaultUi !== false,
+        placement: ncOptions.placement,
         enableBridge: true
       })
     }

--- a/packages/cad-simple-viewer/src/app/notification/AcApNotificationService.ts
+++ b/packages/cad-simple-viewer/src/app/notification/AcApNotificationService.ts
@@ -1,8 +1,13 @@
-import { AcUiDefaultNotificationUi } from '../../ui/AcUiDefaultNotificationUi'
+import {
+  AcUiDefaultNotificationUi,
+  type AcUiNotificationBellPlacement
+} from '../../ui/AcUiDefaultNotificationUi'
 import type { AcApDocManager } from '../AcApDocManager'
 import { AcApNotificationEventBridge } from './AcApNotificationEventBridge'
 import { AcApNotificationStore } from './AcApNotificationStore'
 import type { AcApNotificationCenter } from './AcApNotificationTypes'
+
+export type { AcUiNotificationBellPlacement }
 
 /**
  * Options for {@link AcApNotificationService.install} /
@@ -24,6 +29,14 @@ export interface AcApNotificationServiceOptions {
    * When `false`, skips the event bridge entirely. Default `true`.
    */
   enableBridge?: boolean
+  /**
+   * Corner for the built-in notification bell.
+   *
+   * When omitted: phone uses `top-right` (below the shortcut toolbar); pad and
+   * desktop use `bottom-right`. Pass a value to override, or call
+   * {@link acapSetNotificationUiPlacement} later.
+   */
+  placement?: AcUiNotificationBellPlacement
 }
 
 /**
@@ -46,6 +59,8 @@ class AcApNotificationService {
   private _host?: HTMLElement
   /** Whether the built-in DOM UI should be mounted when not overridden. */
   private _showDefaultUi = true
+  /** Explicit bell placement; `undefined` uses layout defaults. */
+  private _placement?: AcUiNotificationBellPlacement
   /** `true` when {@link _center} is a host-supplied override. */
   private _isCustom = false
   /** Document manager last passed to {@link install}. */
@@ -62,6 +77,7 @@ class AcApNotificationService {
     this._docManager = docManager
     this._host = options.host
     this._showDefaultUi = options.showDefaultUi !== false
+    this._placement = options.placement
 
     if (options.enableBridge !== false) {
       this._bridge?.uninstall()
@@ -76,6 +92,26 @@ class AcApNotificationService {
     if (!this._isCustom && this._showDefaultUi) {
       this.mountDefaultUi()
     }
+  }
+
+  /**
+   * Explicit bell placement, or `undefined` when using layout defaults.
+   */
+  get placement(): AcUiNotificationBellPlacement | undefined {
+    return this._placement
+  }
+
+  /**
+   * Sets or clears the built-in notification bell corner.
+   *
+   * Applies immediately when the default DOM UI is mounted. Pass `undefined`
+   * to restore layout-based defaults.
+   *
+   * @param placement - Corner placement, or `undefined` for auto.
+   */
+  setPlacement(placement: AcUiNotificationBellPlacement | undefined) {
+    this._placement = placement
+    this._defaultUi?.setPlacement(placement)
   }
 
   /**
@@ -161,7 +197,8 @@ class AcApNotificationService {
     if (typeof document === 'undefined') return
     this._defaultUi = new AcUiDefaultNotificationUi(
       this._center,
-      this.resolveHost()
+      this.resolveHost(),
+      { placement: this._placement }
     )
   }
 
@@ -190,6 +227,7 @@ class AcApNotificationService {
     this._docManager = undefined
     this._host = undefined
     this._showDefaultUi = true
+    this._placement = undefined
   }
 }
 
@@ -225,6 +263,40 @@ export function acapSetNotificationCenter(
   center: AcApNotificationCenter | null
 ) {
   notificationService.setCenter(center)
+}
+
+/**
+ * Returns the explicit built-in notification bell placement, if any.
+ *
+ * @returns Placement override, or `undefined` when using layout defaults.
+ */
+export function acapGetNotificationUiPlacement():
+  | AcUiNotificationBellPlacement
+  | undefined {
+  return notificationService.placement
+}
+
+/**
+ * Sets the built-in notification bell corner (default DOM UI only).
+ *
+ * Pass `undefined` / omit override via `null` to restore layout defaults:
+ * phone `top-right`, pad / desktop `bottom-right`.
+ *
+ * Has no effect when a custom center replaced the default UI
+ * (`showDefaultUi: false` or {@link acapSetNotificationCenter}).
+ *
+ * @param placement - Corner placement, or `null` / `undefined` for auto.
+ *
+ * @example
+ * ```ts
+ * acapSetNotificationUiPlacement('bottom-left')
+ * acapSetNotificationUiPlacement(null) // restore auto
+ * ```
+ */
+export function acapSetNotificationUiPlacement(
+  placement: AcUiNotificationBellPlacement | null | undefined
+) {
+  notificationService.setPlacement(placement ?? undefined)
 }
 
 /**

--- a/packages/cad-simple-viewer/src/i18n/ar/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/ar/main.ts
@@ -129,7 +129,9 @@ export default {
     more: 'المزيد',
     undo: 'تراجع',
     redo: 'إعادة',
-    erase: 'حذف'
+    erase: 'حذف',
+    collapse: 'طي شريط الأدوات',
+    expand: 'توسيع شريط الأدوات'
   },
   textHeight: {
     title: 'ارتفاع النص',

--- a/packages/cad-simple-viewer/src/i18n/cs/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/cs/main.ts
@@ -130,7 +130,9 @@ export default {
     more: 'Více',
     undo: 'Zpět',
     redo: 'Znovu',
-    erase: 'Smazat'
+    erase: 'Smazat',
+    collapse: 'Sbalit panel nástrojů',
+    expand: 'Rozbalit panel nástrojů'
   },
   textHeight: {
     title: 'Výška textu',

--- a/packages/cad-simple-viewer/src/i18n/en/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/en/main.ts
@@ -131,7 +131,9 @@ export default {
     more: 'More',
     undo: 'Undo',
     redo: 'Redo',
-    erase: 'Delete'
+    erase: 'Delete',
+    collapse: 'Collapse toolbar',
+    expand: 'Expand toolbar'
   },
   textHeight: {
     title: 'Text Height',

--- a/packages/cad-simple-viewer/src/i18n/tr/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/tr/main.ts
@@ -130,7 +130,9 @@ export default {
     more: 'Daha fazla',
     undo: 'Geri al',
     redo: 'Yinele',
-    erase: 'Sil'
+    erase: 'Sil',
+    collapse: 'Araç çubuğunu daralt',
+    expand: 'Araç çubuğunu genişlet'
   },
   textHeight: {
     title: 'Yazı Yüksekliği',

--- a/packages/cad-simple-viewer/src/i18n/zh/main.ts
+++ b/packages/cad-simple-viewer/src/i18n/zh/main.ts
@@ -127,7 +127,9 @@ export default {
     more: '更多',
     undo: '撤销',
     redo: '重做',
-    erase: '删除'
+    erase: '删除',
+    collapse: '收起工具栏',
+    expand: '展开工具栏'
   },
   textHeight: {
     title: '字高设置',

--- a/packages/cad-simple-viewer/src/ui/AcUiDefaultNotificationUi.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiDefaultNotificationUi.ts
@@ -16,9 +16,10 @@ import {
 } from '../app/notification/AcApNotificationTypes'
 import {
   acedGetUiLayout,
-  acedIsHandheldDevice,
   acedSubscribeUiLayout,
   type AcEdUiLayoutKind,
+  ML_UI_SESSION_PANEL_INSET,
+  ML_UI_SESSION_PANEL_WIDTH,
   ML_UI_Z_NOTIFICATION
 } from '../editor/global/AcEdUiLayout'
 import {
@@ -43,15 +44,37 @@ const SHORTCUT_CLEARANCE_PX = 8
 const FALLBACK_TOP_BELOW_SHORTCUT_PX = 12 + 40 + SHORTCUT_CLEARANCE_PX
 
 /**
+ * Corner placement for the built-in notification bell.
+ *
+ * Panel presentation still follows layout kind (phone / pad sheet vs desktop
+ * popover); this only controls where the bell sits on the canvas host.
+ */
+export type AcUiNotificationBellPlacement =
+  | 'bottom-right'
+  | 'bottom-left'
+  | 'top-right'
+  | 'top-left'
+
+/** Options for {@link AcUiDefaultNotificationUi}. */
+export interface AcUiDefaultNotificationUiOptions {
+  /**
+   * Explicit bell corner. When omitted, phone uses `top-right` (below the
+   * shortcut toolbar) and pad / desktop use `bottom-right`.
+   */
+  placement?: AcUiNotificationBellPlacement
+}
+
+/**
  * Built-in notification UI for hosts that do not supply their own center.
  *
  * Interaction (aligned with iOS Notification Center ideas, adapted to CAD chrome):
  * - Hidden entirely when there are no notifications (no idle bell clutter).
  * - With messages: show only a badge-bearing bell; the list opens on tap.
  * - Anchored to the **canvas host** (view container), not the browser window.
- * - Desktop (fine pointer): bell at the host's bottom-right; panel pops above it.
- * - Phone / pad / handheld: bell sits **below** the shortcut toolbar (measured
- *   live) so it never covers undo/redo/erase; panel is a top sheet on phone.
+ * - Desktop / pad: bell at the host's bottom-right by default; pad panel is a
+ *   top sheet sized like the session input panel.
+ * - Phone: bell sits **below** the shortcut toolbar (measured live); panel is
+ *   a full-width top sheet + dimmed backdrop.
  *
  * Theme tokens follow {@link resolveUiTheme} / `--ml-ui-*`.
  */
@@ -62,7 +85,7 @@ export class AcUiDefaultNotificationUi {
   private readonly _center: AcApNotificationCenter
   /** Absolute overlay root covering the host. */
   private readonly _root: HTMLDivElement
-  /** Full-host dismiss button shown behind the phone sheet. */
+  /** Full-host dismiss button shown behind phone / pad sheets. */
   private readonly _backdrop: HTMLButtonElement
   /** Badge-bearing bell button. */
   private readonly _bell: HTMLButtonElement
@@ -80,6 +103,8 @@ export class AcUiDefaultNotificationUi {
   private _panelOpen = false
   /** Latest UI layout kind from {@link acedGetUiLayout}. */
   private _layoutKind: AcEdUiLayoutKind = 'desktop'
+  /** Explicit placement override; `undefined` means layout-based default. */
+  private _placement?: AcUiNotificationBellPlacement
   /** Unsubscribe callbacks for center / theme / layout subscriptions. */
   private readonly _unsubs: Array<() => void> = []
   /** Observes host / shortcut toolbar size for top-anchor repositioning. */
@@ -92,10 +117,16 @@ export class AcUiDefaultNotificationUi {
    *
    * @param center - Center to observe and mutate (clear / remove).
    * @param host - Element that owns the absolute overlay (typically the canvas container).
+   * @param options - Optional bell placement override.
    */
-  constructor(center: AcApNotificationCenter, host: HTMLElement) {
+  constructor(
+    center: AcApNotificationCenter,
+    host: HTMLElement,
+    options: AcUiDefaultNotificationUiOptions = {}
+  ) {
     this._center = center
     this._host = host
+    this._placement = options.placement
     ensureStyles()
 
     if (getComputedStyle(host).position === 'static') {
@@ -194,6 +225,27 @@ export class AcUiDefaultNotificationUi {
   private _onWindowResize: () => void
 
   /**
+   * Explicit placement override, or `undefined` when using layout defaults.
+   */
+  get placement(): AcUiNotificationBellPlacement | undefined {
+    return this._placement
+  }
+
+  /**
+   * Sets or clears the bell corner placement.
+   *
+   * Pass `undefined` to restore layout-based defaults (phone `top-right`,
+   * pad / desktop `bottom-right`).
+   *
+   * @param placement - Corner placement, or `undefined` for auto.
+   */
+  setPlacement(placement: AcUiNotificationBellPlacement | undefined) {
+    if (this._placement === placement) return
+    this._placement = placement
+    this.applyLayout(this._layoutKind)
+  }
+
+  /**
    * Applies the current UI theme tokens to the overlay root.
    */
   private applyTheme() {
@@ -207,19 +259,32 @@ export class AcUiDefaultNotificationUi {
    */
   private applyLayout(kind: AcEdUiLayoutKind) {
     this._layoutKind = kind
-    const topAnchor = shouldAnchorBelowShortcut(kind)
+    const placement = this.resolvePlacement()
+    const topAnchor = isTopPlacement(placement)
+    const rightSide = isRightPlacement(placement)
     this._root.classList.toggle(`${ROOT_CLASS}--phone`, kind === 'phone')
     this._root.classList.toggle(`${ROOT_CLASS}--pad`, kind === 'pad')
     this._root.classList.toggle(`${ROOT_CLASS}--desktop`, kind === 'desktop')
+    this._root.classList.toggle(`${ROOT_CLASS}--sheet`, usesSheetPanel(kind))
     this._root.classList.toggle(`${ROOT_CLASS}--top-anchor`, topAnchor)
     this._root.classList.toggle(`${ROOT_CLASS}--bottom-anchor`, !topAnchor)
+    this._root.classList.toggle(`${ROOT_CLASS}--right`, rightSide)
+    this._root.classList.toggle(`${ROOT_CLASS}--left`, !rightSide)
     this.syncPanelVisibility()
     this.scheduleReposition()
   }
 
   /**
-   * Places the bell (and non-phone panel) below the live shortcut toolbar on
-   * phone/pad/handheld. Desktop uses CSS bottom-right on the full-host root.
+   * Effective bell placement (explicit override or layout default).
+   */
+  private resolvePlacement(): AcUiNotificationBellPlacement {
+    if (this._placement) return this._placement
+    return this._layoutKind === 'phone' ? 'top-right' : 'bottom-right'
+  }
+
+  /**
+   * Places the bell below the live shortcut toolbar when using a top
+   * placement. Bottom placements use CSS on the full-host root.
    *
    * The root always covers the canvas host (`inset: 0`) so panel `width: 100%`
    * resolves against the drawing area, not the 36px bell box.
@@ -231,12 +296,24 @@ export class AcUiDefaultNotificationUi {
     this._root.style.bottom = ''
     this._root.style.left = ''
 
-    if (!shouldAnchorBelowShortcut(this._layoutKind)) {
+    // Sheet panels (phone / pad) are positioned by CSS, not under the bell.
+    if (usesSheetPanel(this._layoutKind)) {
+      this._panel.style.top = ''
+      this._panel.style.right = ''
+      this._panel.style.left = ''
+      this._panel.style.bottom = ''
+    }
+
+    if (!isTopPlacement(this.resolvePlacement())) {
       this._bell.style.top = ''
       this._bell.style.right = ''
       this._bell.style.bottom = ''
-      this._panel.style.top = ''
-      this._panel.style.right = ''
+      this._bell.style.left = ''
+      if (!usesSheetPanel(this._layoutKind)) {
+        this._panel.style.top = ''
+        this._panel.style.right = ''
+        this._panel.style.left = ''
+      }
       return
     }
 
@@ -257,17 +334,29 @@ export class AcUiDefaultNotificationUi {
     }
 
     top = Math.max(gap, top)
+    const edge = '12px'
+    const rightSide = isRightPlacement(this.resolvePlacement())
     this._bell.style.top = `${top}px`
-    this._bell.style.right = '12px'
     this._bell.style.bottom = 'auto'
-
-    // Phone uses a full-width top sheet; pad keeps a popover under the bell.
-    if (this._layoutKind === 'phone') {
-      this._panel.style.top = ''
-      this._panel.style.right = ''
+    if (rightSide) {
+      this._bell.style.right = edge
+      this._bell.style.left = 'auto'
     } else {
+      this._bell.style.left = edge
+      this._bell.style.right = 'auto'
+    }
+
+    // Desktop popover under the bell when top-placed via API.
+    if (!usesSheetPanel(this._layoutKind)) {
       this._panel.style.top = `${top + 44}px`
-      this._panel.style.right = '12px'
+      this._panel.style.bottom = 'auto'
+      if (rightSide) {
+        this._panel.style.right = edge
+        this._panel.style.left = 'auto'
+      } else {
+        this._panel.style.left = edge
+        this._panel.style.right = 'auto'
+      }
     }
   }
 
@@ -319,7 +408,7 @@ export class AcUiDefaultNotificationUi {
     this._root.hidden = !hasMessages
     this._panel.hidden = !hasMessages || !this._panelOpen
     const showBackdrop =
-      hasMessages && this._panelOpen && this._layoutKind === 'phone'
+      hasMessages && this._panelOpen && usesSheetPanel(this._layoutKind)
     this._backdrop.hidden = !showBackdrop
     this._bell.setAttribute('aria-expanded', String(this._panelOpen))
     if (hasMessages) {
@@ -461,13 +550,28 @@ export class AcUiDefaultNotificationUi {
 }
 
 /**
- * Whether the bell should sit below the shortcut toolbar for this layout.
+ * Whether the layout uses a top sheet panel (phone full-bleed / pad session width).
  *
  * @param kind - Current UI layout kind.
- * @returns `true` for phone, pad, or handheld devices.
  */
-function shouldAnchorBelowShortcut(kind: AcEdUiLayoutKind): boolean {
-  return kind === 'phone' || kind === 'pad' || acedIsHandheldDevice()
+function usesSheetPanel(kind: AcEdUiLayoutKind): boolean {
+  return kind === 'phone' || kind === 'pad'
+}
+
+/**
+ * @param placement - Bell placement.
+ * @returns `true` when the bell is top-anchored.
+ */
+function isTopPlacement(placement: AcUiNotificationBellPlacement): boolean {
+  return placement === 'top-right' || placement === 'top-left'
+}
+
+/**
+ * @param placement - Bell placement.
+ * @returns `true` when the bell is on the right edge.
+ */
+function isRightPlacement(placement: AcUiNotificationBellPlacement): boolean {
+  return placement === 'top-right' || placement === 'bottom-right'
 }
 
 /**
@@ -599,13 +703,13 @@ function ensureStyles() {
   align-items: center;
   justify-content: center;
 }
-.${ROOT_CLASS}--bottom-anchor .${ROOT_CLASS}__bell {
+.${ROOT_CLASS}--bottom-anchor.${ROOT_CLASS}--right .${ROOT_CLASS}__bell {
   right: 12px;
   bottom: max(12px, env(safe-area-inset-bottom, 0px));
 }
-.${ROOT_CLASS}--top-anchor .${ROOT_CLASS}__bell {
-  /* top/right applied inline from shortcut-toolbar measurement */
-  right: 12px;
+.${ROOT_CLASS}--bottom-anchor.${ROOT_CLASS}--left .${ROOT_CLASS}__bell {
+  left: 12px;
+  bottom: max(12px, env(safe-area-inset-bottom, 0px));
 }
 .${ROOT_CLASS}__bell:hover {
   color: var(--ml-ui-accent);
@@ -634,20 +738,27 @@ function ensureStyles() {
   box-shadow: var(--ml-ui-shadow);
   overflow: hidden;
 }
-.${ROOT_CLASS}--bottom-anchor .${ROOT_CLASS}__panel {
+.${ROOT_CLASS}--bottom-anchor.${ROOT_CLASS}--right:not(.${ROOT_CLASS}--sheet) .${ROOT_CLASS}__panel {
   right: 12px;
   bottom: calc(max(12px, env(safe-area-inset-bottom, 0px)) + 44px);
   width: min(360px, calc(100% - 24px));
   max-height: min(420px, 60%);
   border-radius: 8px;
 }
-.${ROOT_CLASS}--top-anchor .${ROOT_CLASS}__panel {
-  /* top/right set inline under the bell on pad; phone overrides below */
+.${ROOT_CLASS}--bottom-anchor.${ROOT_CLASS}--left:not(.${ROOT_CLASS}--sheet) .${ROOT_CLASS}__panel {
+  left: 12px;
+  bottom: calc(max(12px, env(safe-area-inset-bottom, 0px)) + 44px);
+  width: min(360px, calc(100% - 24px));
+  max-height: min(420px, 60%);
+  border-radius: 8px;
+}
+.${ROOT_CLASS}--top-anchor:not(.${ROOT_CLASS}--sheet) .${ROOT_CLASS}__panel {
+  /* top/left/right set inline under the bell */
   width: min(360px, calc(100% - 24px));
   max-height: min(420px, 55%);
   border-radius: 8px;
 }
-.${ROOT_CLASS}--phone.${ROOT_CLASS}--top-anchor .${ROOT_CLASS}__panel {
+.${ROOT_CLASS}--phone.${ROOT_CLASS}--sheet .${ROOT_CLASS}__panel {
   /* Sheet spans the canvas host, not the browser viewport. */
   top: 0;
   left: 0;
@@ -657,6 +768,21 @@ function ensureStyles() {
   border-radius: 0 0 12px 12px;
   border-left: none;
   border-right: none;
+  border-top: none;
+  padding-top: env(safe-area-inset-top, 0px);
+}
+.${ROOT_CLASS}--pad.${ROOT_CLASS}--sheet .${ROOT_CLASS}__panel {
+  /* Same top-sheet interaction as phone; width matches pad session panel.
+   * Cap against the canvas host (100%), not the browser viewport (100vw),
+   * so a narrow host inside a wide window does not overflow the drawing area. */
+  top: 0;
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%);
+  width: ${ML_UI_SESSION_PANEL_WIDTH}px;
+  max-width: calc(100% - ${ML_UI_SESSION_PANEL_INSET}px);
+  max-height: min(55%, 420px);
+  border-radius: 0 0 12px 12px;
   border-top: none;
   padding-top: env(safe-area-inset-top, 0px);
 }

--- a/packages/cad-simple-viewer/src/ui/AcUiShortCutToolbar.ts
+++ b/packages/cad-simple-viewer/src/ui/AcUiShortCutToolbar.ts
@@ -25,7 +25,14 @@ import {
   AcUiSimpleToolbar,
   type AcUiSimpleToolbarItem
 } from './AcUiSimpleToolbar'
-import { ICON_ERASE, ICON_REDO, ICON_UNDO } from './icons'
+import {
+  createIconElement,
+  ICON_CHEVRON_LEFT,
+  ICON_CHEVRON_RIGHT,
+  ICON_ERASE,
+  ICON_REDO,
+  ICON_UNDO
+} from './icons'
 
 const STYLE_ID = 'ml-ui-shortcut-toolbar-styles'
 
@@ -83,6 +90,56 @@ const SHELL_CSS = `
   .ml-ui-shortcut-toolbar-shell.has-accessory .ml-ui-shortcut-divider {
     display: block;
   }
+  .ml-ui-shortcut-toolbar-shell.is-collapsed .ml-ui-shortcut-accessory,
+  .ml-ui-shortcut-toolbar-shell.is-collapsed .ml-ui-shortcut-divider,
+  .ml-ui-shortcut-toolbar-shell.is-collapsed .ml-ui-simple-toolbar {
+    display: none !important;
+  }
+  .ml-ui-shortcut-collapse-btn {
+    position: relative;
+    flex: 0 0 auto;
+    width: calc(var(--ml-ui-simple-toolbar-btn-size, 32px) / 2);
+    height: var(--ml-ui-simple-toolbar-btn-size, 32px);
+    margin-left: -4px;
+    margin-right: -4px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    box-sizing: border-box;
+  }
+  .ml-ui-shortcut-collapse-btn:hover {
+    background: var(--ml-ui-accent-soft, rgba(64, 158, 255, 0.12));
+    border-color: var(--ml-ui-border, #dcdfe6);
+  }
+  .ml-ui-shortcut-collapse-btn .ml-ex-ui-icon,
+  .ml-ui-shortcut-collapse-btn .ml-ui-simple-toolbar__icon {
+    display: inline-flex;
+    width: calc(var(--ml-ui-simple-toolbar-btn-size, 32px) / 2);
+    height: calc(var(--ml-ui-simple-toolbar-btn-size, 32px) / 2);
+    align-items: center;
+    justify-content: center;
+  }
+  .ml-ui-shortcut-collapse-btn .ml-ex-ui-icon svg,
+  .ml-ui-shortcut-collapse-btn .ml-ui-simple-toolbar__icon svg {
+    width: calc(var(--ml-ui-simple-toolbar-btn-size, 32px) / 2);
+    height: calc(var(--ml-ui-simple-toolbar-btn-size, 32px) / 2);
+  }
+  .ml-ui-shortcut-collapse-sep {
+    flex: 0 0 auto;
+    width: 1px;
+    align-self: stretch;
+    margin: 2px 0;
+    background: var(--ml-ui-border, #dcdfe6);
+  }
+  .ml-ui-shortcut-toolbar-shell.is-collapsed .ml-ui-shortcut-collapse-sep {
+    display: none;
+  }
   /* Match simple-toolbar icon buttons: no permanent outer frame. */
   .ml-ui-shortcut-accessory .ml-draw-style-toolbar__controls {
     gap: 4px;
@@ -107,7 +164,8 @@ const SHELL_CSS = `
 
 function ensureShellStyles(): void {
   if (typeof document === 'undefined') return
-  if (document.getElementById(STYLE_ID)) return
+  const existing = document.getElementById(STYLE_ID)
+  if (existing) existing.remove()
   const style = document.createElement('style')
   style.id = STYLE_ID
   style.textContent = SHELL_CSS
@@ -139,6 +197,12 @@ export interface AcUiShortCutToolbarOptions {
    */
   forceVisible?: boolean
   /**
+   * When true (default), shows a collapse/expand toggle at the end of the shell.
+   */
+  collapsible?: boolean
+  /** Initial collapsed state when {@link collapsible} is true. Default false. */
+  defaultCollapsed?: boolean
+  /**
    * Command runners. Hosts without DocManager (HTML export) must supply these.
    * When omitted, clicks are no-ops until {@link setActions} is called.
    */
@@ -158,6 +222,8 @@ export interface AcUiShortCutToolbarOptions {
     undo?: string
     redo?: string
     erase?: string
+    collapse?: string
+    expand?: string
   }
 }
 
@@ -173,8 +239,12 @@ export class AcUiShortCutToolbar {
   readonly accessoryHost: HTMLDivElement
 
   private readonly divider: HTMLDivElement
+  private readonly collapseSep: HTMLDivElement | null
+  private readonly collapseButton: HTMLButtonElement | null
   private readonly toolbar: AcUiSimpleToolbar
   private readonly forceVisible: boolean
+  private readonly collapsible: boolean
+  private collapsed: boolean
   private readonly onSettingsModified: (
     args: AcApSettingManagerEventArgs
   ) => void
@@ -197,6 +267,8 @@ export class AcUiShortCutToolbar {
     }
 
     this.forceVisible = options.forceVisible === true
+    this.collapsible = options.collapsible !== false
+    this.collapsed = this.collapsible && options.defaultCollapsed === true
     this.actions = { ...(options.actions ?? {}) }
     this.getActionState = options.getActionState
 
@@ -223,6 +295,26 @@ export class AcUiShortCutToolbar {
       items: this.buildCoreItems()
     })
 
+    if (this.collapsible) {
+      this.collapseSep = document.createElement('div')
+      this.collapseSep.className = 'ml-ui-shortcut-collapse-sep'
+      this.collapseSep.setAttribute('role', 'separator')
+      this.collapseButton = document.createElement('button')
+      this.collapseButton.type = 'button'
+      this.collapseButton.className = 'ml-ui-shortcut-collapse-btn'
+      this.collapseButton.dataset.toolbarItemId = 'shortcut-collapse'
+      this.collapseButton.addEventListener('click', event => {
+        event.stopPropagation()
+        this.toggleCollapsed()
+      })
+      this.shell.append(this.collapseSep, this.collapseButton)
+      this.syncCollapseToggleButton()
+      this.syncCollapsedClass()
+    } else {
+      this.collapseSep = null
+      this.collapseButton = null
+    }
+
     this.onSettingsModified = args => {
       if (args.key === 'isShowShortCutToolbar') this.syncVisibility()
     }
@@ -243,6 +335,11 @@ export class AcUiShortCutToolbar {
   /** Underlying simple toolbar (for advanced callers). */
   get simpleToolbar(): AcUiSimpleToolbar {
     return this.toolbar
+  }
+
+  /** Whether the toolbar is collapsed to the toggle button only. */
+  get isCollapsed(): boolean {
+    return this.collapsed
   }
 
   /**
@@ -296,6 +393,23 @@ export class AcUiShortCutToolbar {
   }
 
   /**
+   * Sets collapsed state when {@link AcUiShortCutToolbarOptions.collapsible} is enabled.
+   *
+   * @param collapsed - Target collapsed state.
+   */
+  setCollapsed(collapsed: boolean): void {
+    if (!this.collapsible || this.collapsed === collapsed) return
+    this.collapsed = collapsed
+    this.syncCollapsedClass()
+    this.syncCollapseToggleButton()
+  }
+
+  /** Toggles collapsed state when collapsible mode is enabled. */
+  toggleCollapsed(): void {
+    this.setCollapsed(!this.collapsed)
+  }
+
+  /**
    * Updates the shell top offset (e.g. when a status bar appears).
    *
    * @param topOffsetPx - CSS top in pixels.
@@ -333,6 +447,7 @@ export class AcUiShortCutToolbar {
       this.options.labels?.more ?? AcApI18n.t('main.shortCutToolbar.more')
     )
     this.toolbar.setItems(this.buildCoreItems())
+    this.syncCollapseToggleButton()
     this.syncActionState()
   }
 
@@ -363,7 +478,28 @@ export class AcUiShortCutToolbar {
     const visible =
       this.forceVisible || AcApSettingManager.instance.isShowShortCutToolbar
     this.shell.hidden = !visible
-    this.toolbar.setVisible(visible)
+    this.toolbar.setVisible(visible && !this.collapsed)
+  }
+
+  private syncCollapsedClass(): void {
+    this.shell.classList.toggle('is-collapsed', this.collapsed)
+    const visible =
+      this.forceVisible || AcApSettingManager.instance.isShowShortCutToolbar
+    this.toolbar.setVisible(visible && !this.collapsed)
+  }
+
+  private syncCollapseToggleButton(): void {
+    if (!this.collapseButton) return
+    const label = this.collapsed
+      ? (this.options.labels?.expand ??
+        AcApI18n.t('main.shortCutToolbar.expand'))
+      : (this.options.labels?.collapse ??
+        AcApI18n.t('main.shortCutToolbar.collapse'))
+    const icon = this.collapsed ? ICON_CHEVRON_RIGHT : ICON_CHEVRON_LEFT
+    this.collapseButton.replaceChildren(createIconElement(icon))
+    this.collapseButton.title = label
+    this.collapseButton.setAttribute('aria-label', label)
+    this.collapseButton.setAttribute('aria-expanded', String(!this.collapsed))
   }
 
   private buildCoreItems(): AcUiSimpleToolbarItem[] {


### PR DESCRIPTION
## Summary
- Add configurable built-in notification bell placement (`notificationCenter.placement` / `acapSetNotificationUiPlacement`) with layout defaults (phone top-right, pad/desktop bottom-right).
- Treat pad notifications as a top sheet with backdrop, width matched to the session panel and capped to the canvas host (not `100vw`).
- Make the shortcut toolbar collapsible (HTML export included) with i18n for collapse/expand.

## Test plan
- [ ] Desktop: open a drawing with notifications; confirm bell bottom-right and popover above the bell
- [ ] Pad width: confirm sheet + backdrop, width ~440px and does not overflow a narrow canvas host
- [ ] Phone: confirm bell stays below shortcut toolbar; collapse toolbar and confirm bell repositions
- [ ] Call `acapSetNotificationUiPlacement('bottom-left')` / `null` and confirm runtime updates
- [ ] Shortcut toolbar collapse/expand toggles correctly in viewer and HTML export; labels switch locale
