### PR TITLE
fix: clip paper viewports to the canvas to stay within WebGL limits

### DIFF
--- a/packages/cad-html-plugin/__tests__/AcExPaperViewport.spec.ts
+++ b/packages/cad-html-plugin/__tests__/AcExPaperViewport.spec.ts
@@ -1,5 +1,6 @@
 import type { AcExViewportSnapshot } from '../src/AcExSnapshotTypes'
 import {
+  computeOnscreenPaperViewportPass,
   computeViewportCamera,
   findDrillThroughViewport,
   modelPointToPaper,
@@ -79,6 +80,51 @@ describe('AcExPaperViewport', () => {
     expect(fitted.frustum).toBe(50)
     expect(fitted.aspect).toBe(2)
     expect(fitted.zoom).toBe(2)
+  })
+
+  it('clips an oversized paper-viewport CSS window to the canvas', () => {
+    const pass = computeOnscreenPaperViewportPass(
+      viewport,
+      { x: -50000, y: -20000, width: 100000, height: 50000 },
+      { x: 0, y: 0, width: 800, height: 600 }
+    )
+    expect(pass).not.toBeNull()
+    expect(pass!.hit).toEqual({ x: 0, y: 0, width: 800, height: 600 })
+    const visibleW = pass!.model.maxX - pass!.model.minX
+    const fullW = viewport.model.maxX - viewport.model.minX
+    expect(visibleW).toBeLessThan(fullW * 0.5)
+    expect(pass!.hit.width).toBeLessThanOrEqual(800)
+    expect(pass!.hit.height).toBeLessThanOrEqual(600)
+  })
+
+  it('keeps the full DCS view box when the paper viewport is on-screen', () => {
+    const twisted: AcExViewportSnapshot = {
+      ...viewport,
+      twist: Math.PI / 4
+    }
+    const cssVp = { x: 10, y: 20, width: 200, height: 100 }
+    const pass = computeOnscreenPaperViewportPass(twisted, cssVp, {
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600
+    })
+    expect(pass).not.toBeNull()
+    expect(pass!.hit).toEqual(cssVp)
+    expect(pass!.model.minX).toBeCloseTo(viewport.model.minX)
+    expect(pass!.model.minY).toBeCloseTo(viewport.model.minY)
+    expect(pass!.model.maxX).toBeCloseTo(viewport.model.maxX)
+    expect(pass!.model.maxY).toBeCloseTo(viewport.model.maxY)
+  })
+
+  it('returns null when the paper viewport is fully off-screen', () => {
+    expect(
+      computeOnscreenPaperViewportPass(
+        viewport,
+        { x: 2000, y: 2000, width: 100, height: 100 },
+        { x: 0, y: 0, width: 800, height: 600 }
+      )
+    ).toBeNull()
   })
 
   it('detects paper layouts that carry viewports', () => {

--- a/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
+++ b/packages/cad-html-plugin/src/AcExHtmlViewerRuntime.ts
@@ -11,9 +11,7 @@ import {
   type AcExCommandSessionUiState
 } from './AcExCommandSessionPanel'
 import {
-  acexCssRectToWcsBox,
   acexCssTopLeftRectToGl,
-  acexIntersectCssRects,
   acexWcsBoxToCssRect
 } from './AcExCssRect'
 import { acexSetDocsBaseUrl } from './AcExDocsUrl'
@@ -76,6 +74,7 @@ import {
 } from './AcExPackageLoader'
 import type { AcExPackageManifest } from './AcExPackageTypes'
 import {
+  computeOnscreenPaperViewportPass,
   computeViewportCamera,
   findDrillThroughViewport,
   modelPointToPaper,
@@ -1365,81 +1364,6 @@ async function startViewer(): Promise<void> {
     }
   }
 
-  const renderPaperViewports = () => {
-    const viewports = layout.viewports
-    if (
-      layout.isModelSpace ||
-      !viewports?.length ||
-      modelRoot.children.length === 0
-    ) {
-      return
-    }
-    const { width, height } = getCanvasSize()
-    if (width <= 0 || height <= 0) return
-
-    const autoClear = renderer.autoClear
-    renderer.autoClear = false
-    renderer.getViewport(savedViewportBox)
-    renderer.clearDepth()
-
-    for (const viewport of viewports) {
-      const pMin = paperWorldToScreen(
-        viewport.paper.minX,
-        viewport.paper.minY,
-        width,
-        height
-      )
-      const pMax = paperWorldToScreen(
-        viewport.paper.maxX,
-        viewport.paper.maxY,
-        width,
-        height
-      )
-      const minX = Math.min(pMin.x, pMax.x)
-      const maxX = Math.max(pMin.x, pMax.x)
-      const minY = Math.min(pMin.y, pMax.y)
-      const maxY = Math.max(pMin.y, pMax.y)
-      const vpW = maxX - minX
-      const vpH = maxY - minY
-      if (vpW < 1 || vpH < 1) continue
-
-      const scissorX = minX
-      const scissorY = height - maxY
-      renderer.setViewport(scissorX, scissorY, vpW, vpH)
-      renderer.setScissor(scissorX, scissorY, vpW, vpH)
-      renderer.setScissorTest(true)
-
-      const fitted = computeViewportCamera(viewport.model, vpW, vpH)
-      viewportCamera.left = -fitted.aspect * fitted.frustum
-      viewportCamera.right = fitted.aspect * fitted.frustum
-      viewportCamera.top = fitted.frustum
-      viewportCamera.bottom = -fitted.frustum
-      viewportCamera.position.set(
-        fitted.centerX,
-        fitted.centerY,
-        ACEX_CAMERA_DISTANCE
-      )
-      viewportCamera.lookAt(fitted.centerX, fitted.centerY, 0)
-      const twist = viewport.twist ?? 0
-      viewportCamera.up.set(-Math.sin(twist), Math.cos(twist), 0)
-      viewportCamera.setRotationFromEuler(new THREE.Euler(0, 0, twist))
-      viewportCamera.zoom = fitted.zoom
-      viewportCamera.updateProjectionMatrix()
-      AcExCameraZoomUniform.value = fitted.zoom
-      renderer.render(modelScene, viewportCamera)
-      renderer.setScissorTest(false)
-    }
-
-    renderer.setViewport(
-      savedViewportBox.x,
-      savedViewportBox.y,
-      savedViewportBox.z,
-      savedViewportBox.w
-    )
-    renderer.autoClear = autoClear
-    AcExCameraZoomUniform.value = camera.zoom
-  }
-
   /**
    * Fits an orthographic camera so `extents` fills a CSS rectangle of
    * `vpW` × `vpH`, matching {@link computeViewportCamera}.
@@ -1469,6 +1393,78 @@ async function startViewer(): Promise<void> {
     target.zoom = fitted.zoom
     target.updateProjectionMatrix()
     AcExCameraZoomUniform.value = fitted.zoom
+  }
+
+  const renderPaperViewports = () => {
+    const viewports = layout.viewports
+    if (
+      layout.isModelSpace ||
+      !viewports?.length ||
+      modelRoot.children.length === 0
+    ) {
+      return
+    }
+    const { width, height } = getCanvasSize()
+    if (width <= 0 || height <= 0) return
+
+    const autoClear = renderer.autoClear
+    renderer.autoClear = false
+    renderer.getViewport(savedViewportBox)
+    renderer.clearDepth()
+
+    const canvasRect = { x: 0, y: 0, width, height }
+    for (const viewport of viewports) {
+      const pMin = paperWorldToScreen(
+        viewport.paper.minX,
+        viewport.paper.minY,
+        width,
+        height
+      )
+      const pMax = paperWorldToScreen(
+        viewport.paper.maxX,
+        viewport.paper.maxY,
+        width,
+        height
+      )
+      const minX = Math.min(pMin.x, pMax.x)
+      const maxX = Math.max(pMin.x, pMax.x)
+      const minY = Math.min(pMin.y, pMax.y)
+      const maxY = Math.max(pMin.y, pMax.y)
+      const pass = computeOnscreenPaperViewportPass(
+        viewport,
+        {
+          x: minX,
+          y: minY,
+          width: maxX - minX,
+          height: maxY - minY
+        },
+        canvasRect
+      )
+      if (!pass) continue
+
+      const gl = acexCssTopLeftRectToGl(pass.hit, height)
+      renderer.setViewport(gl.x, gl.y, gl.width, gl.height)
+      renderer.setScissor(gl.x, gl.y, gl.width, gl.height)
+      renderer.setScissorTest(true)
+      applyOrthoFit(
+        viewportCamera,
+        pass.model,
+        pass.hit.width,
+        pass.hit.height,
+        viewport.twist ?? 0
+      )
+      renderer.render(modelScene, viewportCamera)
+      renderer.setScissorTest(false)
+    }
+
+    renderer.setViewport(
+      savedViewportBox.x,
+      savedViewportBox.y,
+      savedViewportBox.z,
+      savedViewportBox.w
+    )
+    renderer.autoClear = autoClear
+    AcExCameraZoomUniform.value = camera.zoom
   }
 
   /**
@@ -1519,22 +1515,13 @@ async function startViewer(): Promise<void> {
     ) {
       for (const viewport of layout.viewports) {
         const magRect = acexWcsBoxToCssRect(viewport.paper, viewBox, loupeRect)
-        const hit = acexIntersectCssRects(magRect, loupeRect)
-        if (!hit) continue
-        const paperHit = acexCssRectToWcsBox(hit, viewBox, loupeRect)
-        const corners = [
-          paperPointToModel(viewport, paperHit.minX, paperHit.minY),
-          paperPointToModel(viewport, paperHit.maxX, paperHit.minY),
-          paperPointToModel(viewport, paperHit.maxX, paperHit.maxY),
-          paperPointToModel(viewport, paperHit.minX, paperHit.maxY)
-        ]
-        const modelBox: AcExExtents = {
-          minX: Math.min(...corners.map(c => c.x)),
-          minY: Math.min(...corners.map(c => c.y)),
-          maxX: Math.max(...corners.map(c => c.x)),
-          maxY: Math.max(...corners.map(c => c.y))
-        }
-        const nestedGl = acexCssTopLeftRectToGl(hit, height)
+        const pass = computeOnscreenPaperViewportPass(
+          viewport,
+          magRect,
+          loupeRect
+        )
+        if (!pass) continue
+        const nestedGl = acexCssTopLeftRectToGl(pass.hit, height)
         renderer.setScissor(
           nestedGl.x,
           nestedGl.y,
@@ -1550,9 +1537,9 @@ async function startViewer(): Promise<void> {
         renderer.clearDepth()
         applyOrthoFit(
           loupeCamera,
-          modelBox,
-          hit.width,
-          hit.height,
+          pass.model,
+          pass.hit.width,
+          pass.hit.height,
           viewport.twist ?? 0
         )
         renderer.render(modelScene, loupeCamera)

--- a/packages/cad-html-plugin/src/AcExPaperViewport.ts
+++ b/packages/cad-html-plugin/src/AcExPaperViewport.ts
@@ -1,3 +1,8 @@
+import {
+  type AcExCssRect,
+  acexCssRectToWcsBox,
+  acexIntersectCssRects
+} from './AcExCssRect'
 import type { AcExExtents, AcExViewportSnapshot } from './AcExSnapshotTypes'
 
 const EPS = 1e-12
@@ -181,6 +186,43 @@ export function computeViewportCamera(
     frustum,
     aspect
   }
+}
+
+/**
+ * Clips a paper viewport's CSS rectangle to `clip` and returns the model-space
+ * box that should fill the overlap.
+ *
+ * Zooming paper space can map a viewport to more CSS pixels than WebGL
+ * `MAX_VIEWPORT_DIMS`. Clamping that rect shifts NDC (right-side content
+ * appears in view) and further zoom draws nothing. The on-screen intersection
+ * stays within GPU limits.
+ *
+ * The CSS clip is mapped onto the DCS view box. Do not send corners through
+ * {@link paperPointToModel}: that applies twist, and the renderer already
+ * applies twist after fitting the camera.
+ *
+ * @returns On-canvas CSS rect and matching model extents, or `null` when the
+ *   viewport is fully outside `clip` or has an empty mapping.
+ */
+export function computeOnscreenPaperViewportPass(
+  viewport: AcExViewportSnapshot,
+  cssVp: AcExCssRect,
+  clip: AcExCssRect
+): { hit: AcExCssRect; model: AcExExtents } | null {
+  const hit = acexIntersectCssRects(cssVp, clip)
+  if (!hit) return null
+  const model = acexCssRectToWcsBox(hit, viewport.model, cssVp)
+  if (
+    model.maxX - model.minX <= EPS ||
+    model.maxY - model.minY <= EPS ||
+    !Number.isFinite(model.minX) ||
+    !Number.isFinite(model.minY) ||
+    !Number.isFinite(model.maxX) ||
+    !Number.isFinite(model.maxY)
+  ) {
+    return null
+  }
+  return { hit, model }
 }
 
 /**

--- a/packages/three-renderer/__tests__/AcTrViewportView.isDefaultPaperSpaceViewport.spec.ts
+++ b/packages/three-renderer/__tests__/AcTrViewportView.isDefaultPaperSpaceViewport.spec.ts
@@ -57,6 +57,63 @@ describe('AcTrViewportView twist', () => {
   })
 })
 
+describe('AcTrViewportView.computeOnscreenPass', () => {
+  it('clips an oversized paper-viewport window to the parent canvas', () => {
+    const parent = new AcTrBaseView(createMockRenderer(), 800, 600)
+    parent.internalCamera.position.set(5, 5, 500)
+    parent.internalCamera.zoom = 10000
+    parent.internalCamera.updateProjectionMatrix()
+    parent.internalCamera.updateMatrixWorld()
+
+    const view = new AcTrViewportView(
+      parent,
+      createViewport(0),
+      createMockRenderer()
+    )
+    const pass = view.computeOnscreenPass()
+    expect(pass).not.toBeNull()
+    expect(pass!.hit.x).toBeGreaterThanOrEqual(-1e-6)
+    expect(pass!.hit.y).toBeGreaterThanOrEqual(-1e-6)
+    expect(pass!.hit.x + pass!.hit.width).toBeLessThanOrEqual(800 + 1e-6)
+    expect(pass!.hit.y + pass!.hit.height).toBeLessThanOrEqual(600 + 1e-6)
+
+    const full = view.viewport.viewBox
+    const visibleW = pass!.modelBox.max.x - pass!.modelBox.min.x
+    const fullW = full.max.x - full.min.x
+    expect(visibleW).toBeLessThan(fullW * 0.5)
+  })
+
+  it('keeps the full DCS view box when the paper viewport is on-screen', () => {
+    const parent = new AcTrBaseView(createMockRenderer(), 800, 600)
+    const view = new AcTrViewportView(
+      parent,
+      createViewport(Math.PI / 4),
+      createMockRenderer()
+    )
+    const pass = view.computeOnscreenPass()
+    expect(pass).not.toBeNull()
+    const full = view.viewport.viewBox
+    expect(pass!.modelBox.min.x).toBeCloseTo(full.min.x)
+    expect(pass!.modelBox.min.y).toBeCloseTo(full.min.y)
+    expect(pass!.modelBox.max.x).toBeCloseTo(full.max.x)
+    expect(pass!.modelBox.max.y).toBeCloseTo(full.max.y)
+  })
+
+  it('returns null when the paper viewport is fully off-screen', () => {
+    const parent = new AcTrBaseView(createMockRenderer(), 800, 600)
+    parent.internalCamera.position.set(1e6, 1e6, 500)
+    parent.internalCamera.updateProjectionMatrix()
+    parent.internalCamera.updateMatrixWorld()
+
+    const view = new AcTrViewportView(
+      parent,
+      createViewport(0),
+      createMockRenderer()
+    )
+    expect(view.computeOnscreenPass()).toBeNull()
+  })
+})
+
 describe('AcTrViewportView.isDefaultPaperSpaceViewport', () => {
   it('detects the classic looks-at-itself default', () => {
     expect(

--- a/packages/three-renderer/src/viewport/AcTrViewportView.ts
+++ b/packages/three-renderer/src/viewport/AcTrViewportView.ts
@@ -8,6 +8,12 @@ import * as THREE from 'three'
 
 import { AcTrRenderer } from '../renderer/AcTrRenderer'
 import { AcTrBaseView } from './AcTrBaseView'
+import {
+  type AcTrCssRect,
+  acTrCssRectToWcsBox,
+  acTrCssTopLeftRectToGl,
+  acTrIntersectCssRects
+} from './AcTrCssRect'
 
 /**
  * This class represents view to show viewport.
@@ -260,32 +266,68 @@ export class AcTrViewportView extends AcTrBaseView {
   }
 
   /**
-   * Render the specified scene in this viewport view
-   * @param scene Input the scene to render
+   * Clips this paper viewport to the parent canvas and returns the CSS
+   * rectangle plus the model-space box that should fill it.
+   *
+   * A zoomed paper viewport can map to more CSS pixels than WebGL
+   * `MAX_VIEWPORT_DIMS`. Clamping that rect shifts NDC (right-side content
+   * appears in view) and further zoom draws nothing. The on-screen
+   * intersection stays within GPU limits.
+   *
+   * @returns On-canvas CSS rect and matching model box, or `null` when the
+   *   viewport is fully off-screen or has an empty mapping.
    */
-  render(scene: THREE.Object3D) {
+  computeOnscreenPass(): { hit: AcTrCssRect; modelBox: AcGeBox2d } | null {
     const viewportWindowBox = AcTrViewportView.calculateViewportWindowBox(
       this._parentView,
       this._viewport
     )
-    if (!viewportWindowBox.isEmpty()) {
-      const vpW = viewportWindowBox.size.width
-      const vpH = viewportWindowBox.size.height
-
-      if (vpW !== this._width || vpH !== this._height) {
-        this._width = vpW
-        this._height = vpH
-        this._frustum = vpH / 2
-        this.zoomTo(this._viewport.viewBox, 1.0)
-        this.applyViewTwist()
-      }
-
-      const y = this._parentView.height - viewportWindowBox.min.y - vpH
-      this._renderer.setViewport(viewportWindowBox.min.x, y, vpW, vpH)
-      this._renderer.setScissor(viewportWindowBox.min.x, y, vpW, vpH)
-      this._renderer.setScissorTest(true)
-      this._renderer.render(scene, this._camera)
-      this._renderer.setScissorTest(false)
+    if (viewportWindowBox.isEmpty()) return null
+    const size = viewportWindowBox.size
+    const cssVp: AcTrCssRect = {
+      x: viewportWindowBox.min.x,
+      y: viewportWindowBox.min.y,
+      width: size.width,
+      height: size.height
     }
+    const hit = acTrIntersectCssRects(cssVp, {
+      x: 0,
+      y: 0,
+      width: this._parentView.width,
+      height: this._parentView.height
+    })
+    if (!hit) return null
+    // Map the CSS clip onto the DCS view box. Do not send corners through
+    // `paperPointToModel`: that applies `viewTwistAngle`, and `render()`
+    // already calls `applyViewTwist()` after `zoomTo`. Using the twisted
+    // AABB would zoom out fully on-screen twisted viewports.
+    const mapped = acTrCssRectToWcsBox(hit, this._viewport.viewBox, cssVp)
+    const modelBox = new AcGeBox2d()
+    modelBox.expandByPoint({ x: mapped.minX, y: mapped.minY })
+    modelBox.expandByPoint({ x: mapped.maxX, y: mapped.maxY })
+    if (modelBox.isEmpty()) return null
+    return { hit, modelBox }
+  }
+
+  /**
+   * Render the specified scene in this viewport view
+   * @param scene Input the scene to render
+   */
+  render(scene: THREE.Object3D) {
+    const pass = this.computeOnscreenPass()
+    if (!pass) return
+
+    this._width = pass.hit.width
+    this._height = pass.hit.height
+    this._frustum = pass.hit.height / 2
+    this.zoomTo(pass.modelBox, 1.0)
+    this.applyViewTwist()
+
+    const gl = acTrCssTopLeftRectToGl(pass.hit, this._parentView.height)
+    this._renderer.setViewport(gl.x, gl.y, gl.width, gl.height)
+    this._renderer.setScissor(gl.x, gl.y, gl.width, gl.height)
+    this._renderer.setScissorTest(true)
+    this._renderer.render(scene, this._camera)
+    this._renderer.setScissorTest(false)
   }
 }


### PR DESCRIPTION
## Summary
- Clip paper-space viewport windows to the parent canvas before `setViewport`/`setScissor`, so zoomed layouts stay within WebGL `MAX_VIEWPORT_DIMS` instead of clamping and shifting NDC.
- Refit the nested camera to the DCS `viewBox` subset that fills the on-screen CSS intersection, then apply view twist once (not via `paperPointToModel` corners, which would zoom out twisted viewports).
- Apply the same mapping in the HTML export viewer (`computeOnscreenPaperViewportPass`) for both layout viewports and nested snap-loupe passes.
- Add unit coverage for oversized clip, fully on-screen twist, and fully off-screen viewports in three-renderer and cad-html-plugin.

## Test plan
- [x] `pnpm exec jest packages/three-renderer/__tests__/AcTrViewportView.isDefaultPaperSpaceViewport.spec.ts`
- [x] `pnpm exec jest packages/cad-html-plugin/__tests__/AcExPaperViewport.spec.ts`
- [ ] Open a paper-space drawing, zoom deeply into a viewport, and confirm model content stays aligned (no right-side content jumping into view, no blank viewport on further zoom).
- [ ] Pan a paper viewport partly off-canvas and confirm the visible slice still matches AutoCAD-style framing.
- [ ] Check a layout with non-zero DVIEW twist: fully on-screen viewports should not appear zoomed out.
- [ ] Open an exported HTML viewer of a paper layout and repeat the zoom/pan checks, including the snap loupe over a viewport.